### PR TITLE
fix: stop a message from choosing what this client fetches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,9 +66,25 @@
   is world-readable.
 - Anything that could carry a credential passes through `OAuth.redact` before
   it can reach a label.
-- Remote images in a message body are blocked until the reader asks for them.
-  Qt's rich text engine really does fetch them, so rendering one fires every
-  tracking pixel in the message.
+- Remote images in a message body are blocked until the reader asks for them,
+  and asking covers one message. Qt's rich text engine really does fetch them,
+  so rendering one fires every tracking pixel in the message.
+
+## Anything a stranger wrote
+
+- A message body, a subject, a sender name, a snippet, an attachment filename:
+  all of it is written by whoever sent the mail, and none of it is markup.
+- `Text` defaults to `Text.AutoText`, which promotes anything tag-shaped to rich
+  text — and Qt's rich text engine fetches `<img src>`. Every `Text` showing
+  message content therefore says `textFormat: Text.PlainText`, and
+  `tests/test_qml_text_format.py` fails the build when one forgets.
+- An image is only ever fetched from a host on the public internet. Loopback,
+  private and link-local addresses, single-label and `.local` names, `file:`
+  and relative sources are refused outright — `Html.imageSourceKind` is the one
+  place that decides, and the reader, the popover and the sanitiser all ask it.
+- Values that go back out to Google — a `To`, a `Subject`, an `In-Reply-To`
+  copied off the message being answered — lose their line breaks first, or the
+  reply carries headers nobody typed.
 
 ## Verification
 

--- a/App.qml
+++ b/App.qml
@@ -717,6 +717,7 @@ Item {
           visible: statusBar.hasNotice
           width: Math.min(implicitWidth, parent.width / 2)
           horizontalAlignment: Text.AlignRight
+          textFormat: Text.PlainText
           text: {
             if (root.notice !== "") return root.notice
             if (!root.service) return ""

--- a/CacheStore.qml
+++ b/CacheStore.qml
@@ -34,24 +34,9 @@ Item {
   signal restored()
 
   function get(key) { return Cache.getQuery(store, key) }
-  // Reading a body counts as using it, so the hit is recorded before the entry
-  // is handed back — that stamp is what the LRU evicts on.
-  function body(id) {
-    var entry = Cache.getBody(store, id)
-    if (entry) {
-      store = Cache.touchBody(store, id, Date.now())
-      scheduleSave()
-    }
-    return entry
-  }
 
   function putQuery(key, page) {
     store = Cache.putQuery(store, key, page, Date.now())
-    scheduleSave()
-  }
-
-  function putBody(id, value) {
-    store = Cache.putBody(store, id, value, Date.now())
     scheduleSave()
   }
 
@@ -97,9 +82,16 @@ Item {
     file.reload()
   }
 
+  // The store holds the subject, sender and snippet of every message that has
+  // been listed — the same mail the body files beside it are kept 0600 for. So
+  // the directory is closed to everyone else: FileView writes with whatever
+  // umask the shell process happens to have, and the directory is the only
+  // place this can set the mode itself.
   Process {
     id: directoryMaker
-    command: ["mkdir", "-p", root.directory]
+    // The path arrives as an argument rather than inside the script, so nothing
+    // in it can be read as shell.
+    command: ["sh", "-c", "umask 077; mkdir -p \"$1\" && chmod 700 \"$1\"", "sh", root.directory]
     onExited: file.reload()
   }
 

--- a/Html.js
+++ b/Html.js
@@ -138,16 +138,175 @@ function stripColors(html) {
     })
 }
 
+// A url() in an inline style is a fetch wherever the engine honours it, and
+// which declarations Qt honours is not worth having to be right about: nothing
+// in mail needs one, because pictures arrive as <img>, which is where the image
+// policy lives. The declaration goes rather than the whole attribute, so the
+// padding and the font beside it survive.
+function stripStyleUrls(html) {
+  return String(html || "").replace(/\sstyle\s*=\s*("([^"]*)"|'([^']*)')/gi,
+    function(match, raw, dq, sq) {
+      var value = dq !== undefined ? dq : sq
+      if (!/url\s*\(/i.test(decodeReferences(value))) return match
+      var parts = String(value).split(";")
+      var kept = []
+      for (var i = 0; i < parts.length; i++) {
+        if (/url\s*\(/i.test(decodeReferences(parts[i]))) continue
+        if (parts[i].replace(/\s+/g, "") !== "") kept.push(parts[i])
+      }
+      var cleaned = kept.join(";").replace(/^[;\s]+|[;\s]+$/g, "")
+      return cleaned === "" ? "" : " style=\"" + cleaned + "\""
+    })
+}
+
 function stripElement(text, name) {
   var open = new RegExp("<" + name + "\\b[^>]*>[\\s\\S]*?<\\/" + name + "\\s*>", "gi")
   var lone = new RegExp("<\\/?" + name + "\\b[^>]*>", "gi")
   return String(text).replace(open, "").replace(lone, "")
 }
 
+// ------------------------------------------------------------ image sources
+//
+// An attribute value is not a URL until the HTML parser has resolved the
+// character references inside it. Qt does that before it fetches anything, so
+// src="&#104;ttps://tracker/x.png" is a real https fetch to the engine while a
+// check reading the raw attribute text sees something that starts with an "&"
+// and lets it through. Tab and newline inside a URL are dropped for the same
+// reason: they are not part of it by the time the fetch is made.
+var NAMED_REFERENCES = { amp: "&", quot: "\"", apos: "'", lt: "<", gt: ">", sol: "/", colon: ":" }
+
+function decodeReferences(text) {
+  return String(text).replace(/&(#[0-9]+|#[xX][0-9a-fA-F]+|[a-zA-Z]+);?/g,
+    function(match, body) {
+      if (body.charAt(0) !== "#") {
+        var named = NAMED_REFERENCES[body.toLowerCase()]
+        return named === undefined ? match : named
+      }
+      var code = body.charAt(1) === "x" || body.charAt(1) === "X"
+        ? parseInt(body.substring(2), 16)
+        : parseInt(body.substring(1), 10)
+      if (!isFinite(code) || code < 0 || code > 0x10ffff) return match
+      return String.fromCharCode(code)
+    })
+}
+
+// Decoded twice, because "&amp;#104;" is one reference to Qt and two to a
+// reader looking for a scheme. Over-decoding can only make a source look more
+// remote than it is, and the answer to "remote" is to block it.
+function normalizedUrl(value) {
+  var text = String(value === undefined || value === null ? "" : value)
+  text = decodeReferences(decodeReferences(text))
+  return text.replace(/[\t\n\r]/g, "").replace(/^[\s\u0000-\u001f]+|[\s\u0000-\u001f]+$/g, "")
+}
+
+// The host of an http(s) or protocol-relative URL, lower-cased, with the
+// userinfo, the port and everything after the authority removed. Userinfo
+// matters: "http://gmail.com@127.0.0.1/x.png" is a request to 127.0.0.1.
+function hostOf(url) {
+  var text = String(url || "").replace(/^https?:/i, "")
+  if (text.indexOf("//") !== 0) return ""
+  var authority = text.substring(2)
+  var end = authority.search(/[\/?#]/)
+  if (end >= 0) authority = authority.substring(0, end)
+  var at = authority.lastIndexOf("@")
+  if (at >= 0) authority = authority.substring(at + 1)
+  if (authority.charAt(0) === "[") {
+    var close = authority.indexOf("]")
+    return (close < 0 ? authority : authority.substring(0, close + 1)).toLowerCase()
+  }
+  var colon = authority.indexOf(":")
+  return (colon < 0 ? authority : authority.substring(0, colon)).toLowerCase()
+}
+
+var DOTTED_QUAD = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
+
+function isPublicIpv4(host) {
+  var parts = String(host).match(DOTTED_QUAD)
+  if (!parts) return false
+  var octets = []
+  for (var i = 1; i <= 4; i++) {
+    // A leading zero reads as octal to some resolvers and as decimal to
+    // others, so "0177.0.0.1" is 127.0.0.1 to one of them. Neither reading is
+    // worth the risk of picking the wrong one.
+    if (parts[i].length > 1 && parts[i].charAt(0) === "0") return false
+    var value = Number(parts[i])
+    if (value > 255) return false
+    octets.push(value)
+  }
+  var a = octets[0]
+  var b = octets[1]
+  if (a === 0 || a === 10 || a === 127) return false
+  if (a === 169 && b === 254) return false
+  if (a === 172 && b >= 16 && b <= 31) return false
+  if (a === 192 && (b === 168 || b === 0)) return false
+  if (a === 198 && (b === 18 || b === 19)) return false
+  if (a === 100 && b >= 64 && b <= 127) return false
+  if (a >= 224) return false
+  return true
+}
+
+// Names that are the machine this runs on, or the network around it. The
+// reserved-but-unresolvable ones (.example, .invalid) are left out: they are
+// not internal, they simply do not exist.
+var PRIVATE_SUFFIX = /(^|\.)(localhost|home\.arpa)$|\.(local|localdomain|internal|intranet|lan|home|corp|test)$/
+var PUBLIC_TLD = /\.(xn--[a-z0-9-]+|[a-z]{2,})$/
+
+// A message must not be able to make this client talk to the machine it runs
+// on or to the network that machine sits in. A crafted <img> is a request the
+// reader never asked for, aimed at whatever the sender names — a router's
+// admin page, a printer, a service listening on loopback — and issuing it is
+// the attack whether or not the answer is ever drawn.
+//
+// So the rule is a list of what is allowed rather than a list of what is not:
+// a name whose last label is a real top-level domain, or a public IPv4
+// address. That refuses "localhost", a bare "printer", ".local" and
+// ".internal", every IPv6 literal, and an address written in octal, in hex, or
+// as one number — without having to have thought of each of them first.
+//
+// A public name that resolves to a private address is beyond what any check on
+// the URL can see. That is DNS rebinding, and stopping it needs a resolver
+// this plugin does not own.
+function isPublicHost(host) {
+  var name = String(host || "")
+  if (name === "" || name.length > 253) return false
+  if (isPublicIpv4(name)) return true
+  if (!/^[a-z0-9.-]+$/.test(name)) return false
+  if (name.indexOf("..") >= 0) return false
+  if (PRIVATE_SUFFIX.test(name)) return false
+  return PUBLIC_TLD.test(name)
+}
+
 // Protocol-relative sources are network fetches too — "//cdn/x.png" resolves
 // against the page protocol, which is exactly the tracking case.
 function isRemoteSource(value) {
-  return /^\s*(https?:)?\/\//i.test(String(value || ""))
+  return /^(https?:)?\/\//i.test(normalizedUrl(value))
+}
+
+// What an <img src> is, as far as the fetch it would cause is concerned:
+//
+//   inline  cid: and data: — the message's own bytes, no network at all
+//   remote  http(s) at a host on the public internet
+//   unsafe  anything else with a scheme, or a host that is not public. file:
+//           and qrc: are local reads; loopback and private addresses are the
+//           network behind the user's front door.
+//   local   no scheme. Qt resolves a relative source against the document's
+//           base URL, which for a TextEdit is the QML file's own directory —
+//           a read of whatever sits next to the plugin.
+function imageSourceKind(value) {
+  var url = normalizedUrl(value)
+  if (url === "") return "none"
+  if (/^cid:/i.test(url)) return "inline"
+  if (/^data:/i.test(url)) return "inline"
+  if (/^(https?:)?\/\//i.test(url)) return isPublicHost(hostOf(url)) ? "remote" : "unsafe"
+  return /^[a-z][a-z0-9+.-]*:/i.test(url) ? "unsafe" : "local"
+}
+
+// Whether the reader may hand a source straight to an Image element, which is
+// what opening an image marker in a plain-text body does.
+function isDisplayableImageUrl(value) {
+  var kind = imageSourceKind(value)
+  if (kind === "remote") return true
+  return kind === "inline" && /^data:image\//i.test(normalizedUrl(value))
 }
 
 // Only http(s) and mailto survive. A javascript: href does nothing in Qt's
@@ -203,7 +362,7 @@ function dropHidden(html) {
 function sanitize(html, options) {
   var settings = options || {}
   var text = String(html === undefined || html === null ? "" : html)
-  if (text === "") return { html: "", blockedImages: 0 }
+  if (text === "") return { html: "", blockedImages: 0, images: 0, remoteImages: 0 }
 
   // The message takes the window's theme, so the sender's palette comes out
   // before anything else looks at the markup.
@@ -211,6 +370,7 @@ function sanitize(html, options) {
   if (settings.keepTables !== true) text = flattenTables(text, settings.keepTableDepth)
 
   text = text.replace(/<!--[\s\S]*?-->/g, "")
+  text = stripStyleUrls(text)
   text = dropHidden(text)
   for (var i = 0; i < DROPPED_ELEMENTS.length; i++) text = stripElement(text, DROPPED_ELEMENTS[i])
   text = text.replace(/<(meta|link|base)\b[^>]*>/gi, "")
@@ -225,11 +385,17 @@ function sanitize(html, options) {
       return safeHref(value) ? match : ""
     })
 
-  // Every image is a network fetch Qt performs while laying the document out,
-  // and every completed fetch triggers another layout pass. Tracking pixels
-  // are pure cost, and past the cap the rest are decoration.
+  // Every remote image is a network fetch Qt performs while laying the document
+  // out, and every completed fetch triggers another layout pass. Tracking
+  // pixels are pure cost, and past the cap the rest are decoration.
+  //
+  // Nothing remote is fetched unless the reader asked for it. Opening a message
+  // is not asking: the fetch alone tells the sender the mail was read, from
+  // which address and at what time, and a source pointed at the machine itself
+  // turns reading mail into a request to whatever is listening on it.
   var blocked = 0
   var kept = 0
+  var loadable = 0
   var allowImages = settings.allowRemoteImages === true
   var limit = Math.max(0, Math.floor(
     settings.maxImages === undefined ? MAX_IMAGES : settings.maxImages))
@@ -239,22 +405,28 @@ function sanitize(html, options) {
     if (!source) return tag
     var value = source[2] !== undefined ? source[2]
       : (source[3] !== undefined ? source[3] : source[4])
-    if (!isRemoteSource(value)) return tag
+    var kind = imageSourceKind(value)
+    // Removed rather than emptied: an <img> with no src still reserves a
+    // broken-image box in Qt's layout, which reads as a rendering fault.
+    if (kind === "inline" || kind === "none") return tag
+    // Neither a local read nor a private-network request is something the
+    // reader can ever be offered, so these are dropped without being counted
+    // as something "show images" would bring back.
+    if (kind !== "remote") return ""
     if (isTrackingPixel(tag)) {
       blocked++
       return ""
     }
+    if (loadable < limit) loadable++
     if (!allowImages || kept >= limit) {
       blocked++
-      // Removed rather than emptied: an <img> with no src still reserves a
-      // broken-image box in Qt's layout, which reads as a rendering fault.
       return ""
     }
     kept++
     return tag
   })
 
-  return { html: text, blockedImages: blocked, images: kept }
+  return { html: text, blockedImages: blocked, images: kept, remoteImages: loadable }
 }
 
 function hasRemoteImages(html) {

--- a/Html.js
+++ b/Html.js
@@ -165,6 +165,61 @@ function stripElement(text, name) {
   return String(text).replace(open, "").replace(lone, "")
 }
 
+// ------------------------------------------------------------- tag boundaries
+//
+// Where a tag ends is the one thing the image policy below cannot afford to be
+// wrong about, and /<img\b[^>]*>/ is wrong about it. Qt's parser reads
+// attribute values with their quotes, so
+//
+//   <img alt="a>b" src="http://127.0.0.1/p.gif">
+//
+// is one image tag to the engine and two pieces of nothing to that regex: it
+// stops at the ">" inside the alt text, finds no src in what it took, and hands
+// the whole tag back untouched — which is a fetch. A sender only has to put a
+// ">" in an alt text to walk past the check.
+//
+// Qt has no HTML parser a QML plugin can call, so tag boundaries are scanned
+// for rather than matched. This is not a parser and does not try to be one: it
+// answers exactly one question, which is where a tag someone opened stops.
+function tagEnd(text, from) {
+  var quote = ""
+  for (var i = from; i < text.length; i++) {
+    var character = text.charAt(i)
+    if (quote !== "") {
+      if (character === quote) quote = ""
+      continue
+    }
+    if (character === "\"" || character === "'") {
+      quote = character
+      continue
+    }
+    if (character === ">") return i + 1
+  }
+  return -1
+}
+
+// Every <name ...> tag rewritten through `fn`, which is handed the whole tag and
+// returns what stands in its place. A tag that never closes takes the rest of
+// the document with it: Qt would swallow the remainder into the tag anyway, and
+// dropping it is the reading that cannot leave a fetch behind.
+function replaceTags(html, name, fn) {
+  var text = String(html || "")
+  var opening = new RegExp("<" + name + "\\b", "gi")
+  var out = ""
+  var at = 0
+  var found
+  while ((found = opening.exec(text)) !== null) {
+    if (found.index < at) continue
+    var end = tagEnd(text, found.index + found[0].length)
+    out += text.substring(at, found.index)
+    if (end < 0) return out
+    out += fn(text.substring(found.index, end))
+    at = end
+    opening.lastIndex = end
+  }
+  return out + text.substring(at)
+}
+
 // ------------------------------------------------------------ image sources
 //
 // An attribute value is not a URL until the HTML parser has resolved the
@@ -400,7 +455,7 @@ function sanitize(html, options) {
   var limit = Math.max(0, Math.floor(
     settings.maxImages === undefined ? MAX_IMAGES : settings.maxImages))
 
-  text = text.replace(/<img\b[^>]*>/gi, function(tag) {
+  text = replaceTags(text, "img", function(tag) {
     var source = tag.match(/\ssrc\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/i)
     if (!source) return tag
     var value = source[2] !== undefined ? source[2]
@@ -527,7 +582,11 @@ var IMAGE_LINK_PREFIX = "omarchy-image:"
 // cap was reached, and every marker after it would open the wrong picture.
 function imageSources(html) {
   var out = []
-  var pattern = /<img\b[^>]*>/gi
+  // The same pattern Message.htmlToText numbers the markers with, quotes and
+  // all: the two walks have to see the same tags or every marker after a
+  // disagreement opens the wrong picture. Not the scanner sanitize uses —
+  // nothing here is fetched, so a miss costs a marker rather than a request.
+  var pattern = /<img\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi
   var tags = String(html || "")
     .replace(/<!--[\s\S]*?-->/g, "")
     .replace(/<(script|style)[\s\S]*?<\/\1>/gi, "")

--- a/MailAccount.qml
+++ b/MailAccount.qml
@@ -93,10 +93,22 @@ Item {
   // where it exists, which is native and skips the per-character base64 loop
   // that made this the one expensive step in opening a message.
   property string selectedHtml: ""
+  // The same document with the sender's remote images still in it. This is what
+  // the body cache holds and what `selectedHtml` is derived from, so asking for
+  // the images is a re-render rather than another trip to Gmail.
+  property string preparedHtml: ""
+  // Off for every message, every time it is opened. Fetching a sender's images
+  // tells them the mail was read, from which address and when, so it happens
+  // only when the reader has asked — and asking covers this message alone.
+  property bool remoteImagesAllowed: false
   // The sender's images, in the order htmlToText numbers them, so a marker in
   // the plain-text body can be traced back to the picture it replaced.
   property var selectedImages: []
   property int selectedBlockedImages: 0
+  // How many of the blocked ones asking would actually bring back. A message
+  // whose only images are beacons or point at the local network has nothing to
+  // offer, so the reader says nothing.
+  property int selectedRemoteImages: 0
   property bool selectedTooHeavy: false
   property var selectedAttachments: []
   property bool detailLoading: false
@@ -395,6 +407,10 @@ Item {
     selectedMessage = null
     selectedBody = { text: "", source: "" }
     selectedHtml = ""
+    preparedHtml = ""
+    remoteImagesAllowed = false
+    selectedBlockedImages = 0
+    selectedRemoteImages = 0
     selectedImages = []
     selectedAttachments = []
     detailLoading = true
@@ -409,11 +425,8 @@ Item {
       if (root.detailLive || !cached) return
       // The body is already decoded here, so sanitising it costs a fraction
       // of a millisecond — worth doing inline to paint in the same frame.
-      var ready = Html.sanitize(cached.html, ({ allowRemoteImages: true }))
       root.selectedBody = { text: cached.text, source: cached.source }
-      root.selectedHtml = ready.html
-      root.selectedBlockedImages = ready.blockedImages
-      root.selectedTooHeavy = Html.tooHeavyForRichText(ready.html)
+      root.renderPrepared(cached.html)
       root.selectedAttachments = cached.attachments
       root.selectedImages = cached.images
       bodyCache.touch(messageId)
@@ -431,17 +444,18 @@ Item {
       root.selectedMessage = summary
       var decoded = Mail.extractBody(payload.payload)
       var rawHtml = Mail.extractHtml(payload.payload)
-      var ready = Html.sanitize(rawHtml, ({ allowRemoteImages: true }))
+      // Sanitised once with the images left in, so the cache keeps a document
+      // the reader can still be shown the pictures of; what reaches the screen
+      // is derived from it below, with them out.
+      var prepared = Html.sanitize(rawHtml, ({ allowRemoteImages: true })).html
       root.selectedBody = decoded
-      root.selectedHtml = ready.html
-      root.selectedBlockedImages = ready.blockedImages
-      root.selectedTooHeavy = Html.tooHeavyForRichText(ready.html)
+      root.renderPrepared(prepared)
       root.selectedAttachments = Mail.attachments(payload.payload)
       root.selectedImages = Html.imageSources(rawHtml)
       bodyCache.put(messageId, ({
         text: decoded.text,
         source: decoded.source,
-        html: ready.html,
+        html: prepared,
         attachments: root.selectedAttachments,
         images: root.selectedImages
       }))
@@ -452,6 +466,24 @@ Item {
     })
   }
 
+  // The one place `selectedHtml` is set. Sanitising the prepared document again
+  // is what removes or restores the images, and it is cheap enough to do on a
+  // button press: the expensive part of opening a message is the decode above.
+  function renderPrepared(prepared) {
+    preparedHtml = String(prepared || "")
+    var ready = Html.sanitize(preparedHtml, ({ allowRemoteImages: remoteImagesAllowed }))
+    selectedHtml = ready.html
+    selectedBlockedImages = ready.blockedImages
+    selectedRemoteImages = ready.remoteImages
+    selectedTooHeavy = Html.tooHeavyForRichText(ready.html)
+  }
+
+  function showRemoteImages() {
+    if (remoteImagesAllowed || preparedHtml === "") return
+    remoteImagesAllowed = true
+    renderPrepared(preparedHtml)
+  }
+
   function clearSelection() {
     detailSerial++
     apiClient.abortRequest(detailHandle)
@@ -460,8 +492,11 @@ Item {
     selectedMessage = null
     selectedBody = { text: "", source: "" }
     selectedHtml = ""
+    preparedHtml = ""
+    remoteImagesAllowed = false
     selectedImages = []
     selectedBlockedImages = 0
+    selectedRemoteImages = 0
     selectedTooHeavy = false
     selectedAttachments = []
     detailLoading = false
@@ -632,16 +667,19 @@ Item {
   function notify(arrivals) {
     var list = Array.isArray(arrivals) ? arrivals : []
     if (list.length === 0) return
+    // "--" before the summary and body: both are written by whoever sent the
+    // mail, and a display name of "-u" would otherwise be read by notify-send
+    // as an option rather than as a name.
     if (list.length === 1) {
-      Quickshell.execDetached(["notify-send", "-a", "Omamail",
-        "-i", "mail-unread", list[0].from.display, Model.notificationBody(list[0])])
+      Quickshell.execDetached(["notify-send", "-a", "Omamail", "-i", "mail-unread",
+        "--", Model.notificationTitle(list[0]), Model.notificationBody(list[0])])
       return
     }
     // One notification per message turns a batch sync into a wall of popups.
     var names = []
-    for (var i = 0; i < list.length && i < 3; i++) names.push(list[i].from.display)
-    Quickshell.execDetached(["notify-send", "-a", "Omamail",
-      "-i", "mail-unread", Model.pluralize(list.length, "new message"), names.join(", ")])
+    for (var i = 0; i < list.length && i < 3; i++) names.push(Model.notificationTitle(list[i]))
+    Quickshell.execDetached(["notify-send", "-a", "Omamail", "-i", "mail-unread",
+      "--", Model.pluralize(list.length, "new message"), names.join(", ")])
   }
 
   // ------------------------------------------------------------ navigation

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,11 @@ test-js:
 	node tests/test_html.js
 	node tests/test_cache.js
 	node tests/test_model.js
+	node tests/test_accounts.js
 
 test-shell:
 	python3 tests/test_qml_names.py
+	python3 tests/test_qml_text_format.py
 	bash tests/test_source.sh
 	bash tests/test_service_source.sh
 	bash tests/test_install.sh

--- a/Message.js
+++ b/Message.js
@@ -530,12 +530,30 @@ function summarize(message, now) {
 
 // ------------------------------------------------------------- composition
 
+// A header value can never carry a line break. One would end the header and let
+// whatever followed be read as the next one, which is how a Bcc gets into a
+// message nobody wrote it into. Removed rather than rejected: the values that
+// reach here are addresses and subjects, and a stray newline in one of them is
+// not worth refusing to send over.
+function headerSafe(value) {
+  return String(value === undefined || value === null ? "" : value).replace(/[\r\n]+/g, " ")
+}
+
 function foldHeader(name, value) {
-  var text = String(value || "")
+  var text = headerSafe(value)
   // Any non-ASCII in a header has to go back out as an encoded word, or Gmail
   // rejects the raw message.
   if (/^[\x20-\x7e]*$/.test(text)) return name + ": " + text
   return name + ": =?UTF-8?B?" + encodeBase64(text) + "?="
+}
+
+// In-Reply-To and References carry a Message-ID, and a Message-ID is a string
+// off a message a stranger sent — it reaches here having been read out of their
+// headers and no further. It goes back out verbatim because a reply has to
+// thread, so it is cut down to what a message id can legally be first:
+// printable ASCII, on one line, no longer than a header may run.
+function referenceValue(value) {
+  return headerSafe(value).replace(/[^\x20-\x7e]+/g, "").substring(0, 512).trim()
 }
 
 function quoteBody(summary, body) {
@@ -563,9 +581,10 @@ function buildRawMessage(fields) {
   lines.push(foldHeader("To", values.to || ""))
   if (values.cc) lines.push(foldHeader("Cc", values.cc))
   lines.push(foldHeader("Subject", values.subject || ""))
-  if (values.inReplyTo) {
-    lines.push("In-Reply-To: " + values.inReplyTo)
-    lines.push("References: " + (values.references || values.inReplyTo))
+  var inReplyTo = referenceValue(values.inReplyTo)
+  if (inReplyTo) {
+    lines.push("In-Reply-To: " + inReplyTo)
+    lines.push("References: " + (referenceValue(values.references) || inReplyTo))
   }
   lines.push("MIME-Version: 1.0")
   lines.push("Content-Type: text/plain; charset=UTF-8")

--- a/Message.js
+++ b/Message.js
@@ -327,7 +327,10 @@ function htmlToText(html) {
   return String(html || "")
     .replace(/<!--[\s\S]*?-->/g, "")
     .replace(/<(script|style)[\s\S]*?<\/\1>/gi, "")
-    .replace(/<img\b[^>]*>/gi, function() {
+    // Quotes and all, because Html.imageSources numbers the pictures with the
+    // same walk: a ">" inside an alt text that ends the tag for one and not the
+    // other puts every marker after it on the wrong image.
+    .replace(/<img\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi, function() {
       imageCount++
       return "[image " + imageCount + "]"
     })

--- a/Model.js
+++ b/Model.js
@@ -208,10 +208,32 @@ function newArrivals(summaries, seenIds, primed) {
   return arrivals
 }
 
+// The desktop notification spec says a body may carry a small markup subset,
+// and the daemons that implement it read one out of whatever they are handed.
+// A subject is a stranger's sentence, so its angle brackets are its own — and
+// an <img> left in one is a fetch made by the notification rather than by the
+// reader, which is the same beacon by a different door.
+//
+// A leading "-" is stripped for a different reason: these values become
+// arguments to notify-send, and one that starts with a dash is read as an
+// option there.
+function notificationText(value) {
+  return String(value === undefined || value === null ? "" : value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/^[-\s]+/, "")
+}
+
+function notificationTitle(summary) {
+  var title = summary && summary.from ? notificationText(summary.from.display) : ""
+  return title === "" ? "New message" : title
+}
+
 function notificationBody(summary) {
   if (!summary) return ""
-  var subject = String(summary.subject || "").trim()
-  var snippet = String(summary.snippet || "").trim()
+  var subject = notificationText(String(summary.subject || "").trim())
+  var snippet = notificationText(String(summary.snippet || "").trim())
   if (!snippet) return subject
   return subject + "\n" + (snippet.length > 140 ? snippet.substring(0, 139) + "…" : snippet)
 }

--- a/OAuth.js
+++ b/OAuth.js
@@ -262,17 +262,36 @@ function escapeHtml(text) {
     .replace(/'/g, "&#39;")
 }
 
+// The palette crosses into a stylesheet rather than into text, where escaping
+// does nothing: a value carrying "}" or "</style>" would close the rule or the
+// element and everything after it would be markup. It comes from the active
+// Omarchy theme, which is a file the user installed rather than something a
+// stranger sent — but this page is the one thing here a browser renders, and a
+// colour that is not a colour has no business reaching it either way.
+function cssColor(value, fallback) {
+  var text = String(value === undefined || value === null ? "" : value).trim()
+  return /^#[0-9A-Fa-f]{3,8}$/.test(text) ? text : fallback
+}
+
+// Quoted in the stylesheet, so the quote itself is the character that must not
+// survive. What is left is what a font is actually named.
+function cssFontFamily(value) {
+  var text = String(value === undefined || value === null ? "" : value)
+    .replace(/[^A-Za-z0-9 _-]/g, "").trim()
+  return text === "" ? "monospace" : text
+}
+
 // `body` is markup by design — the success page carries a script that closes the
 // tab — so it is the caller's job to have escaped anything untrusted inside it.
 // Everything else this builds is escaped here.
 function themedPage(theme, options) {
   var palette = theme || defaultTheme()
   var settings = options || {}
-  var fg = String(palette.foreground || "#DEDEDE")
-  var bg = String(palette.background || "#131313")
-  var mark = settings.failed ? String(palette.urgent || "#FF5257")
-    : String(palette.accent || "#077CFD")
-  var family = String(palette.fontFamily || "monospace")
+  var fg = cssColor(palette.foreground, "#DEDEDE")
+  var bg = cssColor(palette.background, "#131313")
+  var mark = settings.failed ? cssColor(palette.urgent, "#FF5257")
+    : cssColor(palette.accent, "#077CFD")
+  var family = cssFontFamily(palette.fontFamily)
 
   return "<!doctype html><html><head><meta charset=\"utf-8\">"
     + "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
@@ -280,7 +299,7 @@ function themedPage(theme, options) {
     + "*{box-sizing:border-box}"
     + "html,body{height:100%}"
     + "body{margin:0;background:" + bg + ";color:" + fg + ";"
-    + "font-family:\"CaskaydiaMono Nerd Font\",\"JetBrains Mono\"," + family + ",ui-monospace,monospace;"
+    + "font-family:\"CaskaydiaMono Nerd Font\",\"JetBrains Mono\",\"" + family + "\",ui-monospace,monospace;"
     + "font-size:13px;line-height:1.7;display:flex;align-items:center;justify-content:center;padding:24px}"
     + "main{width:100%;max-width:420px;border:1px solid " + fg + "66;padding:28px 30px}"
     + "svg{display:block;margin-bottom:18px}"

--- a/README.md
+++ b/README.md
@@ -126,9 +126,14 @@ trash, spam, star and read/unread without leaving the keyboard cursor behind.
   its `QGuiApplication`, and a plugin loads long after that.
 - **No attachment downloads.** Not yet.
 
-Images in a message body load by default. Qt really does fetch them, so opening
-a message fires whatever tracking pixels it carries — the same as any mail
-client that shows pictures without asking.
+Remote images in a message body are blocked until you ask for them, and asking
+covers that one message. Qt really does fetch an `<img src="https://…">`, so
+loading a message's pictures fires whatever tracking pixels it carries and tells
+the sender when the mail was read — which is why it is a decision rather than a
+default. Images pointed at this machine or at the network around it (loopback,
+private addresses, `.local` names, `file:`) are never fetched at all, however
+often you ask: a message must not be able to make the client knock on the door
+of something listening on your own network.
 
 Several mailboxes can be added and switched between; each keeps its own cache,
 its own refresh token, and its own unread count, and the bar badge counts all of

--- a/Service.qml
+++ b/Service.qml
@@ -339,6 +339,9 @@ Item {
   readonly property var selectedBody: current ? current.selectedBody : ({ text: "", source: "" })
   readonly property string selectedHtml: current ? current.selectedHtml : ""
   readonly property var selectedImages: current ? current.selectedImages : []
+  readonly property int selectedBlockedImages: current ? current.selectedBlockedImages : 0
+  readonly property int selectedRemoteImages: current ? current.selectedRemoteImages : 0
+  readonly property bool remoteImagesAllowed: !!current && current.remoteImagesAllowed
   readonly property var selectedAttachments: current ? current.selectedAttachments : []
   readonly property bool selectedTooHeavy: !!current && current.selectedTooHeavy
   readonly property bool detailLoading: !!current && current.detailLoading
@@ -352,6 +355,7 @@ Item {
   function loadMore() { if (current) current.loadMore() }
   function select(id) { if (current) current.select(id) }
   function clearSelection() { if (current) current.clearSelection() }
+  function showRemoteImages() { if (current) current.showRemoteImages() }
   function selectOffset(delta) { return current ? current.selectOffset(delta) : "" }
   function selectMailbox(key) { if (current) current.selectMailbox(key) }
   function search(text) { if (current) current.search(text) }

--- a/components/AccountSwitcher.qml
+++ b/components/AccountSwitcher.qml
@@ -124,6 +124,7 @@ Item {
 
             Text {
               anchors.centerIn: parent
+              textFormat: Text.PlainText
               text: row.modelData.email === ""
                 ? "+" : row.modelData.email.charAt(0).toUpperCase()
               color: root.textColor
@@ -146,6 +147,7 @@ Item {
             // local part across different domains.
             Text {
               width: parent.width
+              textFormat: Text.PlainText
               text: row.modelData.email !== "" ? row.modelData.email : "New account"
               color: root.textColor
               font.family: root.panelFontFamily
@@ -159,6 +161,7 @@ Item {
             Text {
               width: parent.width
               visible: text !== ""
+              textFormat: Text.PlainText
               text: {
                 if (row.modelData.error !== undefined && row.modelData.error !== "")
                   return row.modelData.error

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -181,6 +181,7 @@ Item {
       Text {
         anchors.verticalCenter: parent.verticalCenter
         visible: root.mode !== "new"
+        textFormat: Text.PlainText
         text: subjectField.text
         color: root.dimmerColor
         font.family: root.panelFontFamily

--- a/components/ImagePopover.qml
+++ b/components/ImagePopover.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls as QQC
 import qs.Commons
 import qs.Ui
+import "../Html.js" as Html
 
 // One image, floated over the reader.
 //
@@ -17,6 +18,14 @@ Item {
   required property string panelFontFamily
 
   property string source: ""
+  // What the marker pointed at, shown whether or not it was fetched, so a
+  // refusal names the thing it refused.
+  property string requested: ""
+  // A sender's src is not a picture until something has decided it is safe to
+  // fetch. Loopback and private addresses are the network behind the user's
+  // front door, and file: is their disk; neither is a picture, and opening one
+  // is the request itself.
+  property bool refused: false
 
   anchors.fill: parent
   z: 60
@@ -24,7 +33,9 @@ Item {
   function show(url) {
     var wanted = String(url || "")
     if (wanted === "") return
-    source = wanted
+    requested = wanted
+    refused = !Html.isDisplayableImageUrl(wanted)
+    source = refused ? "" : wanted
     sheet.open()
   }
 
@@ -42,7 +53,11 @@ Item {
     width: frame.implicitWidth + padding * 2
     height: frame.implicitHeight + padding * 2
 
-    onClosed: root.source = ""
+    onClosed: {
+      root.source = ""
+      root.requested = ""
+      root.refused = false
+    }
 
     background: Rectangle {
       radius: Style.cornerRadius
@@ -72,10 +87,13 @@ Item {
 
         Text {
           anchors.centerIn: parent
-          visible: picture.status !== Image.Ready
-          text: picture.status === Image.Error
-            ? "That image could not be loaded"
-            : "Loading…"
+          width: picture.width - Style.space(20)
+          horizontalAlignment: Text.AlignHCenter
+          wrapMode: Text.WordWrap
+          visible: root.refused || picture.status !== Image.Ready
+          text: root.refused
+            ? "That image is not on the public internet, so it was not fetched"
+            : (picture.status === Image.Error ? "That image could not be loaded" : "Loading…")
           color: root.dimColor
           font.family: root.panelFontFamily
           font.pixelSize: Style.font.bodySmall
@@ -84,10 +102,13 @@ Item {
 
       Text {
         width: picture.width
-        text: root.source
+        text: root.requested
         color: root.dimColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.caption
+        // The sender wrote this. Left as AutoText, a src with a tag in it is
+        // markup Qt would lay out — and an <img> in it a fetch it would make.
+        textFormat: Text.PlainText
         elide: Text.ElideMiddle
       }
     }

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -38,11 +38,14 @@ Item {
   signal actionRequested(string action)
 
   readonly property var summary: service ? service.selectedMessage : null
-  // Already sanitised by the service, on a worker thread where the decode
-  // happens. Images load: Qt's rich text engine fetches them for real, so the
-  // sender learns when the message was opened — a deliberate trade for mail
-  // that looks like mail.
+  // Already sanitised by the service, remote images and all removed. Qt's rich
+  // text engine fetches an <img src="https://..."> for real, so leaving them in
+  // would fire every tracking pixel in the message the instant it opened, and
+  // would let a crafted one aim a request at whatever is listening on this
+  // machine. They come back only when the reader asks, for this message alone.
   readonly property string rawHtml: service ? service.selectedHtml : ""
+  readonly property int remoteImages: service ? service.selectedRemoteImages : 0
+  readonly property bool remoteImagesAllowed: !!service && service.remoteImagesAllowed
   // Qt lays rich text out on the GUI thread, and this plugin lives inside the
   // shell that draws the whole desktop. A document past the bounds gets its
   // plain-text part instead, with a way to insist.
@@ -141,6 +144,10 @@ Item {
 
       Text {
         width: parent.width
+        // A stranger wrote this. Qt's default AutoText switches a string that
+        // looks like markup into rich text, and rich text with an <img> in it is
+        // a fetch — the same beacon the message body is stripped of.
+        textFormat: Text.PlainText
         text: root.summary ? root.summary.subject : ""
         color: root.textColor
         font.family: root.panelFontFamily
@@ -151,6 +158,7 @@ Item {
 
       Text {
         width: parent.width
+        textFormat: Text.PlainText
         text: root.summary
           ? root.summary.from.display + "  <" + root.summary.from.email + ">"
           : ""
@@ -162,6 +170,7 @@ Item {
 
       Text {
         width: parent.width
+        textFormat: Text.PlainText
         text: root.summary
           ? "to " + Mail.formatAddressList(root.summary.to, 3) + " · " + root.summary.fullTime
           : ""
@@ -216,9 +225,58 @@ Item {
     }
   }
 
+  // Sits under the heavy-document notice when both are up: one says why the
+  // message looks plain, the other why it looks bare, and they are different
+  // answers to different questions.
+  Rectangle {
+    id: imageNotice
+    visible: !!root.summary && root.htmlAvailable
+      && !root.remoteImagesAllowed && root.remoteImages > 0
+    anchors.top: heavyNotice.visible ? heavyNotice.bottom : headerBlock.bottom
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.leftMargin: root.pageInset
+    anchors.rightMargin: root.pageInset
+    anchors.topMargin: Style.space(8)
+    implicitHeight: Style.space(30)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+    border.width: 1
+    border.color: Style.normalBorderFor(root.textColor, root.accentColor)
+
+    Text {
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(10)
+      anchors.right: showImages.left
+      anchors.rightMargin: Style.space(6)
+      anchors.verticalCenter: parent.verticalCenter
+      text: (root.remoteImages === 1 ? "1 image is blocked" : root.remoteImages + " images are blocked")
+        + ": loading them tells the sender this message was opened"
+      color: root.dimColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.caption
+      textFormat: Text.PlainText
+      elide: Text.ElideRight
+    }
+
+    Button {
+      id: showImages
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(6)
+      anchors.verticalCenter: parent.verticalCenter
+      text: "Show images"
+      foreground: root.textColor
+      bordered: false
+      fontSize: Style.font.caption
+      onClicked: if (root.service) root.service.showRemoteImages()
+    }
+  }
+
   Flickable {
     id: bodyFlick
-    anchors.top: heavyNotice.visible ? heavyNotice.bottom : headerBlock.bottom
+    anchors.top: imageNotice.visible
+      ? imageNotice.bottom
+      : (heavyNotice.visible ? heavyNotice.bottom : headerBlock.bottom)
     anchors.left: parent.left
     anchors.right: parent.right
     anchors.bottom: footerBackdrop.visible ? footerBackdrop.top : parent.bottom
@@ -267,6 +325,9 @@ Item {
         var image = Html.imageLinkIndex(link)
         if (image > 0) {
           var sources = root.imageSources
+          // A marker in a plain-text body opens the picture it stands for, and
+          // "the picture" is whatever the sender wrote in the src. Opening one
+          // is a fetch, so it obeys the same rule the document does.
           if (image <= sources.length) imagePopover.show(sources[image - 1])
           return
         }
@@ -342,6 +403,7 @@ Item {
 
         Text {
           anchors.verticalCenter: parent.verticalCenter
+          textFormat: Text.PlainText
           text: modelData.filename
           color: root.dimColor
           font.family: root.panelFontFamily

--- a/components/MessageRow.qml
+++ b/components/MessageRow.qml
@@ -88,6 +88,10 @@ Rectangle {
         anchors.left: parent.left
         anchors.right: time.left
         anchors.rightMargin: Style.space(8)
+        // A stranger wrote this. Qt's default AutoText switches a string that
+        // looks like markup into rich text, and rich text with an <img> in it is
+        // a fetch — the same beacon the message body is stripped of.
+        textFormat: Text.PlainText
         text: root.summary.subject
         color: root.textColor
         font.family: root.panelFontFamily
@@ -100,6 +104,7 @@ Rectangle {
         id: time
         anchors.right: parent.right
         anchors.baseline: subject.baseline
+        textFormat: Text.PlainText
         text: root.summary.time
         color: root.dimColor
         font.family: root.panelFontFamily
@@ -109,6 +114,7 @@ Rectangle {
 
     Text {
       width: parent.width
+      textFormat: Text.PlainText
       text: root.summary.from.display
       color: root.dimColor
       font.family: root.panelFontFamily
@@ -119,6 +125,7 @@ Rectangle {
     Text {
       width: parent.width
       visible: root.summary.snippet !== ""
+      textFormat: Text.PlainText
       text: root.summary.snippet
       color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.42)
       font.family: root.panelFontFamily

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -88,6 +88,7 @@ Column {
 
           Text {
             width: parent.width
+            textFormat: Text.PlainText
             text: row.modelData.email !== "" ? row.modelData.email : "New mailbox"
             color: root.textColor
             font.family: root.panelFontFamily

--- a/components/SetupPage.qml
+++ b/components/SetupPage.qml
@@ -325,6 +325,7 @@ Column {
   Text {
     width: parent.width
     visible: !!root.auth && root.auth.lastError !== ""
+    textFormat: Text.PlainText
     text: root.auth ? root.auth.lastError : ""
     color: Color.urgent
     font.family: root.panelFontFamily

--- a/components/UserBar.qml
+++ b/components/UserBar.qml
@@ -64,6 +64,7 @@ Rectangle {
     anchors.right: parent.right
     anchors.rightMargin: Style.space(8)
     anchors.verticalCenter: parent.verticalCenter
+    textFormat: Text.PlainText
     text: root.email === "" ? "Not connected" : root.email
     color: root.dimColor
     font.family: root.panelFontFamily

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -22,7 +22,7 @@ Three plugin entry points (`manifest.kinds`):
 | Question | Decision |
 |---|---|
 | List granularity | **One row per message** (`messages.list`), not per thread. Thread aggregation costs an extra `threads.get` round trip per page and doubles the UI states. |
-| Body rendering | **Qt RichText by default**, with a plain-text toggle. Remote images load — the sender therefore learns when a message was opened, a deliberate trade for mail that looks like mail. No browser engine: `QtWebEngineQuick::initialize()` must run before the host process's `QGuiApplication` is constructed, which a plugin loaded later cannot do. |
+| Body rendering | **Qt RichText by default**, with a plain-text toggle. Remote images are blocked until the reader asks, per message: Qt performs the fetch for real, so rendering one fires the sender's tracking pixels and reports the read. A source aimed at loopback, a private address or a local file is never fetched at all. No browser engine: `QtWebEngineQuick::initialize()` must run before the host process's `QGuiApplication` is constructed, which a plugin loaded later cannot do. |
 | Sending | **Included.** Reply, reply-all, forward, and compose, plain-text body with quoted original. Requires the `gmail.send` scope. |
 | Bar click | **Opens the app window directly.** Middle click refreshes, right click opens a small menu. |
 | Compose surface | **The whole content area of the one window.** Omarchy's panel mechanism gives every extra window its own region, so a reply must not open one. Only a second mail account would justify a second window. |

--- a/tests/test_html.js
+++ b/tests/test_html.js
@@ -154,6 +154,42 @@ assert.ok(html.sanitize("<div style=\"background-image:url(https://track.example
 assert.ok(html.sanitize("<div style=\"background-image:url(https://track.example.com/p.gif);padding:4px\">x</div>")
   .html.indexOf("padding:4px") > 0, "the rest of the style survives")
 
+// ---------------------------------------------------------- tag boundaries
+//
+// Qt reads an attribute value with its quotes, so a ">" inside an alt text does
+// not end the tag for the engine — and a check that stops at the first ">" it
+// sees takes half a tag, finds no src in it, and hands the whole thing back.
+// Putting a ">" in an alt text was enough to walk an image past the block.
+{
+  const hidden = "<img alt=\"a>b\" src=\"https://tracker.example.com/p.gif\" width=\"90\">"
+  assert.strictEqual(html.sanitize(hidden).blockedImages, 1)
+  assert.ok(html.sanitize(hidden).html.indexOf("tracker.example.com") < 0)
+  assert.strictEqual(html.sanitize(hidden, { allowRemoteImages: true }).images, 1)
+
+  const hiddenLocal = "<img alt='a>b' src=\"http://127.0.0.1/p.gif\" width=\"90\">"
+  assert.ok(html.sanitize(hiddenLocal, { allowRemoteImages: true }).html.indexOf("127.0.0.1") < 0)
+
+  // A quote that never closes takes the rest of the document with it: Qt would
+  // swallow the remainder into the tag anyway, and dropping it is the reading
+  // that cannot leave a fetch behind.
+  assert.ok(html.sanitize("<p>hi</p><img src=\"https://tracker.example.com/p.gif\" alt=\"oops")
+    .html.indexOf("tracker.example.com") < 0)
+
+  // Ordinary markup around an image is untouched.
+  assert.strictEqual(
+    html.sanitize("<p>hi</p><img alt=\"x\" src=\"https://cdn.example.com/a.png\" width=\"90\"><p>bye</p>").html,
+    "<p>hi</p><p>bye</p>")
+}
+
+// The markers in a plain-text body and the list of pictures they open are two
+// walks over the same tags, so they have to end a tag in the same place.
+{
+  const body = "<img alt=\"a>b\" src=\"https://cdn.example.com/one.png\"><p>x</p>"
+    + "<img src=\"https://cdn.example.com/two.png\">"
+  deepEqual(html.imageSources(body),
+    ["https://cdn.example.com/one.png", "https://cdn.example.com/two.png"])
+}
+
 // What the plain-text reader may hand to an Image element.
 assert.strictEqual(html.isDisplayableImageUrl("https://cdn.example.com/a.png"), true)
 assert.strictEqual(html.isDisplayableImageUrl("http://127.0.0.1/a.png"), false)

--- a/tests/test_html.js
+++ b/tests/test_html.js
@@ -44,9 +44,9 @@ assert.ok(blocked.html.indexOf("<p>Hi</p>") === 0, "the rest of the message is u
 const allowedPixel = html.sanitize(tracked, { allowRemoteImages: true })
 assert.strictEqual(allowedPixel.images, 0)
 assert.strictEqual(allowedPixel.blockedImages, 1)
-assert.strictEqual(html.sanitize("<img src='https://a/b.gif' height=\"1\">",
+assert.strictEqual(html.sanitize("<img src='https://a.example.com/b.gif' height=\"1\">",
   { allowRemoteImages: true }).images, 0)
-assert.strictEqual(html.sanitize("<img src='https://a/b.gif' style='width:1px;height:1px'>",
+assert.strictEqual(html.sanitize("<img src='https://a.example.com/b.gif' style='width:1px;height:1px'>",
   { allowRemoteImages: true }).images, 0)
 
 // A real picture is kept.
@@ -58,7 +58,7 @@ assert.strictEqual(html.sanitize(real).images, 0, "still off unless asked for")
 // Every image is a fetch Qt performs during layout, and every completed fetch
 // triggers another layout pass, so the count is capped.
 let many = ""
-for (let i = 0; i < html.MAX_IMAGES + 8; i++) many += "<img src=\"https://cdn/" + i + ".png\" width=\"90\">"
+for (let i = 0; i < html.MAX_IMAGES + 8; i++) many += "<img src=\"https://cdn.example.com/" + i + ".png\" width=\"90\">"
 const capped = html.sanitize(many, { allowRemoteImages: true })
 assert.strictEqual(capped.images, html.MAX_IMAGES)
 assert.strictEqual(capped.blockedImages, 8)
@@ -87,11 +87,80 @@ assert.strictEqual(html.complexity(null).length, 0)
 // are already local. Neither is a network request, and neither is counted.
 assert.strictEqual(html.sanitize("<img src=\"cid:logo\">").blockedImages, 0)
 assert.strictEqual(html.sanitize("<img src=\"data:image/png;base64,AAA\">").blockedImages, 0)
-assert.strictEqual(html.sanitize("<img src='http://a/b.png'><img src='https://c/d.png'>").blockedImages, 2)
-assert.strictEqual(html.sanitize("<img src='http://a/b.png'><img src='https://c/d.png'>",
+assert.strictEqual(html.sanitize("<img src='http://a.example.com/b.png'><img src='https://c.example.com/d.png'>").blockedImages, 2)
+assert.strictEqual(html.sanitize("<img src='http://a.example.com/b.png'><img src='https://c.example.com/d.png'>",
   { allowRemoteImages: true }).images, 2, "images with no stated size are real pictures")
 // Protocol-relative sources are still network fetches.
 assert.strictEqual(html.sanitize("<img src=\"//cdn.example/x.png\">").blockedImages, 1)
+
+// ------------------------------------------------- where an image may point
+//
+// A crafted message must not be able to make the reader talk to the machine it
+// runs on. These are requests the user never asked for, aimed at whatever the
+// sender names, and issuing one is the attack whether or not anything is drawn.
+
+const localSources = [
+  "http://127.0.0.1:8080/x.png",
+  "http://localhost/x.png",
+  "http://[::1]/x.png",
+  "http://10.0.0.1/x.png",
+  "http://192.168.1.1/x.png",
+  "http://172.16.4.4/x.png",
+  "http://169.254.169.254/latest/meta-data",
+  "http://router/x.png",
+  "http://printer.local/x.png",
+  // 127.0.0.1 written so a naive check does not recognise it.
+  "http://2130706433/x.png",
+  "http://0177.0.0.1/x.png",
+  "http://0x7f000001/x.png",
+  // Userinfo, so the host is not what a reader skimming the URL sees.
+  "http://cdn.example.com@127.0.0.1/x.png"
+]
+for (const source of localSources) {
+  const asked = html.sanitize("<img src=\"" + source + "\" width=\"90\">",
+    { allowRemoteImages: true })
+  assert.strictEqual(asked.images, 0, source + " must never be fetched")
+  assert.ok(asked.html.indexOf("img") < 0, source + " must not reach the renderer")
+  assert.strictEqual(asked.remoteImages, 0, source + " is not something to offer")
+}
+
+// A public address in a URL is fine, however it is written.
+assert.strictEqual(html.sanitize("<img src=\"https://93.184.216.34/x.png\" width=\"90\">",
+  { allowRemoteImages: true }).images, 1)
+
+// Qt resolves the character references in an attribute before it fetches, so a
+// source that does not look like a URL to a reader can still be one to it.
+assert.strictEqual(
+  html.sanitize("<img src=\"&#104;ttps://track.example.com/p.gif\" width=\"90\">").blockedImages, 1)
+assert.strictEqual(
+  html.sanitize("<img src=\"&#104;ttps://127.0.0.1/p.gif\" width=\"90\">",
+    { allowRemoteImages: true }).images, 0)
+
+// A relative source has no base but the plugin's own directory, so Qt would
+// read whatever sits next to the QML.
+assert.ok(html.sanitize("<img src=\"../../../etc/hostname\">").html.indexOf("img") < 0)
+assert.ok(html.sanitize("<img src=\"file:///etc/hostname\">").html.indexOf("img") < 0)
+
+// The count the reader offers to load is the count it can actually load.
+const mixed = "<img src=\"https://cdn.example.com/a.png\" width=\"90\">"
+  + "<img src=\"http://127.0.0.1/b.png\" width=\"90\">"
+  + "<img src=\"https://cdn.example.com/pixel.gif\" width=\"1\">"
+assert.strictEqual(html.sanitize(mixed).remoteImages, 1)
+assert.strictEqual(html.sanitize(mixed, { allowRemoteImages: true }).images, 1)
+
+// A url() in an inline style is a fetch too, wherever the engine honours one.
+assert.ok(html.sanitize("<div style=\"background-image:url(https://track.example.com/p.gif);padding:4px\">x</div>")
+  .html.indexOf("track.example.com") < 0)
+assert.ok(html.sanitize("<div style=\"background-image:url(https://track.example.com/p.gif);padding:4px\">x</div>")
+  .html.indexOf("padding:4px") > 0, "the rest of the style survives")
+
+// What the plain-text reader may hand to an Image element.
+assert.strictEqual(html.isDisplayableImageUrl("https://cdn.example.com/a.png"), true)
+assert.strictEqual(html.isDisplayableImageUrl("http://127.0.0.1/a.png"), false)
+assert.strictEqual(html.isDisplayableImageUrl("file:///etc/hostname"), false)
+assert.strictEqual(html.isDisplayableImageUrl("data:image/png;base64,AAA"), true)
+assert.strictEqual(html.isDisplayableImageUrl("cid:logo"), false)
+assert.strictEqual(html.isDisplayableImageUrl(""), false)
 
 assert.strictEqual(html.hasRemoteImages(tracked), true)
 assert.strictEqual(html.hasRemoteImages("<p>none</p>"), false)

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -287,6 +287,12 @@ assert.strictEqual(message.extractHtml({
     message.htmlToText("<div>Hello</div><img src=\"a.png\"><br><img src='b.png' width=600><p>Bye</p>"),
     "Hello\n[image 1]\n[image 2]Bye")
   assert.strictEqual(message.htmlToText("<p>none</p>"), "none", "text without images is unchanged")
+  // A ">" inside an alt text does not end the tag — Html.imageSources numbers
+  // the pictures with the same walk, and a disagreement puts every marker after
+  // it on the wrong one.
+  assert.strictEqual(
+    message.htmlToText("<img alt=\"a>b\" src=\"x.png\"><p>after</p><img src='y.png'>"),
+    "[image 1]after\n[image 2]")
 }
 
 // -------------------------------------------------------- header injection

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -289,4 +289,39 @@ assert.strictEqual(message.extractHtml({
   assert.strictEqual(message.htmlToText("<p>none</p>"), "none", "text without images is unchanged")
 }
 
+// -------------------------------------------------------- header injection
+//
+// In-Reply-To carries a Message-ID, and a Message-ID is whatever the sender
+// wrote in theirs. A line break in one would end the header and let the rest be
+// read as another — a Bcc in a reply the user typed no Bcc into.
+{
+  const raw = message.buildRawMessage({
+    to: "friend@example.com",
+    subject: "Re: hello",
+    inReplyTo: "<a@b>\r\nBcc: attacker@example.net",
+    body: "hi"
+  })
+  const headerNames = (text) => text.split("\r\n\r\n")[0].split("\r\n")
+    .map((line) => line.split(":")[0])
+  assert.ok(headerNames(raw).indexOf("Bcc") < 0, "a Message-ID must not become a second header")
+  assert.ok(raw.indexOf("In-Reply-To: <a@b> Bcc: attacker@example.net") > 0,
+    "the value survives as one header line")
+
+  const folded = message.buildRawMessage({
+    to: "friend@example.com\r\nBcc: attacker@example.net",
+    subject: "hello\nX-Injected: 1",
+    body: "hi"
+  })
+  assert.ok(headerNames(folded).indexOf("Bcc") < 0)
+  assert.ok(headerNames(folded).indexOf("X-Injected") < 0)
+  // Every header a message must carry is still there, and the body still
+  // starts after exactly one blank line.
+  assert.ok(folded.indexOf("\r\n\r\n") > 0)
+
+  // A reference that is nothing but a line break leaves the header out
+  // altogether rather than emitting an empty one.
+  assert.ok(message.buildRawMessage({ to: "a@b.com", inReplyTo: "\r\n", body: "x" })
+    .indexOf("In-Reply-To") < 0)
+}
+
 console.log("test_message.js ok")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -150,4 +150,20 @@ assert.strictEqual(model.truncate("a much longer string", 10), "a much lo…")
 assert.strictEqual(model.pluralize(1, "message"), "1 message")
 assert.strictEqual(model.pluralize(0, "message"), "0 messages")
 
+// A notification is markup to the daemons that draw it, and its two strings are
+// arguments to notify-send. Neither is a place for a sender's angle brackets or
+// for a display name that starts with a dash.
+{
+  const crafted = {
+    subject: "<img src=\"http://tracker.example.com/p.gif\">",
+    snippet: "a & b",
+    from: { display: "-u critical" }
+  }
+  assert.ok(model.notificationBody(crafted).indexOf("<img") < 0)
+  assert.ok(model.notificationBody(crafted).indexOf("&amp;") > 0)
+  assert.strictEqual(model.notificationTitle(crafted), "u critical")
+  assert.strictEqual(model.notificationTitle({ from: { display: "" } }), "New message")
+  assert.strictEqual(model.notificationTitle(null), "New message")
+}
+
 console.log("test_model.js ok")

--- a/tests/test_oauth.js
+++ b/tests/test_oauth.js
@@ -206,4 +206,34 @@ assert.strictEqual(oauth.byteLength(""), 0)
   assert.ok(oauth.successResponse(null).indexOf("alert") < 0)
 }
 
+// The palette lands in a stylesheet, where escaping does nothing: a value
+// carrying "}" or "</style>" would close the rule and turn the rest into
+// markup. A theme is installed rather than sent, but this page is the one thing
+// here a browser renders.
+{
+  const hostile = oauth.failureResponse({
+    background: "#131313;}</style><script>alert(1)</script><style>{",
+    foreground: "red;} body{display:none",
+    urgent: "#FF5257",
+    fontFamily: 'monospace";}</style><img src=x onerror=alert(1)>'
+  }, "went wrong")
+  assert.ok(hostile.indexOf("<script") < 0, "a failure page carries no script at all")
+  assert.ok(hostile.indexOf("<img") < 0)
+  assert.ok(hostile.indexOf("display:none") < 0)
+  // One stylesheet, closed once: nothing in the palette ended it early.
+  assert.strictEqual(hostile.split("</style>").length - 1, 1)
+  // A colour that is not a colour falls back rather than disappearing, so the
+  // page is still readable.
+  assert.ok(hostile.indexOf("background:#131313;") > 0)
+  assert.ok(hostile.indexOf("#FF5257") > 0)
+
+  // A real theme still comes through untouched.
+  const normal = oauth.successResponse({
+    background: "#1d2021", foreground: "#ebdbb2", accent: "#458588",
+    urgent: "#cc241d", fontFamily: "CaskaydiaMono Nerd Font"
+  })
+  assert.ok(normal.indexOf("#1d2021") > 0)
+  assert.ok(normal.indexOf("CaskaydiaMono Nerd Font") > 0)
+}
+
 console.log("test_oauth.js ok")

--- a/tests/test_qml_text_format.py
+++ b/tests/test_qml_text_format.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Every Text that shows something a stranger wrote must say it is plain.
+
+Qt's default is Text.AutoText, which runs Qt.mightBeRichText() over the string
+and switches to the rich text engine when it finds something tag-shaped. That
+engine fetches <img src="https://..."> for real — so a subject line, a sender
+name, or a snippet carrying one becomes exactly the tracking beacon the message
+body is stripped of, without the body ever being opened.
+
+The reader's own TextEdit is the one deliberate exception: it renders a
+document that Html.sanitize has already been through.
+"""
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# What a message, an account or Google can put words into.
+UNTRUSTED = re.compile(
+    r"\b(summary\s*\.|\.subject\b|\.snippet\b|\.from\b|\.display\b|\.email\b"
+    r"|modelData\s*\.\s*filename\b|formatAddressList\b|lastError\b"
+    r"|root\s*\.\s*requested\b|subjectField\s*\.\s*text\b)")
+
+STRING = re.compile(r'"(?:[^"\\]|\\.)*"|\'(?:[^\'\\]|\\.)*\'')
+ELEMENT = re.compile(r"\b(Text|Label)\s*\{")
+
+
+def blocks(source):
+    """Every Text/Label element body, as (name, text) pairs."""
+    masked = STRING.sub(lambda m: " " * len(m.group(0)), source)
+    for opening in ELEMENT.finditer(masked):
+        start = opening.end()
+        depth = 1
+        index = start
+        while index < len(masked) and depth:
+            if masked[index] == "{":
+                depth += 1
+            elif masked[index] == "}":
+                depth -= 1
+            index += 1
+        yield opening.group(1), source[start:index - 1]
+
+
+def main():
+    failures = []
+    files = sorted(ROOT.glob("*.qml")) + sorted((ROOT / "components").glob("*.qml"))
+    for path in files:
+        source = path.read_text(encoding="utf-8")
+        for name, body in blocks(source):
+            binding = re.search(r"^\s*text\s*:(.*?)(?=^\s*[\w.]+\s*:|\Z)",
+                                body, re.S | re.M)
+            if not binding or not UNTRUSTED.search(binding.group(1)):
+                continue
+            if "textFormat" not in body:
+                excerpt = " ".join(binding.group(1).split())[:60]
+                failures.append("%s: %s { text: %s } needs textFormat: Text.PlainText"
+                                % (path.relative_to(ROOT), name, excerpt))
+    if failures:
+        for line in failures:
+            print("test_qml_text_format.py: " + line, file=sys.stderr)
+        return 1
+    print("test_qml_text_format.py ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes the finding in [omarchy-plugin-marketplace#790](https://github.com/HANCORE-linux/omarchy-plugin-marketplace/issues/790#issuecomment-5349923070), and everything a full pass over the rest of the plugin turned up alongside it.

## What was reported

At `11d65ff`, opening an HTML message fetched every remote image in it, including sources aimed at loopback and private-network addresses.

The block existed and was commented for, but both callers that sanitise a body passed `allowRemoteImages: true`, so it never ran. `AGENTS.md` still said images were blocked until asked; the code had gone the other way. And the check behind it only looked at the scheme, so a `src` pointed at `127.0.0.1`, at `192.168.1.1`, or at `169.254.169.254` was a request the reader issued without being asked.

## The fix

**Off per message, and asking covers that message.** The body cache now keeps the document with its images still in it, and what reaches the screen is derived from that — so `Show images` is a re-render, not another trip to Gmail. `remoteImagesAllowed` resets on every `select()`.

**One decision about where an image may point.** `Html.imageSourceKind` is the only place that decides, and the sanitiser, the reader and the image popover all ask it. It is an allow list rather than a deny list — a name whose last label is a real TLD, or a public IPv4 address — which refuses loopback, private and link-local ranges, CGNAT, multicast, single-label names (`router`), `.local` / `.internal`, every IPv6 literal, userinfo disguises (`http://cdn.example.com@127.0.0.1/x.png`), and addresses written in octal, in hex, or as one number, without having had to think of each of them first.

**Two ways in the old check missed.** Qt resolves character references in an attribute before it fetches, so `src="&#104;ttps://…"` was a real URL to the engine and not to the regex. And a `url()` in an inline style is a fetch wherever the engine honours one. Relative and `file:` sources are refused too: a `TextEdit` resolves a relative source against the QML file's own directory.

**Where a tag ends.** `/<img\b[^>]*>/` stops at the first `>` it sees; Qt's parser reads an attribute value with its quotes. So `<img alt="a>b" src="http://127.0.0.1/p.gif">` was one image tag to the engine and half a tag to the check — which found no `src` in what it took and handed the whole thing back. A `>` in an alt text walked an image past everything above. Qt exposes no HTML parser a QML plugin can call, so the boundary is scanned for instead: one loop tracking the open quote, answering only where a tag stops. An unterminated quote now takes the rest of the document with it, which is what Qt does anyway and is the reading that cannot leave a fetch behind.

DNS rebinding stays out of reach — a public name that resolves to a private address is not visible to any check on the URL — and is recorded as such in the code.

## The same hole by another door

`Text` defaults to `Text.AutoText`, which promotes anything tag-shaped to rich text, and Qt's rich text engine fetches `<img>`. A message whose **subject** was `<img src="http://tracker/x.png">` therefore fired from the list row, without ever being opened; `decodeSnippet` also turned `&lt;img …&gt;` back into a real tag.

Every `Text` showing message content now declares `textFormat: Text.PlainText`, and `tests/test_qml_text_format.py` fails the build when one is forgotten. It found three I had missed by hand.

## Found while reading the rest

- **Header injection in a reply.** `ComposeView` copied the sender's `Message-ID` into `inReplyTo`, which `buildRawMessage` wrote out raw — a newline in one put a `Bcc:` in the user's reply. Header values lose their line breaks now, and a Message-ID is cut down to printable ASCII.
- **`notify-send` argument injection.** A display name of `-u` was read as an option. `--` now separates them, and the two strings are escaped: a notification body is markup to the daemons that draw it.
- **Cache directory mode.** `~/.cache/omamail` was 0755 while the message bodies inside it were 0600 — and the store holds the subject, sender and snippet of everything listed. Now `umask 077` + `chmod 700`, with the path passed as an argument rather than into shell text.
- **OAuth callback page.** The theme's colours and font name were interpolated into a `<style>`, where escaping does nothing. Both are validated now. A theme is installed rather than sent, but this is the one page here a browser renders.
- **Dead code.** `CacheStore.body` / `putBody` called `Cache` functions that no longer exist; either would have thrown.
- **`tests/test_accounts.js` was never wired into the Makefile.**

## Reviewed and left alone

PKCE S256 with a 192-bit state and a listener bound to `127.0.0.1` that takes one connection; refresh tokens to GNOME Keyring over stdin; the OAuth client in a 0600 file rather than in world-readable `shell.json`; every subprocess an argument array with no shell; `safeApiUrl` keeping the bearer token pointed at `gmail.googleapis.com`; `href` restricted to http/https/mailto; no `eval` or `Qt.createQmlObject` anywhere.

## Verification

`make test` — 13 steps, all green, including new coverage for each finding above. `qmllint` could not run on the machine this was written on (a broken Qt install); `make validate` still needs one pass on Omarchy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

