### PR TITLE
fix: anchor the relative-time fixture in local time, not UTC

### DIFF
--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -154,7 +154,13 @@ assert.strictEqual(message.formatSize(2 * 1024 * 1024), "2.0 MB")
 
 // -------------------------------------------------------------------- time
 
-const now = new Date("2026-08-19T15:00:00Z")
+// Local, not UTC. relativeTime reads local calendar fields to decide whether a
+// message arrived today, so a UTC-anchored fixture is only "15:00 on the 19th"
+// for a reader west of UTC+9. From UTC+9 to UTC+11 it is already past local
+// midnight, three hours before it falls on the previous local day, and the
+// clock-time assertion below sees a weekday instead. Anchoring the fixture the
+// same way the function reads it makes the day boundary the same everywhere.
+const now = new Date(2026, 7, 19, 15, 0, 0)
 function ago(ms) { return new Date(now.getTime() - ms) }
 
 assert.strictEqual(message.relativeTime(ago(30 * 1000), now), "now")


### PR DESCRIPTION
`make test` fails from UTC+9 to UTC+11 — Japan, Korea, every Australian state, Vladivostok — and passes everywhere else.

```
AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
  assert.ok(/^\d\d:\d\d$/.test(message.relativeTime(ago(3 * 3600 * 1000), now)))
    at tests/test_message.js:165
```

## Why

`relativeTime()` reads **local** calendar fields to decide whether a message arrived today:

```js
var sameDay = date.getFullYear() === reference.getFullYear()
  && date.getMonth() === reference.getMonth()
  && date.getDate() === reference.getDate()
```

The fixture was pinned to an instant in **UTC**:

```js
const now = new Date("2026-08-19T15:00:00Z")
```

Those two only agree west of UTC+9. At `15:00Z` a reader in Brisbane is already at `01:00` on the 20th, so `ago(3h)` is `22:00` on the **19th** — a different local day. `relativeTime` correctly returns `Wed`, and the assertion expecting a clock time fails.

The failing window is exactly where `15:00Z` lands between local `00:00` and `03:00`:

| Zone | Offset | Local `now` | |
|---|---|---|---|
| Asia/Shanghai | UTC+8 | 23:00 | pass |
| Asia/Tokyo, Asia/Seoul | UTC+9 | 00:00 | **fail** |
| Australia/Adelaide, Darwin | UTC+9:30 | 00:30 | **fail** |
| Australia/Brisbane, Sydney | UTC+10 | 01:00 | **fail** |
| Pacific/Norfolk | UTC+11 | 02:00 | **fail** |
| Pacific/Auckland | UTC+12 | 03:00 | pass |

## The fix

Anchor the fixture the same way the function reads it, so the day boundary is the same in every zone:

```js
const now = new Date(2026, 7, 19, 15, 0, 0)
```

15:00 local means `ago(3h)` is 12:00 the same local day everywhere, including across a DST shift. Test-only — no change to `Message.js`.

## Verification

- **34 timezones pass**, including half-hour (Adelaide, Kolkata), 45-minute (Kathmandu, Chatham) and DST-transition zones (Lord Howe).
- Full suite green under `Australia/Brisbane`, `UTC` and `Asia/Tokyo`.
- **The assertion keeps its teeth** — replacing `if (sameDay)` with `if (false)` in `relativeTime` still fails the test in every timezone, so it is not passing trivially.
- The other uses of `now` in this file are timezone-independent (a 10-minute offset asserting `"10m"`, and a `getUTCHours()` check on a fixed header date), so re-anchoring is safe.

Found while reviewing the plugin before installing it on Omarchy 4 — nice work on the SSRF handling in `isPublicHost`, incidentally.