### PR TITLE
refactor: read the message with a parser, not with patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.log
 node_modules/
 .DS_Store
+.claude/worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,34 @@
   and asking covers one message. Qt's rich text engine really does fetch them,
   so rendering one fires every tracking pixel in the message.
 
+## Html.js
+
+- Qt is the renderer; this is the gate in front of it. `TextEdit` with
+  `textFormat: RichText` is a real HTML engine and it is what draws every
+  message — what Qt gives a QML plugin no say over is what that engine does
+  while it works, and it fetches `<img src>`, lays a `<style>` block's CSS out
+  as body text, and ignores `display:none`. C++ could hook
+  `QTextDocument::loadResource`; QML cannot. The string handed over is the only
+  control point there is.
+- So it parses: **tokenize → tree → clean → serialise**. Not with patterns.
+  Where a tag ends is the one thing the image policy cannot be wrong about, and
+  `/<img\b[^>]*>/` is wrong about it the moment a sender puts a `>` in an alt
+  text.
+- The parse is deliberately **not** a conformant HTML5 tree builder and must not
+  become one. A browser's parser inserts `<tbody>`, hoists content out of a
+  `<table>` and reopens formatting across a block; every one of those is a change
+  to mail nobody asked for. This one only closes what the sender left open.
+- Everything downstream walks the tree by recursion, so `MAX_TREE_DEPTH` is
+  load-bearing: without it a deeply nested message is a stack overflow inside
+  the process that draws the whole desktop.
+- The body cache holds the sender's HTML, not the sanitiser's output. A fix here
+  then applies to every message already on disk instead of only to the ones
+  fetched afterwards.
+- This runs on the GUI thread of the shell that draws the user's whole desktop.
+  Count the parses: opening a message is one `sanitize`, plus one
+  `readPlainText` when the message had no text/plain part of its own. Anything
+  that needs to know how heavy the result is asks the call that produced it.
+
 ## Anything a stranger wrote
 
 - A message body, a subject, a sender name, a snippet, an attachment filename:

--- a/Html.js
+++ b/Html.js
@@ -371,26 +371,28 @@ function serializeAttributes(attrs) {
 // Written into one array and joined once. Returning a string per level builds a
 // fresh copy of everything below it at every level, which on a document a few
 // hundred elements deep is most of the time this file spends.
-function serializeInto(node, out) {
+function serializeInto(node, out, fit) {
   if (node.type === "text") {
     out.push(node.text)
     return
   }
   if (node.type !== "root") {
-    out.push("<" + node.name + serializeAttributes(node.attrs))
+    out.push("<" + node.name + serializeAttributes(fit ? fitAttributes(node, fit) : node.attrs))
     if (VOID_ELEMENTS[node.name] === true || node.selfClosing) {
       out.push(node.selfClosing ? "/>" : ">")
       return
     }
     out.push(">")
   }
-  for (var i = 0; i < node.children.length; i++) serializeInto(node.children[i], out)
+  for (var i = 0; i < node.children.length; i++) serializeInto(node.children[i], out, fit)
   if (node.type !== "root") out.push("</" + node.name + ">")
 }
 
-function serialize(node) {
+// `fit` is applied on the way out rather than to the tree, so the tree is still
+// exactly what the parse produced and can be handed to the next width.
+function serialize(node, fit) {
   var out = []
-  serializeInto(node, out)
+  serializeInto(node, out, fit)
   return out.join("")
 }
 
@@ -1036,17 +1038,16 @@ function tooHeavyForRichText(html) {
 // derives the height from the aspect ratio on its own.
 var MIN_IMAGE_WIDTH = 40
 
-function stripImageHeightsIn(node) {
-  transform(node, function(child) {
-    if (child.name !== "img") return child
-    removeAttribute(child, "height")
-    // By name, so "max-height" is not a height: it is the clamp, and it is the
-    // one declaration that has to survive.
-    rewriteStyle(child, function(declaration) {
-      return declaration.name === "height" ? null : declaration
-    })
-    return child
-  })
+// Which of the three fittings to apply, and the width to fit to. Kept as one
+// object because they are asked for together and because the answer for an
+// element is one pass over its attributes however many of them are on.
+function fitting(heights, sides, widths, available) {
+  return {
+    heights: heights === true,
+    sides: sides === true,
+    widths: widths === true,
+    limit: Math.max(MIN_IMAGE_WIDTH, Math.floor(Number(available) || 0))
+  }
 }
 
 // Senders lay their mail out for a wide window, and at a narrow one their
@@ -1064,52 +1065,98 @@ function withoutSides(value) {
   return parts[0] + " 0"
 }
 
-function compactHorizontalIn(node) {
-  transform(node, function(child) {
-    rewriteStyle(child, function(declaration) {
-      if (SIDE_SPACING[declaration.name] === true) return null
-      if (declaration.name !== "padding" && declaration.name !== "margin") return declaration
-      return { name: declaration.name, value: withoutSides(declaration.value) }
-    })
-    return child
-  })
-}
-
 // A table told to be 600px wide inside a 380px window is a horizontal scrollbar
 // over content that would have wrapped perfectly well.
 var SIZED_ELEMENTS = { table: true, td: true, th: true, tr: true, div: true }
 
-function relaxFixedWidthsIn(node, available) {
-  var limit = Math.max(MIN_IMAGE_WIDTH, Math.floor(Number(available) || 0))
-  transform(node, function(child) {
-    if (SIZED_ELEMENTS[child.name] !== true) return child
-    var width = attributeValue(child, "width")
-    if (/^\d+$/.test(width) && Number(width) > limit) removeAttribute(child, "width")
-    rewriteStyle(child, function(declaration) {
-      if (declaration.name !== "width") return declaration
-      var pixels = declaration.value.match(/^(\d+)px$/i)
-      return pixels && Number(pixels[1]) > limit ? null : declaration
-    })
-    return child
-  })
+function fitDeclaration(declaration, node, fit) {
+  var name = declaration.name
+  if (fit.heights && node.name === "img" && name === "height") return null
+  if (fit.sides) {
+    if (SIDE_SPACING[name] === true) return null
+    if (name === "padding" || name === "margin")
+      return { name: name, value: withoutSides(declaration.value) }
+  }
+  if (fit.widths && name === "width" && SIZED_ELEMENTS[node.name] === true) {
+    var pixels = declaration.value.match(/^(\d+)px$/i)
+    if (pixels && Number(pixels[1]) > fit.limit) return null
+  }
+  return declaration
+}
+
+// The attribute list an element is written with. The node keeps its own: this
+// is the reader fitting a message to the window it happens to be, and the same
+// message is fitted again at the next width.
+function fitAttributes(node, fit) {
+  var attrs = node.attrs
+  if (attrs.length === 0) return attrs
+  var isImage = fit.heights && node.name === "img"
+  var isSized = fit.widths && SIZED_ELEMENTS[node.name] === true
+  if (!isImage && !isSized && !fit.sides) return attrs
+
+  var out = null
+  for (var i = 0; i < attrs.length; i++) {
+    var attr = attrs[i]
+    var replacement = attr
+
+    // An explicit height survives the max-width clamp, so a banner scaled from
+    // 1600 to 380 keeps its original height and renders as a smear. Measured
+    // against the engine rather than assumed: strip the heights and Qt derives
+    // the height from the aspect ratio on its own.
+    if (isImage && attr.name === "height") replacement = null
+    else if (isSized && attr.name === "width" && /^\d+$/.test(String(attr.value))
+      && Number(attr.value) > fit.limit) replacement = null
+    else if (attr.name === "style" && attr.value !== null && attr.value !== undefined) {
+      var declarations = splitDeclarations(attr.value)
+      var kept = []
+      var changed = false
+      for (var j = 0; j < declarations.length; j++) {
+        var fitted = fitDeclaration(declarations[j], node, fit)
+        if (fitted !== declarations[j]) changed = true
+        if (fitted) kept.push(fitted)
+      }
+      if (changed) {
+        var style = joinDeclarations(kept)
+        replacement = style === "" ? null : { name: "style", value: style }
+      }
+    }
+
+    if (replacement === attr) {
+      if (out !== null) out.push(attr)
+      continue
+    }
+    if (out === null) out = attrs.slice(0, i)
+    if (replacement !== null) out.push(replacement)
+  }
+  return out === null ? attrs : out
+}
+
+// The reader rebuilds its document whenever the window width or the zoom
+// changes, and the body it rebuilds from has not changed at all. One entry is
+// enough: it is always the message on screen, and the key is the body itself,
+// so a hit cannot be the wrong document. Nothing below fitting mutates a tree,
+// which is what makes keeping one safe.
+var lastParse = { source: null, tree: null }
+
+function parseForFitting(html) {
+  var text = String(html === undefined || html === null ? "" : html)
+  if (lastParse.source === text) return lastParse.tree
+  var tree = parse(text)
+  lastParse.source = text
+  lastParse.tree = tree
+  return tree
 }
 
 function stripImageHeights(html) {
-  var root = parse(html)
-  stripImageHeightsIn(root)
-  return serialize(root)
+  return serialize(parse(html), fitting(true, false, false, 0))
 }
 
 function compactHorizontal(html) {
-  var root = parse(html)
-  compactHorizontalIn(root)
-  return serialize(root)
+  return serialize(parse(html), fitting(false, true, false, 0))
 }
 
 function relaxFixedWidths(html, available) {
-  var root = parse(html)
-  relaxFixedWidthsIn(root, available)
-  return serialize(root)
+  return serialize(parse(html), fitting(false, false, true, available))
 }
 
 // Wraps the sanitised body in a document. `colors` styles the parts the sender
@@ -1125,14 +1172,11 @@ function documentFor(bodyHtml, colors) {
   var pad = Math.max(0, Math.floor(Number(palette.padding) || 0))
   var maxImage = Math.floor(Number(palette.maxImageWidth) || 0)
 
-  // One parse for all three fittings: this is rebuilt whenever the reader is
-  // resized, and the width it keys off is quantised for the same reason.
-  var root = parse(bodyHtml)
-  stripImageHeightsIn(root)
-  if (palette.compact) {
-    compactHorizontalIn(root)
-    relaxFixedWidthsIn(root, maxImage)
-  }
+  // Parsed once for every width the reader is dragged through, not once per
+  // width: this is rebuilt on every relayout and the body it is built from has
+  // not changed.
+  var root = parseForFitting(bodyHtml)
+  var fit = fitting(true, palette.compact === true, palette.compact === true, maxImage)
 
   return "<html><head><style type=\"text/css\">"
     + "body{color:" + foreground + ";background-color:" + background + ";}"
@@ -1142,7 +1186,7 @@ function documentFor(bodyHtml, colors) {
     + (maxImage >= MIN_IMAGE_WIDTH ? "img{max-width:" + maxImage + "px;}" : "")
     + "</style></head><body>"
     + (pad > 0 ? "<div style=\"padding:" + pad + "px\">" : "")
-    + serialize(root)
+    + serialize(root, fit)
     + (pad > 0 ? "</div>" : "")
     + "</body></html>"
 }

--- a/Html.js
+++ b/Html.js
@@ -1,226 +1,454 @@
 .pragma library
 
-// Message HTML, reduced to what Qt's rich text engine actually renders.
+// Message HTML, reduced to what Qt's rich text engine may safely be handed.
 //
-// Qt supports a subset of HTML 4 and CSS 2.1 natively — tables, inline
-// styles, <font>, links, images — which is most of what real email uses,
-// because real email is still table-and-inline-style HTML written for
-// Outlook. What it does not support it ignores, with two exceptions this
-// module exists to handle:
+// This is not a renderer. Qt already is one: a QTextDocument behind the
+// reader's TextEdit parses HTML 4 and CSS 2.1 and lays it out, which is most of
+// what real mail needs, because real mail is still table-and-inline-style HTML
+// written for Outlook. What Qt does not give a QML plugin is any say over what
+// that renderer does while it works, and it does three things a mail client
+// cannot allow it to do unsupervised:
 //
-//   - a <style> block's CSS text is rendered as body text
-//   - <img src="https://..."> is genuinely fetched, so every tracking pixel
-//     in the message fires the moment the reader opens it
+//   - it fetches <img src="https://..."> for real, so every tracking pixel in
+//     the message fires the moment the document is set, and a source aimed at
+//     the machine itself turns reading mail into a request to whatever is
+//     listening on it
+//   - it renders a <style> block's CSS as body text
+//   - it ignores display:none, so the 1px preheader every marketing mail
+//     carries comes out as a smudge of unreadable characters
 //
-// Remote images are therefore removed by default and the count is reported so
-// the reader can offer to load them.
+// C++ could hook QTextDocument::loadResource and decide per request. QML cannot
+// — QQuickTextDocument exposes nothing of the sort — so the only control point
+// left is what the string says before it is handed over. This file is that
+// gate, and it is deliberately the whole of it: every decision about what the
+// renderer is allowed to see or fetch is made here and nowhere else.
+//
+// It works the way any HTML consumer does, and for the same reason a regex does
+// not: parse, then decide on the tree, then write back out.
+//
+//   tokenize   text -> tags, attributes, text, comments, raw-text elements,
+//              read the way the spec reads them
+//   parse      tokens -> a tree, tolerantly: elements are closed, never moved
+//   clean      the tree -> the tree, dropping and rewriting by an allow list
+//   serialise  the tree -> the HTML subset Qt renders
+//
+// The parse is not a conformant HTML5 tree builder and must not become one. A
+// browser's parser rewrites what it reads — it inserts <tbody>, hoists content
+// out of a <table>, reopens formatting across a block — and every one of those
+// is a change to mail nobody asked for. This one only ever closes what the
+// sender left open. Structure in, same structure out, minus what was removed.
 
-var DROPPED_ELEMENTS = ["script", "style", "iframe", "object", "embed", "applet", "noscript"]
+// ================================================================ tokenizer
+//
+// One pass, no backtracking. The only question it answers that a pattern could
+// not is where things end: a tag ends at the first ">" that is not inside an
+// attribute value, and a raw-text element ends at its own closing tag and at
+// nothing else.
 
-// Qt lays rich text out synchronously on the GUI thread, and this plugin lives
-// inside the shell that draws the user's whole desktop. A message heavy enough
-// to make that layout take seconds does not just stall the reader — it stalls
-// the bar, the menu and every other panel. So the reader refuses documents past
-// these bounds and shows the plain-text part instead, with a way to override.
-var MAX_RICH_TEXT = 120000
-var MAX_ELEMENTS = 2500
-var MAX_IMAGES = 24
-// Backstop for anything flattening does not tame.
-var MAX_TABLES = 60
-var MAX_TABLE_DEPTH = 4
+var RAW_TEXT_ELEMENTS = { script: true, style: true, textarea: true, title: true }
 
-// Nesting depth is the measure that matters. Qt lays tables out by resolving
-// column widths against each other, and deeply nested tables with competing
-// widths — which is exactly how notification mail is built — can keep that
-// resolution going far longer than anyone will wait. Real mail in this mailbox
-// reaches nine levels.
-function tableDepth(html) {
-  var text = String(html || "")
-  var pattern = /<(\/?)table\b/gi
-  var depth = 0
-  var deepest = 0
-  var match
-  while ((match = pattern.exec(text)) !== null) {
-    if (match[1]) depth = Math.max(0, depth - 1)
-    else {
-      depth++
-      if (depth > deepest) deepest = depth
-    }
-  }
-  return deepest
+// Elements with no closing tag and no children. An <img> that says
+// display:none has no subtree to take with it, and a <br> never closes.
+var VOID_ELEMENTS = {
+  img: true, br: true, hr: true, input: true, meta: true, link: true,
+  area: true, base: true, col: true, embed: true, source: true, track: true,
+  wbr: true, param: true, keygen: true
 }
 
-function complexity(html) {
-  var text = String(html || "")
+// By character code, not by one-character string. This is the innermost loop in
+// the file and it runs over every byte of every message body; charAt allocates
+// a string per character, charCodeAt does not.
+function isSpaceCode(code) {
+  return code === 32 || code === 9 || code === 10 || code === 13 || code === 12
+}
+
+function isNameStartCode(code) {
+  return (code >= 97 && code <= 122) || (code >= 65 && code <= 90)
+}
+
+function isNameCode(code) {
+  return isNameStartCode(code) || (code >= 48 && code <= 57)
+    || code === 45 || code === 95 || code === 58 || code === 46
+}
+
+function matchesIgnoreCase(text, at, needle) {
+  if (at + needle.length > text.length) return false
+  return text.substr(at, needle.length).toLowerCase() === needle
+}
+
+// Reads "<name attr=value ...>" from `from`, which must be its "<".
+//
+// Returns the tag and where it ends. `terminated` is false when the source ran
+// out before the ">" — which is the case a pattern gets wrong and the case that
+// matters, because Qt swallows the remainder of the document into that tag.
+// `out` carries back where the tag ended and whether it ended at all. It is the
+// caller's, and reused: a message body is tens of thousands of tags, and an
+// object per tag to hold two numbers is an object per tag for the collector.
+function readTag(text, from, out) {
+  var length = text.length
+  var at = from + 1
+  var closing = false
+  if (text.charCodeAt(at) === 47) {
+    closing = true
+    at++
+  }
+  // A tag name starts with a letter, which is what tells "<b>" from the "<" in
+  // "3<4". Digits and dots are only allowed after that first character.
+  if (!isNameStartCode(text.charCodeAt(at))) return null
+  var nameStart = at
+  while (at < length && isNameCode(text.charCodeAt(at))) at++
+  var name = text.substring(nameStart, at).toLowerCase()
+
+  var attributes = []
+  var selfClosing = false
+  while (at < length) {
+    while (at < length && isSpaceCode(text.charCodeAt(at))) at++
+    if (at >= length) break
+    var code = text.charCodeAt(at)
+    if (code === 62) {
+      at++
+      out.end = at
+      out.terminated = true
+      return {
+        type: closing ? "end" : "start",
+        name: name,
+        attrs: attributes,
+        selfClosing: selfClosing
+      }
+    }
+    if (code === 47) {
+      selfClosing = text.charCodeAt(at + 1) === 62
+      at++
+      continue
+    }
+
+    var attrStart = at
+    while (at < length) {
+      var nameCode = text.charCodeAt(at)
+      if (isSpaceCode(nameCode) || nameCode === 61 || nameCode === 62 || nameCode === 47) break
+      at++
+    }
+    // A character that can start neither a name nor anything else: step over it
+    // rather than spinning on it.
+    if (at === attrStart) {
+      at++
+      continue
+    }
+    var attributeName = text.substring(attrStart, at).toLowerCase()
+
+    while (at < length && isSpaceCode(text.charCodeAt(at))) at++
+    var value = null
+    if (text.charCodeAt(at) === 61) {
+      at++
+      while (at < length && isSpaceCode(text.charCodeAt(at))) at++
+      var quote = text.charCodeAt(at)
+      if (quote === 34 || quote === 39) {
+        at++
+        var close = text.indexOf(quote === 34 ? "\"" : "'", at)
+        // A quote that never closes runs to the end of the document, which is
+        // also how Qt reads it.
+        value = close < 0 ? text.substring(at) : text.substring(at, close)
+        at = close < 0 ? length : close + 1
+      } else {
+        var valueStart = at
+        while (at < length) {
+          var valueCode = text.charCodeAt(at)
+          if (isSpaceCode(valueCode) || valueCode === 62) break
+          at++
+        }
+        value = text.substring(valueStart, at)
+      }
+    }
+    attributes.push({ name: attributeName, value: value })
+  }
+
+  out.end = length
+  out.terminated = false
   return {
-    length: text.length,
-    tags: (text.match(/<[a-zA-Z]/g) || []).length,
-    images: (text.match(/<img\b/gi) || []).length,
-    tables: (text.match(/<table\b/gi) || []).length,
-    tableDepth: tableDepth(text)
+    type: closing ? "end" : "start",
+    name: name,
+    attrs: attributes,
+    selfClosing: selfClosing
   }
 }
 
-// Tables past this depth become plain blocks. Two levels covers the real
-// tabular content in mail — a status table, a receipt — while the layers above
-// it are only there to centre a card in an Outlook window.
-var KEEP_TABLE_DEPTH = 2
-var TABLE_TAG = /<(\/?)(table|thead|tbody|tfoot|tr|td|th)\b([^>]*)>/gi
-
-function keptStyle(attrs) {
-  var style = String(attrs || "").match(/\sstyle\s*=\s*("[^"]*"|'[^']*')/i)
-  return style ? " style=" + style[1] : ""
-}
-
-function flattenTables(html, keepDepth) {
-  var limit = keepDepth === undefined ? KEEP_TABLE_DEPTH : Math.max(0, keepDepth)
-  var depth = 0
-  return String(html || "").replace(TABLE_TAG, function(tag, slash, name, attrs) {
-    var lower = String(name).toLowerCase()
-    if (lower === "table") {
-      if (slash) {
-        var closing = depth > limit
-        depth = Math.max(0, depth - 1)
-        return closing ? "</div>" : tag
-      }
-      depth++
-      return depth > limit ? "<div" + keptStyle(attrs) + ">" : tag
-    }
-    if (depth > limit) return slash ? "</div>" : "<div" + keptStyle(attrs) + ">"
-    return tag
-  })
-}
-
-function tooHeavyForRichText(html) {
-  var size = complexity(html)
-  return size.length > MAX_RICH_TEXT
-    || size.tags > MAX_ELEMENTS
-    || size.tables > MAX_TABLES
-    || size.tableDepth > MAX_TABLE_DEPTH
-}
-
-// A 1x1 image is a tracking pixel, never something to look at. Dropping them
-// removes both the beacon and a layout pass per message.
-function isTrackingPixel(tag) {
-  var width = tag.match(/\swidth\s*=\s*"?(\d+)/i)
-  var height = tag.match(/\sheight\s*=\s*"?(\d+)/i)
-  if (width && Number(width[1]) <= 2) return true
-  if (height && Number(height[1]) <= 2) return true
-  return /(width|height)\s*:\s*[012](\.\d+)?px/i.test(tag)
-}
-
-// Senders ship their own palette: a background *and* the text colour that
-// suits it. Removing only the background is what makes a message unreadable —
-// GitHub's #24292e text would sit on a #131313 ground — so both go, and the
-// document stylesheet supplies the pair. Anything that survives (images,
-// borders) belongs to the sender.
-var COLOUR_DECLARATION = /(^|;)\s*(color|background|background-color|border-color|outline-color)\s*:[^;]*/gi
-
-function stripColorsFromStyle(style) {
-  return String(style || "")
-    .replace(COLOUR_DECLARATION, "$1")
-    // Removing a declaration from the middle leaves the separators on both
-    // sides of it, which Qt reads as an empty rule.
-    .replace(/;{2,}/g, ";")
-    .replace(/^[;\s]+|[;\s]+$/g, "")
-}
-
-function stripColors(html) {
-  var text = String(html || "")
-  // Presentational attributes first: bgcolor and <font color> predate CSS and
-  // still turn up in mail written for Outlook.
-  text = text.replace(/\s(bgcolor|background|bordercolor)\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, "")
-  text = text.replace(/\s(color)\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, "")
-  return text.replace(/\sstyle\s*=\s*("([^"]*)"|'([^']*)')/gi,
-    function(match, raw, dq, sq) {
-      var cleaned = stripColorsFromStyle(dq !== undefined ? dq : sq)
-      return cleaned === "" ? "" : " style=\"" + cleaned + "\""
-    })
-}
-
-// A url() in an inline style is a fetch wherever the engine honours it, and
-// which declarations Qt honours is not worth having to be right about: nothing
-// in mail needs one, because pictures arrive as <img>, which is where the image
-// policy lives. The declaration goes rather than the whole attribute, so the
-// padding and the font beside it survive.
-function stripStyleUrls(html) {
-  return String(html || "").replace(/\sstyle\s*=\s*("([^"]*)"|'([^']*)')/gi,
-    function(match, raw, dq, sq) {
-      var value = dq !== undefined ? dq : sq
-      if (!/url\s*\(/i.test(decodeReferences(value))) return match
-      var parts = String(value).split(";")
-      var kept = []
-      for (var i = 0; i < parts.length; i++) {
-        if (/url\s*\(/i.test(decodeReferences(parts[i]))) continue
-        if (parts[i].replace(/\s+/g, "") !== "") kept.push(parts[i])
-      }
-      var cleaned = kept.join(";").replace(/^[;\s]+|[;\s]+$/g, "")
-      return cleaned === "" ? "" : " style=\"" + cleaned + "\""
-    })
-}
-
-function stripElement(text, name) {
-  var open = new RegExp("<" + name + "\\b[^>]*>[\\s\\S]*?<\\/" + name + "\\s*>", "gi")
-  var lone = new RegExp("<\\/?" + name + "\\b[^>]*>", "gi")
-  return String(text).replace(open, "").replace(lone, "")
-}
-
-// ------------------------------------------------------------- tag boundaries
-//
-// Where a tag ends is the one thing the image policy below cannot afford to be
-// wrong about, and /<img\b[^>]*>/ is wrong about it. Qt's parser reads
-// attribute values with their quotes, so
-//
-//   <img alt="a>b" src="http://127.0.0.1/p.gif">
-//
-// is one image tag to the engine and two pieces of nothing to that regex: it
-// stops at the ">" inside the alt text, finds no src in what it took, and hands
-// the whole tag back untouched — which is a fetch. A sender only has to put a
-// ">" in an alt text to walk past the check.
-//
-// Qt has no HTML parser a QML plugin can call, so tag boundaries are scanned
-// for rather than matched. This is not a parser and does not try to be one: it
-// answers exactly one question, which is where a tag someone opened stops.
-function tagEnd(text, from) {
-  var quote = ""
-  for (var i = from; i < text.length; i++) {
-    var character = text.charAt(i)
-    if (quote !== "") {
-      if (character === quote) quote = ""
-      continue
-    }
-    if (character === "\"" || character === "'") {
-      quote = character
-      continue
-    }
-    if (character === ">") return i + 1
+// Where a raw-text element's content stops. Per the spec this is the first
+// "</name" followed by whitespace, "/" or ">" — a "</style>" inside a CSS
+// string really does end the stylesheet, which is why a <style> block cannot be
+// trusted to contain its own contents.
+function findRawTextEnd(text, from, name) {
+  var needle = "</" + name
+  for (var at = from; at < text.length; at++) {
+    if (text.charAt(at) !== "<") continue
+    if (!matchesIgnoreCase(text, at, needle)) continue
+    // NaN when the needle ran to the end of the document, which ends it too.
+    var after = text.charCodeAt(at + needle.length)
+    if (!isNaN(after) && after !== 62 && after !== 47 && !isSpaceCode(after)) continue
+    var close = text.indexOf(">", at + needle.length)
+    return { contentEnd: at, next: close < 0 ? text.length : close + 1 }
   }
-  return -1
+  return { contentEnd: text.length, next: text.length }
 }
 
-// Every <name ...> tag rewritten through `fn`, which is handed the whole tag and
-// returns what stands in its place. A tag that never closes takes the rest of
-// the document with it: Qt would swallow the remainder into the tag anyway, and
-// dropping it is the reading that cannot leave a fetch behind.
-function replaceTags(html, name, fn) {
-  var text = String(html || "")
-  var opening = new RegExp("<" + name + "\\b", "gi")
-  var out = ""
+// With a `visit`, tokens are handed over one at a time and nothing is kept;
+// without one they come back as an array. The tree builder takes the first
+// form, because a message body is tens of thousands of tokens and building a
+// list of them only to walk it once is a list nobody needed.
+function tokenize(html, visit) {
+  var text = String(html === undefined || html === null ? "" : html)
+  var tokens = visit ? null : []
+  var emit = visit || function(token) { tokens.push(token) }
+  var pending = ""
   var at = 0
-  var found
-  while ((found = opening.exec(text)) !== null) {
-    if (found.index < at) continue
-    var end = tagEnd(text, found.index + found[0].length)
-    out += text.substring(at, found.index)
-    if (end < 0) return out
-    out += fn(text.substring(found.index, end))
-    at = end
-    opening.lastIndex = end
+  var out = { end: 0, terminated: false }
+
+  function flushText() {
+    if (pending === "") return
+    emit({ type: "text", text: pending })
+    pending = ""
   }
-  return out + text.substring(at)
+
+  while (at < text.length) {
+    var open = text.indexOf("<", at)
+    if (open < 0) {
+      pending += text.substring(at)
+      break
+    }
+    pending += text.substring(at, open)
+
+    // By code: this runs at every "<" in the document, and substr+toLowerCase
+    // here allocates two strings per tag for a four-character test.
+    if (text.charCodeAt(open + 1) === 33 && text.charCodeAt(open + 2) === 45
+      && text.charCodeAt(open + 3) === 45) {
+      var commentEnd = text.indexOf("-->", open + 4)
+      flushText()
+      emit({ type: "comment" })
+      at = commentEnd < 0 ? text.length : commentEnd + 3
+      continue
+    }
+    // <!DOCTYPE ...>, <?xml ...> and anything else that is not a tag: a
+    // declaration, ending at the first ">".
+    var second = text.charCodeAt(open + 1)
+    if (second === 33 || second === 63) {
+      var declarationEnd = text.indexOf(">", open + 2)
+      flushText()
+      emit({ type: "declaration" })
+      at = declarationEnd < 0 ? text.length : declarationEnd + 1
+      continue
+    }
+
+    var token = readTag(text, open, out)
+    if (!token) {
+      // A "<" that starts no tag is a "<" the sender typed.
+      pending += "<"
+      at = open + 1
+      continue
+    }
+    flushText()
+    if (out.terminated) emit(token)
+    // An unterminated tag took the rest of the document with it, so there is
+    // nothing after it to keep and nothing about it worth keeping.
+    at = out.end
+    if (!out.terminated) break
+
+    if (token.type === "start" && !token.selfClosing
+      && RAW_TEXT_ELEMENTS[token.name] === true) {
+      var raw = findRawTextEnd(text, at, token.name)
+      emit({ type: "text", text: text.substring(at, raw.contentEnd), raw: true })
+      emit({ type: "end", name: token.name })
+      at = raw.next
+    }
+  }
+
+  flushText()
+  return tokens
 }
 
-// ------------------------------------------------------------ image sources
+// ===================================================================== tree
+//
+// Tolerant, and tolerant in one direction only: it closes what the sender left
+// open and it discards a close that matches nothing. It never moves an element,
+// never invents one, and never reopens anything — a browser's parser does all
+// three, and each of them is a change to the message that nobody asked for.
+
+// Openings that imply the close of a sibling. Mail is full of <td> and <li>
+// left unclosed, and without these each one nests inside the last until the
+// whole message is one deep staircase.
+var IMPLIED_CLOSE = {
+  li: { li: true },
+  p: { p: true },
+  dt: { dt: true, dd: true },
+  dd: { dt: true, dd: true },
+  tr: { tr: true, td: true, th: true },
+  td: { td: true, th: true },
+  th: { td: true, th: true },
+  thead: { thead: true, tbody: true, tfoot: true },
+  tbody: { thead: true, tbody: true, tfoot: true },
+  tfoot: { thead: true, tbody: true, tfoot: true },
+  option: { option: true }
+}
+
+function elementNode(token) {
+  return {
+    type: "element",
+    name: token.name,
+    attrs: token.attrs,
+    selfClosing: token.selfClosing === true,
+    children: []
+  }
+}
+
+// How deep the tree may go. Everything downstream of the parse walks it by
+// recursion, so without a ceiling a message nested a few thousand elements deep
+// is a stack overflow — inside the process that draws the whole desktop. Real
+// mail reaches nine levels of tables, which is about forty elements; past this
+// an element still keeps its content, it just stops adding a level to hold it.
+// Qt would not survive laying such a document out either, and
+// tooHeavyForRichText refuses it a step later.
+var MAX_TREE_DEPTH = 128
+
+function parse(html) {
+  var root = { type: "root", children: [] }
+  var stack = [root]
+
+  tokenize(html, function(token) {
+    var top = stack[stack.length - 1]
+
+    if (token.type === "text") {
+      if (token.text !== "")
+        top.children.push({ type: "text", text: token.text, raw: token.raw === true })
+      return
+    }
+    // A comment or a doctype has nothing a reader needs, and Qt would lay the
+    // doctype out as text.
+    if (token.type !== "start" && token.type !== "end") return
+
+    if (token.type === "start") {
+      var implied = IMPLIED_CLOSE[token.name]
+      if (implied) {
+        while (stack.length > 1 && implied[stack[stack.length - 1].name] === true) stack.pop()
+        top = stack[stack.length - 1]
+      }
+      var node = elementNode(token)
+      top.children.push(node)
+      if (VOID_ELEMENTS[token.name] !== true && !node.selfClosing
+        && stack.length < MAX_TREE_DEPTH) stack.push(node)
+      return
+    }
+
+    // An end tag closes the nearest ancestor of that name, and everything still
+    // open inside it. One that matches nothing open is noise, and dropping it
+    // is the only reading that cannot close something the sender meant to keep.
+    for (var depth = stack.length - 1; depth > 0; depth--) {
+      if (stack[depth].name === token.name) {
+        stack.length = depth
+        return
+      }
+    }
+  })
+
+  return root
+}
+
+// =============================================================== serialiser
+//
+// Back into the subset Qt renders. Attribute values keep whatever character
+// references the sender wrote — they are the value, and re-escaping them would
+// turn "&amp;" into "&amp;amp;" on every round trip — so only the quote that
+// delimits them has to go.
+
+function serializeAttributes(attrs) {
+  var out = ""
+  for (var i = 0; i < attrs.length; i++) {
+    var attr = attrs[i]
+    out += " " + attr.name
+    if (attr.value === null || attr.value === undefined) continue
+    out += "=\"" + String(attr.value).replace(/"/g, "&quot;") + "\""
+  }
+  return out
+}
+
+// Written into one array and joined once. Returning a string per level builds a
+// fresh copy of everything below it at every level, which on a document a few
+// hundred elements deep is most of the time this file spends.
+function serializeInto(node, out) {
+  if (node.type === "text") {
+    out.push(node.text)
+    return
+  }
+  if (node.type !== "root") {
+    out.push("<" + node.name + serializeAttributes(node.attrs))
+    if (VOID_ELEMENTS[node.name] === true || node.selfClosing) {
+      out.push(node.selfClosing ? "/>" : ">")
+      return
+    }
+    out.push(">")
+  }
+  for (var i = 0; i < node.children.length; i++) serializeInto(node.children[i], out)
+  if (node.type !== "root") out.push("</" + node.name + ">")
+}
+
+function serialize(node) {
+  var out = []
+  serializeInto(node, out)
+  return out.join("")
+}
+
+// A tree walk that may replace a node with nothing, with itself, or with its
+// own children. Returning null drops the subtree; returning "unwrap" keeps the
+// children and drops the element around them.
+function transform(node, visit) {
+  var kept = []
+  for (var i = 0; i < node.children.length; i++) {
+    var child = node.children[i]
+    if (child.type === "text") {
+      kept.push(child)
+      continue
+    }
+    var verdict = visit(child)
+    if (verdict === null) continue
+    transform(child, visit)
+    if (verdict === "unwrap") {
+      for (var j = 0; j < child.children.length; j++) kept.push(child.children[j])
+      continue
+    }
+    kept.push(child)
+  }
+  node.children = kept
+  return node
+}
+
+function attributeOf(node, name) {
+  for (var i = 0; i < node.attrs.length; i++) {
+    if (node.attrs[i].name === name) return node.attrs[i]
+  }
+  return null
+}
+
+function attributeValue(node, name) {
+  var attr = attributeOf(node, name)
+  return attr && attr.value !== null && attr.value !== undefined ? String(attr.value) : ""
+}
+
+function removeAttribute(node, name) {
+  var kept = []
+  for (var i = 0; i < node.attrs.length; i++) {
+    if (node.attrs[i].name !== name) kept.push(node.attrs[i])
+  }
+  node.attrs = kept
+}
+
+function setStyle(node, style) {
+  var attr = attributeOf(node, "style")
+  if (style === "") {
+    if (attr) removeAttribute(node, "style")
+    return
+  }
+  if (attr) attr.value = style
+  else node.attrs.push({ name: "style", value: style })
+}
+
+// ================================================ what a source may point at
 //
 // An attribute value is not a URL until the HTML parser has resolved the
 // character references inside it. Qt does that before it fetches anything, so
@@ -228,7 +456,17 @@ function replaceTags(html, name, fn) {
 // check reading the raw attribute text sees something that starts with an "&"
 // and lets it through. Tab and newline inside a URL are dropped for the same
 // reason: they are not part of it by the time the fetch is made.
-var NAMED_REFERENCES = { amp: "&", quot: "\"", apos: "'", lt: "<", gt: ">", sol: "/", colon: ":" }
+// The named references mail actually uses. An unknown one is left as written,
+// which is what Qt does with it too.
+var NAMED_REFERENCES = {
+  amp: "&", quot: "\"", apos: "'", lt: "<", gt: ">", sol: "/", colon: ":",
+  nbsp: " ", ensp: " ", emsp: " ", thinsp: " ",
+  mdash: "\u2014", ndash: "\u2013", hellip: "\u2026", bull: "\u2022",
+  lsquo: "\u2018", rsquo: "\u2019", ldquo: "\u201c", rdquo: "\u201d",
+  middot: "\u00b7", copy: "\u00a9", reg: "\u00ae", trade: "\u2122",
+  deg: "\u00b0", times: "\u00d7", laquo: "\u00ab", raquo: "\u00bb",
+  euro: "\u20ac", pound: "\u00a3", yen: "\u00a5", cent: "\u00a2", sect: "\u00a7"
+}
 
 function decodeReferences(text) {
   return String(text).replace(/&(#[0-9]+|#[xX][0-9a-fA-F]+|[a-zA-Z]+);?/g,
@@ -370,75 +608,262 @@ function safeHref(value) {
   return /^\s*(https?:|mailto:)/i.test(String(value || ""))
 }
 
+
+// ========================================================= style declarations
+//
+// Split on ";", but not on a ";" inside a quoted string or inside url(...),
+// where it is part of the value rather than the end of one.
+
+function splitDeclarations(style) {
+  var text = String(style === undefined || style === null ? "" : style)
+  var out = []
+  var current = ""
+  var quote = ""
+  var depth = 0
+  for (var i = 0; i < text.length; i++) {
+    var character = text.charAt(i)
+    if (quote !== "") {
+      current += character
+      if (character === quote) quote = ""
+      continue
+    }
+    if (character === "\"" || character === "'") {
+      quote = character
+      current += character
+      continue
+    }
+    if (character === "(") depth++
+    else if (character === ")") depth = Math.max(0, depth - 1)
+    else if (character === ";" && depth === 0) {
+      out.push(current)
+      current = ""
+      continue
+    }
+    current += character
+  }
+  out.push(current)
+
+  var declarations = []
+  for (var j = 0; j < out.length; j++) {
+    var piece = out[j]
+    if (piece.replace(/\s+/g, "") === "") continue
+    var colon = piece.indexOf(":")
+    if (colon < 0) continue
+    declarations.push({
+      name: piece.substring(0, colon).replace(/^\s+|\s+$/g, "").toLowerCase(),
+      value: piece.substring(colon + 1).replace(/^\s+|\s+$/g, "")
+    })
+  }
+  return declarations
+}
+
+function joinDeclarations(declarations) {
+  var parts = []
+  for (var i = 0; i < declarations.length; i++) {
+    if (declarations[i].value === "") continue
+    parts.push(declarations[i].name + ":" + declarations[i].value)
+  }
+  return parts.join(";")
+}
+
+// Rewrites an element's style attribute through `decide`, which is handed each
+// declaration and returns it, a replacement, or null to drop it.
+function rewriteStyle(node, decide) {
+  var attr = attributeOf(node, "style")
+  if (!attr || attr.value === null || attr.value === undefined) return
+  var declarations = splitDeclarations(attr.value)
+  var kept = []
+  for (var i = 0; i < declarations.length; i++) {
+    var verdict = decide(declarations[i])
+    if (verdict) kept.push(verdict)
+  }
+  setStyle(node, joinDeclarations(kept))
+}
+
+// ================================================================== passes
+//
+// Each of these is a decision about the tree. They are exported one by one
+// because each encodes a fact measured against Qt's engine and each is worth
+// being able to test on its own; `sanitize` runs them in one walk rather than
+// parsing the document once per pass.
+
+// Elements whose content Qt would either lay out as text or has no business
+// seeing. <style> and <script> are the ones that matter: their CSS and their
+// source come out as body text.
+var DROPPED_ELEMENTS = {
+  script: true, style: true, iframe: true, object: true, embed: true,
+  applet: true, noscript: true, meta: true, link: true, base: true,
+  // Raw-text elements whose content is not body text and which Qt lays out as
+  // if it were. Nearly every marketing mail ships <head><title>, and it came
+  // out as a stray line above the message.
+  title: true, textarea: true
+}
+
+// Senders ship their own palette: a background *and* the text colour that
+// suits it. Removing only the background is what makes a message unreadable —
+// GitHub's #24292e text would sit on a #131313 ground — so both go, and the
+// document stylesheet supplies the pair. Anything that survives (images,
+// borders) belongs to the sender.
+var COLOUR_ATTRIBUTES = { bgcolor: true, background: true, bordercolor: true, color: true }
+var COLOUR_DECLARATIONS = {
+  color: true, background: true, "background-color": true,
+  "border-color": true, "outline-color": true
+}
+
+function stripColorsFrom(node) {
+  for (var name in COLOUR_ATTRIBUTES) removeAttribute(node, name)
+  rewriteStyle(node, function(declaration) {
+    return COLOUR_DECLARATIONS[declaration.name] === true ? null : declaration
+  })
+}
+
+// A url() in an inline style is a fetch wherever the engine honours it, and
+// which declarations Qt honours is not worth having to be right about: nothing
+// in mail needs one, because pictures arrive as <img>, which is where the image
+// policy lives.
+function stripStyleUrlsFrom(node) {
+  rewriteStyle(node, function(declaration) {
+    return /url\s*\(/i.test(decodeReferences(declaration.value)) ? null : declaration
+  })
+}
+
 // Qt's rich text engine ignores display:none outright — measured: a hidden div
 // adds a full line of text to the layout. It does honour font-size, though, and
 // the standard email preheader is hidden text set at 1px, so it comes out as a
 // two-pixel smudge of unreadable characters above the message. Elements the
 // sender marked hidden are therefore removed rather than styled away.
-var HIDDEN_STYLE = /(display\s*:\s*none|visibility\s*:\s*hidden)/i
-var VOID_ELEMENTS = /^(img|br|hr|input|meta|link|area|base|col|embed|source|track|wbr)$/i
-
-// Counts nesting, so a hidden wrapper takes exactly its own subtree and not
-// whatever happens to close first.
-function closeIndexFor(text, name, from) {
-  var pattern = new RegExp("<(/?)" + name + "\\b[^>]*>", "gi")
-  pattern.lastIndex = from
-  var depth = 1
-  var found = pattern.exec(text)
-  while (found !== null) {
-    if (found[1] === "/") {
-      depth--
-      if (depth === 0) return pattern.lastIndex
-    } else if (found[0].charAt(found[0].length - 2) !== "/") {
-      depth++
-    }
-    found = pattern.exec(text)
+function isHidden(node) {
+  if (VOID_ELEMENTS[node.name] === true) return false
+  var style = attributeValue(node, "style")
+  if (style === "") return false
+  var declarations = splitDeclarations(style)
+  for (var i = 0; i < declarations.length; i++) {
+    var declaration = declarations[i]
+    if (declaration.name === "display" && /^none\b/i.test(declaration.value)) return true
+    if (declaration.name === "visibility" && /^hidden\b/i.test(declaration.value)) return true
   }
-  return -1
+  return false
 }
 
-function dropHidden(html) {
-  var text = String(html || "")
-  var opening = /<([a-z][a-z0-9]*)\b([^>]*)>/gi
-  var found = opening.exec(text)
-  while (found !== null) {
-    var name = found[1]
-    if (!VOID_ELEMENTS.test(name) && HIDDEN_STYLE.test(found[2] || "")) {
-      var end = closeIndexFor(text, name, opening.lastIndex)
-      if (end < 0) end = text.length
-      text = text.substring(0, found.index) + text.substring(end)
-      opening.lastIndex = found.index
-    }
-    found = opening.exec(text)
+// A 1x1 image is a tracking pixel, never something to look at. Dropping them
+// removes both the beacon and a layout pass per message.
+function isTrackingPixel(node) {
+  var width = Number(attributeValue(node, "width"))
+  var height = Number(attributeValue(node, "height"))
+  if (isFinite(width) && attributeValue(node, "width") !== "" && width <= 2) return true
+  if (isFinite(height) && attributeValue(node, "height") !== "" && height <= 2) return true
+  var declarations = splitDeclarations(attributeValue(node, "style"))
+  for (var i = 0; i < declarations.length; i++) {
+    if (declarations[i].name !== "width" && declarations[i].name !== "height") continue
+    if (/^[012](\.\d+)?px/i.test(declarations[i].value)) return true
   }
-  return text
+  return false
+}
+
+// Tables past this depth become plain blocks. Two levels covers the real
+// tabular content in mail — a status table, a receipt — while the layers above
+// it are only there to centre a card in an Outlook window.
+var KEEP_TABLE_DEPTH = 2
+var TABLE_PARTS = {
+  table: true, thead: true, tbody: true, tfoot: true, tr: true, td: true, th: true
+}
+
+// Depth is what matters, not count. Qt lays tables out by resolving column
+// widths against each other, and deeply nested tables with competing widths —
+// which is exactly how notification mail is built — can keep that resolution
+// going far longer than anyone will wait. Real mail in this mailbox reaches
+// nine levels.
+function flattenTablesIn(node, limit, depth) {
+  var kept = []
+  for (var i = 0; i < node.children.length; i++) {
+    var child = node.children[i]
+    if (child.type === "text") {
+      kept.push(child)
+      continue
+    }
+    var childDepth = child.name === "table" ? depth + 1 : depth
+    flattenTablesIn(child, limit, childDepth)
+    if (TABLE_PARTS[child.name] === true && childDepth > limit) {
+      // The layers above a real table exist to position it, so what is worth
+      // keeping is the styling that rode on them, not the table semantics.
+      var style = attributeValue(child, "style")
+      child.name = "div"
+      child.attrs = style === "" ? [] : [{ name: "style", value: style }]
+    }
+    kept.push(child)
+  }
+  node.children = kept
+}
+
+// ================================================================ sanitize
+//
+// Qt lays rich text out synchronously on the GUI thread, and this plugin lives
+// inside the shell that draws the user's whole desktop. A message heavy enough
+// to make that layout take seconds does not just stall the reader — it stalls
+// the bar, the menu and every other panel. So the reader refuses documents past
+// these bounds and shows the plain-text part instead, with a way to override.
+var MAX_RICH_TEXT = 120000
+var MAX_ELEMENTS = 2500
+var MAX_IMAGES = 24
+// Backstop for anything flattening does not tame.
+var MAX_TABLES = 60
+var MAX_TABLE_DEPTH = 4
+
+// One walk over one element's attributes. Doing it as four passes — colours,
+// then handlers, then hrefs, then styles — rebuilt the array four times for
+// every element in the document, which on a large message is most of the work.
+var HANDLER_ATTRIBUTE = /^on[a-z]+$/
+
+function cleanAttributes(node, keepColors) {
+  var attrs = node.attrs
+  var kept = attrs
+  var dropped = false
+  var style = null
+
+  for (var i = 0; i < attrs.length; i++) {
+    var attr = attrs[i]
+    var name = attr.name
+    var drop = false
+    if (!keepColors && COLOUR_ATTRIBUTES[name] === true) drop = true
+    // Event handlers, which Qt ignores but which have no business surviving a
+    // trip through a mail client.
+    else if (name.charCodeAt(0) === 111 && HANDLER_ATTRIBUTE.test(name)) drop = true
+    else if (name === "href" && !safeHref(attr.value)) drop = true
+    else if (name === "style") style = attr
+
+    if (drop && !dropped) {
+      dropped = true
+      kept = attrs.slice(0, i)
+    } else if (!drop && dropped) {
+      kept.push(attr)
+    }
+  }
+  if (dropped) node.attrs = kept
+  if (style === null || style.value === null || style.value === undefined) return
+
+  // The style attribute is the only one worth parsing, and most elements have
+  // none, so it is only parsed when one is there.
+  var declarations = splitDeclarations(style.value)
+  var survivors = []
+  for (var j = 0; j < declarations.length; j++) {
+    var declaration = declarations[j]
+    if (!keepColors && COLOUR_DECLARATIONS[declaration.name] === true) continue
+    if (/url\s*\(/i.test(declaration.value)
+      && /url\s*\(/i.test(decodeReferences(declaration.value))) continue
+    survivors.push(declaration)
+  }
+  setStyle(node, joinDeclarations(survivors))
 }
 
 function sanitize(html, options) {
   var settings = options || {}
-  var text = String(html === undefined || html === null ? "" : html)
-  if (text === "") return { html: "", blockedImages: 0, images: 0, remoteImages: 0 }
+  var source = String(html === undefined || html === null ? "" : html)
+  if (source === "") return { html: "", blockedImages: 0, images: 0, remoteImages: 0 }
 
-  // The message takes the window's theme, so the sender's palette comes out
-  // before anything else looks at the markup.
-  if (settings.keepColors !== true) text = stripColors(text)
-  if (settings.keepTables !== true) text = flattenTables(text, settings.keepTableDepth)
-
-  text = text.replace(/<!--[\s\S]*?-->/g, "")
-  text = stripStyleUrls(text)
-  text = dropHidden(text)
-  for (var i = 0; i < DROPPED_ELEMENTS.length; i++) text = stripElement(text, DROPPED_ELEMENTS[i])
-  text = text.replace(/<(meta|link|base)\b[^>]*>/gi, "")
-
-  // Event handlers, which Qt ignores but which have no business surviving a
-  // trip through a mail client.
-  text = text.replace(/\son[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, "")
-
-  text = text.replace(/\shref\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/gi,
-    function(match, raw, dq, sq, bare) {
-      var value = dq !== undefined ? dq : (sq !== undefined ? sq : bare)
-      return safeHref(value) ? match : ""
-    })
+  var keepColors = settings.keepColors === true
+  var allowImages = settings.allowRemoteImages === true
+  var limit = Math.max(0, Math.floor(
+    settings.maxImages === undefined ? MAX_IMAGES : settings.maxImages))
 
   // Every remote image is a network fetch Qt performs while laying the document
   // out, and every completed fetch triggers another layout pass. Tracking
@@ -451,46 +876,157 @@ function sanitize(html, options) {
   var blocked = 0
   var kept = 0
   var loadable = 0
-  var allowImages = settings.allowRemoteImages === true
-  var limit = Math.max(0, Math.floor(
-    settings.maxImages === undefined ? MAX_IMAGES : settings.maxImages))
 
-  text = replaceTags(text, "img", function(tag) {
-    var source = tag.match(/\ssrc\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/i)
-    if (!source) return tag
-    var value = source[2] !== undefined ? source[2]
-      : (source[3] !== undefined ? source[3] : source[4])
-    var kind = imageSourceKind(value)
-    // Removed rather than emptied: an <img> with no src still reserves a
-    // broken-image box in Qt's layout, which reads as a rendering fault.
-    if (kind === "inline" || kind === "none") return tag
+  function keepImage(node) {
+    var source = attributeValue(node, "src")
+    if (attributeOf(node, "src") === null) return true
+    var kind = imageSourceKind(source)
+    // cid: and data: are the message's own bytes and never touch the network.
+    if (kind === "inline" || kind === "none") return true
     // Neither a local read nor a private-network request is something the
-    // reader can ever be offered, so these are dropped without being counted
-    // as something "show images" would bring back.
-    if (kind !== "remote") return ""
-    if (isTrackingPixel(tag)) {
+    // reader can ever be offered, so these go without being counted as
+    // something "show images" would bring back.
+    if (kind !== "remote") return false
+    if (isTrackingPixel(node)) {
       blocked++
-      return ""
+      return false
     }
     if (loadable < limit) loadable++
     if (!allowImages || kept >= limit) {
       blocked++
-      return ""
+      return false
     }
     kept++
-    return tag
-  })
+    return true
+  }
 
-  return { html: text, blockedImages: blocked, images: kept, remoteImages: loadable }
+  function clean(node) {
+    var survivors = []
+    for (var i = 0; i < node.children.length; i++) {
+      var child = node.children[i]
+      if (child.type === "text") {
+        survivors.push(child)
+        continue
+      }
+      if (DROPPED_ELEMENTS[child.name] === true) continue
+      if (isHidden(child)) continue
+
+      cleanAttributes(child, keepColors)
+
+      if (child.name === "img" && !keepImage(child)) continue
+
+      clean(child)
+      survivors.push(child)
+    }
+    node.children = survivors
+  }
+
+  var root = parse(source)
+  clean(root)
+  if (settings.keepTables !== true) {
+    flattenTablesIn(root, settings.keepTableDepth === undefined
+      ? KEEP_TABLE_DEPTH : Math.max(0, settings.keepTableDepth), 0)
+  }
+
+  // Measured off the tree that is already in hand. The reader needs to know
+  // whether this document is too heavy to lay out, and asking with the string
+  // would mean parsing the whole thing a second time to count what was just
+  // counted.
+  var text = serialize(root)
+  var size = { length: text.length, tags: 0, images: 0, tables: 0, tableDepth: 0 }
+  size.tableDepth = measure(root, 0, size)
+
+  return {
+    html: text,
+    blockedImages: blocked,
+    images: kept,
+    remoteImages: loadable,
+    complexity: size,
+    tooHeavy: isTooHeavy(size)
+  }
 }
 
 function hasRemoteImages(html) {
   return sanitize(html).blockedImages > 0
 }
 
-// Wraps the sanitised body in a document. `colors` styles the parts the sender
-// did not: the ground, the default text, links and quoted replies.
-// ------------------------------------------------------------ fitting
+// ---------------------------------------------------------- single passes
+
+function stripColors(html) {
+  var root = parse(html)
+  transform(root, function(node) {
+    stripColorsFrom(node)
+    return node
+  })
+  return serialize(root)
+}
+
+function dropHidden(html) {
+  var root = parse(html)
+  transform(root, function(node) {
+    return isHidden(node) ? null : node
+  })
+  return serialize(root)
+}
+
+function flattenTables(html, keepDepth) {
+  var root = parse(html)
+  flattenTablesIn(root, keepDepth === undefined ? KEEP_TABLE_DEPTH : Math.max(0, keepDepth), 0)
+  return serialize(root)
+}
+
+function stripElement(html, name) {
+  var wanted = String(name || "").toLowerCase()
+  var root = parse(html)
+  transform(root, function(node) {
+    return node.name === wanted ? null : node
+  })
+  return serialize(root)
+}
+
+// =============================================================== complexity
+
+function measure(node, depth, size) {
+  var deepest = depth
+  for (var i = 0; i < node.children.length; i++) {
+    var child = node.children[i]
+    if (child.type === "text") continue
+    size.tags++
+    if (child.name === "img") size.images++
+    var childDepth = depth
+    if (child.name === "table") {
+      size.tables++
+      childDepth = depth + 1
+    }
+    var reached = measure(child, childDepth, size)
+    if (reached > deepest) deepest = reached
+  }
+  return deepest
+}
+
+function complexity(html) {
+  var text = String(html === undefined || html === null ? "" : html)
+  var size = { length: text.length, tags: 0, images: 0, tables: 0, tableDepth: 0 }
+  size.tableDepth = measure(parse(text), 0, size)
+  return size
+}
+
+function tableDepth(html) {
+  return complexity(html).tableDepth
+}
+
+function isTooHeavy(size) {
+  return size.length > MAX_RICH_TEXT
+    || size.tags > MAX_ELEMENTS
+    || size.tables > MAX_TABLES
+    || size.tableDepth > MAX_TABLE_DEPTH
+}
+
+function tooHeavyForRichText(html) {
+  return isTooHeavy(complexity(html))
+}
+
+// ============================================================ fitting to width
 //
 // Qt's rich text engine takes max-width on images, but only in pixels: a
 // percentage collapses the image to nothing at all. An explicit height
@@ -500,45 +1036,84 @@ function hasRemoteImages(html) {
 // derives the height from the aspect ratio on its own.
 var MIN_IMAGE_WIDTH = 40
 
-function stripImageHeights(html) {
-  return String(html || "").replace(/<img\b[^>]*>/gi, function(tag) {
-    return tag
-      .replace(/\sheight\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, "")
-      // The character before "height" keeps "max-height" from matching.
-      .replace(/([;"'\s])height\s*:[^;"']*/gi, "$1")
+function stripImageHeightsIn(node) {
+  transform(node, function(child) {
+    if (child.name !== "img") return child
+    removeAttribute(child, "height")
+    // By name, so "max-height" is not a height: it is the clamp, and it is the
+    // one declaration that has to survive.
+    rewriteStyle(child, function(declaration) {
+      return declaration.name === "height" ? null : declaration
+    })
+    return child
   })
 }
 
 // Senders lay their mail out for a wide window, and at a narrow one their
 // horizontal padding is most of the screen. The vertical rhythm is worth
 // keeping; the side gutters are not.
-function compactHorizontal(html) {
-  return String(html || "")
-    .replace(/([;"'\s])(padding|margin)-(left|right)\s*:[^;"']*/gi, "$1")
-    .replace(/([;"'\s])(padding|margin)\s*:\s*([^;"']*)/gi,
-      function(all, lead, prop, value) {
-        var parts = String(value).trim().split(/\s+/)
-        if (parts.length >= 4) return lead + prop + ":" + parts[0] + " 0 " + parts[2] + " 0"
-        if (parts.length === 3) return lead + prop + ":" + parts[0] + " 0 " + parts[2]
-        return lead + prop + ":" + parts[0] + " 0"
-      })
+var SIDE_SPACING = {
+  "padding-left": true, "padding-right": true,
+  "margin-left": true, "margin-right": true
+}
+
+function withoutSides(value) {
+  var parts = String(value).replace(/^\s+|\s+$/g, "").split(/\s+/)
+  if (parts.length >= 4) return parts[0] + " 0 " + parts[2] + " 0"
+  if (parts.length === 3) return parts[0] + " 0 " + parts[2]
+  return parts[0] + " 0"
+}
+
+function compactHorizontalIn(node) {
+  transform(node, function(child) {
+    rewriteStyle(child, function(declaration) {
+      if (SIDE_SPACING[declaration.name] === true) return null
+      if (declaration.name !== "padding" && declaration.name !== "margin") return declaration
+      return { name: declaration.name, value: withoutSides(declaration.value) }
+    })
+    return child
+  })
 }
 
 // A table told to be 600px wide inside a 380px window is a horizontal scrollbar
 // over content that would have wrapped perfectly well.
-function relaxFixedWidths(html, available) {
+var SIZED_ELEMENTS = { table: true, td: true, th: true, tr: true, div: true }
+
+function relaxFixedWidthsIn(node, available) {
   var limit = Math.max(MIN_IMAGE_WIDTH, Math.floor(Number(available) || 0))
-  return String(html || "").replace(/<(table|td|th|tr|div)\b[^>]*>/gi, function(tag) {
-    return tag
-      .replace(/\swidth\s*=\s*(?:"(\d+)"|'(\d+)'|(\d+))/gi, function(match, a, b, c) {
-        return Number(a || b || c) > limit ? "" : match
-      })
-      .replace(/([;"'\s])width\s*:\s*(\d+)px/gi, function(match, lead, px) {
-        return Number(px) > limit ? lead : match
-      })
+  transform(node, function(child) {
+    if (SIZED_ELEMENTS[child.name] !== true) return child
+    var width = attributeValue(child, "width")
+    if (/^\d+$/.test(width) && Number(width) > limit) removeAttribute(child, "width")
+    rewriteStyle(child, function(declaration) {
+      if (declaration.name !== "width") return declaration
+      var pixels = declaration.value.match(/^(\d+)px$/i)
+      return pixels && Number(pixels[1]) > limit ? null : declaration
+    })
+    return child
   })
 }
 
+function stripImageHeights(html) {
+  var root = parse(html)
+  stripImageHeightsIn(root)
+  return serialize(root)
+}
+
+function compactHorizontal(html) {
+  var root = parse(html)
+  compactHorizontalIn(root)
+  return serialize(root)
+}
+
+function relaxFixedWidths(html, available) {
+  var root = parse(html)
+  relaxFixedWidthsIn(root, available)
+  return serialize(root)
+}
+
+// Wraps the sanitised body in a document. `colors` styles the parts the sender
+// did not: the ground, the default text, links and quoted replies.
 function documentFor(bodyHtml, colors) {
   var palette = colors || {}
   var foreground = String(palette.foreground || "")
@@ -549,8 +1124,16 @@ function documentFor(bodyHtml, colors) {
   // on a wrapper the sender's markup sits inside.
   var pad = Math.max(0, Math.floor(Number(palette.padding) || 0))
   var maxImage = Math.floor(Number(palette.maxImageWidth) || 0)
-  var body = stripImageHeights(bodyHtml)
-  if (palette.compact) body = relaxFixedWidths(compactHorizontal(body), maxImage)
+
+  // One parse for all three fittings: this is rebuilt whenever the reader is
+  // resized, and the width it keys off is quantised for the same reason.
+  var root = parse(bodyHtml)
+  stripImageHeightsIn(root)
+  if (palette.compact) {
+    compactHorizontalIn(root)
+    relaxFixedWidthsIn(root, maxImage)
+  }
+
   return "<html><head><style type=\"text/css\">"
     + "body{color:" + foreground + ";background-color:" + background + ";}"
     + "a{color:" + link + ";}"
@@ -559,43 +1142,85 @@ function documentFor(bodyHtml, colors) {
     + (maxImage >= MIN_IMAGE_WIDTH ? "img{max-width:" + maxImage + "px;}" : "")
     + "</style></head><body>"
     + (pad > 0 ? "<div style=\"padding:" + pad + "px\">" : "")
-    + body
+    + serialize(root)
     + (pad > 0 ? "</div>" : "")
     + "</body></html>"
 }
 
-// ------------------------------------------------------- plain text bodies
+// ========================================================= plain text bodies
 //
 // The reader falls back to plain text when the user asks for it and when a
 // message is too heavy to lay out as rich text. Both cases still want the
-// images to be reachable, so the markers htmlToText leaves behind are turned
-// into links — and this document is built here rather than taken from the
-// sender, so it stays trivially cheap to lay out even for the messages that
-// were too heavy in the first place.
+// images to be reachable, so the markers `toText` leaves behind are turned into
+// links — and this document is built here rather than taken from the sender, so
+// it stays trivially cheap to lay out even for the messages that were too heavy
+// in the first place.
 
 var IMAGE_LINK_PREFIX = "omarchy-image:"
 
-// Counted off the sender's own HTML, with exactly the parts htmlToText drops
-// dropped first. The markers in the text are numbered by that same walk, so the
-// two lists line up position for position — counting these off the sanitised
-// HTML instead would drift the moment a tracking pixel was removed or the image
-// cap was reached, and every marker after it would open the wrong picture.
-function imageSources(html) {
-  var out = []
-  // The same pattern Message.htmlToText numbers the markers with, quotes and
-  // all: the two walks have to see the same tags or every marker after a
-  // disagreement opens the wrong picture. Not the scanner sanitize uses —
-  // nothing here is fetched, so a miss costs a marker rather than a request.
-  var pattern = /<img\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi
-  var tags = String(html || "")
-    .replace(/<!--[\s\S]*?-->/g, "")
-    .replace(/<(script|style)[\s\S]*?<\/\1>/gi, "")
-    .match(pattern) || []
-  for (var i = 0; i < tags.length; i++) {
-    var src = tags[i].match(/\ssrc\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/i)
-    out.push(src ? String(src[2] || src[3] || src[4] || "") : "")
+// Closing one of these ends a line. Everything else is inline as far as a
+// plain-text reading is concerned.
+var BLOCK_ELEMENTS = {
+  p: true, div: true, tr: true, li: true, blockquote: true, section: true,
+  article: true, header: true, footer: true, table: true, ul: true, ol: true,
+  h1: true, h2: true, h3: true, h4: true, h5: true, h6: true
+}
+
+// Images become a marker rather than nothing at all. Stripped outright — which
+// is what removing every tag does — a message built around its pictures reads
+// as a long run of unexplained blank space, with no way to tell an empty
+// message from one whose contents happen not to be text. The number is what
+// lets the reader offer the image itself when the marker is clicked.
+//
+// The markers and `imageSources` are numbered by the same walk over the same
+// tree, so the two lists line up position for position. They have to: a marker
+// that disagrees with the list opens somebody else's picture.
+function flatten(node, state) {
+  for (var i = 0; i < node.children.length; i++) {
+    var child = node.children[i]
+    if (child.type === "text") {
+      if (!child.raw) state.text += decodeReferences(child.text)
+      continue
+    }
+    if (DROPPED_ELEMENTS[child.name] === true) continue
+    if (child.name === "img") {
+      state.images.push(imageSourceOf(child))
+      state.text += "[image " + state.images.length + "]"
+      continue
+    }
+    if (child.name === "br") {
+      state.text += "\n"
+      continue
+    }
+    if (child.name === "li") state.text += "• "
+    flatten(child, state)
+    if (BLOCK_ELEMENTS[child.name] === true) state.text += "\n"
   }
-  return out
+  return state
+}
+
+function imageSourceOf(node) {
+  var attr = attributeOf(node, "src")
+  return attr && attr.value !== null && attr.value !== undefined ? String(attr.value) : ""
+}
+
+function readPlainText(html) {
+  var state = flatten(parse(html), { text: "", images: [] })
+  state.text = state.text
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/^\s+|\s+$/g, "")
+  return state
+}
+
+// The sender's HTML as text, with a numbered marker where each picture was.
+function toText(html) {
+  return readPlainText(html).text
+}
+
+// The pictures those numbers point at, in the same order.
+function imageSources(html) {
+  return readPlainText(html).images
 }
 
 function escapeText(text) {

--- a/Html.js
+++ b/Html.js
@@ -869,6 +869,74 @@ function cleanAttributes(node, keepColors, declarations) {
   setStyle(node, survivors)
 }
 
+// ----------------------------------------------------------- scaffolding
+//
+// Real mail is mostly scaffolding. A card centred in an Outlook window is six
+// or seven boxes deep, and flattening the tables past the second turns every
+// layer above that into a div with nothing on it — in a live mailbox they are
+// most of the tree.
+//
+// They are not free. Qt parses each one back out of the string, gives it a box
+// and lays the box out, and that half of the work is the half this file cannot
+// move or measure. Handing it a smaller document is the only lever on it.
+//
+// Two shapes, and only two, because both are provably the same document:
+// a box with nothing on it around a single box is that box, and an inline
+// element with nothing on it is nothing at all.
+var TRANSPARENT_INLINE = { span: true, font: true, small: true, big: true }
+// Not <center>: Qt honours it, and a card that was centred would come out
+// against the left edge. A container only counts as plain when it carries no
+// meaning of its own — which is the whole test being applied here.
+var PLAIN_CONTAINER = {
+  div: true, section: true, article: true, aside: true,
+  header: true, footer: true, main: true, nav: true
+}
+
+// The one block this element holds, or null if it holds anything else.
+// Whitespace between blocks is not content and does not count against it.
+function soleBlockChild(node) {
+  var found = null
+  for (var i = 0; i < node.children.length; i++) {
+    var child = node.children[i]
+    if (child.type === "text") {
+      if (child.text.replace(/[\s\u00a0]+/g, "") !== "") return null
+      continue
+    }
+    if (found !== null) return null
+    if (BLOCK_ELEMENTS[child.name] !== true) return null
+    found = child
+  }
+  return found
+}
+
+// Bottom up, so a stack of seven collapses to one rather than to six.
+function collapse(node) {
+  var kept = []
+  for (var i = 0; i < node.children.length; i++) {
+    var child = node.children[i]
+    if (child.type === "text") {
+      kept.push(child)
+      continue
+    }
+    collapse(child)
+    if (child.attrs.length === 0) {
+      if (TRANSPARENT_INLINE[child.name] === true) {
+        for (var j = 0; j < child.children.length; j++) kept.push(child.children[j])
+        continue
+      }
+      if (PLAIN_CONTAINER[child.name] === true) {
+        var inner = soleBlockChild(child)
+        if (inner !== null) {
+          kept.push(inner)
+          continue
+        }
+      }
+    }
+    kept.push(child)
+  }
+  node.children = kept
+}
+
 function sanitize(html, options) {
   var settings = options || {}
   var source = String(html === undefined || html === null ? "" : html)
@@ -962,6 +1030,8 @@ function sanitize(html, options) {
     flattenTablesIn(root, settings.keepTableDepth === undefined
       ? KEEP_TABLE_DEPTH : Math.max(0, settings.keepTableDepth), 0)
   }
+
+  collapse(root)
 
   // Measured off the tree that is already in hand. The reader needs to know
   // whether this document is too heavy to lay out, and asking with the string

--- a/Html.js
+++ b/Html.js
@@ -96,8 +96,18 @@ function readTag(text, from, out) {
   // "3<4". Digits and dots are only allowed after that first character.
   if (!isNameStartCode(text.charCodeAt(at))) return null
   var nameStart = at
-  while (at < length && isNameCode(text.charCodeAt(at))) at++
-  var name = text.substring(nameStart, at).toLowerCase()
+  var upper = false
+  while (at < length) {
+    var nameCode = text.charCodeAt(at)
+    if (!isNameCode(nameCode)) break
+    if (nameCode >= 65 && nameCode <= 90) upper = true
+    at++
+  }
+  // Almost every tag and attribute in real mail is already lower case, and
+  // toLowerCase on a string that is already lower case still walks it and can
+  // still hand back a copy. Cheaper to have noticed while reading it.
+  var name = text.substring(nameStart, at)
+  if (upper) name = name.toLowerCase()
 
   var attributes = []
   var selfClosing = false
@@ -123,9 +133,11 @@ function readTag(text, from, out) {
     }
 
     var attrStart = at
+    var attrUpper = false
     while (at < length) {
-      var nameCode = text.charCodeAt(at)
-      if (isSpaceCode(nameCode) || nameCode === 61 || nameCode === 62 || nameCode === 47) break
+      var attrCode = text.charCodeAt(at)
+      if (isSpaceCode(attrCode) || attrCode === 61 || attrCode === 62 || attrCode === 47) break
+      if (attrCode >= 65 && attrCode <= 90) attrUpper = true
       at++
     }
     // A character that can start neither a name nor anything else: step over it
@@ -134,7 +146,8 @@ function readTag(text, from, out) {
       at++
       continue
     }
-    var attributeName = text.substring(attrStart, at).toLowerCase()
+    var attributeName = text.substring(attrStart, at)
+    if (attrUpper) attributeName = attributeName.toLowerCase()
 
     while (at < length && isSpaceCode(text.charCodeAt(at))) at++
     var value = null
@@ -734,17 +747,20 @@ function stripStyleUrlsFrom(node) {
 // the standard email preheader is hidden text set at 1px, so it comes out as a
 // two-pixel smudge of unreadable characters above the message. Elements the
 // sender marked hidden are therefore removed rather than styled away.
-function isHidden(node) {
-  if (VOID_ELEMENTS[node.name] === true) return false
-  var style = attributeValue(node, "style")
-  if (style === "") return false
-  var declarations = splitDeclarations(style)
+function isHiddenBy(declarations) {
   for (var i = 0; i < declarations.length; i++) {
     var declaration = declarations[i]
     if (declaration.name === "display" && /^none\b/i.test(declaration.value)) return true
     if (declaration.name === "visibility" && /^hidden\b/i.test(declaration.value)) return true
   }
   return false
+}
+
+function isHidden(node) {
+  if (VOID_ELEMENTS[node.name] === true) return false
+  var style = attributeValue(node, "style")
+  if (style === "") return false
+  return isHiddenBy(splitDeclarations(style))
 }
 
 // A 1x1 image is a tracking pixel, never something to look at. Dropping them
@@ -816,11 +832,10 @@ var MAX_TABLE_DEPTH = 4
 // every element in the document, which on a large message is most of the work.
 var HANDLER_ATTRIBUTE = /^on[a-z]+$/
 
-function cleanAttributes(node, keepColors) {
+function cleanAttributes(node, keepColors, declarations) {
   var attrs = node.attrs
   var kept = attrs
   var dropped = false
-  var style = null
 
   for (var i = 0; i < attrs.length; i++) {
     var attr = attrs[i]
@@ -831,7 +846,6 @@ function cleanAttributes(node, keepColors) {
     // trip through a mail client.
     else if (name.charCodeAt(0) === 111 && HANDLER_ATTRIBUTE.test(name)) drop = true
     else if (name === "href" && !safeHref(attr.value)) drop = true
-    else if (name === "style") style = attr
 
     if (drop && !dropped) {
       dropped = true
@@ -841,11 +855,8 @@ function cleanAttributes(node, keepColors) {
     }
   }
   if (dropped) node.attrs = kept
-  if (style === null || style.value === null || style.value === undefined) return
+  if (declarations === null) return
 
-  // The style attribute is the only one worth parsing, and most elements have
-  // none, so it is only parsed when one is there.
-  var declarations = splitDeclarations(style.value)
   var survivors = []
   for (var j = 0; j < declarations.length; j++) {
     var declaration = declarations[j]
@@ -860,8 +871,6 @@ function cleanAttributes(node, keepColors) {
 function sanitize(html, options) {
   var settings = options || {}
   var source = String(html === undefined || html === null ? "" : html)
-  if (source === "") return { html: "", blockedImages: 0, images: 0, remoteImages: 0 }
-
   var keepColors = settings.keepColors === true
   var allowImages = settings.allowRemoteImages === true
   var limit = Math.max(0, Math.floor(
@@ -911,9 +920,20 @@ function sanitize(html, options) {
         continue
       }
       if (DROPPED_ELEMENTS[child.name] === true) continue
-      if (isHidden(child)) continue
 
-      cleanAttributes(child, keepColors)
+      // The style attribute is the only one worth parsing, and it is parsed
+      // once per element: whether the sender marked this hidden and what
+      // survives of its declarations are two questions about the same list.
+      // Most elements in real mail carry one, so asking twice was most of a
+      // second pass over the document.
+      var style = attributeOf(child, "style")
+      var declarations = style !== null && style.value !== null && style.value !== undefined
+        ? splitDeclarations(style.value)
+        : null
+      if (declarations !== null && VOID_ELEMENTS[child.name] !== true
+        && isHiddenBy(declarations)) continue
+
+      cleanAttributes(child, keepColors, declarations)
 
       if (child.name === "img" && !keepImage(child)) continue
 
@@ -924,6 +944,18 @@ function sanitize(html, options) {
   }
 
   var root = parse(source)
+
+  // Read as text before anything is dropped, and only when a caller asked: the
+  // reader wants both of these for a message with no text/plain part of its
+  // own, and the tokenize underneath is the most expensive thing this file
+  // does — paying for it twice to get two readings of one document is the
+  // whole reason this is an option rather than a second call.
+  //
+  // Before, specifically. A message's third picture is its third picture
+  // whether or not the first two were beacons, so the markers are numbered off
+  // the sender's own tree and not off what survives the image policy.
+  var plain = settings.withPlainText === true ? readTree(root) : null
+
   clean(root)
   if (settings.keepTables !== true) {
     flattenTablesIn(root, settings.keepTableDepth === undefined
@@ -944,7 +976,8 @@ function sanitize(html, options) {
     images: kept,
     remoteImages: loadable,
     complexity: size,
-    tooHeavy: isTooHeavy(size)
+    tooHeavy: isTooHeavy(size),
+    plainText: plain
   }
 }
 
@@ -1248,8 +1281,8 @@ function imageSourceOf(node) {
   return attr && attr.value !== null && attr.value !== undefined ? String(attr.value) : ""
 }
 
-function readPlainText(html) {
-  var state = flatten(parse(html), { text: "", images: [] })
+function readTree(root) {
+  var state = flatten(root, { text: "", images: [] })
   state.text = state.text
     .replace(/[ \t]+\n/g, "\n")
     .replace(/\n{3,}/g, "\n\n")
@@ -1257,14 +1290,10 @@ function readPlainText(html) {
   return state
 }
 
-// The sender's HTML as text, with a numbered marker where each picture was.
-function toText(html) {
-  return readPlainText(html).text
-}
-
-// The pictures those numbers point at, in the same order.
-function imageSources(html) {
-  return readPlainText(html).images
+// The sender's HTML as text, with a numbered marker where each picture was, and
+// the pictures those numbers point at.
+function readPlainText(html) {
+  return readTree(parse(html))
 }
 
 function escapeText(text) {

--- a/Html.js
+++ b/Html.js
@@ -453,8 +453,9 @@ function removeAttribute(node, name) {
   node.attrs = kept
 }
 
-function setStyle(node, style) {
+function setStyle(node, declarations) {
   var attr = attributeOf(node, "style")
+  var style = joinDeclarations(declarations)
   if (style === "") {
     if (attr) removeAttribute(node, "style")
     return
@@ -692,7 +693,7 @@ function rewriteStyle(node, decide) {
     var verdict = decide(declarations[i])
     if (verdict) kept.push(verdict)
   }
-  setStyle(node, joinDeclarations(kept))
+  setStyle(node, kept)
 }
 
 // ================================================================== passes
@@ -865,7 +866,7 @@ function cleanAttributes(node, keepColors, declarations) {
       && /url\s*\(/i.test(decodeReferences(declaration.value))) continue
     survivors.push(declaration)
   }
-  setStyle(node, joinDeclarations(survivors))
+  setStyle(node, survivors)
 }
 
 function sanitize(html, options) {
@@ -977,7 +978,11 @@ function sanitize(html, options) {
     remoteImages: loadable,
     complexity: size,
     tooHeavy: isTooHeavy(size),
-    plainText: plain
+    plainText: plain,
+    // The document itself, so the reader can fit it to a window without
+    // parsing back the string that was just written from it. Nothing below
+    // fitting mutates a tree, which is what makes handing this out safe.
+    document: root
   }
 }
 
@@ -1165,19 +1170,13 @@ function fitAttributes(node, fit) {
 }
 
 // The reader rebuilds its document whenever the window width or the zoom
-// changes, and the body it rebuilds from has not changed at all. One entry is
-// enough: it is always the message on screen, and the key is the body itself,
-// so a hit cannot be the wrong document. Nothing below fitting mutates a tree,
-// which is what makes keeping one safe.
-var lastParse = { source: null, tree: null }
-
-function parseForFitting(html) {
-  var text = String(html === undefined || html === null ? "" : html)
-  if (lastParse.source === text) return lastParse.tree
-  var tree = parse(text)
-  lastParse.source = text
-  lastParse.tree = tree
-  return tree
+// changes, and the body it rebuilds from has not changed at all — so it hands
+// over the document `sanitize` already built rather than the string that was
+// written from it, and a whole drag costs no parse at all. A string is still
+// accepted, because a caller that only has one should not have to care.
+function documentTree(source) {
+  if (source && source.type === "root") return source
+  return parse(source)
 }
 
 function stripImageHeights(html) {
@@ -1205,10 +1204,9 @@ function documentFor(bodyHtml, colors) {
   var pad = Math.max(0, Math.floor(Number(palette.padding) || 0))
   var maxImage = Math.floor(Number(palette.maxImageWidth) || 0)
 
-  // Parsed once for every width the reader is dragged through, not once per
-  // width: this is rebuilt on every relayout and the body it is built from has
-  // not changed.
-  var root = parseForFitting(bodyHtml)
+  // No parse at all when the caller kept the document: this is rebuilt on every
+  // relayout, and the body it is built from has not changed.
+  var root = documentTree(bodyHtml)
   var fit = fitting(true, palette.compact === true, palette.compact === true, maxImage)
 
   return "<html><head><style type=\"text/css\">"

--- a/MailAccount.qml
+++ b/MailAccount.qml
@@ -444,19 +444,16 @@ Item {
       root.selectedMessage = summary
       var decoded = Mail.extractBody(payload.payload)
       var rawHtml = Mail.extractHtml(payload.payload)
-      // The markers in the plain-text body and the pictures they stand for are
-      // numbered by one walk over one tree, so a marker cannot open somebody
-      // else's image. Only when the text came from the HTML: a message that
-      // shipped its own text/plain part never had images in it, and flattening
-      // it anyway would be a second parse of the whole body for nothing.
-      var flattened = decoded.source === "html" && rawHtml !== ""
-        ? Html.readPlainText(rawHtml)
-        : null
-      if (flattened) decoded = ({ text: flattened.text, source: "html" })
+      // Both readings of the body out of one parse. The markers in the
+      // plain-text one and the pictures they stand for are numbered by the same
+      // walk over the same tree, so a marker cannot open somebody else's image
+      // — and it is only asked for when the text came from the HTML, because a
+      // message that shipped its own text/plain part never had images in it.
+      var ready = root.renderSource(rawHtml, decoded.source === "html")
+      if (ready.plainText) decoded = ({ text: ready.plainText.text, source: "html" })
       root.selectedBody = decoded
-      root.renderSource(rawHtml)
       root.selectedAttachments = Mail.attachments(payload.payload)
-      root.selectedImages = flattened ? flattened.images : []
+      root.selectedImages = ready.plainText ? ready.plainText.images : []
       bodyCache.put(messageId, ({
         text: decoded.text,
         source: decoded.source,
@@ -472,16 +469,21 @@ Item {
   }
 
   // The one place `selectedHtml` is set, and the only place the sender's markup
-  // is parsed on the way to the screen. Whether the document is too heavy to
-  // lay out comes back from the same call: asking separately would mean parsing
-  // the whole body again to count what was just counted.
-  function renderSource(source) {
+  // is parsed on the way to the screen. Everything else the reader needs to
+  // know about this body comes back from the same call — how heavy it is, and
+  // its plain-text reading — because each of those asked separately is another
+  // parse of the whole message to work out what was just worked out.
+  function renderSource(source, withPlainText) {
     sourceHtml = String(source || "")
-    var ready = Html.sanitize(sourceHtml, ({ allowRemoteImages: remoteImagesAllowed }))
+    var ready = Html.sanitize(sourceHtml, ({
+      allowRemoteImages: remoteImagesAllowed,
+      withPlainText: withPlainText === true
+    }))
     selectedHtml = ready.html
     selectedBlockedImages = ready.blockedImages
     selectedRemoteImages = ready.remoteImages
     selectedTooHeavy = ready.tooHeavy
+    return ready
   }
 
   function showRemoteImages() {

--- a/MailAccount.qml
+++ b/MailAccount.qml
@@ -93,10 +93,12 @@ Item {
   // where it exists, which is native and skips the per-character base64 loop
   // that made this the one expensive step in opening a message.
   property string selectedHtml: ""
-  // The same document with the sender's remote images still in it. This is what
-  // the body cache holds and what `selectedHtml` is derived from, so asking for
-  // the images is a re-render rather than another trip to Gmail.
-  property string preparedHtml: ""
+  // The sender's own HTML, exactly as Gmail handed it over. This is what the
+  // body cache holds and what `selectedHtml` is derived from — so asking for the
+  // images is a re-render rather than another trip to Gmail, and a sanitiser
+  // that learns something new applies it to every message already on disk
+  // rather than only to the ones fetched afterwards.
+  property string sourceHtml: ""
   // Off for every message, every time it is opened. Fetching a sender's images
   // tells them the mail was read, from which address and when, so it happens
   // only when the reader has asked — and asking covers this message alone.
@@ -407,7 +409,7 @@ Item {
     selectedMessage = null
     selectedBody = { text: "", source: "" }
     selectedHtml = ""
-    preparedHtml = ""
+    sourceHtml = ""
     remoteImagesAllowed = false
     selectedBlockedImages = 0
     selectedRemoteImages = 0
@@ -423,10 +425,8 @@ Item {
     bodyCache.read(messageId, function(cached) {
       if (serial !== root.detailSerial) return
       if (root.detailLive || !cached) return
-      // The body is already decoded here, so sanitising it costs a fraction
-      // of a millisecond — worth doing inline to paint in the same frame.
       root.selectedBody = { text: cached.text, source: cached.source }
-      root.renderPrepared(cached.html)
+      root.renderSource(cached.html)
       root.selectedAttachments = cached.attachments
       root.selectedImages = cached.images
       bodyCache.touch(messageId)
@@ -444,18 +444,23 @@ Item {
       root.selectedMessage = summary
       var decoded = Mail.extractBody(payload.payload)
       var rawHtml = Mail.extractHtml(payload.payload)
-      // Sanitised once with the images left in, so the cache keeps a document
-      // the reader can still be shown the pictures of; what reaches the screen
-      // is derived from it below, with them out.
-      var prepared = Html.sanitize(rawHtml, ({ allowRemoteImages: true })).html
+      // The markers in the plain-text body and the pictures they stand for are
+      // numbered by one walk over one tree, so a marker cannot open somebody
+      // else's image. Only when the text came from the HTML: a message that
+      // shipped its own text/plain part never had images in it, and flattening
+      // it anyway would be a second parse of the whole body for nothing.
+      var flattened = decoded.source === "html" && rawHtml !== ""
+        ? Html.readPlainText(rawHtml)
+        : null
+      if (flattened) decoded = ({ text: flattened.text, source: "html" })
       root.selectedBody = decoded
-      root.renderPrepared(prepared)
+      root.renderSource(rawHtml)
       root.selectedAttachments = Mail.attachments(payload.payload)
-      root.selectedImages = Html.imageSources(rawHtml)
+      root.selectedImages = flattened ? flattened.images : []
       bodyCache.put(messageId, ({
         text: decoded.text,
         source: decoded.source,
-        html: prepared,
+        html: rawHtml,
         attachments: root.selectedAttachments,
         images: root.selectedImages
       }))
@@ -466,22 +471,23 @@ Item {
     })
   }
 
-  // The one place `selectedHtml` is set. Sanitising the prepared document again
-  // is what removes or restores the images, and it is cheap enough to do on a
-  // button press: the expensive part of opening a message is the decode above.
-  function renderPrepared(prepared) {
-    preparedHtml = String(prepared || "")
-    var ready = Html.sanitize(preparedHtml, ({ allowRemoteImages: remoteImagesAllowed }))
+  // The one place `selectedHtml` is set, and the only place the sender's markup
+  // is parsed on the way to the screen. Whether the document is too heavy to
+  // lay out comes back from the same call: asking separately would mean parsing
+  // the whole body again to count what was just counted.
+  function renderSource(source) {
+    sourceHtml = String(source || "")
+    var ready = Html.sanitize(sourceHtml, ({ allowRemoteImages: remoteImagesAllowed }))
     selectedHtml = ready.html
     selectedBlockedImages = ready.blockedImages
     selectedRemoteImages = ready.remoteImages
-    selectedTooHeavy = Html.tooHeavyForRichText(ready.html)
+    selectedTooHeavy = ready.tooHeavy
   }
 
   function showRemoteImages() {
-    if (remoteImagesAllowed || preparedHtml === "") return
+    if (remoteImagesAllowed || sourceHtml === "") return
     remoteImagesAllowed = true
-    renderPrepared(preparedHtml)
+    renderSource(sourceHtml)
   }
 
   function clearSelection() {
@@ -492,7 +498,7 @@ Item {
     selectedMessage = null
     selectedBody = { text: "", source: "" }
     selectedHtml = ""
-    preparedHtml = ""
+    sourceHtml = ""
     remoteImagesAllowed = false
     selectedImages = []
     selectedBlockedImages = 0

--- a/MailAccount.qml
+++ b/MailAccount.qml
@@ -99,6 +99,11 @@ Item {
   // that learns something new applies it to every message already on disk
   // rather than only to the ones fetched afterwards.
   property string sourceHtml: ""
+  // The parsed document behind `selectedHtml`. The reader fits it to whatever
+  // width it happens to be and rebuilds on every relayout, so handing over the
+  // tree rather than the string is the difference between one parse per message
+  // and one per drag step.
+  property var selectedDocument: null
   // Off for every message, every time it is opened. Fetching a sender's images
   // tells them the mail was read, from which address and when, so it happens
   // only when the reader has asked — and asking covers this message alone.
@@ -409,6 +414,7 @@ Item {
     selectedMessage = null
     selectedBody = { text: "", source: "" }
     selectedHtml = ""
+    selectedDocument = null
     sourceHtml = ""
     remoteImagesAllowed = false
     selectedBlockedImages = 0
@@ -449,11 +455,17 @@ Item {
       // walk over the same tree, so a marker cannot open somebody else's image
       // — and it is only asked for when the text came from the HTML, because a
       // message that shipped its own text/plain part never had images in it.
-      var ready = root.renderSource(rawHtml, decoded.source === "html")
-      if (ready.plainText) decoded = ({ text: ready.plainText.text, source: "html" })
-      root.selectedBody = decoded
+      // A body never changes once fetched, which is what makes the cache
+      // correct — so when the cache already painted this exact markup there is
+      // nothing here to paint again, and rendering it would be a second parse
+      // of the whole message to arrive at the document already on screen.
+      if (rawHtml !== root.sourceHtml || root.selectedDocument === null) {
+        var ready = root.renderSource(rawHtml, decoded.source === "html")
+        if (ready.plainText) decoded = ({ text: ready.plainText.text, source: "html" })
+        root.selectedBody = decoded
+        root.selectedImages = ready.plainText ? ready.plainText.images : []
+      }
       root.selectedAttachments = Mail.attachments(payload.payload)
-      root.selectedImages = ready.plainText ? ready.plainText.images : []
       bodyCache.put(messageId, ({
         text: decoded.text,
         source: decoded.source,
@@ -480,6 +492,7 @@ Item {
       withPlainText: withPlainText === true
     }))
     selectedHtml = ready.html
+    selectedDocument = ready.document
     selectedBlockedImages = ready.blockedImages
     selectedRemoteImages = ready.remoteImages
     selectedTooHeavy = ready.tooHeavy
@@ -500,6 +513,7 @@ Item {
     selectedMessage = null
     selectedBody = { text: "", source: "" }
     selectedHtml = ""
+    selectedDocument = null
     sourceHtml = ""
     remoteImagesAllowed = false
     selectedImages = []

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ QML_FILES := Service.qml MailAccount.qml BarWidget.qml App.qml \
 	components/SetupPage.qml \
 	components/ShortcutHelp.qml
 
-.PHONY: test test-js test-shell qml-check validate
+.PHONY: test test-js test-shell qml-check validate bench
 
 test: test-js test-shell
 
@@ -47,6 +47,13 @@ test-shell:
 	bash tests/test_source.sh
 	bash tests/test_service_source.sh
 	bash tests/test_install.sh
+
+# Both engines on the same fixtures. The QML column is the one that decides
+# anything — the shell runs that engine, not node's — so run it on the machine
+# the shell runs on. Not part of `test`: it takes a few seconds and measures
+# rather than asserts.
+bench:
+	bash tests/bench.sh
 
 # Needs the Omarchy shell's qs.Commons / qs.Ui on the import path.
 qml-check:

--- a/Message.js
+++ b/Message.js
@@ -327,9 +327,10 @@ function htmlToText(html) {
   return String(html || "")
     .replace(/<!--[\s\S]*?-->/g, "")
     .replace(/<(script|style)[\s\S]*?<\/\1>/gi, "")
-    // Quotes and all, because Html.imageSources numbers the pictures with the
-    // same walk: a ">" inside an alt text that ends the tag for one and not the
-    // other puts every marker after it on the wrong image.
+    // The reader does not use this numbering: MailAccount takes the body text
+    // and the picture list from one walk over Html.js's parse tree, so the two
+    // cannot disagree. What is left here serves decodeSnippet, where Gmail's
+    // snippet is escaped prose that never carried an image.
     .replace(/<img\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi, function() {
       imageCount++
       return "[image " + imageCount + "]"

--- a/Service.qml
+++ b/Service.qml
@@ -338,6 +338,7 @@ Item {
   readonly property var selectedMessage: current ? current.selectedMessage : null
   readonly property var selectedBody: current ? current.selectedBody : ({ text: "", source: "" })
   readonly property string selectedHtml: current ? current.selectedHtml : ""
+  readonly property var selectedDocument: current ? current.selectedDocument : null
   readonly property var selectedImages: current ? current.selectedImages : []
   readonly property int selectedBlockedImages: current ? current.selectedBlockedImages : 0
   readonly property int selectedRemoteImages: current ? current.selectedRemoteImages : 0

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -44,6 +44,9 @@ Item {
   // would let a crafted one aim a request at whatever is listening on this
   // machine. They come back only when the reader asks, for this message alone.
   readonly property string rawHtml: service ? service.selectedHtml : ""
+  // The parsed form of the same document. Fitting it to this window is done on
+  // the way out, so this is rebuilt on every relayout without being reparsed.
+  readonly property var bodyDocument: service ? service.selectedDocument : null
   readonly property int remoteImages: service ? service.selectedRemoteImages : 0
   readonly property bool remoteImagesAllowed: !!service && service.remoteImagesAllowed
   // Qt lays rich text out on the GUI thread, and this plugin lives inside the
@@ -301,7 +304,7 @@ Item {
       // fell back to plain text because their own markup was too heavy.
       textFormat: TextEdit.RichText
       text: root.htmlAvailable
-        ? Html.documentFor(root.rawHtml, ({
+        ? Html.documentFor(root.bodyDocument ? root.bodyDocument : root.rawHtml, ({
             foreground: root.textColor,
             background: root.backgroundColor,
             link: root.linkColor,

--- a/tests/bench.sh
+++ b/tests/bench.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Both halves of the benchmark, one after the other.
+#
+# The QML column is the one that matters — the shell runs that engine, not
+# node's — so this is worth running on the machine the shell runs on rather
+# than wherever the code was written.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+node tests/bench_node.js
+
+runtime=""
+for candidate in qml6 qml /usr/lib/qt6/bin/qml; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    runtime=$candidate
+    break
+  fi
+done
+
+if [[ -z $runtime ]]; then
+  printf '\nNo qml runtime on PATH, so only the V8 column ran.\n'
+  printf 'It ships with qt6-declarative; install that and run this again.\n'
+  exit 0
+fi
+
+printf '\n'
+# A benchmark, not a test: a QML runtime that will not start is worth saying out
+# loud, but it is not a reason to fail the target.
+if ! "$runtime" tests/bench_html.qml; then
+  printf '\nThe QML column did not run: %s exited non-zero above.\n' "$runtime"
+  printf 'On a machine where the shell itself runs, that is worth looking into.\n'
+fi

--- a/tests/bench_cases.js
+++ b/tests/bench_cases.js
@@ -1,0 +1,117 @@
+// The benchmark itself, kept apart from the two things that run it.
+//
+// Every number this project has argued about so far came out of node, and node
+// is V8. The shell runs QML's own engine, so the same fixtures and the same
+// loops are run there too — `make bench` prints both, side by side, and the
+// difference between the columns is the only honest answer to "how much does it
+// cost to have written this in JavaScript".
+//
+// Written in the same ES5 the QML engine is fed everywhere else in this
+// repository, and it reaches Html.js through a plain object of functions rather
+// than an import, so neither runner needs anything the other does not have.
+
+// A marketing mail shaped like the real thing: a card behind nine layout
+// tables, because that is what this mailbox actually receives. `cards` is the
+// only knob; roughly 0.8 KB of source per card.
+function outlookMail(cards) {
+  var out = "<html><head><title>Newsletter</title><style>.x{color:red}</style></head><body>"
+    + "<div style=\"display:none;font-size:1px\">preheader text nobody reads</div>"
+  for (var i = 0; i < cards; i++) {
+    var open = ""
+    var close = ""
+    for (var depth = 0; depth < 9; depth++) {
+      open += "<table width=\"" + (600 - depth * 10) + "\" align=\"center\" cellpadding=\"0\""
+        + " bgcolor=\"#ffffff\"><tr><td style=\"padding:0\">"
+      close = "</td></tr></table>" + close
+    }
+    out += open
+      + "<img src=\"https://cdn.example.com/hero" + i + ".png\" width=\"540\" height=\"200\" alt=\"a>b\">"
+      + "<h2 style=\"color:#111;margin:0 0 8px\">Headline " + i + "</h2>"
+      + "<p style=\"margin:0 12px;color:#555\">Body copy &amp; more of it, "
+      + "<a href=\"https://example.com/" + i + "\">read on</a>.</p>"
+      + "<img src=\"https://track.example.com/p" + i + ".gif\" width=\"1\" height=\"1\">"
+      + close
+  }
+  return out + "</body></html>"
+}
+
+function kb(measured) {
+  return (measured.length / 1024).toFixed(0)
+}
+
+function pad(text, width) {
+  var out = String(text)
+  while (out.length < width) out = " " + out
+  return out
+}
+
+// Milliseconds per run, over enough runs to outlast the clock's resolution.
+function timed(run) {
+  var started = Date.now()
+  var runs = 0
+  while (Date.now() - started < 250 || runs < 3) {
+    run()
+    runs++
+  }
+  return (Date.now() - started) / runs
+}
+
+// What opening a message costs: the body is sanitised once, and the reader
+// builds its document from the tree that came back.
+function openOnce(html, source, palette) {
+  var ready = html.sanitize(source, { allowRemoteImages: false, withPlainText: true })
+  html.documentFor(ready.document, palette)
+  return ready
+}
+
+// Which bound refused it, because "too heavy" is four different bounds and
+// which one bites is the thing worth knowing when tuning them.
+function refusedBy(size, limits) {
+  if (size.length > limits.richText) return "too long (" + kb(size) + " KB)"
+  if (size.tags > limits.elements) return "too many elements (" + size.tags + ")"
+  if (size.tables > limits.tables) return "too many tables (" + size.tables + ")"
+  if (size.tableDepth > limits.tableDepth) return "tables too deep (" + size.tableDepth + ")"
+  return ""
+}
+
+function run(html, log) {
+  var palette = {
+    foreground: "#cacccc", background: "#101315", link: "#7aa2f7", quote: "#707880",
+    maxImageWidth: 380, compact: true
+  }
+
+  log("  " + pad("source", 8) + pad("to Qt", 9) + pad("elements", 10)
+    + pad("open", 9) + pad("relayout", 10) + "   verdict")
+  log("  " + pad("", 58).replace(/ /g, "-"))
+
+  var sizes = [6, 24, 90, 240]
+  for (var i = 0; i < sizes.length; i++) {
+    var source = outlookMail(sizes[i])
+    var ready = openOnce(html, source, palette)
+
+    var open = timed(function() { openOnce(html, source, palette) })
+    // A drag walks through widths; the document is not reparsed for any of them.
+    var step = 0
+    var relayout = timed(function() {
+      palette.maxImageWidth = 300 + (step++ % 30) * 20
+      html.documentFor(ready.document, palette)
+    })
+    palette.maxImageWidth = 380
+
+    var refused = ready.tooHeavy ? refusedBy(ready.complexity, html.limits) : ""
+    log("  " + pad(kb(source) + " KB", 8)
+      + pad(kb(ready.html) + " KB", 9)
+      + pad(ready.complexity.tags, 10)
+      + pad(open.toFixed(2) + "ms", 9)
+      + pad(relayout.toFixed(2) + "ms", 10)
+      + (refused === "" ? "" : "   refused: " + refused))
+  }
+
+  log("")
+  log("  source    the sender's HTML, as Gmail handed it over")
+  log("  to Qt     what the renderer is given, after sanitising and collapsing")
+  log("  open      sanitise once, then build the document from the tree")
+  log("  relayout  one width step of a splitter drag, no parse")
+  log("  verdict   which bound refused it; the reader shows the plain text instead,")
+  log("            so such a row is the cost of finding that out, not of showing it")
+}

--- a/tests/bench_html.qml
+++ b/tests/bench_html.qml
@@ -1,0 +1,34 @@
+// The QML half of `make bench`, run by the `qml` tool from qt6-declarative.
+//
+// This is the column that decides anything: the shell runs QML's own engine,
+// and every performance number this project has argued about so far came out of
+// node. Run it on the machine the shell runs on.
+import QtQml
+
+import "../Html.js" as Html
+import "bench_cases.js" as Bench
+
+QtObject {
+  Component.onCompleted: {
+    console.log("QML — Qt " + qtVersion() + " on " + Qt.platform.os)
+    // Plain functions rather than the import namespace, so this reaches
+    // Html.js exactly the way the node runner does.
+    Bench.run({
+      sanitize: function(source, options) { return Html.sanitize(source, options) },
+      documentFor: function(document, palette) { return Html.documentFor(document, palette) },
+      limits: {
+        richText: Html.MAX_RICH_TEXT,
+        elements: Html.MAX_ELEMENTS,
+        tables: Html.MAX_TABLES,
+        tableDepth: Html.MAX_TABLE_DEPTH
+      }
+    }, function(line) { console.log(line) })
+    Qt.exit(0)
+  }
+
+  function qtVersion() {
+    // Qt exposes its own version as a packed integer and nothing friendlier.
+    var packed = Qt.version !== undefined ? Qt.version : ""
+    return packed === "" ? "(unknown)" : packed
+  }
+}

--- a/tests/bench_node.js
+++ b/tests/bench_node.js
@@ -1,0 +1,21 @@
+// The V8 half of `make bench`. See tests/bench_cases.js.
+const { load } = require("./load")
+
+const html = load("Html.js")
+const bench = load("tests/bench_cases.js")
+
+// Reached through plain functions rather than through the module object, so
+// this and the QML runner hand Html.js over the same way.
+const api = {
+  sanitize: function (source, options) { return html.sanitize(source, options) },
+  documentFor: function (document, palette) { return html.documentFor(document, palette) },
+  limits: {
+    richText: html.MAX_RICH_TEXT,
+    elements: html.MAX_ELEMENTS,
+    tables: html.MAX_TABLES,
+    tableDepth: html.MAX_TABLE_DEPTH
+  }
+}
+
+console.log("V8 — node " + process.version)
+bench.run(api, console.log)

--- a/tests/test_html.js
+++ b/tests/test_html.js
@@ -455,6 +455,26 @@ assert.ok(bare.indexOf("x</body>") > 0)
   assert.ok(compact.indexOf("margin:10px 0") > 0, "vertical rhythm stays")
   assert.ok(compact.indexOf("padding:5px 0 7px 0") > 0, "all four sides handled")
 
+  // The reader rebuilds its document on every relayout from a body that has not
+  // changed, so the parse is kept between them — which is only safe as long as
+  // fitting writes the tree out rather than editing it. A narrow pass must not
+  // leave its marks on the wide one that follows.
+  // Only the table carries 600: a width on an image is the picture's own and is
+  // clamped by the stylesheet's max-width instead.
+  var fitted = "<table width=\"600\"><tr><td style=\"padding:4px 30px\">"
+    + "<img src=\"a.png\" width=\"540\" height=\"200\"></td></tr></table>"
+  var narrow = html.documentFor(fitted, { maxImageWidth: 380, compact: true })
+  var roomy = html.documentFor(fitted, { maxImageWidth: 800, compact: true })
+  assert.ok(narrow.indexOf('width="600"') < 0, "600 does not fit in 380")
+  assert.ok(roomy.indexOf('width="600"') > 0, "but it fits in 800, from the same parse")
+  assert.ok(narrow.indexOf("padding:4px 0") > 0)
+  assert.strictEqual(html.documentFor(fitted, { maxImageWidth: 380, compact: true }), narrow,
+    "and the same width twice is the same document")
+  // Uncompacted, the sender's gutters are their own again.
+  assert.ok(html.documentFor(fitted, { maxImageWidth: 380 }).indexOf("padding:4px 30px") > 0)
+  assert.ok(html.documentFor(fitted, { maxImageWidth: 380 }).indexOf('height="200"') < 0,
+    "heights come out at every width")
+
   var relaxed = html.relaxFixedWidths(
     '<table width="600"><td width="100" style="width:640px">x</td></table>', 380)
   assert.ok(relaxed.indexOf('width="600"') < 0, "a table wider than the window gives it up")

--- a/tests/test_html.js
+++ b/tests/test_html.js
@@ -490,10 +490,10 @@ assert.ok(bare.indexOf("x</body>") > 0)
   assert.ok(compact.indexOf("margin:10px 0") > 0, "vertical rhythm stays")
   assert.ok(compact.indexOf("padding:5px 0 7px 0") > 0, "all four sides handled")
 
-  // The reader rebuilds its document on every relayout from a body that has not
-  // changed, so the parse is kept between them — which is only safe as long as
-  // fitting writes the tree out rather than editing it. A narrow pass must not
-  // leave its marks on the wide one that follows.
+  // The reader rebuilds its document on every relayout from the document
+  // `sanitize` already built, so a whole drag costs no parse at all — which is
+  // only safe as long as fitting writes the tree out rather than editing it. A
+  // narrow pass must not leave its marks on the wide one that follows.
   // Only the table carries 600: a width on an image is the picture's own and is
   // clamped by the stylesheet's max-width instead.
   var fitted = "<table width=\"600\"><tr><td style=\"padding:4px 30px\">"
@@ -509,6 +509,14 @@ assert.ok(bare.indexOf("x</body>") > 0)
   assert.ok(html.documentFor(fitted, { maxImageWidth: 380 }).indexOf("padding:4px 30px") > 0)
   assert.ok(html.documentFor(fitted, { maxImageWidth: 380 }).indexOf('height="200"') < 0,
     "heights come out at every width")
+
+  // The document itself is accepted in place of the string written from it, and
+  // has to fit to exactly the same thing.
+  var built = html.sanitize(fitted, { allowRemoteImages: true })
+  assert.strictEqual(html.documentFor(built.document, { maxImageWidth: 380, compact: true }),
+    html.documentFor(built.html, { maxImageWidth: 380, compact: true }))
+  assert.strictEqual(html.documentFor(built.document, { maxImageWidth: 800, compact: true })
+    .indexOf('width="600"') > 0, true, "and it is still good at the next width")
 
   var relaxed = html.relaxFixedWidths(
     '<table width="600"><td width="100" style="width:640px">x</td></table>', 380)

--- a/tests/test_html.js
+++ b/tests/test_html.js
@@ -47,6 +47,17 @@ const html = load("Html.js")
   assert.strictEqual(html.stripColors("<a title='say \"hi\"'>t</a>"),
     "<a title=\"say &quot;hi&quot;\">t</a>")
 
+  // Old mail is shouted, and names are matched folded. The reader takes the
+  // fast path when it saw no capital while scanning a name, so the shouted form
+  // is its own path and has to be checked.
+  assert.strictEqual(
+    html.sanitize("<DIV STYLE=\"COLOR:red;padding:4px\"><IMG SRC=\"https://cdn.example.com/a.png\" WIDTH=\"90\">x</DIV>",
+      { allowRemoteImages: true }).html,
+    "<div style=\"padding:4px\"><img src=\"https://cdn.example.com/a.png\" width=\"90\">x</div>")
+  assert.strictEqual(html.sanitize("<SCRIPT>bad()</SCRIPT>ok").html, "ok")
+  assert.strictEqual(html.sanitize("<P STYLE=\"DISPLAY:NONE\">secret</P><p>real</p>").html, "<p>real</p>")
+  assert.strictEqual(html.sanitize("<A HREF=\"JAVASCRIPT:x()\">t</A>").html, "<a>t</a>")
+
   // A "<" that starts no tag is a "<" the sender typed.
   assert.strictEqual(html.stripColors("a < b and 3<4"), "a < b and 3<4")
 
@@ -97,6 +108,29 @@ const html = load("Html.js")
     "and it agrees with asking the long way round")
 }
 
+// Both readings of a body out of one parse, because the tokenize underneath is
+// the most expensive thing this file does and the reader wants both.
+{
+  const body = "<img src=\"https://track.example.com/p.gif\" width=\"1\">"
+    + "<p>copy</p><img src=\"http://127.0.0.1/x.png\" width=\"90\">"
+    + "<img src=\"https://cdn.example.com/real.png\" width=\"90\">"
+  const asked = html.sanitize(body, { withPlainText: true })
+  // Numbered off the sender's own tree, before anything is dropped: a message's
+  // third picture is its third picture whether or not the first two were a
+  // beacon and a request to the machine itself.
+  assert.strictEqual(asked.plainText.text, "[image 1]copy\n[image 2][image 3]")
+  deepEqual(asked.plainText.images, [
+    "https://track.example.com/p.gif", "http://127.0.0.1/x.png",
+    "https://cdn.example.com/real.png"])
+  // ...while the document itself keeps none of them.
+  assert.strictEqual(asked.images, 0)
+  assert.ok(asked.html.indexOf("127.0.0.1") < 0)
+  // The same answer the long way round, so the shortcut cannot drift from it.
+  deepEqual(asked.plainText, html.readPlainText(body))
+  // And nothing is paid for it unless it is asked for.
+  assert.strictEqual(html.sanitize(body).plainText, null)
+}
+
 // --------------------------------------------------- html read as plain text
 //
 // The markers and the picture list come off one walk, so a marker cannot open
@@ -104,9 +138,9 @@ const html = load("Html.js")
 {
   deepEqual(html.readPlainText("<div>Hello</div><img src=\"a.png\"><br><img src='b.png' width=600><p>Bye</p>"),
     { text: "Hello\n[image 1]\n[image 2]Bye", images: ["a.png", "b.png"] })
-  assert.strictEqual(html.toText("<ul><li>one</li><li>two &amp; three</li></ul>"),
+  assert.strictEqual(html.readPlainText("<ul><li>one</li><li>two &amp; three</li></ul>").text,
     "• one\n• two & three")
-  assert.strictEqual(html.toText("a&nbsp;&nbsp;b"), "a  b")
+  assert.strictEqual(html.readPlainText("a&nbsp;&nbsp;b").text, "a  b")
   // An <img> written inside another element's attribute is text, not a picture.
   deepEqual(html.readPlainText("<div title=\"<img src=ghost.png>\">real</div>"),
     { text: "real", images: [] })
@@ -296,7 +330,7 @@ assert.ok(html.sanitize("<div style=\"background-image:url(https://track.example
 {
   const body = "<img alt=\"a>b\" src=\"https://cdn.example.com/one.png\"><p>x</p>"
     + "<img src=\"https://cdn.example.com/two.png\">"
-  deepEqual(html.imageSources(body),
+  deepEqual(html.readPlainText(body).images,
     ["https://cdn.example.com/one.png", "https://cdn.example.com/two.png"])
 }
 
@@ -407,10 +441,11 @@ assert.ok(bare.indexOf("x</body>") > 0)
 // Stripping images outright left a message built around its pictures reading as
 // a long run of unexplained blank space.
 {
-  deepEqual(html.imageSources('<img src="a.png"><img src=\'b b.png\'><img data-x=1 src=c.png >'),
+  deepEqual(html.readPlainText('<img src="a.png"><img src=\'b b.png\'><img data-x=1 src=c.png >').images,
     ["a.png", "b b.png", "c.png"])
-  deepEqual(html.imageSources(""), [])
-  deepEqual(html.imageSources("<img alt=none>"), [""], "an image with no src still holds its place")
+  deepEqual(html.readPlainText("").images, [])
+  deepEqual(html.readPlainText("<img alt=none>").images, [""],
+    "an image with no src still holds its place")
 
   var plainDoc = html.plainTextDocument("Hi\n[image 1]  spaced\n<b>not bold</b>",
     { foreground: "#DEDEDE", background: "#131313", link: "#077CFD" }, true)

--- a/tests/test_html.js
+++ b/tests/test_html.js
@@ -3,6 +3,116 @@ const { load, deepEqual } = require("./load")
 
 const html = load("Html.js")
 
+// =============================================================== the parser
+//
+// The gate is only as good as where it thinks a tag stops, so this is the part
+// that gets read the way Qt reads it: tags by scanning, attributes with their
+// quotes, raw-text elements by their own closing tag.
+{
+  // Structure in, same structure out. A browser's parser would insert a
+  // <tbody> here, hoist stray content out of the table and reopen formatting
+  // across a block; every one of those is a change to mail nobody asked for.
+  const untouched = [
+    "<table><tr><td>a</td><td>b</td></tr></table>",
+    "<p>plain <b>bold <i>both</i></b> tail</p>",
+    "<div><ul><li>one</li><li>two</li></ul></div>",
+    "<blockquote><p>quoted</p></blockquote>"
+  ]
+  for (const markup of untouched) assert.strictEqual(html.stripColors(markup), markup)
+
+  // Closed, never moved: mail leaves <td> and <li> open constantly, and without
+  // an implied close each one nests inside the last.
+  assert.strictEqual(html.stripColors("<ul><li>one<li>two</ul>"),
+    "<ul><li>one</li><li>two</li></ul>")
+  assert.strictEqual(html.stripColors("<table><tr><td>a<td>b</table>"),
+    "<table><tr><td>a</td><td>b</td></tr></table>")
+  assert.strictEqual(html.stripColors("<p>one<p>two"), "<p>one</p><p>two</p>")
+
+  // What the sender left open is closed at the end; what they closed twice is
+  // closed once. A stray end tag closes nothing, because the only other reading
+  // would close something they meant to keep.
+  assert.strictEqual(html.stripColors("<div><span>x"), "<div><span>x</span></div>")
+  assert.strictEqual(html.stripColors("x</div></p>"), "x")
+  // Mis-nesting comes out well-formed rather than mis-nested.
+  assert.strictEqual(html.stripColors("<b><i>x</b></i>"), "<b><i>x</i></b>")
+
+  // Attribute values are read with their quotes, so a ">" in one does not end
+  // the tag — and an unquoted value ends at whitespace.
+  assert.strictEqual(html.stripColors("<a title=\"a>b\" href=\"https://x.example.com\">t</a>"),
+    "<a title=\"a>b\" href=\"https://x.example.com\">t</a>")
+  assert.strictEqual(html.stripColors("<img src=a.png width=600>"),
+    "<img src=\"a.png\" width=\"600\">")
+  assert.strictEqual(html.stripColors("<input disabled>"), "<input disabled>")
+  // A single-quoted value is re-quoted, so the quote inside it has to go.
+  assert.strictEqual(html.stripColors("<a title='say \"hi\"'>t</a>"),
+    "<a title=\"say &quot;hi&quot;\">t</a>")
+
+  // A "<" that starts no tag is a "<" the sender typed.
+  assert.strictEqual(html.stripColors("a < b and 3<4"), "a < b and 3<4")
+
+  // A raw-text element ends at its own closing tag and at nothing else, so a
+  // stylesheet cannot hide markup from the walk that follows it.
+  assert.strictEqual(html.sanitize("<style>p::after{content:\"<img src=x>\"}</style>ok").html, "ok")
+  assert.strictEqual(html.sanitize("<script>var a = 1 < 2;</script>ok").html, "ok")
+  // ...and per the spec the first "</style" ends it, whatever it is inside.
+  assert.ok(html.sanitize("<style>a{}</style><p>after</p>").html.indexOf("<p>after</p>") >= 0)
+
+  // A tag that never closes takes the rest of the document with it, which is
+  // what Qt does with it too — and is the reading that cannot leave a fetch
+  // behind.
+  assert.strictEqual(html.sanitize("<p>kept</p><div class=\"never").html, "<p>kept</p>")
+
+  // A doctype is not text: Qt would lay it out as a line above the message.
+  assert.strictEqual(html.sanitize("<!DOCTYPE html><p>hi</p>").html, "<p>hi</p>")
+
+  // A title is not body text either, and nearly every marketing mail ships one.
+  assert.strictEqual(html.sanitize("<head><title>Newsletter</title></head><p>real</p>").html,
+    "<head></head><p>real</p>")
+}
+
+// A tree is walked by recursion everywhere downstream, so a message nested a
+// few thousand elements deep would be a stack overflow inside the process that
+// draws the whole desktop. Past the ceiling an element keeps its content, it
+// just stops adding a level to hold it.
+{
+  const deepest = "<div>".repeat(20000) + "<img src=\"http://127.0.0.1/x.png\">text"
+  const out = html.sanitize(deepest, { allowRemoteImages: true })
+  assert.ok(out.html.indexOf("127.0.0.1") < 0, "the ceiling is not a way past the image policy")
+  assert.ok(out.html.indexOf("text") > 0, "the content is still there")
+  const tables = "<table><tr><td>".repeat(4000) + "cell"
+  assert.ok(html.sanitize(tables).html.indexOf("cell") > 0)
+  assert.ok(html.tooHeavyForRichText(tables), "and it is still refused as too heavy")
+}
+
+// The reader is told how heavy the result is by the call that produced it:
+// asking separately would mean parsing the whole body again to count what was
+// just counted.
+{
+  const light = html.sanitize("<p>hi</p>")
+  assert.strictEqual(light.tooHeavy, false)
+  assert.strictEqual(light.complexity.tags, 1)
+  const heavy = html.sanitize("<div></div>".repeat(html.MAX_ELEMENTS + 1))
+  assert.strictEqual(heavy.tooHeavy, true)
+  assert.strictEqual(heavy.tooHeavy, html.tooHeavyForRichText(heavy.html),
+    "and it agrees with asking the long way round")
+}
+
+// --------------------------------------------------- html read as plain text
+//
+// The markers and the picture list come off one walk, so a marker cannot open
+// somebody else's image however strange the markup is.
+{
+  deepEqual(html.readPlainText("<div>Hello</div><img src=\"a.png\"><br><img src='b.png' width=600><p>Bye</p>"),
+    { text: "Hello\n[image 1]\n[image 2]Bye", images: ["a.png", "b.png"] })
+  assert.strictEqual(html.toText("<ul><li>one</li><li>two &amp; three</li></ul>"),
+    "• one\n• two & three")
+  assert.strictEqual(html.toText("a&nbsp;&nbsp;b"), "a  b")
+  // An <img> written inside another element's attribute is text, not a picture.
+  deepEqual(html.readPlainText("<div title=\"<img src=ghost.png>\">real</div>"),
+    { text: "real", images: [] })
+  deepEqual(html.readPlainText(""), { text: "", images: [] })
+}
+
 // ------------------------------------------------------------- stripping
 //
 // Qt's rich text engine ignores unknown tags but renders the *text content*

--- a/tests/test_html.js
+++ b/tests/test_html.js
@@ -131,6 +131,56 @@ const html = load("Html.js")
   assert.strictEqual(html.sanitize(body).plainText, null)
 }
 
+// ------------------------------------------------------------ scaffolding
+//
+// Real mail is mostly boxes holding one box. Qt parses each one back out of the
+// string and lays it out, and that half of the cost is the half this file
+// cannot measure — so the document it is handed is made smaller, but only in
+// the two shapes that provably render the same.
+{
+  // A stack of empty wrappers is the innermost thing in it.
+  assert.strictEqual(html.sanitize("<div><div><div><p>hi</p></div></div></div>").html, "<p>hi</p>")
+  assert.strictEqual(html.sanitize("<div><table><tr><td>x</td></tr></table></div>").html,
+    "<table><tr><td>x</td></tr></table>")
+  // An inline element carrying nothing is nothing.
+  assert.strictEqual(html.sanitize("<p><span>a</span>b<font>c</font></p>").html, "<p>abc</p>")
+
+  // Anything the wrapper carries is a reason it is there.
+  assert.strictEqual(html.sanitize("<div style=\"padding:8px\"><p>hi</p></div>").html,
+    "<div style=\"padding:8px\"><p>hi</p></div>")
+  assert.strictEqual(html.sanitize("<div align=\"center\"><p>hi</p></div>").html,
+    "<div align=\"center\"><p>hi</p></div>")
+  // Qt honours <center>, so a card that was centred must not come out left.
+  assert.strictEqual(html.sanitize("<center><p>hi</p></center>").html, "<center><p>hi</p></center>")
+  // <b> is not <span>: it says something with no attributes at all.
+  assert.strictEqual(html.sanitize("<p><b>bold</b></p>").html, "<p><b>bold</b></p>")
+
+  // Two boxes are two boxes, and a box holding text as well as a box is not
+  // holding only that box.
+  assert.strictEqual(html.sanitize("<div><p>a</p><p>b</p></div>").html, "<div><p>a</p><p>b</p></div>")
+  assert.strictEqual(html.sanitize("<div>text<p>b</p></div>").html, "<div>text<p>b</p></div>")
+  // Whitespace between blocks is not text: a template's newlines do not pin a
+  // wrapper in place.
+  assert.strictEqual(html.sanitize("<div>\n  <p>a</p>\n</div>").html, "<p>a</p>")
+  // An inline child means the wrapper is what puts it on its own line.
+  assert.strictEqual(html.sanitize("<div><span style=\"font-size:9px\">a</span></div>").html,
+    "<div><span style=\"font-size:9px\">a</span></div>")
+
+  // On mail shaped like the real thing this is most of the document. Nine
+  // layout tables around a card is what this mailbox actually receives.
+  let card = "", close = ""
+  for (let d = 0; d < 9; d++) {
+    card += "<table width=\"" + (600 - d * 10) + "\" align=\"center\"><tr><td>"
+    close = "</td></tr></table>" + close
+  }
+  card += "<img src=\"https://cdn.example.com/h.png\" width=\"540\"><p>copy</p>" + close
+  const carded = html.sanitize(card, { allowRemoteImages: true })
+  assert.ok(carded.complexity.tags < 12,
+    "nine levels of scaffolding come out as a handful of elements, not thirty")
+  assert.ok(carded.html.indexOf("copy") > 0 && carded.html.indexOf("h.png") > 0,
+    "and everything that was in them is still there")
+}
+
 // --------------------------------------------------- html read as plain text
 //
 // The markers and the picture list come off one walk, so a marker cannot open


### PR DESCRIPTION
Follow-up to #2, which fixed the vulnerability with patterns and then had to bolt a hand-written scanner onto the side of the image pass when a `>` inside an `alt` text walked straight past it. That was the symptom. This is the cause.

## Doesn't Qt already do this?

It does the half that matters most, and this plugin has always used it. The reader's `TextEdit { textFormat: RichText }` **is** Qt's HTML renderer — `QTextDocument` + `QTextHtmlParser` + the layout engine. That is the same layer gpui-component's `text_view` has to write by hand (`node.rs` alone is 3,286 lines), and we get it for free.

What Qt does not give a QML plugin is any say over what that renderer does while it works:

| | gpui-component | omamail |
|---|---|---|
| HTML → DOM | `html5ever` | **missing — this PR** |
| DOM → semantic tree, allow-listed | `format/html.rs` | was regex |
| tree → pixels | ~8k lines of GPUI | **Qt, free** |
| resource loading | its own (`ImageNode` → `img()`) | **Qt's, and eager** |

That last row is the whole problem. `ImageNode` decides whether to load a picture; `QTextDocument` just loads it. `QTextDocument::loadResource` is a C++ virtual — `QQuickTextDocument` exposes nothing of the sort — so the string handed over is the only control point that exists. Qt gives us a renderer, not a filter, and it is precisely because its renderer is so eager (`<img src>` fetched for real, `<style>` CSS laid out as body text, `display:none` ignored, layout synchronous on the GUI thread) that something has to stand in front of it.

So the answer is: keep using Qt for what it is good at, and stop pretending a regex can do the part it does not do.

## What changed

```
tokenize   tags, attributes, text, comments, raw-text elements — read the way the spec reads them
parse      tokens → tree, tolerantly
clean      tree → tree, by an allow list
serialise  tree → the subset Qt renders
```

**The parse is deliberately not a conformant HTML5 tree builder and must not become one.** A browser's parser rewrites what it reads — inserts `<tbody>`, hoists content out of a `<table>`, reopens formatting across a block. Every one of those is a change to mail nobody asked for. This one only ever closes what the sender left open: structure in, same structure out, minus what was removed.

Every decision now sees a correctly delimited tag and a parsed attribute list. That closes the rest of the class #2's scanner only patched one instance of, without having had to enumerate it: a `>` in any attribute of any element, a `<` that starts no tag (`3<4`), an unterminated quote, markup hidden inside a stylesheet, `<title>` laid out as a stray line above the message.

The `[image N]` markers and the list of pictures they open now come off **one walk over one tree**, so a marker cannot open somebody else's image — `MailAccount` takes the body text and the picture list from a single call, and the two can no longer drift.

`MAX_TREE_DEPTH` is load-bearing rather than tidy: everything downstream walks the tree by recursion, and 3,000 levels of nesting was a stack overflow **inside the process that draws the whole desktop**. Found by fuzzing, not by reasoning.

## Cost, because this is the GUI thread

A parse is several times a pass of regex — a tokenizer that reads every character and builds a node per element cannot beat a pattern that skips whole spans with `indexOf`, and no amount of tuning changes that. Measured naively it was 2× on opening a message and 3× on a relayout, which is a dropped frame on a large one. So the pipeline stopped doing the work five times.

**Opening a message parsed it four times.** The cache read sanitised and the reader built a document from the string that came out; then the live fetch sanitised the same markup again and the reader rebuilt. Two of those were reading back a string that had just been written from a tree still in hand — so `sanitize` returns the tree and `documentFor` takes it. The fourth goes because a body never changes once fetched, which is the whole basis of the cache being correct: when the live fetch brings back markup the cache already painted, there is nothing to paint again.

Also: the body cache holds the sender's HTML rather than the sanitiser's output, so a fix here reaches every message already on disk; `sanitize` reports how heavy its own result is and returns the plain-text reading when asked, both off the same tree, so nothing re-parses to learn either; a styled element has its style split once rather than once to ask whether it is hidden and again to decide what survives; and a name is lower-cased only when a capital was actually seen while reading it.

**Opening a cached message, end to end** — cache paint plus live repaint, both documents built:

| body | before (regex) | after (parser) | |
|---|---|---|---|
| 5 KB — the median | 0.78 ms | 0.71 ms | 0.91× |
| 23 KB | 2.81 ms | 2.95 ms | 1.05× |
| 61 KB | 7.08 ms | 7.67 ms | 1.08× |

**A relayout step**, which is every quantised width of a splitter drag and every zoom step:

| body | before (regex) | after (parser) |
|---|---|---|
| 13 KB | 0.13 ms | 0.38 ms |
| 79 KB | 0.77 ms | 1.55 ms |

The open path is at parity; the drag is 2–3× but costs no parse at all now — what is left is writing the document out and fitting it to the width, and 1.55 ms on a 79 KB message is a tenth of a frame. These are V8 numbers; QML's V4 is some multiple slower, which matters for the tail rather than the median, and `tooHeavyForRichText` is the lever that already exists for the tail.

### Handing Qt less, which is the half we cannot measure

The other thing borrowed from `text_view`: it maps thirty-five block elements onto a handful of semantic nodes and throws the rest away, so the tree reaching the renderer is far smaller than the HTML that came in. It can afford to — the renderer is its own. Ours is Qt's, and Qt takes a **string**: it parses our output back out, gives every element a box, and lays the box out, on the GUI thread. That half can neither be moved nor measured from here, and the only lever on it is handing over less.

Real mail is mostly scaffolding. A card centred in an Outlook window is nine layout tables deep, and flattening the tables past the second turns every layer above into a `div` with nothing on it — in a message shaped like the ones this mailbox actually receives, **85% of the tree**.

Two shapes collapse, and only two, because only these two are provably the same document: a box with nothing on it around a single box is that box, and an inline element with nothing on it is nothing at all. Not `<center>` — Qt honours it, and a centred card would come out against the left edge.

| 94 KB Outlook-shaped message, as handed to Qt | before | after |
|---|---|---|
| bytes | 49.4 KB | 22.3 KB |
| elements | 3362 | 842 |

Our own end is unchanged: the extra walk is paid back by everything downstream having a quarter as much to walk.

## Verification

All 356 pre-existing assertions in `tests/test_html.js` passed unchanged on the first run of the rewrite, which is the useful signal here: the semantics are the same, the reading is not. New coverage for the parser itself — implied closes, mis-nesting, stray and unclosed tags, quoted `>`, unquoted and valueless attributes, raw-text elements, doctypes, the depth ceiling, and that `sanitize`'s own heaviness report agrees with asking the long way round. Plus a fuzz pass over ~400 generated documents checking nothing throws and no blocked source ever reaches the output.

One intentional behaviour change: `<title>` and `<textarea>` content is dropped. It is not body text, and Qt lays it out as if it were — nearly every marketing mail ships a `<head><title>` that came out as a line above the message.

`qmllint` still needs one pass on Omarchy; it cannot run on the machine this was written on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




