### PR TITLE
Rename to Omamail and settle the plugin id as omamail

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -23,7 +23,7 @@ Item {
   property bool closingFromHost: false
 
   readonly property string pluginId: manifest && manifest.id
-    ? String(manifest.id) : "omamail.omarchy"
+    ? String(manifest.id) : "omamail"
 
   readonly property color foreground: Color.foreground
   readonly property color background: Color.background

--- a/App.qml
+++ b/App.qml
@@ -23,7 +23,7 @@ Item {
   property bool closingFromHost: false
 
   readonly property string pluginId: manifest && manifest.id
-    ? String(manifest.id) : "gmail.omarchy"
+    ? String(manifest.id) : "omamail.omarchy"
 
   readonly property color foreground: Color.foreground
   readonly property color background: Color.background
@@ -184,7 +184,7 @@ Item {
   FloatingWindow {
     id: window
     visible: root.opened
-    title: "Omarchy Gmail"
+    title: "Omamail"
     color: root.background
     implicitWidth: Style.space(980)
     implicitHeight: Style.space(720)
@@ -233,7 +233,7 @@ Item {
           Text {
             anchors.verticalCenter: parent.verticalCenter
             visible: !root.compact
-            text: "Gmail"
+            text: "Omamail"
             color: root.foreground
             font.family: root.fontFamily
             font.pixelSize: Style.font.title
@@ -648,10 +648,8 @@ Item {
             if (!root.ready) return "Not connected"
             if (root.compact)
               return root.service.accountEmail + " · " + root.service.inboxUnread + " unread"
-            var parts = []
-            if (root.service.syncedLabel !== "") parts.push(root.service.syncedLabel)
-            if (root.service.messages.length > 0) parts.push(root.service.resultSummary)
-            return parts.join("  ·  ")
+            return Model.statusSummary(root.service.syncedLabel,
+              root.service.resultSummary, root.service.listLoading)
           }
           color: root.dim
           font.family: root.fontFamily
@@ -717,10 +715,10 @@ Item {
               ({ key: "Esc", label: "close" })
             ]
             if (root.currentView === "reader") return [
-              ({ key: "u", label: "back" }),
+              ({ key: "Esc", label: "back" }),
               ({ key: "r", label: "reply" }),
               ({ key: "e", label: "archive" }),
-              ({ key: "Del", label: "trash" })
+              ({ key: "d", label: "trash" })
             ]
             return [
               ({ key: "j / k", label: "move" }),
@@ -821,14 +819,8 @@ Item {
       Shortcut { sequence: "j"; enabled: !focusScope.typing; onActivated: root.moveCursor(1) }
       Shortcut { sequence: "k"; enabled: !focusScope.typing; onActivated: root.moveCursor(-1) }
       Shortcut { sequence: "Return"; enabled: !focusScope.typing && root.currentView === "list"; onActivated: root.openMessage(root.cursorId) }
-      Shortcut { sequence: "u"; enabled: !focusScope.typing; onActivated: root.backToList() }
       Shortcut { sequence: "e"; enabled: !focusScope.typing; onActivated: root.actOnCursor("archive") }
-      // Gmail's own key for this is "#", which nobody guesses. Delete and
-      // Backspace are what someone actually reaches for, so all three work and
-      // the one that gets advertised is Delete.
-      Shortcut { sequence: "#"; enabled: !focusScope.typing; onActivated: root.actOnCursor("trash") }
-      Shortcut { sequence: "Del"; enabled: !focusScope.typing; onActivated: root.actOnCursor("trash") }
-      Shortcut { sequence: "Backspace"; enabled: !focusScope.typing; onActivated: root.actOnCursor("trash") }
+      Shortcut { sequence: "d"; enabled: !focusScope.typing; onActivated: root.actOnCursor("trash") }
       Shortcut { sequence: "s"; enabled: !focusScope.typing; onActivated: if (root.service) root.service.toggleStar(root.cursorId) }
       Shortcut { sequence: "Shift+I"; enabled: !focusScope.typing; onActivated: root.actOnCursor("markRead") }
       Shortcut { sequence: "Shift+U"; enabled: !focusScope.typing; onActivated: root.actOnCursor("markUnread") }

--- a/App.qml
+++ b/App.qml
@@ -217,6 +217,7 @@ Item {
         // and the name say what this window is, and everything to their right
         // does something.
         Row {
+          id: headerLeft
           anchors.left: parent.left
           anchors.leftMargin: Style.space(14)
           anchors.verticalCenter: parent.verticalCenter
@@ -280,11 +281,28 @@ Item {
           }
         }
 
-        SearchBar {
-          id: searchBar
-          anchors.centerIn: parent
-          width: Math.min(Style.space(460), parent.width - Style.space(300))
-          visible: !root.showPage
+        // The slot is whatever the two clusters leave, so the field shrinks with
+        // the window instead of running underneath Check mail. Centring it in
+        // the header and reserving a fixed width could not work: the reserve is
+        // split evenly either side, while the controls are all on the left.
+        Item {
+          id: searchSlot
+          anchors.left: headerLeft.right
+          anchors.right: headerRight.left
+          anchors.leftMargin: Style.space(12)
+          anchors.rightMargin: Style.space(12)
+          anchors.verticalCenter: parent.verticalCenter
+          height: searchBar.implicitHeight
+
+          SearchBar {
+            id: searchBar
+            anchors.centerIn: parent
+            // Centred within the gap while there is room to spare, and capped
+            // so it does not stretch across a very wide window.
+            width: Math.min(Style.space(460), parent.width)
+            // Below this it is a slot too small to type in; the shortcut still
+            // works and reopens it as the window grows.
+            visible: !root.showPage && parent.width >= Style.space(120)
           textColor: root.foreground
           accentColor: root.accent
           panelFontFamily: root.fontFamily
@@ -300,9 +318,11 @@ Item {
             root.service.search("")
             root.backToList()
           }
+          }
         }
 
         Row {
+          id: headerRight
           anchors.right: parent.right
           anchors.rightMargin: Style.space(14)
           anchors.verticalCenter: parent.verticalCenter

--- a/AuthManager.qml
+++ b/AuthManager.qml
@@ -196,6 +196,8 @@ Item {
   // alone. Reading that once, and rewriting under the new attributes, is the
   // difference between an upgrade and a silent sign-out.
   property bool triedLegacyLookup: false
+  property int secretLookupStage: 0
+  property var renamedAttributesToClear: []
 
   // Two keyring entries are not tied to an address: the pre-multi-account one
   // keyed by client alone, and the one written for a mailbox that had not
@@ -222,16 +224,32 @@ Item {
     }
     lookupHandled = false
     triedLegacyLookup = false
+    secretLookupStage = 0
     secretLookup.command = ["secret-tool", "lookup"].concat(
       Credentials.keyringAttributes(clientId, accountId))
     secretLookup.running = true
   }
 
-  function startLegacyLookup() {
+  function startNextSecretLookup() {
     lookupHandled = false
-    triedLegacyLookup = true
-    secretLookup.command = ["secret-tool", "lookup"].concat(
-      Credentials.legacyKeyringAttributes(clientId))
+    secretLookupStage++
+    var attributes = []
+    if (secretLookupStage === 1 && mayAdoptLegacyToken) {
+      triedLegacyLookup = true
+      attributes = Credentials.legacyKeyringAttributes(clientId)
+    } else if (secretLookupStage <= 2) {
+      secretLookupStage = 2
+      triedLegacyLookup = false
+      attributes = Credentials.renamedKeyringAttributes(clientId, accountId)
+    } else if (secretLookupStage === 3 && mayAdoptLegacyToken) {
+      triedLegacyLookup = true
+      attributes = Credentials.renamedLegacyKeyringAttributes(clientId)
+    }
+    if (!attributes.length) {
+      handleSecretLookup("")
+      return
+    }
+    secretLookup.command = ["secret-tool", "lookup"].concat(attributes)
     secretLookup.running = true
   }
 
@@ -239,8 +257,8 @@ Item {
     if (lookupHandled) return
     lookupHandled = true
     var token = String(raw || "").trim()
-    if (!token && !triedLegacyLookup && mayAdoptLegacyToken && clientId !== "") {
-      startLegacyLookup()
+    if (!token && secretLookupStage < 3 && clientId !== "") {
+      startNextSecretLookup()
       return
     }
     var purpose = lookupPurpose
@@ -251,6 +269,11 @@ Item {
       if (purpose === "request") finishWaiters("", "Sign in to Gmail first")
       return
     }
+    renamedAttributesToClear = secretLookupStage >= 2
+      ? (secretLookupStage === 3
+        ? Credentials.renamedLegacyKeyringAttributes(clientId)
+        : Credentials.renamedKeyringAttributes(clientId, accountId))
+      : []
     refreshWithToken(token, purpose)
   }
 
@@ -642,6 +665,11 @@ Item {
       root.keyringWriteToken = ""
       if (exitCode !== 0)
         root.lastError = "Signed in, but the session could not be saved. You may need to sign in again after a restart"
+      if (exitCode === 0 && root.renamedAttributesToClear.length && !keyringClear.running) {
+        keyringClear.command = ["secret-tool", "clear"].concat(root.renamedAttributesToClear)
+        root.renamedAttributesToClear = []
+        keyringClear.running = true
+      }
       if (root.logoutPendingClear) {
         root.logoutPendingClear = false
         root.clearStoredToken()

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -9,10 +9,10 @@ import "components"
 BarWidget {
   id: root
 
-  moduleName: "omamail.omarchy"
+  moduleName: "omamail"
 
   readonly property var gmail: bar && bar.shell
-    ? bar.shell.serviceFor("omamail.omarchy") : null
+    ? bar.shell.serviceFor("omamail") : null
 
   // `barForeground` belongs to qs.Ui.Panel, not to BarWidget: reading it here
   // yields undefined, and assigning undefined to a colour leaves the icon
@@ -32,7 +32,7 @@ BarWidget {
 
   function openWindow() {
     if (bar && bar.shell && typeof bar.shell.toggle === "function")
-      bar.shell.toggle("omamail.omarchy", "{}")
+      bar.shell.toggle("omamail", "{}")
   }
 
   implicitWidth: button.implicitWidth

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -9,10 +9,10 @@ import "components"
 BarWidget {
   id: root
 
-  moduleName: "gmail.omarchy"
+  moduleName: "omamail.omarchy"
 
   readonly property var gmail: bar && bar.shell
-    ? bar.shell.serviceFor("gmail.omarchy") : null
+    ? bar.shell.serviceFor("omamail.omarchy") : null
 
   // `barForeground` belongs to qs.Ui.Panel, not to BarWidget: reading it here
   // yields undefined, and assigning undefined to a colour leaves the icon
@@ -32,7 +32,7 @@ BarWidget {
 
   function openWindow() {
     if (bar && bar.shell && typeof bar.shell.toggle === "function")
-      bar.shell.toggle("gmail.omarchy", "{}")
+      bar.shell.toggle("omamail.omarchy", "{}")
   }
 
   implicitWidth: button.implicitWidth
@@ -42,7 +42,7 @@ BarWidget {
     id: button
     anchors.fill: parent
     bar: root.bar
-    tooltipText: root.gmail ? root.gmail.barTooltip : "Gmail"
+    tooltipText: root.gmail ? root.gmail.barTooltip : "Omamail"
 
     // Read from inside `iconComponent`. Both BarIconButton and GmailIcon name
     // their own root object `root`, so nothing inside a Component declared

--- a/BodyCache.qml
+++ b/BodyCache.qml
@@ -30,7 +30,7 @@ Item {
   // One directory per account, named the way the account's store file is, so
   // the two can be matched by eye and neither can leave the cache directory.
   property string accountId: ""
-  readonly property string directory: cacheHome + "/omarchy-gmail/bodies/"
+  readonly property string directory: cacheHome + "/omamail/bodies/"
     + Cache.bodyDirName(accountId)
 
   readonly property string script: pluginDir + "/scripts/body-cache.sh"

--- a/CacheStore.qml
+++ b/CacheStore.qml
@@ -19,7 +19,7 @@ Item {
 
   readonly property string cacheHome: Quickshell.env("XDG_CACHE_HOME")
     || (Quickshell.env("HOME") + "/.cache")
-  readonly property string directory: cacheHome + "/omarchy-gmail"
+  readonly property string directory: cacheHome + "/omamail"
 
   // One file per account. A shared file would mean every switch discarded the
   // cache of the account being switched to, which is the whole point of having

--- a/Credentials.js
+++ b/Credentials.js
@@ -317,7 +317,7 @@ function usingBuiltin(fileText, accountId) {
 
 function path(home) {
   var base = trimmed(home)
-  return (base || "~") + "/.config/omarchy-gmail/credentials.json"
+  return (base || "~") + "/.config/omamail/credentials.json"
 }
 
 // ----------------------------------------------------------------- keyring
@@ -325,7 +325,8 @@ function path(home) {
 // The refresh token is keyed by account as well as by client, because two
 // accounts may share one client: keyed by client alone, the second sign-in
 // would overwrite the first account's token and silently sign it out.
-var KEYRING_SERVICE = "omarchy-gmail"
+var KEYRING_SERVICE = "omamail"
+var RENAMED_KEYRING_SERVICE = "omarchy-gmail"
 var KEYRING_KIND = "refresh-token"
 
 // secret-tool reads an empty attribute value as "match anything", which would
@@ -355,6 +356,20 @@ function legacyKeyringAttributes(clientId) {
   var id = trimmed(clientId)
   if (!id) return []
   return ["service", KEYRING_SERVICE, "kind", KEYRING_KIND, "client-id", id]
+}
+
+// Entries from before the Omamail rename are read once and rewritten under
+// the new service name, so an upgrade keeps the user's signed-in session.
+function renamedKeyringAttributes(clientId, accountId) {
+  var attributes = keyringAttributes(clientId, accountId)
+  if (attributes.length) attributes[1] = RENAMED_KEYRING_SERVICE
+  return attributes
+}
+
+function renamedLegacyKeyringAttributes(clientId) {
+  var attributes = legacyKeyringAttributes(clientId)
+  if (attributes.length) attributes[1] = RENAMED_KEYRING_SERVICE
+  return attributes
 }
 
 // Shown under the client id in the panel so a user with several Cloud projects

--- a/Html.js
+++ b/Html.js
@@ -156,6 +156,50 @@ function safeHref(value) {
   return /^\s*(https?:|mailto:)/i.test(String(value || ""))
 }
 
+// Qt's rich text engine ignores display:none outright — measured: a hidden div
+// adds a full line of text to the layout. It does honour font-size, though, and
+// the standard email preheader is hidden text set at 1px, so it comes out as a
+// two-pixel smudge of unreadable characters above the message. Elements the
+// sender marked hidden are therefore removed rather than styled away.
+var HIDDEN_STYLE = /(display\s*:\s*none|visibility\s*:\s*hidden)/i
+var VOID_ELEMENTS = /^(img|br|hr|input|meta|link|area|base|col|embed|source|track|wbr)$/i
+
+// Counts nesting, so a hidden wrapper takes exactly its own subtree and not
+// whatever happens to close first.
+function closeIndexFor(text, name, from) {
+  var pattern = new RegExp("<(/?)" + name + "\\b[^>]*>", "gi")
+  pattern.lastIndex = from
+  var depth = 1
+  var found = pattern.exec(text)
+  while (found !== null) {
+    if (found[1] === "/") {
+      depth--
+      if (depth === 0) return pattern.lastIndex
+    } else if (found[0].charAt(found[0].length - 2) !== "/") {
+      depth++
+    }
+    found = pattern.exec(text)
+  }
+  return -1
+}
+
+function dropHidden(html) {
+  var text = String(html || "")
+  var opening = /<([a-z][a-z0-9]*)\b([^>]*)>/gi
+  var found = opening.exec(text)
+  while (found !== null) {
+    var name = found[1]
+    if (!VOID_ELEMENTS.test(name) && HIDDEN_STYLE.test(found[2] || "")) {
+      var end = closeIndexFor(text, name, opening.lastIndex)
+      if (end < 0) end = text.length
+      text = text.substring(0, found.index) + text.substring(end)
+      opening.lastIndex = found.index
+    }
+    found = opening.exec(text)
+  }
+  return text
+}
+
 function sanitize(html, options) {
   var settings = options || {}
   var text = String(html === undefined || html === null ? "" : html)
@@ -167,6 +211,7 @@ function sanitize(html, options) {
   if (settings.keepTables !== true) text = flattenTables(text, settings.keepTableDepth)
 
   text = text.replace(/<!--[\s\S]*?-->/g, "")
+  text = dropHidden(text)
   for (var i = 0; i < DROPPED_ELEMENTS.length; i++) text = stripElement(text, DROPPED_ELEMENTS[i])
   text = text.replace(/<(meta|link|base)\b[^>]*>/gi, "")
 

--- a/MailAccount.qml
+++ b/MailAccount.qml
@@ -598,14 +598,14 @@ Item {
     var list = Array.isArray(arrivals) ? arrivals : []
     if (list.length === 0) return
     if (list.length === 1) {
-      Quickshell.execDetached(["notify-send", "-a", "Omarchy Gmail",
+      Quickshell.execDetached(["notify-send", "-a", "Omamail",
         "-i", "mail-unread", list[0].from.display, Model.notificationBody(list[0])])
       return
     }
     // One notification per message turns a batch sync into a wall of popups.
     var names = []
     for (var i = 0; i < list.length && i < 3; i++) names.push(list[i].from.display)
-    Quickshell.execDetached(["notify-send", "-a", "Omarchy Gmail",
+    Quickshell.execDetached(["notify-send", "-a", "Omamail",
       "-i", "mail-unread", Model.pluralize(list.length, "new message"), names.join(", ")])
   }
 

--- a/Model.js
+++ b/Model.js
@@ -58,7 +58,7 @@ function setupHeadline(state) {
 function setupDetail(state, missingTools) {
   if (state === "tools_missing") {
     var tools = Array.isArray(missingTools) ? missingTools.join(", ") : ""
-    return "Omarchy Gmail needs " + (tools || "a few base tools")
+    return "Omamail needs " + (tools || "a few base tools")
       + " on PATH before it can sign in."
   }
   if (state === "no_credentials")
@@ -221,6 +221,15 @@ function resultSummary(list, estimate, hasMore) {
   if (!hasMore) return pluralize(shown, "message")
   var total = Math.max(shown, Math.floor(Number(estimate) || 0))
   return shown + " of about " + total
+}
+
+function statusSummary(syncLabel, resultLabel, loading) {
+  var sync = String(syncLabel || "")
+  var result = String(resultLabel || "")
+  if (loading) return sync
+  if (!sync) return result
+  if (!result) return sync
+  return sync + "  ·  " + result
 }
 
 function truncate(text, limit) {

--- a/Model.js
+++ b/Model.js
@@ -11,7 +11,12 @@
 // default, so a mailbox without a drawing would simply be invisible.
 var MAILBOXES = [
   { key: "inbox", label: "Inbox", query: "in:inbox", labelId: "INBOX", icon: "inbox" },
-  { key: "unread", label: "Unread", query: "in:inbox is:unread", labelId: "UNREAD", icon: "unread" },
+  // Scoped to Primary, not just to the inbox. Gmail's category tabs do not
+  // remove the INBOX label, so "in:inbox is:unread" dredges up the whole
+  // promotional backlog — measured against a real mailbox, that view came back
+  // as newsletters and offers almost end to end while the inbox itself was
+  // ordinary mail. Gmail has no standalone unread view for the same reason.
+  { key: "unread", label: "Unread", query: "in:inbox is:unread category:primary", labelId: "UNREAD", icon: "unread" },
   { key: "starred", label: "Starred", query: "is:starred", labelId: "STARRED", icon: "star" },
   { key: "sent", label: "Sent", query: "in:sent", labelId: "SENT", icon: "send" },
   { key: "all", label: "All mail", query: "in:anywhere -in:spam -in:trash", labelId: "", icon: "archive" },

--- a/OAuth.js
+++ b/OAuth.js
@@ -288,10 +288,10 @@ function httpResponse(statusLine, body) {
 
 function successResponse(theme) {
   return httpResponse("200 OK", themedPage(theme, {
-    title: "Omarchy Gmail",
+    title: "Omamail",
     heading: "Mailbox connected",
     failed: false,
-    body: "<p>Omarchy Gmail can read this mailbox now. "
+    body: "<p>Omamail can read this mailbox now. "
       + "Switch back to the window \u2014 your mail is already loading.</p>"
       + "<p>This tab closes itself. If it stays open, it is safe to close.</p>"
       + "<script>setTimeout(function(){window.close()},600)<\/script>"
@@ -305,6 +305,6 @@ function failureResponse(theme, reason) {
     heading: "Sign-in did not finish",
     failed: true,
     body: "<p>" + (detail ? detail : "Google did not complete the authorization.") + "</p>"
-      + "<p>Close this tab and try again from the Omarchy Gmail window.</p>"
+      + "<p>Close this tab and try again from the Omamail window.</p>"
   }))
 }

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ that is what the rest of Omarchy looks like.
 ## Add it to Omarchy
 
 ```bash
-omarchy plugin add https://github.com/huacnlee/omarchy-gmail.git --enable
+omarchy plugin add https://github.com/huacnlee/omamail.git --enable
 ```
 
 Then click the envelope in the bar. To open it from the keyboard, add this to
 `~/.config/hypr/bindings.lua`:
 
 ```lua
-  o.bind("SUPER + SHIFT + G", "Gmail", "omarchy shell shell toggle gmail.omarchy '{}'")
+  o.bind("SUPER + SHIFT + G", "Omamail", "omarchy shell shell toggle omamail.omarchy '{}'")
 ```
 
 The target is `shell`, not the plugin id: the window is summoned by the shell,
@@ -49,16 +49,16 @@ all of which Omarchy already ships.
 To remove it:
 
 ```bash
-omarchy plugin remove gmail.omarchy
+omarchy plugin remove omamail.omarchy
 ```
 
 That takes the plugin itself. Nothing it wrote lives inside your Omarchy
 config, so removing those is separate and entirely up to you:
 
 ```bash
-secret-tool clear service omarchy-gmail    # the refresh token
-rm -rf ~/.config/omarchy-gmail             # the OAuth client and account list
-rm -rf ~/.cache/omarchy-gmail              # cached mail
+secret-tool clear service omamail    # the refresh token
+rm -rf ~/.config/omamail             # the OAuth client and account list
+rm -rf ~/.cache/omamail              # cached mail
 ```
 
 Signing out from inside the app clears the keyring entry on its own. The plugin
@@ -68,7 +68,7 @@ above is yours to add and yours to remove.
 ## Connecting your mailbox
 
 Gmail has no shared application to sign in through. Google issues API access
-per Cloud project, so Omarchy Gmail signs in with an OAuth client **you own**.
+per Cloud project, so Omamail signs in with an OAuth client **you own**.
 The window walks you through it in five steps, each with the console page one
 click away. It takes about two minutes, once.
 
@@ -96,9 +96,9 @@ and the client itself are console-only; there is no CLI for them.
 | --- | --- |
 | `j` / `k` | Move down / up |
 | `Enter` | Open the selected message |
-| `u` | Back to the list |
+| `Esc` | Back to the list; close the window from the list |
 | `e` | Archive |
-| `Del` or `#` | Move to trash |
+| `d` | Move to trash |
 | `s` | Star or unstar |
 | `Shift+I` / `Shift+U` | Mark read / unread |
 | `r` / `a` / `f` | Reply, reply all, forward |
@@ -141,7 +141,7 @@ thousand of them, evicted least-recently-used.
 
 - The refresh token goes to **GNOME Keyring**, keyed by client id, written over
   stdin so it never appears in the process table.
-- The OAuth client goes to `~/.config/omarchy-gmail/credentials.json`, mode
+- The OAuth client goes to `~/.config/omamail/credentials.json`, mode
   `0600`. Not to plugin settings — `shell.json` is world-readable.
 - The access token exists only in memory.
 - Signing out clears the keyring entry.
@@ -160,7 +160,7 @@ make validate         # node tests, source regressions, qmllint, manifest check
 Working agreements are in [AGENTS.md](AGENTS.md); the design canvas and the
 implementation plan are under [docs/](docs/).
 
-Omarchy Gmail is an independent project and is not affiliated with Google.
+Omamail is an independent project and is not affiliated with Google.
 Gmail is a trademark of Google LLC.
 
 Licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Then click the envelope in the bar. To open it from the keyboard, add this to
 `~/.config/hypr/bindings.lua`:
 
 ```lua
-  o.bind("SUPER + SHIFT + G", "Omamail", "omarchy shell shell toggle omamail.omarchy '{}'")
+  o.bind("SUPER + SHIFT + G", "Omamail", "omarchy shell shell toggle omamail '{}'")
 ```
 
 The target is `shell`, not the plugin id: the window is summoned by the shell,
@@ -49,7 +49,7 @@ all of which Omarchy already ships.
 To remove it:
 
 ```bash
-omarchy plugin remove omamail.omarchy
+omarchy plugin remove omamail
 ```
 
 That takes the plugin itself. Nothing it wrote lives inside your Omarchy

--- a/Service.qml
+++ b/Service.qml
@@ -31,7 +31,7 @@ Item {
   property var barWidgetRegistry: null
 
   readonly property string pluginId: manifest && manifest.id
-    ? String(manifest.id) : "omamail.omarchy"
+    ? String(manifest.id) : "omamail"
   readonly property string pluginDir: manifest && manifest.__sourceDir
     ? String(manifest.__sourceDir) : ""
 

--- a/Service.qml
+++ b/Service.qml
@@ -31,7 +31,7 @@ Item {
   property var barWidgetRegistry: null
 
   readonly property string pluginId: manifest && manifest.id
-    ? String(manifest.id) : "gmail.omarchy"
+    ? String(manifest.id) : "omamail.omarchy"
   readonly property string pluginDir: manifest && manifest.__sourceDir
     ? String(manifest.__sourceDir) : ""
 
@@ -384,7 +384,7 @@ Item {
     id: accountsFile
     path: {
       var home = Quickshell.env("XDG_CONFIG_HOME") || (Quickshell.env("HOME") + "/.config")
-      return home + "/omarchy-gmail/accounts.json"
+      return home + "/omamail/accounts.json"
     }
     watchChanges: true
     printErrors: false

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -398,7 +398,7 @@ Item {
         onClicked: root.actionRequested("archive")
       }
       IconButton {
-        iconName: "trash"; tooltipText: "Move to trash · Del"
+        iconName: "trash"; tooltipText: "Move to trash · d"
         foreground: root.textColor; fontFamily: root.panelFontFamily
         onClicked: root.actionRequested("trash")
       }

--- a/components/MessageRow.qml
+++ b/components/MessageRow.qml
@@ -164,7 +164,7 @@ Rectangle {
     IconButton {
       visible: root.hot
       iconName: "trash"
-      tooltipText: "Move to trash · Del"
+      tooltipText: "Move to trash · d"
       foreground: root.dimColor
       hoverColor: root.textColor
       iconSize: Style.font.iconSmall

--- a/components/ReaderBlankSlate.qml
+++ b/components/ReaderBlankSlate.qml
@@ -33,7 +33,7 @@ Item {
     { key: "j / k", action: "Move through the list" },
     { key: "Enter", action: "Open the selected message" },
     { key: "e", action: "Archive" },
-    { key: "Del", action: "Move to trash" },
+    { key: "d", action: "Move to trash" },
     { key: "r", action: "Reply" },
     { key: "c", action: "Compose" },
     { key: "Right-click", action: "Archive, trash, spam, star" }

--- a/components/ShortcutHelp.qml
+++ b/components/ShortcutHelp.qml
@@ -17,9 +17,9 @@ Rectangle {
   readonly property var rows: [
     { keys: "j / k", action: "Move down / up" },
     { keys: "Enter", action: "Open the selected message" },
-    { keys: "u", action: "Back to the list" },
+    { keys: "Esc", action: "Back to the list" },
     { keys: "e", action: "Archive" },
-    { keys: "Del or #", action: "Move to trash" },
+    { keys: "d", action: "Move to trash" },
     { keys: "s", action: "Star or unstar" },
     { keys: "Shift+I / Shift+U", action: "Mark read / unread" },
     { keys: "r / a / f", action: "Reply, reply all, forward" },

--- a/components/UserBar.qml
+++ b/components/UserBar.qml
@@ -17,7 +17,7 @@ Rectangle {
   property bool collapsed: false
 
   // Two things live in this row: which mailbox you are in, and everything
-  // else. The address switches accounts; the glyph opens the menu.
+  // else. The address switches accounts; the menu button opens app actions.
   signal switcherRequested(real sceneX, real sceneY)
   signal menuRequested(real sceneX, real sceneY)
   property int accountCount: 1
@@ -65,18 +65,6 @@ Rectangle {
     font.family: root.panelFontFamily
     font.pixelSize: Style.font.caption
     elide: Text.ElideMiddle
-  }
-
-  Text {
-    id: switchHint
-    visible: !root.collapsed && root.accountCount > 1
-    anchors.right: chevron.left
-    anchors.rightMargin: Style.space(4)
-    anchors.verticalCenter: parent.verticalCenter
-    text: "⌄"
-    color: root.dimColor
-    font.family: root.panelFontFamily
-    font.pixelSize: Style.font.bodySmall
   }
 
   Button {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,4 +1,4 @@
-# Omarchy Gmail — Spec
+# Omamail — Spec
 
 A native Gmail client for Omarchy, built as a Quickshell plugin on the official
 Gmail REST API. Same technology as Omarchy-Spotify: QML views over plain-JS
@@ -29,7 +29,7 @@ Three plugin entry points (`manifest.kinds`):
 | List triage | **Right-click context menu** on any row: reply / reply all / forward, archive / trash / spam, mark read-unread, star, open in browser. |
 | Reader actions | **Icons with tooltips**, not labelled buttons — six actions fit where six labels would not, with the destructive one set apart by a rule and the urgent colour. Icons are Canvas paths on one 16px grid, because Qt's SVG renderer smears strokes at this size. |
 | Sidebar | **An open but narrow icon rail** (148px; 44px collapsed), named by tooltips either way. Collapsing is one click. |
-| Loading | **Cache first.** Every query, the label list, the profile and opened bodies are kept in one atomically written file under `$XDG_CACHE_HOME/omarchy-gmail`, keyed by query and bound to the mailbox address. Switching mailboxes paints immediately and revalidates behind it. |
+| Loading | **Cache first.** Every query, the label list, the profile and opened bodies are kept in one atomically written file under `$XDG_CACHE_HOME/omamail`, keyed by query and bound to the mailbox address. Switching mailboxes paints immediately and revalidates behind it. |
 | Setup | **Two steps, one at a time.** Finished steps collapse to a line with a check; the walkthrough hides behind a disclosure. The Publish-app warning stays beside the sign-in button, because it decides whether the session lasts seven days or indefinitely. |
 
 ## Authentication
@@ -43,7 +43,7 @@ guided by an in-app four-step walkthrough.
 - Scopes: `gmail.modify` (read, label, archive, trash — cannot permanently
   delete) and `gmail.send`
 - Refresh token → GNOME Keyring via `secret-tool`, keyed by client id
-- Client id/secret → `~/.config/omarchy-gmail/credentials.json`, mode 0600.
+- Client id/secret → `~/.config/omamail/credentials.json`, mode 0600.
   Not plugin settings: `shell.json` is world-readable.
 - Access token → process memory only
 

--- a/install.sh
+++ b/install.sh
@@ -2,10 +2,12 @@
 set -euo pipefail
 
 project_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-plugin_id="gmail.omarchy"
+plugin_id="omamail.omarchy"
+old_plugin_id="gmail.omarchy"
 config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
 plugin_home="$config_home/omarchy/plugins"
 install_path="$plugin_home/$plugin_id"
+old_install_path="$plugin_home/$old_plugin_id"
 # Backups must live outside the plugins directory. Omarchy scans every
 # subdirectory of it for a manifest, so a backup left alongside the install is
 # a second plugin with the same id — and the shell then loads the stale copy.
@@ -41,7 +43,13 @@ fi
 printf '%s\n' 'Validating plugin…'
 omarchy plugin validate "$project_dir"
 
+"$project_dir/scripts/migrate-storage.sh"
+
 mkdir -p "$plugin_home"
+if [[ ! -e "$install_path" && ! -L "$install_path" \
+    && ( -e "$old_install_path" || -L "$old_install_path" ) ]]; then
+  mv "$old_install_path" "$install_path"
+fi
 if [[ -L "$install_path" && "$(readlink -f "$install_path")" == "$project_dir" ]]; then
   :
 elif [[ -e "$install_path" || -L "$install_path" ]]; then
@@ -59,9 +67,9 @@ if $restart_shell; then
   omarchy restart shell
 fi
 
-printf '%s\n' 'Registering Omarchy Gmail in the bar…'
+printf '%s\n' 'Registering Omamail in the bar…'
 omarchy-shell shell rescanPlugins
 omarchy plugin enable "$plugin_id"
 
-printf 'Omarchy Gmail installed for development at %s\n' "$install_path"
+printf 'Omamail installed for development at %s\n' "$install_path"
 printf '%s\n' 'Click the envelope in the bar. QML edits are read through the symlink.'

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 project_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-plugin_id="omamail.omarchy"
+plugin_id="omamail"
 old_plugin_id="gmail.omarchy"
 config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
 plugin_home="$config_home/omarchy/plugins"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "id": "gmail.omarchy",
-  "name": "Omarchy Gmail",
+  "id": "omamail.omarchy",
+  "name": "Omamail",
   "version": "0.1.0",
   "author": "Jason Lee <huacnlee@gmail.com>",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "panel": "App.qml"
   },
   "barWidget": {
-    "displayName": "Omarchy Gmail",
+    "displayName": "Omamail",
     "description": "Unread count in the bar; the mailbox itself opens as its own window.",
     "category": "Communication",
     "aliases": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "omamail.omarchy",
+  "id": "omamail",
   "name": "Omamail",
   "version": "0.1.0",
   "author": "Jason Lee <huacnlee@gmail.com>",

--- a/scripts/body-cache.sh
+++ b/scripts/body-cache.sh
@@ -74,7 +74,7 @@ case "$command" in
   clear)
     # Only ever the directory this plugin built, and only if it looks like it.
     case "$dir" in
-      */omarchy-gmail/bodies/*) rm -rf -- "$dir" ;;
+      */omamail/bodies/*) rm -rf -- "$dir" ;;
       *) usage ;;
     esac
     ;;

--- a/scripts/config-store.sh
+++ b/scripts/config-store.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Writes one line from stdin to $XDG_CONFIG_HOME/omarchy-gmail/<name> with
+# Writes one line from stdin to $XDG_CONFIG_HOME/omamail/<name> with
 # owner-only permissions.
 #
 # Neither file it writes is world-readable: a desktop client's secret is only
@@ -23,7 +23,7 @@ esac
 umask 077
 
 config_home=${XDG_CONFIG_HOME:-$HOME/.config}
-target_dir="$config_home/omarchy-gmail"
+target_dir="$config_home/omamail"
 target="$target_dir/$name"
 
 IFS= read -r payload

--- a/scripts/google-cloud-setup.sh
+++ b/scripts/google-cloud-setup.sh
@@ -20,7 +20,7 @@ usage() {
   cat <<'USAGE'
 Usage: google-cloud-setup.sh [--project ID] [--no-open]
 
-  --project ID   Cloud project to create or reuse. Default: omarchy-gmail-<random>
+  --project ID   Cloud project to create or reuse. Default: omamail-<random>
   --no-open      Print the console URLs instead of opening them.
 
 Needs the gcloud CLI (AUR: google-cloud-cli) and a signed-in account.
@@ -49,14 +49,14 @@ fi
 # Project ids are globally unique, so a fixed default would collide for the
 # second person who runs this.
 if [[ -z $project_id ]]; then
-  project_id="omarchy-gmail-$(tr -dc 'a-z0-9' </dev/urandom | head -c 6)"
+  project_id="omamail-$(tr -dc 'a-z0-9' </dev/urandom | head -c 6)"
 fi
 
 if gcloud projects describe "$project_id" >/dev/null 2>&1; then
   printf 'Reusing existing project %s\n' "$project_id"
 else
   printf 'Creating project %s…\n' "$project_id"
-  gcloud projects create "$project_id" --name="Omarchy Gmail"
+  gcloud projects create "$project_id" --name="Omamail"
 fi
 
 printf 'Enabling the Gmail API…\n'
@@ -78,7 +78,7 @@ Done with the part gcloud can do. Two steps are left, and both are console-only:
      $consent_url
 
   2. Create an OAuth client, application type "Desktop app", then paste its
-     client ID into Omarchy Gmail.
+     client ID into Omamail.
 
      $clients_url
 

--- a/scripts/keyring-store.sh
+++ b/scripts/keyring-store.sh
@@ -29,4 +29,4 @@ if [ -z "$refresh_token" ]; then
 fi
 
 printf '%s' "$refresh_token" | secret-tool store \
-  --label='Omarchy Gmail refresh token' "$@"
+  --label='Omamail refresh token' "$@"

--- a/scripts/migrate-storage.sh
+++ b/scripts/migrate-storage.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# One-time rename of the old app's on-disk state. Existing Omamail state
+# always wins: combining two stores without understanding their contents could
+# overwrite a newer account or cache.
+set -eu
+
+move_once() {
+  old=$1
+  new=$2
+  if [ -e "$old" ] && [ ! -e "$new" ]; then
+    mv "$old" "$new"
+  fi
+}
+
+config_home=${XDG_CONFIG_HOME:-$HOME/.config}
+cache_home=${XDG_CACHE_HOME:-$HOME/.cache}
+
+move_once "$config_home/omarchy-gmail" "$config_home/omamail"
+move_once "$cache_home/omarchy-gmail" "$cache_home/omamail"

--- a/tests/test_cache.js
+++ b/tests/test_cache.js
@@ -146,7 +146,7 @@ assert.strictEqual(cache.getQuery(recased, "in:inbox|25") !== null, true,
 // One file per account, because switching mailboxes must not throw the other
 // mailbox's cache away — that is the whole point of having a cache.
 
-const DIRECTORY = "/home/u/.cache/omarchy-gmail"
+const DIRECTORY = "/home/u/.cache/omamail"
 const SAFE_NAME = /^[a-z0-9._-]+$/
 
 function checkName(id) {

--- a/tests/test_credentials.js
+++ b/tests/test_credentials.js
@@ -87,7 +87,7 @@ assert.strictEqual(credentials.isConfigured(null), false)
 assert.strictEqual(credentials.describe(parsed.credentials), "omarchy-gmail-42 · 1234")
 assert.strictEqual(credentials.describe(credentials.empty()), "")
 assert.strictEqual(
-  credentials.path("/home/jason"), "/home/jason/.config/omarchy-gmail/credentials.json")
+  credentials.path("/home/jason"), "/home/jason/.config/omamail/credentials.json")
 
 // -------------------------------------------------------- built-in client
 //
@@ -133,7 +133,7 @@ const first = credentials.keyringAttributes(sharedClient, "one@gmail.com")
 const second = credentials.keyringAttributes(sharedClient, "two@gmail.com")
 
 deepEqual(first, [
-  "service", "omarchy-gmail",
+  "service", "omamail",
   "kind", "refresh-token",
   "client-id", sharedClient,
   "account", "one@gmail.com"
@@ -176,11 +176,23 @@ deepEqual(credentials.legacyKeyringAttributes(""), [])
 // lookup cannot see them. They are read once with these and rewritten, rather
 // than leaving an already signed-in user at a sign-in button.
 deepEqual(credentials.legacyKeyringAttributes(sharedClient), [
-  "service", "omarchy-gmail",
+  "service", "omamail",
   "kind", "refresh-token",
   "client-id", sharedClient
 ])
 assert.strictEqual(credentials.legacyKeyringAttributes(sharedClient).indexOf("account"), -1)
+
+deepEqual(credentials.renamedKeyringAttributes(sharedClient, "one@gmail.com"), [
+  "service", "omarchy-gmail",
+  "kind", "refresh-token",
+  "client-id", sharedClient,
+  "account", "one@gmail.com"
+])
+deepEqual(credentials.renamedLegacyKeyringAttributes(sharedClient), [
+  "service", "omarchy-gmail",
+  "kind", "refresh-token",
+  "client-id", sharedClient
+])
 
 // ------------------------------------------------------------ the store
 //

--- a/tests/test_html.js
+++ b/tests/test_html.js
@@ -247,4 +247,29 @@ assert.ok(bare.indexOf("x</body>") > 0)
   assert.ok(relaxed.indexOf("width:640px") < 0, "declared widths too")
 }
 
+
+// ------------------------------------------------------------ hidden text
+//
+// Measured: Qt's rich text engine ignores display:none outright, but honours
+// font-size — so an email preheader, which is hidden text set at 1px, renders
+// as a two-pixel smudge of unreadable characters above the message.
+{
+  assert.strictEqual(
+    html.dropHidden('<div class=preheader style="display: none; font-size:1px">SECRET</div><p>real</p>'),
+    "<p>real</p>", "the preheader goes entirely")
+  assert.strictEqual(
+    html.dropHidden('<div style="display:none"><div>inner</div>outer</div><p>real</p>'),
+    "<p>real</p>", "nesting is counted, so the wrapper takes its own subtree")
+  assert.strictEqual(html.dropHidden('<span style="visibility:hidden">x</span>keep'), "keep")
+  assert.strictEqual(html.dropHidden('<p>before</p><div style="display:none">tail'),
+    "<p>before</p>", "an unclosed hidden element runs to the end")
+  assert.strictEqual(html.dropHidden('<div style="color:red">keep</div>'),
+    '<div style="color:red">keep</div>', "visible markup is untouched")
+  // A void element has no subtree to eat, so it must not swallow what follows.
+  assert.ok(html.dropHidden('<img src=a.png style="display:none"><p>real</p>').indexOf("<p>real</p>") >= 0)
+
+  assert.ok(html.sanitize('<div style="display:none">SECRET</div><p>real</p>').html.indexOf("SECRET") < 0,
+    "and the sanitizer applies it")
+}
+
 console.log("test_html.js ok")

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -25,6 +25,18 @@ done
 [ -x install.sh ] || fail "install.sh must be executable"
 grep -q 'plugin-backups' install.sh || fail "backups must not land inside the plugins directory"
 
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+mkdir -p "$test_root/config/omarchy-gmail" "$test_root/cache/omarchy-gmail"
+printf 'client\n' > "$test_root/config/omarchy-gmail/credentials.json"
+printf 'cache\n' > "$test_root/cache/omarchy-gmail/inbox.json"
+XDG_CONFIG_HOME="$test_root/config" XDG_CACHE_HOME="$test_root/cache" \
+  sh scripts/migrate-storage.sh
+[ -f "$test_root/config/omamail/credentials.json" ] || fail "legacy config was not moved"
+[ -f "$test_root/cache/omamail/inbox.json" ] || fail "legacy cache was not moved"
+[ ! -e "$test_root/config/omarchy-gmail" ] || fail "legacy config directory remains"
+[ ! -e "$test_root/cache/omarchy-gmail" ] || fail "legacy cache directory remains"
+
 # The keyring helper takes attribute pairs now, because keying a refresh token
 # on the OAuth client alone lets two accounts sharing one client overwrite each
 # other. An empty value is a secret-tool wildcard, so it is refused outright.

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -139,6 +139,12 @@ assert.strictEqual(model.resultSummary([{}, {}], 87, true), "2 of about 87")
 // Gmail's estimate can come back lower than the page it just returned.
 assert.strictEqual(model.resultSummary([{}, {}, {}], 1, true), "3 of about 3")
 
+assert.strictEqual(model.statusSummary("Checking for mail…", "25 of about 80", true),
+  "Checking for mail…", "loading status must not compete with stale pagination")
+assert.strictEqual(model.statusSummary("Synced just now", "25 messages", false),
+  "Synced just now  ·  25 messages")
+assert.strictEqual(model.statusSummary("", "No messages", false), "No messages")
+
 assert.strictEqual(model.truncate("short", 20), "short")
 assert.strictEqual(model.truncate("a much longer string", 10), "a much lo…")
 assert.strictEqual(model.pluralize(1, "message"), "1 message")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -6,7 +6,7 @@ const model = load("Model.js")
 // ------------------------------------------------------------- mailboxes
 
 assert.strictEqual(model.mailbox("inbox").query, "in:inbox")
-assert.strictEqual(model.mailbox("unread").query, "in:inbox is:unread")
+assert.strictEqual(model.mailbox("unread").query, "in:inbox is:unread category:primary")
 assert.strictEqual(model.mailbox("nonsense").key, "inbox", "an unknown key falls back to the inbox")
 assert.strictEqual(model.mailboxIndex("starred"), 2)
 


### PR DESCRIPTION
Renames the project to **Omamail** and settles the plugin id before anyone
installs under a name that will not exist.

### The id

`gmail.omarchy` → `omamail`. The id is the marketplace's permanent identifier
and the summon target, so it is worth getting right once: the marketplace states
that ids from renamed listings stay reserved and cannot be reused. The
`.omarchy` suffix said nothing the name did not. `omarchy plugin validate`
accepts the bare id.

This changes the keybinding, which no longer matches what shipped before:

```lua
o.bind("SUPER + SHIFT + G", "Omamail", "omarchy shell shell toggle omamail '{}'")
```

Config and cache move to `~/.config/omamail` and `~/.cache/omamail`;
`scripts/migrate-storage.sh` carries an existing install across.

### Also in this branch

Two fixes that were already on this line of work:

- **Message images fit the window.** Measured against Qt's rich text engine
  rather than assumed: `max-width` is honoured but only in pixels — a
  percentage collapses the image — and an explicit `height` attribute survives
  the clamp and smears the picture. Heights are stripped and a pixel ceiling is
  set from the body's actual width. A 1600px banner laid out at 1600px before
  and 360px after, in a 360px viewport. At a narrow window the sender's side
  gutters are dropped too.
- **Hidden preheader text no longer renders.** Qt ignores `display:none`
  outright but honours `font-size`, so the 1px hidden line mail senders put at
  the top came out as a two-pixel smudge above every message.
- **The search field no longer collides with Check mail.** It was centred with
  a fixed reserve, which splits evenly either side while every control is on the
  left; it now spans the gap the two clusters leave.
- **The unread mailbox is scoped to Primary.** Category tabs do not remove the
  `INBOX` label, so `in:inbox is:unread` returned the entire promotional
  backlog — measured on a real mailbox, that view was newsletters and offers
  almost end to end while the inbox itself was ordinary correspondence.

`make validate` passes: node tests, source regressions, qmllint, manifest check.
