### PR TITLE
Keys that work every time: one table, one context, one keyboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,44 @@ three directories away from the client that calls it.
 - A popup that would overflow flips to the other side of its trigger, then
   clamps to the window edge, then clamps to zero. All three, in that order.
 
+## Keys and focus
+
+- Every keyboard shortcut lives in `keys/Keymap.js`, and nothing else describes
+  one. The help sheet and the status-bar hints render from that table, so a key
+  added in one place is added everywhere. Three hand-written copies used to
+  exist and had already drifted apart.
+- Whether a key stands down while the user is typing is *derived* from the key,
+  never declared: bare keys stand down, `Ctrl`/`Alt`/`Meta` and the function
+  keys do not. Shift is not a modifier for this purpose — `Shift+I` is how a
+  capital I is typed. `Escape` is the only row that overrides it. The derivation
+  is per key, so one row holds both `/` and `Ctrl+K`.
+- The sheet enumerates and the status bar hints: `displayFor` names every key
+  that works, `hintKeyFor` gives the one short form. One field doing both put
+  "j / k — Move down" on the sheet, which is true of neither key.
+- Qt's sequence syntax is not the UI's. `readableSequence` turns "g,i" into
+  "g then i" and names Esc and Enter for the keycaps. A rule, not a per-row
+  override, so a chord added later reads properly without anyone spelling it out.
+- `focus: true` may not sit on a component that can be invisible while holding
+  it. Qt does not exclude hidden items from owning the focus, so a hidden owner
+  that accepts keys is a key sink — this swallowed every `Escape` in the window
+  and made the key look intermittent. Bind focus to whatever means "in use":
+  `focus: root.opened`.
+- Route keys through `KeyRouter`, never a `Keys.on...Pressed` handler. A window
+  `Shortcut` beats a focused item's `Keys` handler, so a local handler looks
+  live and never runs — `SearchBar` had one that a routed `Escape` would have
+  silently killed. Anything Escape should do belongs in `goBack()`, in the order
+  the window is stacked.
+- `KeyRouter` builds its shortcuts with an `Instantiator`. A `Shortcut` is a
+  `QtObject` and a `Repeater` builds only `Item`s, so a `Repeater` there creates
+  nothing at all and every key goes silently dead.
+- A `QQC.Popup` with `CloseOnEscape` consumes `Escape` itself, so the router
+  never sees it. Do not add a branch for an open popup; do add one for a plain
+  overlay like the shortcut sheet, which is not a Popup.
+- The list cursor and the open message are two different things. `cursorId` is
+  where the keyboard is; `selectedId` is what the reader shows. Move the cursor
+  with `Model.cursorAfterOffset`, anchored on the cursor — anchoring it on the
+  open message pinned it to the first row.
+
 ## Providers
 
 - A mailbox is a **provider**: `gmail`, `imap`, or `hey`. `Provider.js` is the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,11 @@ three directories away from the client that calls it.
   one. The help sheet and the status-bar hints render from that table, so a key
   added in one place is added everywhere. Three hand-written copies used to
   exist and had already drifted apart.
+- Keys are guarded three times over, and the order matters when reasoning about
+  a report. Qt hands a focused `TextInput` the bare keys before any `Shortcut`
+  sees them; the key context stands the mailbox keys down on a form; and only
+  then does the typing guard below cover what is left — a focus target that is
+  neither a text input nor out of context.
 - Whether a key stands down while the user is typing is *derived* from the key,
   never declared: bare keys stand down, `Ctrl`/`Alt`/`Meta` and the function
   keys do not. Shift is not a modifier for this purpose — `Shift+I` is how a
@@ -107,6 +112,10 @@ three directories away from the client that calls it.
 - Qt's sequence syntax is not the UI's. `readableSequence` turns "g,i" into
   "g then i" and names Esc and Enter for the keycaps. A rule, not a per-row
   override, so a chord added later reads properly without anyone spelling it out.
+- The typing guard asks whether the focused item is *visible*. Closing compose
+  leaves its field holding the window's focus while hidden; without that check
+  the guard pins true and stands every bare key down for the rest of the
+  session, which is `j` and `k` dying after one Esc out of a reply.
 - `focus: true` may not sit on a component that can be invisible while holding
   it. Qt does not exclude hidden items from owning the focus, so a hidden owner
   that accepts keys is a key sink — this swallowed every `Escape` in the window

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,50 +92,35 @@ three directories away from the client that calls it.
 
 ## Keys and focus
 
-- Every keyboard shortcut lives in `keys/Keymap.js`, and nothing else describes
-  one. The help sheet and the status-bar hints render from that table, so a key
-  added in one place is added everywhere. Three hand-written copies used to
-  exist and had already drifted apart.
-- Keys are guarded three times over, and the order matters when reasoning about
-  a report. Qt hands a focused `TextInput` the bare keys before any `Shortcut`
-  sees them; the key context stands the mailbox keys down on a form; and only
-  then does the typing guard below cover what is left — a focus target that is
-  neither a text input nor out of context.
-- Whether a key stands down while the user is typing is *derived* from the key,
-  never declared: bare keys stand down, `Ctrl`/`Alt`/`Meta` and the function
-  keys do not. Shift is not a modifier for this purpose — `Shift+I` is how a
-  capital I is typed. `Escape` is the only row that overrides it. The derivation
-  is per key, so one row holds both `/` and `Ctrl+K`.
-- The sheet enumerates and the status bar hints: `displayFor` names every key
-  that works, `hintKeyFor` gives the one short form. One field doing both put
-  "j / k — Move down" on the sheet, which is true of neither key.
-- Qt's sequence syntax is not the UI's. `readableSequence` turns "g,i" into
-  "g then i" and names Esc and Enter for the keycaps. A rule, not a per-row
-  override, so a chord added later reads properly without anyone spelling it out.
-- The typing guard asks whether the focused item is *visible*. Closing compose
-  leaves its field holding the window's focus while hidden; without that check
-  the guard pins true and stands every bare key down for the rest of the
-  session, which is `j` and `k` dying after one Esc out of a reply.
+The design and the full table are in `docs/KEYS.md`; read it before touching a
+key. What matters while working:
+
+- Every binding lives in `keys/Keymap.js` and nothing else describes one. The
+  shortcut sheet and the status hints render from it, and a test asserts
+  `docs/KEYS.md` matches it. Three hand-written copies used to exist and had
+  already drifted apart.
+- The context is the only guard. Name the contexts a key means something in;
+  there is no second question to answer. A text-entry context binds no bare key
+  but `Escape`.
+- The context owns the keyboard: changing it moves the focus, and a context that
+  types into nothing parks the keyboard on a plain `Item`. Never hand focus back
+  by calling `forceActiveFocus()` on the focus scope — that re-elects the field
+  being left, so it does nothing and the dismissed field keeps eating keys.
 - `focus: true` may not sit on a component that can be invisible while holding
-  it. Qt does not exclude hidden items from owning the focus, so a hidden owner
-  that accepts keys is a key sink — this swallowed every `Escape` in the window
-  and made the key look intermittent. Bind focus to whatever means "in use":
-  `focus: root.opened`.
-- Route keys through `KeyRouter`, never a `Keys.on...Pressed` handler. A window
-  `Shortcut` beats a focused item's `Keys` handler, so a local handler looks
-  live and never runs — `SearchBar` had one that a routed `Escape` would have
-  silently killed. Anything Escape should do belongs in `goBack()`, in the order
-  the window is stacked.
-- `KeyRouter` builds its shortcuts with an `Instantiator`. A `Shortcut` is a
-  `QtObject` and a `Repeater` builds only `Item`s, so a `Repeater` there creates
-  nothing at all and every key goes silently dead.
-- A `QQC.Popup` with `CloseOnEscape` consumes `Escape` itself, so the router
-  never sees it. Do not add a branch for an open popup; do add one for a plain
-  overlay like the shortcut sheet, which is not a Popup.
+  it, and a component in a context does not place its own focus — the context
+  does. Two mechanisms for one thing is the bug this design replaces.
+- Route keys through `KeyRouter`, never a `Keys.on...Pressed` handler: a window
+  `Shortcut` beats a focused item's `Keys` handler, so a local one looks live and
+  never runs. Anything `Escape` should do belongs in `goBack()`.
+- `KeyRouter` builds its shortcuts with an `Instantiator`. A `Repeater` builds
+  only `Item`s, so it creates no `Shortcut`s at all and every key goes dead.
+- A `QQC.Popup` with `CloseOnEscape` consumes `Escape` itself. Do not add a
+  branch for an open popup; do add one for a plain overlay like the sheet.
 - The list cursor and the open message are two different things. `cursorId` is
   where the keyboard is; `selectedId` is what the reader shows. Move the cursor
-  with `Model.cursorAfterOffset`, anchored on the cursor — anchoring it on the
-  open message pinned it to the first row.
+  with `Model.cursorAfterOffset`, and bring the row on screen with
+  `Model.contentYToReveal` — the list is a `Column`, so there is no
+  `positionViewAtIndex`.
 
 ## Providers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,10 @@ key. What matters while working:
   only `Item`s, so it creates no `Shortcut`s at all and every key goes dead.
 - A `QQC.Popup` with `CloseOnEscape` consumes `Escape` itself. Do not add a
   branch for an open popup; do add one for a plain overlay like the sheet.
+- The mouse does not move the keyboard's cursor. Qt re-reports hover when
+  content moves under a still pointer and the list scrolls to follow the
+  keyboard, so a hover that wrote `cursorId` pulled it back to whatever the
+  mouse was resting on and `j` went nowhere. A row draws its own hover.
 - The list cursor and the open message are two different things. `cursorId` is
   where the keyboard is; `selectedId` is what the reader shows. Move the cursor
   with `Model.cursorAfterOffset`, and bring the row on screen with

--- a/App.qml
+++ b/App.qml
@@ -165,7 +165,7 @@ Item {
 
   function moveCursor(delta) {
     if (!service) return
-    var next = service.selectOffset(delta)
+    var next = service.cursorOffset(cursorId, delta)
     if (next === "") return
     cursorId = next
     // Moving is not opening. This used to open whatever it landed on while the
@@ -183,7 +183,7 @@ Item {
   function actOnCursor(action) {
     if (!service || cursorId === "") return
     var wasOpen = currentView === "reader" && service.selectedId === cursorId
-    var next = service.selectOffset(1)
+    var next = service.cursorOffset(cursorId, 1)
     service.act(cursorId, action)
     if (wasOpen && !Model.survivesAction(service.mailboxKey, action)) {
       if (next !== "" && next !== cursorId) openMessage(next)
@@ -201,6 +201,14 @@ Item {
     target: root.service
     ignoreUnknownSignals: true
     function onReplySent() { compose.finish() }
+    // A list with no cursor cannot be driven: the window opens, the user
+    // presses j, and there is no row to move from. The first row is where the
+    // eye already is, so that is where the cursor starts.
+    function onMessagesChanged() {
+      if (root.cursorId !== "") return
+      var rows = root.service ? root.service.messages : []
+      if (rows.length > 0) root.cursorId = rows[0].id
+    }
     // A new account has no mailbox yet, so the only useful place to be is the
     // page that gives it one.
     // A new mailbox appears as a row in Settings, waiting to be signed in.

--- a/App.qml
+++ b/App.qml
@@ -165,11 +165,28 @@ Item {
     Qt.callLater(function() { focusScope.forceActiveFocus() })
   }
 
+  // Moving the cursor has to bring the row with it. The list is a Column in a
+  // Flickable rather than a ListView — the panel already owns a scroller — so
+  // there is no positionViewAtIndex and this has to be said out loud.
+  //
+  // Called from here rather than from cursorId changing, because hovering a row
+  // moves the cursor too, and scrolling a half-visible row into view under the
+  // pointer fights the mouse that is pointing at it.
+  function revealCursorRow() {
+    if (!listFlick.visible) return
+    var bounds = list.boundsFor(cursorId)
+    if (!bounds) return
+    listFlick.contentY = Model.contentYToReveal(listFlick.contentY,
+      listFlick.height, list.y + bounds.y, bounds.height,
+      listFlick.contentHeight, Style.space(8))
+  }
+
   function moveCursor(delta) {
     if (!service) return
     var next = service.cursorOffset(cursorId, delta)
     if (next === "") return
     cursorId = next
+    revealCursorRow()
     // Moving is not opening. This used to open whatever it landed on while the
     // reader was up, which made stepping through a list a way to mark half of
     // it read without having looked at any of it. Enter and "o" open.

--- a/App.qml
+++ b/App.qml
@@ -757,7 +757,6 @@ Item {
               panelFontFamily: root.fontFamily
               cursorId: root.cursorId
               onMessageActivated: function(id) { root.openMessage(id) }
-              onRowHovered: function(id, isHovered) { if (isHovered) root.cursorId = id }
               onMenuRequested: function(id, sceneX, sceneY) {
                 root.cursorId = id
                 rowMenu.openAt(id, sceneX, sceneY)

--- a/App.qml
+++ b/App.qml
@@ -134,6 +134,10 @@ Item {
     if (service) service.windowOpen = true
     if (payload.mailbox && service) service.selectMailbox(String(payload.mailbox))
     if (payload.compose === true) startCompose("new")
+    // The list is usually already loaded by the time the window is summoned —
+    // the service keeps running while it is shut — so waiting for the next
+    // change to seat the cursor leaves the first j with nowhere to move from.
+    cursorId = Model.cursorAfterReload(service ? service.messages : [], cursorId)
     Qt.callLater(function() { focusScope.applyContextFocus() })
   }
 
@@ -201,13 +205,23 @@ Item {
   // Acting on the open message closes it: it is about to leave this list.
   function actOnCursor(action) {
     if (!service || cursorId === "") return
-    var wasOpen = currentView === "reader" && service.selectedId === cursorId
-    var next = service.cursorOffset(cursorId, 1)
-    service.act(cursorId, action)
-    if (wasOpen && !Model.survivesAction(service.mailboxKey, action)) {
-      if (next !== "" && next !== cursorId) openMessage(next)
+    var acted = cursorId
+    var wasOpen = currentView === "reader" && service.selectedId === acted
+    // Worked out before the action, while the row still has neighbours.
+    var next = Model.cursorAfterRemoval(service.messages, acted)
+    var leaves = !Model.survivesAction(service.mailboxKey, action)
+    service.act(acted, action)
+    if (!leaves) return
+    // The row is going and the cursor must not go with it: a cursor on a
+    // message that is no longer listed cannot be found, so the next j restarts
+    // at the top. Archiving one message used to send it back to the first row.
+    if (wasOpen) {
+      if (next !== "") openMessage(next)
       else backToList()
+      return
     }
+    cursorId = next
+    revealCursorRow()
   }
 
   function goMailbox(key) {
@@ -286,13 +300,13 @@ Item {
     target: root.service
     ignoreUnknownSignals: true
     function onReplySent() { compose.finish() }
-    // A list with no cursor cannot be driven: the window opens, the user
-    // presses j, and there is no row to move from. The first row is where the
-    // eye already is, so that is where the cursor starts.
+    // Every time the list is replaced — first arrival, a mailbox switch, a
+    // search, a refresh that dropped things. A cursor whose message survived
+    // keeps its place; one whose message is gone would be unfindable, and an
+    // unfindable cursor sends the next j to the top of the list.
     function onMessagesChanged() {
-      if (root.cursorId !== "") return
-      var rows = root.service ? root.service.messages : []
-      if (rows.length > 0) root.cursorId = rows[0].id
+      root.cursorId = Model.cursorAfterReload(
+        root.service ? root.service.messages : [], root.cursorId)
     }
     // A new account has no mailbox yet, so the only useful place to be is the
     // page that gives it one.

--- a/App.qml
+++ b/App.qml
@@ -10,9 +10,9 @@ import "components"
 // The application window. The shell loads this entry point when the plugin is
 // summoned and calls open()/close() on it; the FloatingWindow follows.
 //
-// Compose is a second window rather than a column. Hyprland tiles it beside
-// the mailbox, so the message being answered stays on screen instead of being
-// covered by the form.
+// Compose takes over the content area of this same window rather than opening
+// a second one; Omarchy's panel mechanism would give an extra window a region
+// of its own, which is not what a reply is.
 Item {
   id: root
 
@@ -174,9 +174,9 @@ Item {
   }
 
   function startCompose(mode) {
-    compose.begin(String(mode || "new"),
-      service ? service.selectedMessage : null,
-      service ? service.selectedBody.text : "")
+    if (!service) return
+    compose.begin(String(mode || "new"), service.selectedMessage,
+      service.selectedBody.text)
   }
 
   // Acting on the open message closes it: it is about to leave this list.
@@ -195,6 +195,65 @@ Item {
     if (!service) return
     service.selectMailbox(key)
     backToList()
+  }
+
+  // One answer per key id. The ids come from keys/Keymap.js; adding a key is a
+  // row there and a case here, and nothing else.
+  function runShortcut(id) {
+    if (id === "cursorDown") return moveCursor(1)
+    if (id === "cursorUp") return moveCursor(-1)
+    if (id === "open") return openMessage(cursorId)
+    if (id === "backToList") return backToList()
+    if (id === "archive") return actOnCursor("archive")
+    if (id === "trash") return actOnCursor("trash")
+    // Through the same guard actOnCursor applies rather than around it:
+    // starring with nothing selected used to call through with an empty id.
+    if (id === "star") {
+      if (service && cursorId !== "") service.toggleStar(cursorId)
+      return
+    }
+    if (id === "markRead") return actOnCursor("markRead")
+    if (id === "markUnread") return actOnCursor("markUnread")
+    if (id === "reply") return startCompose("reply")
+    if (id === "replyAll") return startCompose("replyAll")
+    if (id === "forward") return startCompose("forward")
+    if (id === "compose") return startCompose("new")
+    if (id === "send") return compose.submit()
+    if (id === "search") return searchBar.focusField()
+    if (id === "goInbox") return goMailbox("inbox")
+    if (id === "goStarred") return goMailbox("starred")
+    if (id === "goUnread") return goMailbox("unread")
+    if (id === "goSent") return goMailbox("sent")
+    if (id === "zoomIn") return zoomBy(0.1)
+    if (id === "zoomOut") return zoomBy(-0.1)
+    if (id === "zoomReset") { bodyZoom = 1.0; return }
+    if (id === "refresh") {
+      if (service) service.refresh()
+      return
+    }
+    if (id === "help") {
+      shortcutHelpVisible = !shortcutHelpVisible
+      return
+    }
+    if (id === "back") return goBack()
+  }
+
+  // What Escape means, in the order the window is stacked. The row menu, the
+  // app menu and the account switcher are absent on purpose: a QQC.Popup with
+  // CloseOnEscape consumes the key itself, so a branch for them here would
+  // never run.
+  function goBack() {
+    if (shortcutHelpVisible) shortcutHelpVisible = false
+    // A query being typed is the nearest thing to leave. This used to live in
+    // SearchBar as its own Keys handler, which a window Shortcut silently beats
+    // — so the layering is stated here, where Escape is actually decided.
+    else if (searchBar.fieldFocused && searchBar.queryText !== "") searchBar.clear()
+    else if (composing) compose.finish()
+    else if (currentView === "reader") backToList()
+    else if (setupVisible) setupVisible = false
+    else if (settingsVisible) settingsVisible = false
+    else if (service && service.searchQuery !== "") service.search("")
+    else requestClose()
   }
 
   Connections {
@@ -344,10 +403,26 @@ Item {
       anchors.fill: parent
       focus: true
 
-      // Every shortcut below is a bare letter, so all of them stand down while
-      // text is being typed. The search field is the only input in this window
-      // — compose is a window of its own — so it is the only thing to ask.
-      readonly property bool typing: searchBar.fieldFocused || root.composing
+      // Ask the window who holds the focus rather than listing the fields.
+      // The list was the bug: it named the search field only, while the setup,
+      // IMAP and settings forms put nine more text fields in this same scope —
+      // so typing an IMAP host archived mail on `e` and opened compose on `c`.
+      readonly property bool typing: {
+        var item = window.activeFocusItem
+        return !!item
+            && item.hasOwnProperty("cursorPosition")
+            && item.hasOwnProperty("selectedText")
+            && item.hasOwnProperty("readOnly")
+            && !item.readOnly
+      }
+
+      // Exactly one context at a time, by precedence: a page is a form before
+      // it is anything else, composing beats reading, reading beats the list.
+      readonly property string keyContext:
+          root.showPage  ? "page"
+        : root.composing ? "compose"
+        : root.currentView === "reader" ? "reader"
+        : "list"
 
       // ------------------------------------------------------------ header
 
@@ -983,48 +1058,12 @@ Item {
 
       // ---------------------------------------------------------- keyboard
 
-      Keys.onEscapePressed: function(event) {
-        if (root.shortcutHelpVisible) root.shortcutHelpVisible = false
-        else if (rowMenu.opened) rowMenu.close()
-        else if (appMenu.opened) appMenu.close()
-        else if (accountSwitcher.opened) accountSwitcher.close()
-        else if (root.composing) compose.finish()
-        else if (root.currentView === "reader") root.backToList()
-        else if (root.setupVisible) root.setupVisible = false
-        else if (root.settingsVisible) root.settingsVisible = false
-        else if (root.service && root.service.searchQuery !== "") root.service.search("")
-        else root.requestClose()
-        event.accepted = true
+      KeyRouter {
+        context: focusScope.keyContext
+        typing: focusScope.typing
+        overlay: root.shortcutHelpVisible
+        onTriggered: function(id) { root.runShortcut(id) }
       }
-
-      Shortcut { sequence: "Ctrl+K"; onActivated: searchBar.focusField() }
-      Shortcut { sequence: "/"; enabled: !focusScope.typing; onActivated: searchBar.focusField() }
-      Shortcut { sequence: "j"; enabled: !focusScope.typing; onActivated: root.moveCursor(1) }
-      Shortcut { sequence: "k"; enabled: !focusScope.typing; onActivated: root.moveCursor(-1) }
-      Shortcut { sequence: "Return"; enabled: !focusScope.typing && root.currentView === "list"; onActivated: root.openMessage(root.cursorId) }
-      // "o" for open, next to j/k on the home row, so the whole read cycle can
-      // be driven without leaving it.
-      Shortcut { sequence: "o"; enabled: !focusScope.typing && root.currentView === "list"; onActivated: root.openMessage(root.cursorId) }
-      Shortcut { sequence: "e"; enabled: !focusScope.typing; onActivated: root.actOnCursor("archive") }
-      Shortcut { sequence: "d"; enabled: !focusScope.typing; onActivated: root.actOnCursor("trash") }
-      Shortcut { sequence: "s"; enabled: !focusScope.typing; onActivated: if (root.service) root.service.toggleStar(root.cursorId) }
-      Shortcut { sequence: "Shift+I"; enabled: !focusScope.typing; onActivated: root.actOnCursor("markRead") }
-      Shortcut { sequence: "Shift+U"; enabled: !focusScope.typing; onActivated: root.actOnCursor("markUnread") }
-      Shortcut { sequence: "r"; enabled: !focusScope.typing && root.currentView === "reader"; onActivated: root.startCompose("reply") }
-      Shortcut { sequence: "a"; enabled: !focusScope.typing && root.currentView === "reader"; onActivated: root.startCompose("replyAll") }
-      Shortcut { sequence: "f"; enabled: !focusScope.typing && root.currentView === "reader"; onActivated: root.startCompose("forward") }
-      Shortcut { sequence: "c"; enabled: !focusScope.typing; onActivated: root.startCompose("new") }
-      Shortcut { sequence: "g,i"; enabled: !focusScope.typing; onActivated: root.goMailbox("inbox") }
-      Shortcut { sequence: "g,s"; enabled: !focusScope.typing; onActivated: root.goMailbox("starred") }
-      Shortcut { sequence: "g,u"; enabled: !focusScope.typing; onActivated: root.goMailbox("unread") }
-      Shortcut { sequence: "g,t"; enabled: !focusScope.typing; onActivated: root.goMailbox("sent") }
-      Shortcut { sequence: "Ctrl++"; onActivated: root.zoomBy(0.1) }
-      Shortcut { sequence: "Ctrl+="; onActivated: root.zoomBy(0.1) }
-      Shortcut { sequence: "Ctrl+-"; onActivated: root.zoomBy(-0.1) }
-      Shortcut { sequence: "Ctrl+0"; onActivated: root.bodyZoom = 1.0 }
-      Shortcut { sequence: "Ctrl+/"; onActivated: root.shortcutHelpVisible = !root.shortcutHelpVisible }
-      Shortcut { sequence: "Ctrl+?"; onActivated: root.shortcutHelpVisible = !root.shortcutHelpVisible }
-      Shortcut { sequence: "F5"; onActivated: if (root.service) root.service.refresh() }
     }
   }
 

--- a/App.qml
+++ b/App.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Window
 import Quickshell
 import qs.Commons
 import qs.Ui
@@ -409,7 +410,10 @@ Item {
       // IMAP and settings forms put nine more text fields in this same scope —
       // so typing an IMAP host archived mail on `e` and opened compose on `c`.
       readonly property bool typing: {
-        var item = window.activeFocusItem
+        // The attached property, not `window.activeFocusItem`: Quickshell's
+        // FloatingWindow is a proxy and does not forward that one, so reading
+        // it off the window gives undefined and every guard silently passes.
+        var item = focusScope.Window.activeFocusItem
         return !!item
             && item.hasOwnProperty("cursorPosition")
             && item.hasOwnProperty("selectedText")

--- a/App.qml
+++ b/App.qml
@@ -5,6 +5,7 @@ import qs.Commons
 import qs.Ui
 
 import "account/Model.js" as Model
+import "keys/Keymap.js" as Keymap
 import "components"
 
 // The application window. The shell loads this entry point when the plugin is
@@ -958,25 +959,7 @@ Item {
           textColor: root.foreground
           dimColor: root.dimmer
           panelFontFamily: root.fontFamily
-          hints: {
-            if (root.showPage) return [({ key: "Esc", label: "back" })]
-            if (root.composing) return [
-              ({ key: "Ctrl+Enter", label: "send" }),
-              ({ key: "Esc", label: "close" })
-            ]
-            if (root.currentView === "reader") return [
-              ({ key: "Esc", label: "back" }),
-              ({ key: "r", label: "reply" }),
-              ({ key: "e", label: "archive" }),
-              ({ key: "d", label: "trash" })
-            ]
-            return [
-              ({ key: "j / k", label: "move" }),
-              ({ key: "o", label: "open" }),
-              ({ key: "e", label: "archive" }),
-              ({ key: "c", label: "compose" })
-            ]
-          }
+          hints: Keymap.hintsFor(focusScope.keyContext)
         }
       }
 

--- a/App.qml
+++ b/App.qml
@@ -157,6 +157,7 @@ Item {
   // per-message decision about one specific message and does not.
   function openMessage(id) {
     if (!service) return
+    pendingComposeMode = ""
     reader.forceRichAnyway = false
     cursorId = String(id || "")
     service.select(cursorId)
@@ -164,6 +165,7 @@ Item {
   }
 
   function backToList() {
+    pendingComposeMode = ""
     if (service) service.clearSelection()
     currentView = "list"
     Qt.callLater(function() { focusScope.applyContextFocus() })
@@ -196,10 +198,30 @@ Item {
     // it read without having looked at any of it. Enter and "o" open.
   }
 
+  // An answer needs the message it is answering, and opening one only starts
+  // the fetch — select() clears the summary and the body first. Beginning the
+  // draft in the same breath addressed nobody and quoted nothing, which is what
+  // the list row's own Reply menu did. Held until the fetch lands instead.
+  property string pendingComposeMode: ""
+
   function startCompose(mode) {
     if (!service) return
-    compose.begin(String(mode || "new"), service.selectedMessage,
-      service.selectedBody.text)
+    var next = String(mode || "new")
+    if (next !== "new" && !service.selectedMessage) {
+      pendingComposeMode = next
+      return
+    }
+    pendingComposeMode = ""
+    compose.begin(next, service.selectedMessage, service.selectedBody.text)
+  }
+
+  // Answering from the list opens what is being answered first, the way the
+  // row's own menu does. Anything already open is left alone: re-selecting it
+  // would throw away the body that is on screen and fetch it again.
+  function composeFromCursor(mode) {
+    if (!service || cursorId === "") return
+    if (service.selectedId !== cursorId) openMessage(cursorId)
+    startCompose(mode)
   }
 
   // Acting on the open message closes it: it is about to leave this list.
@@ -247,9 +269,9 @@ Item {
     }
     if (id === "markRead") return actOnCursor("markRead")
     if (id === "markUnread") return actOnCursor("markUnread")
-    if (id === "reply") return startCompose("reply")
-    if (id === "replyAll") return startCompose("replyAll")
-    if (id === "forward") return startCompose("forward")
+    if (id === "reply") return composeFromCursor("reply")
+    if (id === "replyAll") return composeFromCursor("replyAll")
+    if (id === "forward") return composeFromCursor("forward")
     if (id === "compose") return startCompose("new")
     if (id === "send") return compose.submit()
     if (id === "search") return searchBar.focusField()
@@ -304,6 +326,17 @@ Item {
     // search, a refresh that dropped things. A cursor whose message survived
     // keeps its place; one whose message is gone would be unfindable, and an
     // unfindable cursor sends the next j to the top of the list.
+    // The message a held draft was waiting for. Selecting one clears the body
+    // and refills it from the network, so this fires twice: the guard is the
+    // summary, which is null until the fetch lands.
+    function onSelectedBodyChanged() {
+      if (root.pendingComposeMode === "") return
+      if (!root.service || !root.service.selectedMessage) return
+      var mode = root.pendingComposeMode
+      root.pendingComposeMode = ""
+      root.startCompose(mode)
+    }
+
     function onMessagesChanged() {
       root.cursorId = Model.cursorAfterReload(
         root.service ? root.service.messages : [], root.cursorId)

--- a/App.qml
+++ b/App.qml
@@ -125,12 +125,6 @@ Item {
   // Anything the window goes *into*. The mail chrome stands down for all of it.
   readonly property bool showPage: showSetup || showSettings
   readonly property bool composing: compose.opened
-  // Compose holds the focus while it is up. Handing it back when it closes
-  // keeps the window's focus on something that is actually on screen; leaving
-  // it on a hidden field is the shape of bug that ate every Escape once already.
-  onComposingChanged: if (!composing) Qt.callLater(function() {
-    focusScope.forceActiveFocus()
-  })
 
   function open(payloadJson) {
     var payload = ({})
@@ -140,7 +134,7 @@ Item {
     if (service) service.windowOpen = true
     if (payload.mailbox && service) service.selectMailbox(String(payload.mailbox))
     if (payload.compose === true) startCompose("new")
-    Qt.callLater(function() { focusScope.forceActiveFocus() })
+    Qt.callLater(function() { focusScope.applyContextFocus() })
   }
 
   function close() {
@@ -168,7 +162,7 @@ Item {
   function backToList() {
     if (service) service.clearSelection()
     currentView = "list"
-    Qt.callLater(function() { focusScope.forceActiveFocus() })
+    Qt.callLater(function() { focusScope.applyContextFocus() })
   }
 
   // Moving the cursor has to bring the row with it. The list is a Column in a
@@ -269,10 +263,17 @@ Item {
   // never run.
   function goBack() {
     if (shortcutHelpVisible) shortcutHelpVisible = false
-    // A query being typed is the nearest thing to leave. This used to live in
-    // SearchBar as its own Keys handler, which a window Shortcut silently beats
-    // — so the layering is stated here, where Escape is actually decided.
-    else if (searchBar.fieldFocused && searchBar.queryText !== "") searchBar.clear()
+    // A query being typed is the nearest thing to leave: clear it if there is
+    // one, then hand the keyboard back to the mailbox. This used to live in
+    // SearchBar as its own Keys handler, which a window Shortcut silently beats.
+    // A query being typed is the nearest thing to leave: clear it if there is
+    // one, then hand the keyboard back. Parked directly rather than through
+    // applyContextFocus, which would still read the context as "search" —
+    // the field has not lost the focus yet at this point.
+    else if (searchBar.fieldFocused) {
+      if (searchBar.queryText !== "") searchBar.clear()
+      focusScope.parkKeyboard()
+    }
     else if (composing) compose.finish()
     else if (currentView === "reader") backToList()
     else if (setupVisible) setupVisible = false
@@ -428,40 +429,44 @@ Item {
       anchors.fill: parent
       focus: true
 
-      // Ask the window who holds the focus rather than listing the fields, so
-      // a field added later is covered without being remembered. The old list
-      // named the search field only, while the setup, IMAP and settings forms
-      // put nine more in this same scope.
-      //
-      // This is a third line of defence, not the only one: a focused TextInput
-      // already takes bare keys for itself before a Shortcut sees them, and the
-      // key context already stands the mailbox keys down on a form. What is
-      // left for this is a focus target that is neither — a custom input, or a
-      // field that does not claim the key it is given.
-      readonly property bool typing: {
-        // The attached property, not `window.activeFocusItem`: Quickshell's
-        // FloatingWindow is a proxy and does not forward that one, so reading
-        // it off the window gives undefined and every guard silently passes.
-        var item = focusScope.Window.activeFocusItem
-        return !!item
-            && item.hasOwnProperty("cursorPosition")
-            && item.hasOwnProperty("selectedText")
-            && item.hasOwnProperty("readOnly")
-            // Nobody is typing into something they cannot see. Closing compose
-            // leaves its field holding the focus while invisible, which pinned
-            // this true and stood every bare key down for the rest of the
-            // session — j and k included.
-            && item.visible
-            && !item.readOnly
-      }
-
-      // Exactly one context at a time, by precedence: a page is a form before
-      // it is anything else, composing beats reading, reading beats the list.
+      // Where the window is, and the only thing that says what a key means.
+      // A page is a form before it is anything else, a draft beats reading, a
+      // query being typed beats the list underneath it.
       readonly property string keyContext:
           root.showPage  ? "page"
         : root.composing ? "compose"
+        : searchBar.fieldFocused ? "search"
         : root.currentView === "reader" ? "reader"
         : "list"
+
+      // The context owns the keyboard. Changing it moves the focus to whatever
+      // that context types into, or parks it when the context types into
+      // nothing — so a field that has been dismissed cannot go on eating keys.
+      //
+      // Keeping these as two things is the bug this replaces: the context came
+      // from the screen while the focus stayed wherever the last click left it,
+      // and a closed compose field kept swallowing j and k. One mechanism now,
+      // and there is nothing to keep in step.
+      onKeyContextChanged: Qt.callLater(applyContextFocus)
+      function applyContextFocus() {
+        if (keyContext === "compose") compose.takeFocus()
+        else if (keyContext === "search") searchBar.focusField()
+        else parkKeyboard()
+      }
+
+      // forceActiveFocus on the scope itself is a no-op: it re-elects the
+      // scope's current focus item, which is the very field being left. It has
+      // to land on a plain Item for the field to actually let go.
+      function parkKeyboard() {
+        keyboardHome.forceActiveFocus()
+      }
+
+      // Where the keyboard lives when nothing is being typed into.
+      Item {
+        id: keyboardHome
+        width: 1
+        height: 1
+      }
 
       // ------------------------------------------------------------ header
 
@@ -1081,7 +1086,6 @@ Item {
 
       KeyRouter {
         context: focusScope.keyContext
-        typing: focusScope.typing
         overlay: root.shortcutHelpVisible
         onTriggered: function(id) { root.runShortcut(id) }
       }

--- a/App.qml
+++ b/App.qml
@@ -125,6 +125,12 @@ Item {
   // Anything the window goes *into*. The mail chrome stands down for all of it.
   readonly property bool showPage: showSetup || showSettings
   readonly property bool composing: compose.opened
+  // Compose holds the focus while it is up. Handing it back when it closes
+  // keeps the window's focus on something that is actually on screen; leaving
+  // it on a hidden field is the shape of bug that ate every Escape once already.
+  onComposingChanged: if (!composing) Qt.callLater(function() {
+    focusScope.forceActiveFocus()
+  })
 
   function open(payloadJson) {
     var payload = ({})
@@ -422,10 +428,16 @@ Item {
       anchors.fill: parent
       focus: true
 
-      // Ask the window who holds the focus rather than listing the fields.
-      // The list was the bug: it named the search field only, while the setup,
-      // IMAP and settings forms put nine more text fields in this same scope —
-      // so typing an IMAP host archived mail on `e` and opened compose on `c`.
+      // Ask the window who holds the focus rather than listing the fields, so
+      // a field added later is covered without being remembered. The old list
+      // named the search field only, while the setup, IMAP and settings forms
+      // put nine more in this same scope.
+      //
+      // This is a third line of defence, not the only one: a focused TextInput
+      // already takes bare keys for itself before a Shortcut sees them, and the
+      // key context already stands the mailbox keys down on a form. What is
+      // left for this is a focus target that is neither — a custom input, or a
+      // field that does not claim the key it is given.
       readonly property bool typing: {
         // The attached property, not `window.activeFocusItem`: Quickshell's
         // FloatingWindow is a proxy and does not forward that one, so reading
@@ -435,6 +447,11 @@ Item {
             && item.hasOwnProperty("cursorPosition")
             && item.hasOwnProperty("selectedText")
             && item.hasOwnProperty("readOnly")
+            // Nobody is typing into something they cannot see. Closing compose
+            // leaves its field holding the focus while invisible, which pinned
+            // this true and stood every bare key down for the rest of the
+            // session — j and k included.
+            && item.visible
             && !item.readOnly
       }
 

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -48,10 +48,22 @@ BarWidget {
     // their own root object `root`, so nothing inside a Component declared
     // here refers to `root` — it would be ambiguous about which one it meant.
     readonly property bool connected: !!root.gmail && root.gmail.ready
-    readonly property color glyphColor: connected
-      ? root.foreground
-      : Qt.darker(root.foreground, 1.55)
+    // A trigger holds a selected style for as long as what it opened is on
+    // screen, which is what answers "which of these opened that window". The
+    // service is what knows: it outlives the window and is told either way.
+    readonly property bool windowOpen: !!root.gmail && root.gmail.windowOpen
+    // `activeColor` is the bar's own active token — the theme's `bar.active`,
+    // which the bar hands down under the name `urgent`. It is the colour for a
+    // widget whose thing is open, not a colour for danger.
+    readonly property color glyphColor: windowOpen
+      ? activeColor
+      : (connected ? root.foreground : Qt.darker(root.foreground, 1.55))
     readonly property bool hasUnread: !!root.gmail && root.gmail.unreadTotal > 0
+
+    // Said declaratively as well as drawn: the glyph comes from iconComponent,
+    // which BarIconButton does not colour for us, so `active` alone would show
+    // nothing — but it is still the state the bar asks about.
+    active: windowOpen
 
     iconComponent: Component {
       Item {

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -52,21 +52,32 @@ BarWidget {
     // screen, which is what answers "which of these opened that window". The
     // service is what knows: it outlives the window and is told either way.
     readonly property bool windowOpen: !!root.gmail && root.gmail.windowOpen
-    // `activeColor` is the bar's own active token — the theme's `bar.active`,
-    // which the bar hands down under the name `urgent`. It is the colour for a
-    // widget whose thing is open, not a colour for danger.
-    readonly property color glyphColor: windowOpen
-      ? activeColor
-      : (connected ? root.foreground : Qt.darker(root.foreground, 1.55))
+    // Not `activeColor`: the bar hands that down from the theme's `bar.active`,
+    // which falls back to `urgent` — a warning colour for a window simply being
+    // open. The glyph keeps its own colour and the open state is a fill behind
+    // it, which is what a selected control looks like everywhere else here.
+    readonly property color glyphColor: connected
+      ? root.foreground
+      : Qt.darker(root.foreground, 1.55)
     readonly property bool hasUnread: !!root.gmail && root.gmail.unreadTotal > 0
 
-    // Said declaratively as well as drawn: the glyph comes from iconComponent,
-    // which BarIconButton does not colour for us, so `active` alone would show
-    // nothing — but it is still the state the bar asks about.
-    active: windowOpen
+    // The bar's own `active` is left alone on purpose: it exists to recolour a
+    // glyph, and this widget draws its own.
+    readonly property color openFill: Style.selectedFillFor(root.foreground, Color.accent)
 
     iconComponent: Component {
       Item {
+        // The same fill a selected control carries anywhere else in this
+        // application, so an open window reads as open rather than as urgent.
+        Rectangle {
+          anchors.centerIn: parent
+          width: Style.space(20)
+          height: width
+          radius: Style.cornerRadius
+          visible: button.windowOpen
+          color: button.openFill
+        }
+
         GmailIcon {
           anchors.centerIn: parent
           iconSize: Style.space(12)

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/ListSkeleton.qml \
 	components/MessageRow.qml \
 	components/MessageMenu.qml \
+	components/KeyRouter.qml \
 	components/ActionIcon.qml \
 	components/IconButton.qml \
 	components/IconTextButton.qml \

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ test-js:
 	node tests/test_html.js
 	node tests/test_cache.js
 	node tests/test_model.js
+	node tests/test_keymap.js
 	node tests/test_accounts.js
 	node tests/test_provider.js
 	node tests/test_imap.js

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/SetupPage.qml \
 	components/ShortcutHelp.qml
 
-.PHONY: test test-js test-shell qml-check validate bench
+.PHONY: test test-js test-shell test-qml qml-check validate bench
 
-test: test-js test-shell
+test: test-js test-shell test-qml
 
 # The parsing, formatting, and decision rules live in plain JS precisely so
 # they can be tested without a compositor. These run anywhere node does.
@@ -56,6 +56,13 @@ test-shell:
 	bash tests/test_service_source.sh
 	bash tests/test_install.sh
 	bash tests/test_transport.sh
+
+# Focus ownership cannot be tested without a focus scope, and a focus scope
+# needs the QML engine. Offscreen, so it needs no compositor: the bug this
+# catches — a hidden component owning the focus and swallowing keys — is
+# invisible to any test that cannot instantiate one.
+test-qml:
+	QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner -input tests/qml
 
 # Both engines on the same fixtures. The QML column is the one that decides
 # anything — the shell runs that engine, not node's — so run it on the machine

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ server — including one you run yourself.
   mailbox with an address and an app password. Several accounts at once, each
   with its own inbox, cache and unread count.
 - **Keyboard-first.** `j`/`k` to move, `e` to archive, `s` to star, `r` to
-  reply, `c` to compose, `g i` for the inbox, `/` to search — Gmail's own
-  shortcuts, so there is nothing new to learn.
+  reply, `c` to compose, `g i` for the inbox, `/` to search, `?` for the rest —
+  Gmail's own shortcuts, so there is nothing new to learn.
 - **Always counting.** The unread badge keeps working while the window is shut,
   for every account, with a desktop notification when new mail lands.
 - **One window.** Read, archive, star, trash, search, and answer without a

--- a/Service.qml
+++ b/Service.qml
@@ -439,7 +439,9 @@ Item {
   function select(id) { if (current) current.select(id) }
   function clearSelection() { if (current) current.clearSelection() }
   function showRemoteImages() { if (current) current.showRemoteImages() }
-  function selectOffset(delta) { return current ? current.selectOffset(delta) : "" }
+  function cursorOffset(cursorId, delta) {
+    return current ? current.cursorOffset(cursorId, delta) : ""
+  }
   function selectMailbox(key) { if (current) current.selectMailbox(key) }
   function search(text) { if (current) current.search(text) }
   function selectLabel(name) { if (current) current.selectLabel(name) }

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -597,13 +597,10 @@ Item {
     detailLoading = false
   }
 
-  function selectOffset(delta) {
-    if (messages.length === 0) return ""
-    var index = Model.indexById(messages, selectedId)
-    var next = index < 0 ? 0 : index + Math.floor(Number(delta) || 0)
-    if (next < 0) next = 0
-    if (next > messages.length - 1) next = messages.length - 1
-    return messages[next].id
+  // The cursor is the list's own position and moves relative to itself.
+  // `selectedId` keeps its separate meaning: which message the reader shows.
+  function cursorOffset(cursorId, delta) {
+    return Model.cursorAfterOffset(messages, cursorId, delta)
   }
 
   // -------------------------------------------------------------- actions

--- a/account/Model.js
+++ b/account/Model.js
@@ -199,6 +199,32 @@ function cursorAfterOffset(list, cursorId, delta) {
   return source[next].id
 }
 
+// Where the scroller has to sit for a row to be on screen. The list is a Column
+// in a Flickable rather than a ListView — the panel already owns a scroller and
+// nesting a second one gives every wheel event two plausible targets — so there
+// is no positionViewAtIndex, and keyboard movement has to say this itself.
+//
+// Unchanged while the row is already visible. Recentring on every press would
+// drag the list under someone who is only stepping one row down it.
+function contentYToReveal(contentY, viewportHeight, itemY, itemHeight,
+                          contentHeight, margin) {
+  var top = Number(contentY) || 0
+  var view = Number(viewportHeight) || 0
+  var y = Number(itemY) || 0
+  var height = Number(itemHeight) || 0
+  var pad = Number(margin) || 0
+  var furthest = Math.max(0, (Number(contentHeight) || 0) - view)
+  var next = top
+  // A row that cannot fit shows its beginning. Aligning its bottom, which is
+  // what the off-the-bottom rule would do, pushes the part being read away.
+  if (height + pad + pad > view) next = y - pad
+  else if (y - pad < top) next = y - pad
+  else if (y + height + pad > top + view) next = y + height + pad - view
+  if (next < 0) next = 0
+  if (next > furthest) next = furthest
+  return next
+}
+
 function unreadCount(list) {
   var source = Array.isArray(list) ? list : []
   var count = 0

--- a/account/Model.js
+++ b/account/Model.js
@@ -180,6 +180,25 @@ function indexById(list, id) {
   return -1
 }
 
+// Where the list cursor lands after a step. Anchored on the cursor itself,
+// because the cursor and the open message are two different things: nothing is
+// open while the list is being walked, and walking must not move the reader.
+// Anchoring this on the open message pinned it — every step in the list
+// resolved to row 0, and in the reader the anchor never advanced.
+function cursorAfterOffset(list, cursorId, delta) {
+  var source = Array.isArray(list) ? list : []
+  if (source.length === 0) return ""
+  var step = Math.floor(Number(delta) || 0)
+  var index = indexById(source, cursorId)
+  // No cursor, or one whose message has left the list: start from the end the
+  // move is coming from, so j opens at the top and k opens at the bottom.
+  if (index < 0) return step < 0 ? source[source.length - 1].id : source[0].id
+  var next = index + step
+  if (next < 0) next = 0
+  if (next > source.length - 1) next = source.length - 1
+  return source[next].id
+}
+
 function unreadCount(list) {
   var source = Array.isArray(list) ? list : []
   var count = 0

--- a/account/Model.js
+++ b/account/Model.js
@@ -199,6 +199,32 @@ function cursorAfterOffset(list, cursorId, delta) {
   return source[next].id
 }
 
+// Where the cursor goes when the row it is on is about to leave the list.
+// Called with the list as it still is, so the departing row still has
+// neighbours: the one below takes its place, or the one above at the end.
+//
+// Leaving the cursor on a row that has gone is not harmless. cursorAfterOffset
+// cannot find it, so it restarts at the top — which is how archiving one
+// message sent the next j back to the first row.
+function cursorAfterRemoval(list, cursorId) {
+  var source = Array.isArray(list) ? list : []
+  var index = indexById(source, cursorId)
+  if (index < 0) return ""
+  if (index + 1 < source.length) return source[index + 1].id
+  if (index > 0) return source[index - 1].id
+  return ""
+}
+
+// Where the cursor goes when the whole list is replaced under it — a mailbox
+// switch, a search, a refresh that dropped things. The message it was on keeps
+// it if it survived; otherwise the top, which is where the eye goes anyway.
+function cursorAfterReload(list, cursorId) {
+  var source = Array.isArray(list) ? list : []
+  if (source.length === 0) return ""
+  if (indexById(source, cursorId) >= 0) return cursorId
+  return source[0].id
+}
+
 // Where the scroller has to sit for a row to be on screen. The list is a Column
 // in a Flickable rather than a ListView — the panel already owns a scroller and
 // nesting a second one gives every wheel event two plausible targets — so there

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -120,7 +120,12 @@ Item {
   }
 
   anchors.fill: parent
-  focus: true
+  // Only while it is actually in use. A component that declares `focus: true`
+  // owns the window's focus even when invisible — Qt does not exclude hidden
+  // items — and an owner that accepts keys is a sink. This swallowed every
+  // Escape in the window, which is why Esc looked intermittent: whether it
+  // worked depended on where the user had last clicked.
+  focus: root.opened
 
   Keys.onEscapePressed: function(event) {
     root.finish()

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -91,14 +91,20 @@ Item {
       bodyEdit.text = "\n\n" + Mail.quoteBody(summary, String(bodyText || ""))
     }
 
-    Qt.callLater(function() {
-      if (root.mode === "reply" || root.mode === "replyAll") {
-        bodyEdit.forceActiveFocus()
-        bodyEdit.cursorPosition = 0
-      } else {
-        toField.forceActiveFocus()
-      }
-    })
+    // Focus is not placed here. Opening this changes the window's key context,
+    // and the context is what moves the keyboard — one mechanism, so the two
+    // cannot disagree about where the typing goes.
+  }
+
+  // Where the keyboard goes when composing becomes the context. A reply starts
+  // in the body above the quote; a new message starts at the address.
+  function takeFocus() {
+    if (mode === "reply" || mode === "replyAll") {
+      bodyEdit.forceActiveFocus()
+      bodyEdit.cursorPosition = 0
+    } else {
+      toField.forceActiveFocus()
+    }
   }
 
   function finish() {

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -216,7 +216,11 @@ Item {
 
     Item {
       width: parent.width
-      implicitHeight: Style.space(34)
+      // The field plus the same breathing room it carries inside itself, so
+      // its border is not crowded against the rules above and below. Derived
+      // rather than a fixed height: the field grows with the theme's font
+      // scale, and a fixed row would scale that growth a second time.
+      implicitHeight: toField.implicitHeight + Style.space(14)
 
       Text {
         id: toLabel
@@ -268,7 +272,11 @@ Item {
     Item {
       visible: root.ccVisible
       width: parent.width
-      implicitHeight: Style.space(34)
+      // The field plus the same breathing room it carries inside itself, so
+      // its border is not crowded against the rules above and below. Derived
+      // rather than a fixed height: the field grows with the theme's font
+      // scale, and a fixed row would scale that growth a second time.
+      implicitHeight: ccField.implicitHeight + Style.space(14)
 
       Text {
         id: ccLabel
@@ -306,7 +314,11 @@ Item {
 
     Item {
       width: parent.width
-      implicitHeight: Style.space(34)
+      // The field plus the same breathing room it carries inside itself, so
+      // its border is not crowded against the rules above and below. Derived
+      // rather than a fixed height: the field grows with the theme's font
+      // scale, and a fixed row would scale that growth a second time.
+      implicitHeight: subjectField.implicitHeight + Style.space(14)
 
       Text {
         id: subjectLabel

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -127,11 +127,6 @@ Item {
   // worked depended on where the user had last clicked.
   focus: root.opened
 
-  Keys.onEscapePressed: function(event) {
-    root.finish()
-    event.accepted = true
-  }
-
   // ----------------------------------------------------------- header
   //
   // There is no client-side titlebar under Hyprland, so the window has to
@@ -430,12 +425,6 @@ Item {
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.caption
     }
-  }
-
-  Shortcut {
-    sequence: "Ctrl+Return"
-    enabled: root.opened && root.visible
-    onActivated: root.submit()
   }
 
 }

--- a/components/KeyRouter.qml
+++ b/components/KeyRouter.qml
@@ -4,11 +4,12 @@ import "../keys/Keymap.js" as Keymap
 
 // Turns the key table into live Shortcuts, and reports what was pressed by id.
 //
-// One place decides whether a binding is live, so there is no per-line
-// `enabled:` expression to copy wrongly — which is how a hand-written typing
-// guard came to miss nine text fields. Escape is routed here like every other
-// key rather than through Keys.onEscapePressed, so it no longer depends on
-// which item happens to hold the focus.
+// The keyboard belongs to the application, and the context says what a key
+// means where — actions are scoped, the way a TUI or GPUI scopes them. One
+// place decides whether a binding is live, so there is no per-line `enabled:`
+// expression to copy wrongly. Escape is routed here like every other key
+// rather than through Keys.onEscapePressed, so it does not depend on which
+// item happens to hold the focus.
 //
 // An Instantiator rather than a Repeater: a Shortcut is a QtObject, and a
 // Repeater only builds Items, so a Repeater here creates nothing at all and
@@ -19,10 +20,10 @@ import "../keys/Keymap.js" as Keymap
 Item {
   id: root
 
-  // Where the window is: one of Keymap.CONTEXTS.
+  // Where the window is: one of Keymap.CONTEXTS. It is the only thing that
+  // decides what is live — a text-entry context binds no bare keys, so there is
+  // no separate "are they typing" question to keep in step with this one.
   property string context: "list"
-  // The focused item is a text entry, so bare keys belong to it.
-  property bool typing: false
   // Something is covering the window and should be dismissed before anything
   // else acts. Popups are excluded on purpose: a QQC.Popup with CloseOnEscape
   // consumes its own keys, so the router never sees them.
@@ -36,10 +37,7 @@ Item {
     delegate: Shortcut {
       required property var modelData
       sequence: modelData.sequence
-      // The sequence is passed as well as the row: whether a key stands down
-      // while typing is a property of that key, not of its row.
-      enabled: Keymap.isEnabled(modelData.binding, modelData.sequence,
-                                root.context, root.typing, root.overlay)
+      enabled: Keymap.isEnabled(modelData.binding, root.context, root.overlay)
       onActivated: root.triggered(modelData.id)
     }
   }

--- a/components/KeyRouter.qml
+++ b/components/KeyRouter.qml
@@ -1,0 +1,46 @@
+import QtQuick
+import QtQml
+import "../keys/Keymap.js" as Keymap
+
+// Turns the key table into live Shortcuts, and reports what was pressed by id.
+//
+// One place decides whether a binding is live, so there is no per-line
+// `enabled:` expression to copy wrongly — which is how a hand-written typing
+// guard came to miss nine text fields. Escape is routed here like every other
+// key rather than through Keys.onEscapePressed, so it no longer depends on
+// which item happens to hold the focus.
+//
+// An Instantiator rather than a Repeater: a Shortcut is a QtObject, and a
+// Repeater only builds Items, so a Repeater here creates nothing at all and
+// every key silently goes dead.
+//
+// This component draws nothing and deliberately imports no theme, so it can be
+// instantiated without the shell's singletons and exercised in tests/qml.
+Item {
+  id: root
+
+  // Where the window is: one of Keymap.CONTEXTS.
+  property string context: "list"
+  // The focused item is a text entry, so bare keys belong to it.
+  property bool typing: false
+  // Something is covering the window and should be dismissed before anything
+  // else acts. Popups are excluded on purpose: a QQC.Popup with CloseOnEscape
+  // consumes its own keys, so the router never sees them.
+  property bool overlay: false
+
+  signal triggered(string id)
+
+  Instantiator {
+    model: Keymap.sequencesFor(root.context)
+
+    delegate: Shortcut {
+      required property var modelData
+      sequence: modelData.sequence
+      // The sequence is passed as well as the row: whether a key stands down
+      // while typing is a property of that key, not of its row.
+      enabled: Keymap.isEnabled(modelData.binding, modelData.sequence,
+                                root.context, root.typing, root.overlay)
+      onActivated: root.triggered(modelData.id)
+    }
+  }
+}

--- a/components/MessageList.qml
+++ b/components/MessageList.qml
@@ -6,6 +6,13 @@ import "../account/Model.js" as Model
 // The message list. A Repeater in a Column rather than a ListView because the
 // panel already owns one Flickable and nesting a second scroller inside it
 // gives every wheel event two plausible targets.
+//
+// Hovering a row does not move the keyboard's cursor. A row reports its own
+// hover appearance (MessageRow.hot), and letting hover write `cursorId` as well
+// put the mouse and the keyboard in a fight the mouse won: pressing j scrolls
+// the list to follow the cursor, and Qt re-reports hover when content moves
+// under a pointer that has not moved — so the cursor was pulled straight back
+// to whatever the mouse happened to be resting on, and j went nowhere.
 Column {
   id: root
 
@@ -17,7 +24,6 @@ Column {
   property string cursorId: ""
 
   signal messageActivated(string id)
-  signal rowHovered(string id, bool isHovered)
   signal menuRequested(string id, real sceneX, real sceneY)
 
   width: parent ? parent.width : 0
@@ -54,7 +60,6 @@ Column {
       onStarToggled: root.service.toggleStar(modelData.id)
       onArchiveRequested: root.service.act(modelData.id, "archive")
       onTrashRequested: root.service.act(modelData.id, "trash")
-      onHovered: function(isHovered) { root.rowHovered(modelData.id, isHovered) }
       onMenuRequested: function(sceneX, sceneY) {
         root.menuRequested(modelData.id, sceneX, sceneY)
       }

--- a/components/MessageList.qml
+++ b/components/MessageList.qml
@@ -23,7 +23,20 @@ Column {
   width: parent ? parent.width : 0
   spacing: Style.space(2)
 
+  // Where a row sits in this column's own coordinates, so the panel's scroller
+  // can bring it into view. Found by index rather than by asking the rows which
+  // one holds the cursor: the answer must not wait on a binding to propagate.
+  function boundsFor(id) {
+    if (!root.service) return null
+    var index = Model.indexById(root.service.messages, id)
+    if (index < 0) return null
+    var item = rows.itemAt(index)
+    if (!item) return null
+    return ({ y: item.y, height: item.height })
+  }
+
   Repeater {
+    id: rows
     model: root.service.messages
 
     MessageRow {

--- a/components/MessageRow.qml
+++ b/components/MessageRow.qml
@@ -24,7 +24,6 @@ Rectangle {
   signal archiveRequested()
   signal trashRequested()
   signal menuRequested(real sceneX, real sceneY)
-  signal hovered(bool isHovered)
 
   readonly property bool hot: mouse.containsMouse || hasCursor
 
@@ -40,8 +39,6 @@ Rectangle {
     anchors.fill: parent
     hoverEnabled: true
     acceptedButtons: Qt.LeftButton | Qt.MiddleButton | Qt.RightButton
-    onEntered: root.hovered(true)
-    onExited: root.hovered(false)
     onClicked: function(event) {
       if (event.button === Qt.RightButton) {
         var scene = mapToGlobal(event.x, event.y)

--- a/components/SearchBar.qml
+++ b/components/SearchBar.qml
@@ -16,6 +16,10 @@ Item {
 
   // The window's single-letter shortcuts stand down while this has focus.
   readonly property bool fieldFocused: field.activeFocus
+  // What Escape has to decide between clearing and leaving alone. The window
+  // owns that decision now: a window Shortcut beats a focused item's Keys
+  // handler, so a local one here would look live and never run.
+  readonly property string queryText: field.text
 
   implicitHeight: field.implicitHeight
 
@@ -63,14 +67,6 @@ Item {
       border.color: field.activeFocus
         ? Style.hoverBorderFor(root.textColor, root.accentColor)
         : Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.12)
-    }
-
-    // Escape clears the query before it reaches the window, where the same key
-    // would close the whole thing.
-    Keys.onEscapePressed: function(event) {
-      if (text === "") return
-      root.clear()
-      event.accepted = true
     }
   }
 

--- a/components/ShortcutHelp.qml
+++ b/components/ShortcutHelp.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import qs.Commons
 import qs.Ui
+import "../keys/Keymap.js" as Keymap
 
 // The reference sheet behind Ctrl+?. A plain list rather than a dialog because
 // it never needs an answer — Esc, Ctrl+? again, or a click puts it away.
@@ -14,26 +15,10 @@ Rectangle {
 
   signal dismissed()
 
-  readonly property var rows: [
-    { keys: "j / k", action: "Move down / up" },
-    { keys: "Enter or o", action: "Open the selected message" },
-    { keys: "Esc", action: "Back to the list" },
-    { keys: "e", action: "Archive" },
-    { keys: "d", action: "Move to trash" },
-    { keys: "s", action: "Star or unstar" },
-    { keys: "Shift+I / Shift+U", action: "Mark read / unread" },
-    { keys: "r / a / f", action: "Reply, reply all, forward" },
-    { keys: "c", action: "Compose" },
-    { keys: "Ctrl+Enter", action: "Send" },
-    { keys: "/ or Ctrl+K", action: "Search" },
-    { keys: "g then i / s / u / t", action: "Inbox, starred, unread, sent" },
-    { keys: "Right-click a row", action: "Archive, trash, spam, star" },
-    { keys: "Ctrl+= / Ctrl+-", action: "Zoom the message body" },
-    { keys: "Ctrl+0", action: "Reset the zoom" },
-    { keys: "F5", action: "Check for mail" },
-    { keys: "Ctrl+?", action: "Toggle this sheet" },
-    { keys: "Esc", action: "Back, or close the window" }
-  ]
+  // From the table, so this sheet cannot drift from what the keys actually do.
+  // It used to be written by hand, and had: Esc listed twice, no `u` and no
+  // `?`, and "Right-click a row" among the keyboard shortcuts.
+  readonly property var groups: Keymap.helpGroups()
 
   color: Qt.rgba(backgroundColor.r, backgroundColor.g, backgroundColor.b, 0.96)
 
@@ -44,7 +29,7 @@ Rectangle {
 
   Column {
     anchors.centerIn: parent
-    width: Math.min(parent.width - Style.space(80), Style.space(420))
+    width: Math.min(parent.width - Style.space(80), Style.space(460))
     spacing: Style.space(6)
 
     Text {
@@ -61,34 +46,58 @@ Rectangle {
     }
 
     Repeater {
-      model: root.rows
+      model: root.groups
 
-      Item {
+      Column {
+        id: group
         required property var modelData
         width: parent.width
-        implicitHeight: Style.space(20)
+        spacing: Style.space(6)
 
-        Text {
-          anchors.left: parent.left
-          anchors.verticalCenter: parent.verticalCenter
-          width: Style.space(150)
-          text: modelData.keys
-          color: root.textColor
-          font.family: root.panelFontFamily
-          font.pixelSize: Style.font.caption
-          elide: Text.ElideRight
+        Item {
+          width: parent.width
+          implicitHeight: Style.space(8)
         }
 
         Text {
-          anchors.left: parent.left
-          anchors.leftMargin: Style.space(155)
-          anchors.right: parent.right
-          anchors.verticalCenter: parent.verticalCenter
-          text: modelData.action
+          text: group.modelData.name
           color: root.dimColor
           font.family: root.panelFontFamily
           font.pixelSize: Style.font.caption
-          elide: Text.ElideRight
+          font.bold: true
+        }
+
+        Repeater {
+          model: group.modelData.rows
+
+          Item {
+            required property var modelData
+            width: group.width
+            implicitHeight: Style.space(20)
+
+            Text {
+              anchors.left: parent.left
+              anchors.verticalCenter: parent.verticalCenter
+              width: Style.space(178)
+              text: modelData.keys
+              color: root.textColor
+              font.family: root.panelFontFamily
+              font.pixelSize: Style.font.caption
+              elide: Text.ElideRight
+            }
+
+            Text {
+              anchors.left: parent.left
+              anchors.leftMargin: Style.space(183)
+              anchors.right: parent.right
+              anchors.verticalCenter: parent.verticalCenter
+              text: modelData.action
+              color: root.dimColor
+              font.family: root.panelFontFamily
+              font.pixelSize: Style.font.caption
+              elide: Text.ElideRight
+            }
+          }
         }
       }
     }

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -155,6 +155,20 @@ row does not drag the list under someone reading it. It is called from
 `moveCursor`, not from `cursorId` changing, because hovering a row moves the
 cursor too and scrolling under the pointer fights the mouse.
 
+## The mouse
+
+The mouse does not move the keyboard's cursor. A row draws its own hover
+(`MessageRow.hot`), clicking one opens it, and right-clicking one sets the
+cursor explicitly before opening its menu — but hovering does nothing to
+`cursorId`.
+
+That is not a preference. Qt re-reports hover when content moves under a
+pointer that has not moved, and the list scrolls to follow the keyboard. With
+hover writing `cursorId`, pressing `j` moved the cursor, the scroll brought a
+different row under the still pointer, and the cursor snapped back to it — so
+`j` and `k` stuck on whichever rows the mouse was resting near.
+`tests/qml/tst_hover_under_scroll.qml` pins the Qt behaviour that makes this so.
+
 ## Adding a key
 
 1. Add a row to `BINDINGS` in `keys/Keymap.js`. Name the contexts it means

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -36,7 +36,7 @@ readonly property string keyContext:
 | Context | What it is | What it binds |
 |---|---|---|
 | `list` | The message list | The mailbox keys |
-| `reader` | A message open | The mailbox keys, plus reply/forward and zoom |
+| `reader` | A message open | The mailbox keys, plus reply/forward and zoom. `j`/`k` move the cursor without opening; `o` or `Enter` opens what they landed on |
 | `search` | A query being typed | `Escape`, and the modified keys |
 | `compose` | A draft being written | `Escape`, `Ctrl+Return`, and the modified keys |
 | `page` | Setup or settings | `Escape`, and the modified keys |
@@ -85,7 +85,7 @@ used to exist, and they had.
 |---|---|---|---|
 | `cursorDown` | `j`, `Down` | mail | Move down |
 | `cursorUp` | `k`, `Up` | mail | Move up |
-| `open` | `Return`, `o` | list | Open the selected message |
+| `open` | `Return`, `o` | mail | Open the selected message |
 | `backToList` | `u` | reader | Back to the list |
 | `archive` | `e` | mail | Archive |
 | `trash` | `d` | mail | Move to trash |
@@ -120,6 +120,40 @@ answers to, and a draft is not a mailbox.
 `Escape` is the only bare key bound everywhere, because it is the way out of
 everywhere. What it means in each place is one list in `goBack()`, in the order
 the window is stacked.
+
+## The cursor
+
+`cursorId` is where the keyboard is. `selectedId` is what the reader shows.
+They are two different things, and conflating them was the first bug in this
+area: movement was anchored on the opened message, so in the list — where
+nothing is open — every step resolved to the first row, and `j` moved once and
+then stopped.
+
+Three rules, all in `account/Model.js` so the node tests reach them:
+
+- **`cursorAfterOffset`** — moving. Anchored on the cursor itself, clamped at
+  both ends, and starting from the end the move came from when there is no
+  cursor yet, so `j` opens at the top and `k` at the bottom.
+- **`cursorAfterRemoval`** — the row the cursor is on is about to leave, because
+  it was archived or trashed. The cursor takes its place: the row below, or the
+  row above at the end. Worked out *before* the action, while the row still has
+  neighbours.
+- **`cursorAfterReload`** — the whole list was replaced, by a mailbox switch, a
+  search, or a refresh. A cursor whose message survived keeps its place; one
+  whose message is gone starts at the top.
+
+The last two exist because a cursor pointing at a message that is not listed
+cannot be found, and `cursorAfterOffset` restarts at the top from there. Every
+"the cursor jumped back to the first row" report is that.
+
+The list is a `Column` of rows inside a `Flickable`, not a `ListView` — the
+panel already owns a scroller, and nesting a second gives every wheel event two
+plausible targets. So there is no `positionViewAtIndex`, and keyboard movement
+has to scroll the list itself: **`Model.contentYToReveal`** decides where the
+scroller goes, leaving it alone while the row is already visible so stepping one
+row does not drag the list under someone reading it. It is called from
+`moveCursor`, not from `cursorId` changing, because hovering a row moves the
+cursor too and scrolling under the pointer fights the mouse.
 
 ## Adding a key
 

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -1,0 +1,165 @@
+# Omamail — Keybindings
+
+How the keyboard works in this application, and why it is built this way.
+
+## The model
+
+**The keyboard belongs to the application, and the context says what a key
+means where.** This is the model a TUI uses, and the one GPUI uses for actions:
+a key is not owned by whichever widget happens to hold the focus — it is owned
+by the app, and scoped to the contexts where it means something.
+
+Everything follows from that:
+
+- Every binding lives in one table, `keys/Keymap.js`. Nothing else describes a
+  key. The shortcut sheet and the status-bar hints render from that table.
+- `components/KeyRouter.qml` turns the table into `Shortcut` objects and reports
+  what was pressed by id. `App.qml` answers with one `runShortcut` function.
+- `Escape` is a binding like any other, not a `Keys.onEscapePressed` handler, so
+  it does not depend on who holds the focus.
+
+## The contexts
+
+The window is in exactly one context at a time. `App.qml` derives it from what
+is on screen, by precedence — a page is a form before it is anything else, a
+draft beats reading, a query being typed beats the list underneath it:
+
+```qml
+readonly property string keyContext:
+    root.showPage  ? "page"
+  : root.composing ? "compose"
+  : searchBar.fieldFocused ? "search"
+  : root.currentView === "reader" ? "reader"
+  : "list"
+```
+
+| Context | What it is | What it binds |
+|---|---|---|
+| `list` | The message list | The mailbox keys |
+| `reader` | A message open | The mailbox keys, plus reply/forward and zoom |
+| `search` | A query being typed | `Escape`, and the modified keys |
+| `compose` | A draft being written | `Escape`, `Ctrl+Return`, and the modified keys |
+| `page` | Setup or settings | `Escape`, and the modified keys |
+
+`mail` in the table below is shorthand for `list` and `reader`; `all` is every
+context.
+
+**A text-entry context binds no bare key but `Escape`.** That is the whole rule.
+There is no "is the user typing" question anywhere in the code, because there is
+nothing left for it to answer: if a bare letter is not bound in `compose`, it
+cannot fire there, and the field gets it the way any other character arrives.
+
+## One mechanism
+
+**The context owns the keyboard.** Changing context moves the focus — to
+whatever that context types into, or to a parked home item when the context
+types into nothing:
+
+```qml
+onKeyContextChanged: Qt.callLater(applyContextFocus)
+function applyContextFocus() {
+  if (keyContext === "compose") compose.takeFocus()
+  else if (keyContext === "search") searchBar.focusField()
+  else parkKeyboard()
+}
+```
+
+This is the part that has to stay one thing. When the context came from what was
+on screen and the focus stayed wherever the last click left it, the two drifted:
+closing a reply left its text field holding the keyboard while invisible, Qt kept
+handing that field every keystroke, and `j` and `k` were simply gone for the rest
+of the session. Nothing warned — the keys stopped arriving.
+
+`ComposeView` therefore does **not** place its own focus when it opens. Opening
+it changes the context, and the context moves the keyboard. One mechanism, so
+the two cannot disagree.
+
+## The bindings
+
+Generated from `keys/Keymap.js`. `tests/test_keymap.js` asserts this table
+matches it, so the two cannot drift — three hand-written copies of this list
+used to exist, and they had.
+
+<!-- BEGIN BINDINGS -->
+| id | keys | contexts | action |
+|---|---|---|---|
+| `cursorDown` | `j`, `Down` | mail | Move down |
+| `cursorUp` | `k`, `Up` | mail | Move up |
+| `open` | `Return`, `o` | list | Open the selected message |
+| `backToList` | `u` | reader | Back to the list |
+| `archive` | `e` | mail | Archive |
+| `trash` | `d` | mail | Move to trash |
+| `star` | `s` | mail | Star or unstar |
+| `markRead` | `Shift+I` | mail | Mark read |
+| `markUnread` | `Shift+U` | mail | Mark unread |
+| `reply` | `r` | reader | Reply |
+| `replyAll` | `a` | reader | Reply to all |
+| `forward` | `f` | reader | Forward |
+| `compose` | `c` | mail | Compose |
+| `send` | `Ctrl+Return` | compose | Send |
+| `search` | `/` | mail | Search |
+| `searchAnywhere` | `Ctrl+K` | all | Search from anywhere |
+| `goInbox` | `g,i` | mail | Go to the inbox |
+| `goStarred` | `g,s` | mail | Go to starred |
+| `goUnread` | `g,u` | mail | Go to unread |
+| `goSent` | `g,t` | mail | Go to sent |
+| `zoomIn` | `Ctrl++`, `Ctrl+=` | reader | Zoom the message body in |
+| `zoomOut` | `Ctrl+-` | reader | Zoom the message body out |
+| `zoomReset` | `Ctrl+0` | reader | Reset the zoom |
+| `refresh` | `F5` | all | Check for mail |
+| `help` | `?`, `Ctrl+/`, `Ctrl+?` | mail | Toggle this sheet |
+| `back` | `Escape` | all | Back, or close the window |
+<!-- END BINDINGS -->
+
+Two rows are split on purpose. `search` keeps the bare `/` in the mailbox while
+`searchAnywhere` reaches search from inside a draft or a form — the bare key
+cannot live in a text-entry context, and the modified one should. `help` is a
+mailbox action rather than a global one: the sheet lists what the mailbox
+answers to, and a draft is not a mailbox.
+
+`Escape` is the only bare key bound everywhere, because it is the way out of
+everywhere. What it means in each place is one list in `goBack()`, in the order
+the window is stacked.
+
+## Adding a key
+
+1. Add a row to `BINDINGS` in `keys/Keymap.js`. Name the contexts it means
+   something in — that is the guard, and there is no other.
+2. Add a case to `runShortcut` in `App.qml`.
+3. Add the row to the table above. The test will tell you if you forget.
+
+That is all. The shortcut sheet and the status hints pick it up on their own.
+
+## Why it looks like this
+
+Four things were found by running the code rather than reading it. Each cost a
+release-shaped bug, and each is now pinned by a test.
+
+**A `Repeater` builds no `Shortcut`s.** A `Shortcut` is a `QtObject` and a
+`Repeater` only builds `Item`s, so a `Repeater` creates nothing at all and every
+key goes silently dead. `KeyRouter` uses an `Instantiator`.
+
+**`FloatingWindow` does not forward `activeFocusItem`.** Quickshell's window is a
+proxy; reading `window.activeFocusItem` gives `undefined`, which reads as falsy
+and quietly passes every guard built on it. The attached `Window.activeFocusItem`
+is the one that works.
+
+**`forceActiveFocus()` on a `FocusScope` is a no-op.** It re-elects that scope's
+current focus item — which is the field you are trying to leave. Parking the
+keyboard has to land on a plain `Item`.
+
+**A window `Shortcut` beats a focused item's `Keys` handler.** A local
+`Keys.onEscapePressed` looks live and never runs. `SearchBar` had one; what it
+did lives in `goBack()` now.
+
+And one thing that is *not* a problem, recorded because it was assumed to be:
+Qt already gives a focused `TextInput` the bare keys before any `Shortcut` sees
+them. Typing a letter into a visible field never fired a shortcut. The old
+hand-written "is the user typing" guard was not holding that line, and removing
+it changed no behaviour.
+
+## Not here
+
+**User-configurable bindings.** The table makes it possible — the rows are data
+— but nothing has asked for it, and a config file for bindings needs a merge
+story and a conflict story this does not need.

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -92,9 +92,9 @@ used to exist, and they had.
 | `star` | `s` | mail | Star or unstar |
 | `markRead` | `Shift+I` | mail | Mark read |
 | `markUnread` | `Shift+U` | mail | Mark unread |
-| `reply` | `r` | reader | Reply |
-| `replyAll` | `a` | reader | Reply to all |
-| `forward` | `f` | reader | Forward |
+| `reply` | `r` | mail | Reply |
+| `replyAll` | `a` | mail | Reply to all |
+| `forward` | `f` | mail | Forward |
 | `compose` | `c` | mail | Compose |
 | `send` | `Ctrl+Return` | compose | Send |
 | `search` | `/` | mail | Search |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -70,10 +70,17 @@ guided by an in-app four-step walkthrough.
 
 ## Keyboard
 
-`j`/`k` move · `Enter` open · `u` back to list · `e` archive · `#` trash ·
-`s` star · `r` reply · `a` reply all · `f` forward · `c` compose ·
-`/` or `Ctrl+K` search · `g i` inbox · `g s` starred · `Shift+I`/`Shift+U`
-read/unread · `Ctrl+/` shortcut reference · `Esc` back or close
+The keyboard belongs to the application and the context says what a key means
+where, the way a TUI scopes its keys. Every binding lives in one table,
+`keys/Keymap.js`; the shortcut sheet, the status hints and `docs/KEYS.md` all
+render or are checked against it, so no second list is maintained by hand.
+
+`j`/`k` move · `Enter` or `o` open · `u` back to list · `e` archive · `d` trash ·
+`s` star · `r`/`a`/`f` reply, reply all, forward · `c` compose · `/` or `Ctrl+K`
+search · `g i` inbox · `?` the reference sheet · `Esc` back or close.
+
+**See `docs/KEYS.md`** for the model, the contexts, the full table, and the four
+Qt behaviours this design is shaped around.
 
 ## Constraints
 

--- a/keys/Keymap.js
+++ b/keys/Keymap.js
@@ -137,6 +137,22 @@ function bindingsFor(context) {
   return out
 }
 
+// One entry per sequence rather than per row, because that is the shape a
+// Shortcut needs: each sequence is its own object, and each decides its own
+// `enabled` — a row holding both `/` and Ctrl+K has them disagree while the
+// user is typing.
+function sequencesFor(context) {
+  var out = []
+  var rows = bindingsFor(context)
+  for (var i = 0; i < rows.length; i++) {
+    var keys = rows[i].keys || []
+    for (var k = 0; k < keys.length; k++) {
+      out.push(({ id: rows[i].id, sequence: keys[k], binding: rows[i] }))
+    }
+  }
+  return out
+}
+
 // How a row reads. Usually its own keys; `display` overrides it where one line
 // stands for a pair, as "j / k" does for moving.
 function displayFor(binding) {

--- a/keys/Keymap.js
+++ b/keys/Keymap.js
@@ -8,10 +8,12 @@
 // mouse gesture among the keys. Anything that shows or fires a binding now
 // reads this file, so there is nothing left to keep in step by hand.
 
-// The window is in exactly one of these at a time, resolved by precedence in
-// App.qml: a page beats composing, composing beats the reader, the reader beats
-// the list.
-var CONTEXTS = ["list", "reader", "compose", "page"]
+// The window is in exactly one of these at a time. The context is the single
+// owner of "where am I": App.qml derives it from the screen, and the keyboard
+// follows it — a context that is not text entry parks the focus rather than
+// leaving it wherever the last click put it. Keeping those two as separate
+// things is what let a dismissed compose field go on eating j and k.
+var CONTEXTS = ["list", "reader", "search", "compose", "page"]
 
 // Shorthands, so a row says where it lives rather than restating the set.
 var MAIL = ["list", "reader"]
@@ -56,8 +58,13 @@ var BINDINGS = [
   // One row holding both, because suppression is decided per key: `/` stands
   // down inside a text field and Ctrl+K, whose whole point is reaching search
   // from inside one, does not.
-  { id: "search", keys: ["/", "Ctrl+K"], contexts: ANY,
+  // Reachable from anywhere. `/` is a bare key, so it is only offered where
+  // bare keys mean anything — inside the field it is a character being typed,
+  // and Qt gives the field its keys before any Shortcut sees them.
+  { id: "search", keys: ["/"], contexts: MAIL,
     group: "Finding", label: "Search" },
+  { id: "searchAnywhere", keys: ["Ctrl+K"], contexts: ANY,
+    group: "Finding", label: "Search from anywhere" },
 
   { id: "goInbox", keys: ["g,i"], contexts: MAIL,
     group: "Going", label: "Go to the inbox" },
@@ -79,41 +86,16 @@ var BINDINGS = [
 
   { id: "refresh", keys: ["F5"], contexts: ANY,
     group: "Mailbox", label: "Check for mail" },
-  { id: "help", keys: ["?", "Ctrl+/", "Ctrl+?"], contexts: ANY,
+  // A mailbox action, not a global one: the sheet lists what the mailbox
+  // answers to, and a draft or a form is neither. Esc first, then `?`.
+  { id: "help", keys: ["?", "Ctrl+/", "Ctrl+?"], contexts: MAIL,
     survivesOverlay: true,
     group: "Mailbox", label: "Toggle this sheet" },
   { id: "back", keys: ["Escape"], contexts: ANY,
-    survivesTyping: true, survivesOverlay: true,
+    survivesOverlay: true,
     group: "Mailbox", label: "Back, or close the window",
-    hint: { reader: "back", page: "back", compose: "close" } }
+    hint: { reader: "back", page: "back", compose: "close", search: "leave" } }
 ]
-
-// A sequence is bare when typing it into a text field is a thing a person would
-// do. Shift is not a modifier for this purpose: Shift+I is simply how a capital
-// I is typed. Ctrl, Alt and Meta are unreachable that way, and so are the
-// function keys.
-function isBareSequence(sequence) {
-  var text = String(sequence || "")
-  if (text.indexOf("Ctrl+") >= 0) return false
-  if (text.indexOf("Alt+") >= 0) return false
-  if (text.indexOf("Meta+") >= 0) return false
-  if (/^F[0-9]+$/.test(text)) return false
-  return true
-}
-
-// Derived, never declared. A new binding cannot forget its typing guard,
-// because there is no guard to write — the hand-written one had missed nine
-// text fields. It backs up two defences rather than standing alone: Qt gives a
-// focused TextInput the bare keys before any Shortcut sees them, and a key that
-// does not belong to a context is not live there in the first place.
-//
-// Decided per key rather than per row, so one row can hold `/` and Ctrl+K and
-// have each behave as its own shape demands.
-function suppressedByTyping(binding, sequence) {
-  if (!binding) return false
-  if (binding.survivesTyping) return false
-  return isBareSequence(sequence)
-}
 
 function matchesContext(binding, context) {
   if (!binding) return false
@@ -124,10 +106,12 @@ function matchesContext(binding, context) {
   return false
 }
 
-function isEnabled(binding, sequence, context, typing, overlay) {
+// Context decides what is live, and nothing else does. There is no "are they
+// typing" question left to get wrong: a text-entry context binds no bare keys,
+// and Qt hands a focused field its keys before any Shortcut sees them.
+function isEnabled(binding, context, overlay) {
   if (!matchesContext(binding, context)) return false
   if (overlay && !binding.survivesOverlay) return false
-  if (typing && suppressedByTyping(binding, sequence)) return false
   return true
 }
 

--- a/keys/Keymap.js
+++ b/keys/Keymap.js
@@ -48,11 +48,14 @@ var BINDINGS = [
   { id: "markUnread", keys: ["Shift+U"], contexts: MAIL,
     group: "Acting", label: "Mark unread" },
 
-  { id: "reply", keys: ["r"], contexts: ["reader"],
+  // Answering works from the list too, the way the row's own menu does: the
+  // message is opened first and the draft waits for it. Binding these to the
+  // reader only left the keyboard able to do less than a right-click.
+  { id: "reply", keys: ["r"], contexts: MAIL,
     group: "Writing", label: "Reply", hint: { reader: "reply" } },
-  { id: "replyAll", keys: ["a"], contexts: ["reader"],
+  { id: "replyAll", keys: ["a"], contexts: MAIL,
     group: "Writing", label: "Reply to all" },
-  { id: "forward", keys: ["f"], contexts: ["reader"],
+  { id: "forward", keys: ["f"], contexts: MAIL,
     group: "Writing", label: "Forward" },
   { id: "compose", keys: ["c"], contexts: MAIL,
     group: "Writing", label: "Compose", hint: { list: "compose" } },

--- a/keys/Keymap.js
+++ b/keys/Keymap.js
@@ -1,0 +1,206 @@
+.pragma library
+
+// Every key this window answers to, in one table.
+//
+// Three descriptions of this list used to exist — the Shortcut declarations in
+// App.qml, the help sheet, and the status-bar hints — and they had already
+// drifted: the sheet listed Esc twice, was missing `u` and `?`, and carried a
+// mouse gesture among the keys. Anything that shows or fires a binding now
+// reads this file, so there is nothing left to keep in step by hand.
+
+// The window is in exactly one of these at a time, resolved by precedence in
+// App.qml: a page beats composing, composing beats the reader, the reader beats
+// the list.
+var CONTEXTS = ["list", "reader", "compose", "page"]
+
+// Shorthands, so a row says where it lives rather than restating the set.
+var MAIL = ["list", "reader"]
+var ANY = ["*"]
+
+var BINDINGS = [
+  { id: "cursorDown", keys: ["j", "Down"], contexts: MAIL,
+    group: "Moving", label: "Move down",
+    display: "j / k", hint: { list: "move" } },
+  { id: "cursorUp", keys: ["k", "Up"], contexts: MAIL,
+    group: "Moving", label: "Move up" },
+  { id: "open", keys: ["Return", "o"], contexts: ["list"],
+    group: "Moving", label: "Open the selected message",
+    hint: { list: "open" } },
+  { id: "backToList", keys: ["u"], contexts: ["reader"],
+    group: "Moving", label: "Back to the list" },
+
+  { id: "archive", keys: ["e"], contexts: MAIL,
+    group: "Acting", label: "Archive",
+    hint: { list: "archive", reader: "archive" } },
+  { id: "trash", keys: ["d"], contexts: MAIL,
+    group: "Acting", label: "Move to trash",
+    hint: { reader: "trash" } },
+  { id: "star", keys: ["s"], contexts: MAIL,
+    group: "Acting", label: "Star or unstar" },
+  { id: "markRead", keys: ["Shift+I"], contexts: MAIL,
+    group: "Acting", label: "Mark read" },
+  { id: "markUnread", keys: ["Shift+U"], contexts: MAIL,
+    group: "Acting", label: "Mark unread" },
+
+  { id: "reply", keys: ["r"], contexts: ["reader"],
+    group: "Writing", label: "Reply", hint: { reader: "reply" } },
+  { id: "replyAll", keys: ["a"], contexts: ["reader"],
+    group: "Writing", label: "Reply to all" },
+  { id: "forward", keys: ["f"], contexts: ["reader"],
+    group: "Writing", label: "Forward" },
+  { id: "compose", keys: ["c"], contexts: MAIL,
+    group: "Writing", label: "Compose", hint: { list: "compose" } },
+  { id: "send", keys: ["Ctrl+Return"], contexts: ["compose"],
+    group: "Writing", label: "Send", hint: { compose: "send" } },
+
+  // One row holding both, because suppression is decided per key: `/` stands
+  // down inside a text field and Ctrl+K, whose whole point is reaching search
+  // from inside one, does not.
+  { id: "search", keys: ["/", "Ctrl+K"], contexts: ANY,
+    group: "Finding", label: "Search" },
+
+  { id: "goInbox", keys: ["g,i"], contexts: MAIL,
+    group: "Going", label: "Go to the inbox" },
+  { id: "goStarred", keys: ["g,s"], contexts: MAIL,
+    group: "Going", label: "Go to starred" },
+  { id: "goUnread", keys: ["g,u"], contexts: MAIL,
+    group: "Going", label: "Go to unread" },
+  { id: "goSent", keys: ["g,t"], contexts: MAIL,
+    group: "Going", label: "Go to sent" },
+
+  // Only where there is a message body to size. These carried no context at
+  // all, which left them live on a settings form.
+  { id: "zoomIn", keys: ["Ctrl++", "Ctrl+="], contexts: ["reader"],
+    group: "Reading", label: "Zoom the message body in" },
+  { id: "zoomOut", keys: ["Ctrl+-"], contexts: ["reader"],
+    group: "Reading", label: "Zoom the message body out" },
+  { id: "zoomReset", keys: ["Ctrl+0"], contexts: ["reader"],
+    group: "Reading", label: "Reset the zoom" },
+
+  { id: "refresh", keys: ["F5"], contexts: ANY,
+    group: "Mailbox", label: "Check for mail" },
+  { id: "help", keys: ["?", "Ctrl+/", "Ctrl+?"], contexts: ANY,
+    survivesOverlay: true,
+    group: "Mailbox", label: "Toggle this sheet" },
+  { id: "back", keys: ["Escape"], contexts: ANY,
+    survivesTyping: true, survivesOverlay: true,
+    group: "Mailbox", label: "Back, or close the window",
+    hint: { reader: "back", page: "back", compose: "close" } }
+]
+
+// A sequence is bare when typing it into a text field is a thing a person would
+// do. Shift is not a modifier for this purpose: Shift+I is simply how a capital
+// I is typed. Ctrl, Alt and Meta are unreachable that way, and so are the
+// function keys.
+function isBareSequence(sequence) {
+  var text = String(sequence || "")
+  if (text.indexOf("Ctrl+") >= 0) return false
+  if (text.indexOf("Alt+") >= 0) return false
+  if (text.indexOf("Meta+") >= 0) return false
+  if (/^F[0-9]+$/.test(text)) return false
+  return true
+}
+
+// Derived, never declared. A new binding cannot forget its typing guard,
+// because there is no guard to write — which is the whole point, since the
+// hand-written guard is what missed nine text fields.
+//
+// Decided per key rather than per row, so one row can hold `/` and Ctrl+K and
+// have each behave as its own shape demands.
+function suppressedByTyping(binding, sequence) {
+  if (!binding) return false
+  if (binding.survivesTyping) return false
+  return isBareSequence(sequence)
+}
+
+function matchesContext(binding, context) {
+  if (!binding) return false
+  var contexts = binding.contexts || []
+  for (var i = 0; i < contexts.length; i++) {
+    if (contexts[i] === "*" || contexts[i] === context) return true
+  }
+  return false
+}
+
+function isEnabled(binding, sequence, context, typing, overlay) {
+  if (!matchesContext(binding, context)) return false
+  if (overlay && !binding.survivesOverlay) return false
+  if (typing && suppressedByTyping(binding, sequence)) return false
+  return true
+}
+
+function bindingsFor(context) {
+  var out = []
+  for (var i = 0; i < BINDINGS.length; i++) {
+    if (matchesContext(BINDINGS[i], context)) out.push(BINDINGS[i])
+  }
+  return out
+}
+
+// How a row reads. Usually its own keys; `display` overrides it where one line
+// stands for a pair, as "j / k" does for moving.
+function displayFor(binding) {
+  if (!binding) return ""
+  if (binding.display) return binding.display
+  return (binding.keys || []).join(" / ")
+}
+
+function hintTextFor(binding, context) {
+  var hint = binding ? binding.hint : null
+  if (!hint) return ""
+  if (typeof hint === "string") return hint
+  return hint[context] || ""
+}
+
+// Grouped in the order the groups first appear in the table, so the sheet's
+// shape is a property of the table rather than a second list to maintain.
+function helpGroups() {
+  var groups = []
+  var byName = ({})
+  for (var i = 0; i < BINDINGS.length; i++) {
+    var binding = BINDINGS[i]
+    if (!byName[binding.group]) {
+      byName[binding.group] = ({ name: binding.group, rows: [] })
+      groups.push(byName[binding.group])
+    }
+    byName[binding.group].rows.push(({
+      keys: displayFor(binding),
+      action: binding.label
+    }))
+  }
+  return groups
+}
+
+// What the status bar offers from where the user is standing.
+function hintsFor(context) {
+  var out = []
+  var rows = bindingsFor(context)
+  for (var i = 0; i < rows.length; i++) {
+    var text = hintTextFor(rows[i], context)
+    if (text !== "") out.push(({ key: displayFor(rows[i]), label: text }))
+  }
+  return out
+}
+
+// Two bindings claiming one sequence in one context is a bug the table can find
+// by itself. Sequences compare whole, so `s` and `g,s` are different keys
+// rather than a collision.
+function conflicts() {
+  var found = []
+  for (var c = 0; c < CONTEXTS.length; c++) {
+    var seen = ({})
+    var rows = bindingsFor(CONTEXTS[c])
+    for (var i = 0; i < rows.length; i++) {
+      var keys = rows[i].keys || []
+      for (var k = 0; k < keys.length; k++) {
+        if (seen[keys[k]]) {
+          found.push(({ context: CONTEXTS[c], keys: keys[k],
+            ids: [seen[keys[k]], rows[i].id] }))
+        } else {
+          seen[keys[k]] = rows[i].id
+        }
+      }
+    }
+  }
+  return found
+}

--- a/keys/Keymap.js
+++ b/keys/Keymap.js
@@ -20,12 +20,12 @@ var ANY = ["*"]
 var BINDINGS = [
   { id: "cursorDown", keys: ["j", "Down"], contexts: MAIL,
     group: "Moving", label: "Move down",
-    display: "j / k", hint: { list: "move" } },
+    hintKey: "j / k", hint: { list: "move" } },
   { id: "cursorUp", keys: ["k", "Up"], contexts: MAIL,
     group: "Moving", label: "Move up" },
   { id: "open", keys: ["Return", "o"], contexts: ["list"],
     group: "Moving", label: "Open the selected message",
-    hint: { list: "open" } },
+    hintKey: "o", hint: { list: "open" } },
   { id: "backToList", keys: ["u"], contexts: ["reader"],
     group: "Moving", label: "Back to the list" },
 
@@ -153,12 +153,37 @@ function sequencesFor(context) {
   return out
 }
 
-// How a row reads. Usually its own keys; `display` overrides it where one line
-// stands for a pair, as "j / k" does for moving.
+// Qt's sequence syntax is not the UI's. A chord is written "g,i" and read "g
+// then i"; Escape and Return are named for the keycaps people look at. Written
+// as rules rather than per-row overrides, so a chord added later reads properly
+// without anyone remembering to spell it out.
+function readableSequence(sequence) {
+  var text = String(sequence || "")
+  if (text.indexOf(",") > 0) return text.split(",").join(" then ")
+  text = text.replace("Return", "Enter")
+  if (text === "Escape") return "Esc"
+  return text
+}
+
+// How a row reads on the help sheet, which enumerates: every key that works is
+// named, separated so a slash inside a sequence is not mistaken for the
+// separator.
 function displayFor(binding) {
   if (!binding) return ""
-  if (binding.display) return binding.display
-  return (binding.keys || []).join(" / ")
+  var keys = binding.keys || []
+  var out = []
+  for (var i = 0; i < keys.length; i++) out.push(readableSequence(keys[i]))
+  return out.join(", ")
+}
+
+// How a row reads on the status bar, which is a hint rather than a reference:
+// one short form, and sometimes one line standing for a pair, as "j / k" does
+// for moving. These are two different jobs, and one field could not do both —
+// enumerating gave the sheet "j / k  Move down", which is not true of either.
+function hintKeyFor(binding) {
+  if (!binding) return ""
+  if (binding.hintKey) return binding.hintKey
+  return displayFor(binding)
 }
 
 function hintTextFor(binding, context) {
@@ -193,7 +218,7 @@ function hintsFor(context) {
   var rows = bindingsFor(context)
   for (var i = 0; i < rows.length; i++) {
     var text = hintTextFor(rows[i], context)
-    if (text !== "") out.push(({ key: displayFor(rows[i]), label: text }))
+    if (text !== "") out.push(({ key: hintKeyFor(rows[i]), label: text }))
   }
   return out
 }

--- a/keys/Keymap.js
+++ b/keys/Keymap.js
@@ -25,9 +25,13 @@ var BINDINGS = [
     hintKey: "j / k", hint: { list: "move" } },
   { id: "cursorUp", keys: ["k", "Up"], contexts: MAIL,
     group: "Moving", label: "Move up" },
-  { id: "open", keys: ["Return", "o"], contexts: ["list"],
+  // Live in the reader as well as the list. Moving is deliberately not opening
+  // — stepping through with j used to mark half a mailbox read without anyone
+  // looking at it — so with the reader up there has to be a key that says open,
+  // or the only way to read the next message is to leave and come back.
+  { id: "open", keys: ["Return", "o"], contexts: MAIL,
     group: "Moving", label: "Open the selected message",
-    hintKey: "o", hint: { list: "open" } },
+    hintKey: "o", hint: { list: "open", reader: "open" } },
   { id: "backToList", keys: ["u"], contexts: ["reader"],
     group: "Moving", label: "Back to the list" },
 

--- a/keys/Keymap.js
+++ b/keys/Keymap.js
@@ -102,8 +102,10 @@ function isBareSequence(sequence) {
 }
 
 // Derived, never declared. A new binding cannot forget its typing guard,
-// because there is no guard to write — which is the whole point, since the
-// hand-written guard is what missed nine text fields.
+// because there is no guard to write — the hand-written one had missed nine
+// text fields. It backs up two defences rather than standing alone: Qt gives a
+// focused TextInput the bare keys before any Shortcut sees them, and a key that
+// does not belong to a context is not live there in the first place.
 //
 // Decided per key rather than per row, so one row can hold `/` and Ctrl+K and
 // have each behave as its own shape demands.

--- a/tests/qml/tst_focus.qml
+++ b/tests/qml/tst_focus.qml
@@ -1,0 +1,67 @@
+import QtQuick
+import QtTest
+
+// Focus ownership. A child that declares `focus: true` becomes the window's
+// activeFocusItem even while it is invisible — Qt does not exclude hidden items
+// — so a component holding focus it is not using becomes a sink for everything
+// that travels by focus rather than by Shortcut. That is what made Esc work
+// only sometimes: whether it worked depended on where the user last clicked.
+Item {
+  id: host
+  width: 300; height: 200
+
+  property string escapeWentTo: ""
+
+  FocusScope {
+    id: scope
+    anchors.fill: parent
+    focus: true
+
+    Keys.onEscapePressed: function(event) {
+      host.escapeWentTo = "scope"
+      event.accepted = true
+    }
+
+    // Stands in for ComposeView: always instantiated, in use only sometimes.
+    Item {
+      id: compose
+      anchors.fill: parent
+      property bool opened: false
+      visible: opened
+      focus: opened
+      Keys.onEscapePressed: function(event) {
+        host.escapeWentTo = "compose"
+        event.accepted = true
+      }
+    }
+  }
+
+  TestCase {
+    name: "FocusOwnership"
+    when: windowShown
+
+    function test_a_closed_compose_does_not_hold_focus() {
+      compare(compose.opened, false)
+      compare(compose.activeFocus, false,
+        "a closed compose must not own the focus")
+    }
+
+    function test_escape_reaches_the_scope_when_compose_is_closed() {
+      host.escapeWentTo = ""
+      keyClick(Qt.Key_Escape)
+      compare(host.escapeWentTo, "scope")
+    }
+
+    function test_an_open_compose_does_hold_focus() {
+      compose.opened = true
+      wait(50)
+      compare(compose.activeFocus, true,
+        "an open compose is exactly when it should own the focus")
+      host.escapeWentTo = ""
+      keyClick(Qt.Key_Escape)
+      compare(host.escapeWentTo, "compose")
+      compose.opened = false
+      wait(50)
+    }
+  }
+}

--- a/tests/qml/tst_hover_under_scroll.qml
+++ b/tests/qml/tst_hover_under_scroll.qml
@@ -1,0 +1,64 @@
+import QtQuick
+import QtTest
+
+// Why hovering a row must not move the keyboard's cursor.
+//
+// Qt re-reports hover when content moves under a pointer that has not moved.
+// The list scrolls to follow the keyboard, so a hover that wrote `cursorId`
+// handed it straight back to whatever the mouse was resting on: j moved the
+// cursor, the scroll brought a different row under the still pointer, and the
+// cursor snapped back. It looked like j and k sticking on a few rows.
+//
+// This asserts the Qt behaviour rather than the app's wiring, because the
+// behaviour is the reason the wiring has to stay apart.
+Item {
+  id: host
+  width: 200; height: 100
+
+  property string entered: ""
+
+  Flickable {
+    id: flick
+    anchors.fill: parent
+    contentWidth: width
+    contentHeight: col.height
+    clip: true
+
+    Column {
+      id: col
+      width: flick.width
+      Repeater {
+        model: 10
+        Rectangle {
+          id: row
+          required property int index
+          width: col.width
+          height: 40
+          MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            onEntered: host.entered = "row" + row.index
+          }
+        }
+      }
+    }
+  }
+
+  TestCase {
+    name: "HoverUnderScroll"
+    when: windowShown
+
+    function test_scrolling_under_a_still_pointer_reports_a_new_row() {
+      mouseMove(host, 100, 50)
+      wait(50)
+      compare(host.entered, "row1", "the pointer is parked on a row")
+
+      host.entered = ""
+      flick.contentY = 160          // the list scrolls; the pointer does not move
+      wait(80)
+      compare(host.entered, "row5",
+        "a still pointer reports a different row once the content moves under it "
+        + "— which is why hover must not be allowed to write the keyboard cursor")
+    }
+  }
+}

--- a/tests/qml/tst_keyrouter.qml
+++ b/tests/qml/tst_keyrouter.qml
@@ -1,0 +1,99 @@
+import QtQuick
+import QtTest
+import "../../components" as Omamail
+
+// The router turns the table into Shortcuts. What matters here is that the
+// table's rules actually reach the keyboard: context gates a key, typing stands
+// bare keys down but leaves modified ones alone, and Escape arrives as a
+// Shortcut rather than travelling by focus — which is what made it depend on
+// where the user had last clicked.
+Item {
+  id: host
+  width: 300; height: 200
+
+  property string lastId: ""
+  property string context: "list"
+  property bool typing: false
+  property bool overlay: false
+
+  Omamail.KeyRouter {
+    context: host.context
+    typing: host.typing
+    overlay: host.overlay
+    onTriggered: function(id) { host.lastId = id }
+  }
+
+  TestCase {
+    name: "KeyRouter"
+    when: windowShown
+
+    function init() {
+      host.context = "list"
+      host.typing = false
+      host.overlay = false
+      host.lastId = ""
+      wait(20)
+    }
+
+    function test_a_bare_letter_fires_in_its_context() {
+      keyClick(Qt.Key_E)
+      compare(host.lastId, "archive")
+    }
+
+    function test_the_same_letter_is_dead_on_a_form() {
+      host.context = "page"
+      wait(20)
+      keyClick(Qt.Key_E)
+      compare(host.lastId, "", "e is not archive on a settings form")
+    }
+
+    function test_typing_stands_bare_keys_down() {
+      host.typing = true
+      wait(20)
+      keyClick(Qt.Key_E)
+      compare(host.lastId, "", "e belongs to the field being typed in")
+    }
+
+    function test_typing_leaves_modified_keys_alone() {
+      // The same row as the bare `/`, which is standing down at this moment.
+      host.typing = true
+      wait(20)
+      keyClick(Qt.Key_K, Qt.ControlModifier)
+      compare(host.lastId, "search")
+    }
+
+    function test_escape_is_a_shortcut_not_a_focus_handler() {
+      host.typing = true
+      wait(20)
+      keyClick(Qt.Key_Escape)
+      compare(host.lastId, "back",
+        "Escape must not depend on who holds the focus")
+    }
+
+    function test_an_overlay_stands_the_mailbox_down() {
+      host.overlay = true
+      wait(20)
+      keyClick(Qt.Key_E)
+      compare(host.lastId, "", "nothing acts on mail behind the shortcut sheet")
+    }
+
+    function test_but_the_sheets_own_key_still_closes_it() {
+      host.overlay = true
+      wait(20)
+      keyClick(Qt.Key_Question)
+      compare(host.lastId, "help")
+    }
+
+    function test_a_reader_key_is_dead_in_the_list() {
+      keyClick(Qt.Key_R)
+      compare(host.lastId, "", "there is nothing to reply to from the list")
+    }
+
+    function test_and_live_in_the_reader() {
+      host.context = "reader"
+      wait(20)
+      keyClick(Qt.Key_R)
+      compare(host.lastId, "reply")
+    }
+  }
+}

--- a/tests/qml/tst_keyrouter.qml
+++ b/tests/qml/tst_keyrouter.qml
@@ -33,6 +33,7 @@ Item {
         && item.hasOwnProperty("cursorPosition")
         && item.hasOwnProperty("selectedText")
         && item.hasOwnProperty("readOnly")
+        && item.visible
         && !item.readOnly
   }
   readonly property bool typingByFocus:
@@ -40,6 +41,16 @@ Item {
 
   QQC.TextField { id: someField; width: 80 }
   QQC.Button { id: someButton; y: 40; text: "b" }
+
+  // A compose that owns the focus only while it is up, exactly as App.qml has
+  // it. Closing it leaves its field holding the window's focus while invisible.
+  Item {
+    id: compose
+    property bool opened: false
+    visible: opened
+    focus: opened
+    QQC.TextField { id: composeField; width: 80 }
+  }
 
   TestCase {
     name: "KeyRouter"
@@ -50,7 +61,11 @@ Item {
       host.typing = false
       host.overlay = false
       host.lastId = ""
-      wait(20)
+      // Each case starts with the focus somewhere harmless. A field left
+      // holding it swallows the printable keys the next case presses.
+      compose.opened = false
+      someButton.forceActiveFocus()
+      wait(30)
     }
 
     function test_a_bare_letter_fires_in_its_context() {
@@ -112,6 +127,20 @@ Item {
       someButton.forceActiveFocus()
       wait(30)
       compare(host.typingByFocus, false, "a button is not a text field")
+    }
+
+    // Closing compose used to leave its field holding the focus while hidden,
+    // which pinned the typing guard true and stood every bare key down for the
+    // rest of the session — Esc out of a reply and j/k were simply gone.
+    function test_a_hidden_field_is_not_being_typed_into() {
+      compose.opened = true
+      composeField.forceActiveFocus()
+      wait(30)
+      compare(host.typingByFocus, true, "a field on screen is being typed into")
+      compose.opened = false
+      wait(30)
+      compare(host.typingByFocus, false,
+        "nobody is typing into a field they cannot see")
     }
 
     function test_a_reader_key_is_dead_in_the_list() {

--- a/tests/qml/tst_keyrouter.qml
+++ b/tests/qml/tst_keyrouter.qml
@@ -4,52 +4,47 @@ import QtQuick.Controls as QQC
 import QtTest
 import "../../components" as Omamail
 
-// The router turns the table into Shortcuts. What matters here is that the
-// table's rules actually reach the keyboard: context gates a key, typing stands
-// bare keys down but leaves modified ones alone, and Escape arrives as a
-// Shortcut rather than travelling by focus — which is what made it depend on
-// where the user had last clicked.
+// The keyboard belongs to the application, and the context says what a key
+// means where. Two things are exercised: that a key is live only in the
+// contexts its row names, and that changing context takes the keyboard with it
+// — the part that, kept separate, let a dismissed field eat every key.
 Item {
   id: host
   width: 300; height: 200
 
   property string lastId: ""
   property string context: "list"
-  property bool typing: false
   property bool overlay: false
 
   Omamail.KeyRouter {
     context: host.context
-    typing: host.typing
     overlay: host.overlay
     onTriggered: function(id) { host.lastId = id }
   }
 
-  // The real `typing` in App.qml is answered by asking the window who holds the
-  // focus, rather than by naming the fields — the naming is what missed nine of
-  // them. This exercises that decision against real focus rather than a bool.
-  function looksLikeTextEntry(item) {
-    return !!item
-        && item.hasOwnProperty("cursorPosition")
-        && item.hasOwnProperty("selectedText")
-        && item.hasOwnProperty("readOnly")
-        && item.visible
-        && !item.readOnly
-  }
-  readonly property bool typingByFocus:
-    looksLikeTextEntry(host.Window.activeFocusItem)
+  readonly property Item focusItem: host.Window.activeFocusItem
 
-  QQC.TextField { id: someField; width: 80 }
-  QQC.Button { id: someButton; y: 40; text: "b" }
+  // Stands in for the window's focus scope: a home for the keyboard, and a
+  // field that is only on screen while its context is.
+  FocusScope {
+    id: scope
+    anchors.fill: parent
+    focus: true
 
-  // A compose that owns the focus only while it is up, exactly as App.qml has
-  // it. Closing it leaves its field holding the window's focus while invisible.
-  Item {
-    id: compose
-    property bool opened: false
-    visible: opened
-    focus: opened
-    QQC.TextField { id: composeField; width: 80 }
+    Item { id: keyboardHome; width: 1; height: 1 }
+
+    Item {
+      id: compose
+      anchors.fill: parent
+      property bool opened: false
+      visible: opened
+      QQC.TextField { id: composeField; width: 80 }
+    }
+
+    function applyContextFocus() {
+      if (host.context === "compose") composeField.forceActiveFocus()
+      else keyboardHome.forceActiveFocus()
+    }
   }
 
   TestCase {
@@ -58,13 +53,10 @@ Item {
 
     function init() {
       host.context = "list"
-      host.typing = false
       host.overlay = false
       host.lastId = ""
-      // Each case starts with the focus somewhere harmless. A field left
-      // holding it swallows the printable keys the next case presses.
       compose.opened = false
-      someButton.forceActiveFocus()
+      scope.applyContextFocus()
       wait(30)
     }
 
@@ -80,27 +72,37 @@ Item {
       compare(host.lastId, "", "e is not archive on a settings form")
     }
 
-    function test_typing_stands_bare_keys_down() {
-      host.typing = true
+    function test_a_bare_letter_is_dead_in_a_draft() {
+      host.context = "compose"
       wait(20)
       keyClick(Qt.Key_E)
-      compare(host.lastId, "", "e belongs to the field being typed in")
+      compare(host.lastId, "", "e is a letter in a sentence, not archive")
     }
 
-    function test_typing_leaves_modified_keys_alone() {
-      // The same row as the bare `/`, which is standing down at this moment.
-      host.typing = true
+    function test_a_bare_letter_is_dead_in_a_query() {
+      host.context = "search"
+      wait(20)
+      keyClick(Qt.Key_E)
+      compare(host.lastId, "", "e is a letter in a query")
+    }
+
+    function test_a_modified_key_still_reaches_a_draft() {
+      host.context = "compose"
       wait(20)
       keyClick(Qt.Key_K, Qt.ControlModifier)
-      compare(host.lastId, "search")
+      compare(host.lastId, "searchAnywhere",
+        "search is reachable from inside a draft, which is why it is bound twice")
     }
 
-    function test_escape_is_a_shortcut_not_a_focus_handler() {
-      host.typing = true
-      wait(20)
-      keyClick(Qt.Key_Escape)
-      compare(host.lastId, "back",
-        "Escape must not depend on who holds the focus")
+    function test_escape_is_the_way_out_of_every_context() {
+      var contexts = ["list", "reader", "search", "compose", "page"]
+      for (var i = 0; i < contexts.length; i++) {
+        host.context = contexts[i]
+        host.lastId = ""
+        wait(20)
+        keyClick(Qt.Key_Escape)
+        compare(host.lastId, "back", "Escape must leave " + contexts[i])
+      }
     }
 
     function test_an_overlay_stands_the_mailbox_down() {
@@ -117,32 +119,6 @@ Item {
       compare(host.lastId, "help")
     }
 
-    // A field nobody named. This is the whole point: the guard is answered by
-    // the focus, so a text field added later is covered without being listed.
-    function test_focus_on_any_text_field_counts_as_typing() {
-      someField.forceActiveFocus()
-      wait(30)
-      compare(host.typingByFocus, true,
-        "a field nobody added to a list still stands the letters down")
-      someButton.forceActiveFocus()
-      wait(30)
-      compare(host.typingByFocus, false, "a button is not a text field")
-    }
-
-    // Closing compose used to leave its field holding the focus while hidden,
-    // which pinned the typing guard true and stood every bare key down for the
-    // rest of the session — Esc out of a reply and j/k were simply gone.
-    function test_a_hidden_field_is_not_being_typed_into() {
-      compose.opened = true
-      composeField.forceActiveFocus()
-      wait(30)
-      compare(host.typingByFocus, true, "a field on screen is being typed into")
-      compose.opened = false
-      wait(30)
-      compare(host.typingByFocus, false,
-        "nobody is typing into a field they cannot see")
-    }
-
     function test_a_reader_key_is_dead_in_the_list() {
       keyClick(Qt.Key_R)
       compare(host.lastId, "", "there is nothing to reply to from the list")
@@ -153,6 +129,32 @@ Item {
       wait(20)
       keyClick(Qt.Key_R)
       compare(host.lastId, "reply")
+    }
+
+    // The mechanism, not a key: leaving a text-entry context has to take the
+    // keyboard with it. Handing it back to the focus scope does not — that
+    // re-elects the scope's current focus item, which is the field being left,
+    // so the dismissed field kept swallowing j and k for the rest of the
+    // session. It has to land on a plain Item.
+    function test_leaving_a_draft_takes_the_keyboard_with_it() {
+      host.context = "compose"
+      compose.opened = true
+      scope.applyContextFocus()
+      wait(30)
+      compare(host.focusItem, composeField, "the draft is what is typed into")
+
+      compose.opened = false
+      host.context = "list"
+      scope.applyContextFocus()
+      wait(30)
+      verify(host.focusItem !== composeField,
+        "a dismissed field must not keep the keyboard")
+      compare(host.focusItem, keyboardHome, "which parks on the home item")
+
+      host.lastId = ""
+      keyClick(Qt.Key_J)
+      compare(host.lastId, "cursorDown",
+        "and j reaches the mailbox again, which is the whole point")
     }
   }
 }

--- a/tests/qml/tst_keyrouter.qml
+++ b/tests/qml/tst_keyrouter.qml
@@ -119,6 +119,19 @@ Item {
       compare(host.lastId, "help")
     }
 
+    // Moving is deliberately not opening, so with a message up there has to be
+    // a key that says open — otherwise reading the next one means leaving the
+    // reader and coming back.
+    function test_open_works_from_the_reader_too() {
+      host.context = "reader"
+      wait(20)
+      keyClick(Qt.Key_O)
+      compare(host.lastId, "open")
+      host.lastId = ""
+      keyClick(Qt.Key_Return)
+      compare(host.lastId, "open")
+    }
+
     function test_a_reader_key_is_dead_in_the_list() {
       keyClick(Qt.Key_R)
       compare(host.lastId, "", "there is nothing to reply to from the list")

--- a/tests/qml/tst_keyrouter.qml
+++ b/tests/qml/tst_keyrouter.qml
@@ -132,16 +132,28 @@ Item {
       compare(host.lastId, "open")
     }
 
-    function test_a_reader_key_is_dead_in_the_list() {
+    // Answering works from the list as well as the reader: the row's own menu
+    // has always offered it, and the keyboard was able to do less than a
+    // right-click. What is opened first is App.qml's job.
+    function test_answering_works_from_the_list_and_the_reader() {
       keyClick(Qt.Key_R)
-      compare(host.lastId, "", "there is nothing to reply to from the list")
-    }
-
-    function test_and_live_in_the_reader() {
+      compare(host.lastId, "reply", "from the list")
       host.context = "reader"
+      host.lastId = ""
       wait(20)
       keyClick(Qt.Key_R)
-      compare(host.lastId, "reply")
+      compare(host.lastId, "reply", "and from the reader")
+    }
+
+    // Zoom is not: there is no message body to size until one is open.
+    function test_a_reader_only_key_is_dead_in_the_list() {
+      keyClick(Qt.Key_0, Qt.ControlModifier)
+      compare(host.lastId, "", "nothing to zoom from the list")
+      host.context = "reader"
+      host.lastId = ""
+      wait(20)
+      keyClick(Qt.Key_0, Qt.ControlModifier)
+      compare(host.lastId, "zoomReset")
     }
 
     // The mechanism, not a key: leaving a text-entry context has to take the

--- a/tests/qml/tst_keyrouter.qml
+++ b/tests/qml/tst_keyrouter.qml
@@ -1,4 +1,6 @@
 import QtQuick
+import QtQuick.Window
+import QtQuick.Controls as QQC
 import QtTest
 import "../../components" as Omamail
 
@@ -22,6 +24,22 @@ Item {
     overlay: host.overlay
     onTriggered: function(id) { host.lastId = id }
   }
+
+  // The real `typing` in App.qml is answered by asking the window who holds the
+  // focus, rather than by naming the fields — the naming is what missed nine of
+  // them. This exercises that decision against real focus rather than a bool.
+  function looksLikeTextEntry(item) {
+    return !!item
+        && item.hasOwnProperty("cursorPosition")
+        && item.hasOwnProperty("selectedText")
+        && item.hasOwnProperty("readOnly")
+        && !item.readOnly
+  }
+  readonly property bool typingByFocus:
+    looksLikeTextEntry(host.Window.activeFocusItem)
+
+  QQC.TextField { id: someField; width: 80 }
+  QQC.Button { id: someButton; y: 40; text: "b" }
 
   TestCase {
     name: "KeyRouter"
@@ -82,6 +100,18 @@ Item {
       wait(20)
       keyClick(Qt.Key_Question)
       compare(host.lastId, "help")
+    }
+
+    // A field nobody named. This is the whole point: the guard is answered by
+    // the focus, so a text field added later is covered without being listed.
+    function test_focus_on_any_text_field_counts_as_typing() {
+      someField.forceActiveFocus()
+      wait(30)
+      compare(host.typingByFocus, true,
+        "a field nobody added to a list still stands the letters down")
+      someButton.forceActiveFocus()
+      wait(30)
+      compare(host.typingByFocus, false, "a button is not a text field")
     }
 
     function test_a_reader_key_is_dead_in_the_list() {

--- a/tests/test_keymap.js
+++ b/tests/test_keymap.js
@@ -111,15 +111,33 @@ groups.forEach(function (group) {
   })
 })
 
-assert.strictEqual(keymap.displayFor(byId("cursorUp")), "k / Up",
-  "keys read as themselves unless the row overrides it")
-assert.strictEqual(keymap.displayFor(byId("cursorDown")), "j / k",
-  "the pair reads as a pair where one line stands for both")
+// The sheet enumerates and the status bar hints; one field could not do both.
+// Enumerating put "j / k  Move down" on the sheet, which is true of neither.
+assert.strictEqual(keymap.displayFor(byId("cursorUp")), "k, Up",
+  "the sheet names every key that works")
+assert.strictEqual(keymap.displayFor(byId("cursorDown")), "j, Down")
+assert.strictEqual(keymap.displayFor(byId("search")), "/, Ctrl+K",
+  "a slash inside a sequence must not read as the separator")
+
+// Qt's sequence syntax is not the UI's.
+assert.strictEqual(keymap.readableSequence("g,i"), "g then i",
+  "a chord reads as a chord, not as Qt's comma")
+assert.strictEqual(keymap.readableSequence("Escape"), "Esc")
+assert.strictEqual(keymap.readableSequence("Ctrl+Return"), "Ctrl+Enter")
+assert.strictEqual(keymap.displayFor(byId("goInbox")), "g then i")
+assert.strictEqual(keymap.displayFor(byId("open")), "Enter, o")
+assert.strictEqual(keymap.displayFor(byId("back")), "Esc")
+assert.strictEqual(keymap.hintKeyFor(byId("cursorDown")), "j / k",
+  "the status bar shows one line for the pair")
+assert.strictEqual(keymap.hintKeyFor(byId("open")), "o",
+  "and the short form of a row with several keys")
+assert.strictEqual(keymap.hintKeyFor(byId("archive")), "e",
+  "falling back to the keys when there is nothing to shorten")
 
 const listHints = keymap.hintsFor("list")
-deepEqual(listHints.map(function (h) { return h.label }),
-  ["move", "open", "archive", "compose"],
-  "the status bar offers what the list can do")
+deepEqual(listHints.map(function (h) { return h.key + " " + h.label }),
+  ["j / k move", "o open", "e archive", "c compose"],
+  "the status bar offers what the list can do, in its short form")
 const composeHints = keymap.hintsFor("compose")
 deepEqual(composeHints.map(function (h) { return h.label }),
   ["send", "close"],

--- a/tests/test_keymap.js
+++ b/tests/test_keymap.js
@@ -150,4 +150,38 @@ listSequences.forEach(function (row) {
     "each entry carries its id, its sequence, and the row it came from")
 })
 
+// -------------------------------------------------- the doc cannot drift
+
+// docs/KEYS.md carries the table for people rather than for the engine. Three
+// hand-written copies of this list used to exist and had already drifted apart,
+// so this one is asserted against the source rather than trusted.
+{
+  const fs = require("fs")
+  const path = require("path")
+  const doc = fs.readFileSync(
+    path.join(__dirname, "..", "docs", "KEYS.md"), "utf8")
+  const body = doc.split("<!-- BEGIN BINDINGS -->")[1]
+  assert.ok(body, "docs/KEYS.md must fence its table with BEGIN/END BINDINGS")
+  const rows = body.split("<!-- END BINDINGS -->")[0]
+    .split("\n")
+    .filter(function (line) { return line.indexOf("| `") === 0 })
+
+  function shorthand(binding) {
+    return binding.contexts.join("+")
+      .replace("list+reader", "mail")
+      .replace("*", "all")
+  }
+
+  assert.strictEqual(rows.length, keymap.BINDINGS.length,
+    "docs/KEYS.md lists every binding and no others")
+
+  keymap.BINDINGS.forEach(function (binding, i) {
+    const expected = "| `" + binding.id + "` | "
+      + binding.keys.map(function (k) { return "`" + k + "`" }).join(", ")
+      + " | " + shorthand(binding) + " | " + binding.label + " |"
+    assert.strictEqual(rows[i].trim(), expected,
+      "docs/KEYS.md row " + (i + 1) + " is out of step with keys/Keymap.js")
+  })
+}
+
 console.log("test_keymap.js ok")

--- a/tests/test_keymap.js
+++ b/tests/test_keymap.js
@@ -30,71 +30,62 @@ assert.strictEqual(new Set(ids).size, ids.length, "ids are unique")
 deepEqual(keymap.conflicts(), [],
   "no sequence is bound twice within one context")
 
-// ------------------------------------------------- standing down for typing
+// ------------------------------------------------------------ every context
 
 function byId(id) {
   return keymap.BINDINGS.filter(function (b) { return b.id === id })[0]
 }
 
-// Derived from the key, never declared. The guard that used to be written by
-// hand on every line is the guard that was forgotten on nine text fields.
-assert.strictEqual(keymap.suppressedByTyping(byId("archive"), "e"), true,
-  "a bare letter must not fire into a text field")
-assert.strictEqual(keymap.suppressedByTyping(byId("open"), "Return"), true,
-  "Return is a bare key: it belongs to the field being typed in")
-assert.strictEqual(keymap.suppressedByTyping(byId("cursorDown"), "Down"), true,
-  "the arrows move the caret while typing")
-assert.strictEqual(keymap.suppressedByTyping(byId("markRead"), "Shift+I"), true,
-  "Shift+I is what typing a capital I looks like, so Shift is not a modifier here")
-assert.strictEqual(keymap.suppressedByTyping(byId("goInbox"), "g,i"), true,
-  "a chord of bare keys is still bare")
-assert.strictEqual(keymap.suppressedByTyping(byId("refresh"), "F5"), false,
-  "F5 is not a character")
-assert.strictEqual(keymap.suppressedByTyping(byId("back"), "Escape"), false,
-  "Escape is the one bare key that must survive typing")
-
-// Per key, not per row. This is what lets one Search row hold both `/`, which
-// has to stand down inside a field, and Ctrl+K, whose whole purpose is reaching
-// search from inside one. Deciding by row would have forced them apart and put
-// two identical lines in the help sheet.
-const search = byId("search")
-assert.strictEqual(keymap.suppressedByTyping(search, "/"), true,
-  "a bare slash is a character someone is typing")
-assert.strictEqual(keymap.suppressedByTyping(search, "Ctrl+K"), false,
-  "Ctrl+K is unreachable by typing, so it stays live in the same row")
+// Context is the only thing that decides what is live. A text-entry context
+// binds no bare keys, so there is no "are they typing" question to get wrong:
+// the field is on screen and Qt gives it its own keys first.
+;["search", "compose", "page"].forEach(function (context) {
+  keymap.bindingsFor(context).forEach(function (binding) {
+    binding.keys.forEach(function (key) {
+      var bare = key.indexOf("Ctrl+") < 0 && key.indexOf("Alt+") < 0
+        && key.indexOf("Meta+") < 0 && !/^F[0-9]+$/.test(key)
+      assert.ok(!bare || key === "Escape",
+        context + " must bind no bare key but Escape, and binds " + key
+          + " for " + binding.id)
+    })
+  })
+})
 
 // ------------------------------------------------------------------ enabling
 
 const archive = byId("archive")
-assert.strictEqual(keymap.isEnabled(archive, "e", "list", false, false), true)
-assert.strictEqual(keymap.isEnabled(archive, "e", "reader", false, false), true)
-assert.strictEqual(keymap.isEnabled(archive, "e", "page", false, false), false,
+assert.strictEqual(keymap.isEnabled(archive, "list", false), true)
+assert.strictEqual(keymap.isEnabled(archive, "reader", false), true)
+assert.strictEqual(keymap.isEnabled(archive, "page", false), false,
   "a settings form is a form; e is not archive there")
-assert.strictEqual(keymap.isEnabled(archive, "e", "compose", false, false), false)
-assert.strictEqual(keymap.isEnabled(archive, "e", "list", true, false), false,
-  "typing stands it down")
-assert.strictEqual(keymap.isEnabled(archive, "e", "list", false, true), false,
+assert.strictEqual(keymap.isEnabled(archive, "compose", false), false,
+  "nor is it archive in the middle of a sentence")
+assert.strictEqual(keymap.isEnabled(archive, "search", false), false,
+  "nor in a query being typed")
+assert.strictEqual(keymap.isEnabled(archive, "list", true), false,
   "an overlay stands it down")
 
-assert.strictEqual(keymap.isEnabled(search, "/", "list", true, false), false,
-  "the bare key of a mixed row stands down")
-assert.strictEqual(keymap.isEnabled(search, "Ctrl+K", "list", true, false), true,
-  "while its modified key, in the same row, does not")
-
 const back = byId("back")
-assert.strictEqual(keymap.isEnabled(back, "Escape", "page", true, true), true,
-  "Escape dismisses the overlay and leaves the field, so it survives both")
+keymap.CONTEXTS.forEach(function (context) {
+  assert.strictEqual(keymap.isEnabled(back, context, false), true,
+    "Escape is the way out of " + context)
+})
+assert.strictEqual(keymap.isEnabled(back, "list", true), true,
+  "including out of the overlay itself")
 
 const help = byId("help")
-assert.strictEqual(keymap.isEnabled(help, "Ctrl+?", "list", false, true), true,
+assert.strictEqual(keymap.isEnabled(help, "list", true), true,
   "the sheet's own key has to close the sheet")
-assert.strictEqual(keymap.isEnabled(help, "?", "list", false, true), true,
-  "and so does the bare one: an overlay is not a text field")
 
-// The zoom keys used to be live everywhere, including on a settings form.
+// Reaching search from inside a form or a draft is the whole point of binding
+// it to a modified key as well.
+assert.strictEqual(keymap.isEnabled(byId("searchAnywhere"), "compose", false), true)
+assert.strictEqual(keymap.isEnabled(byId("search"), "compose", false), false,
+  "while the bare slash is a character in the draft")
+
 const zoomIn = byId("zoomIn")
-assert.strictEqual(keymap.isEnabled(zoomIn, "Ctrl+=", "reader", false, false), true)
-assert.strictEqual(keymap.isEnabled(zoomIn, "Ctrl+=", "page", false, false), false,
+assert.strictEqual(keymap.isEnabled(zoomIn, "reader", false), true)
+assert.strictEqual(keymap.isEnabled(zoomIn, "page", false), false,
   "there is no message body to size on a form")
 
 // ------------------------------------------------------------ what renders
@@ -116,7 +107,7 @@ groups.forEach(function (group) {
 assert.strictEqual(keymap.displayFor(byId("cursorUp")), "k, Up",
   "the sheet names every key that works")
 assert.strictEqual(keymap.displayFor(byId("cursorDown")), "j, Down")
-assert.strictEqual(keymap.displayFor(byId("search")), "/, Ctrl+K",
+assert.strictEqual(keymap.displayFor(byId("help")), "?, Ctrl+/, Ctrl+?",
   "a slash inside a sequence must not read as the separator")
 
 // Qt's sequence syntax is not the UI's.
@@ -148,18 +139,8 @@ deepEqual(keymap.hintsFor("page").map(function (h) { return h.label }),
 
 // ------------------------------------------------- one entry per sequence
 
-// A Shortcut binds one sequence, so the router needs the table flattened. It
-// also needs each sequence to carry its own row, since `enabled` is decided per
-// key: the two halves of the Search row disagree while the user is typing.
+// A Shortcut binds one sequence, so the router needs the table flattened.
 const listSequences = keymap.sequencesFor("list")
-const searchRows = listSequences.filter(function (r) { return r.id === "search" })
-assert.strictEqual(searchRows.length, 2, "/ and Ctrl+K arrive separately")
-deepEqual(searchRows.map(function (r) { return r.sequence }), ["/", "Ctrl+K"])
-assert.strictEqual(
-  keymap.isEnabled(searchRows[0].binding, searchRows[0].sequence, "list", true, false), false)
-assert.strictEqual(
-  keymap.isEnabled(searchRows[1].binding, searchRows[1].sequence, "list", true, false), true)
-
 const expectedCount = keymap.bindingsFor("list").reduce(
   function (n, b) { return n + b.keys.length }, 0)
 assert.strictEqual(listSequences.length, expectedCount,

--- a/tests/test_keymap.js
+++ b/tests/test_keymap.js
@@ -1,0 +1,131 @@
+const assert = require("assert")
+const { load, deepEqual } = require("./load")
+
+const keymap = load("keys/Keymap.js")
+
+// ---------------------------------------------------------------- the table
+
+assert.ok(keymap.BINDINGS.length > 20, "the table describes the whole keyboard")
+
+// Anything that renders a binding needs all of these, so a row missing one
+// would reach the help sheet as a blank line.
+keymap.BINDINGS.forEach(function (binding) {
+  assert.ok(binding.id, "every binding has an id")
+  assert.ok(binding.group, binding.id + " needs a group for the help sheet")
+  assert.ok(binding.label, binding.id + " needs a label for the help sheet")
+  assert.ok(binding.keys.length > 0, binding.id + " binds at least one key")
+  binding.contexts.forEach(function (context) {
+    assert.ok(context === "*" || keymap.CONTEXTS.indexOf(context) >= 0,
+      binding.id + " names a context that exists: " + context)
+  })
+})
+
+const ids = keymap.BINDINGS.map(function (b) { return b.id })
+assert.strictEqual(new Set(ids).size, ids.length, "ids are unique")
+
+// ------------------------------------------------------------ no collisions
+
+// Two bindings claiming one sequence in one context is a bug the table finds by
+// itself. Sequences compare whole, so `s` and `g,s` are different keys.
+deepEqual(keymap.conflicts(), [],
+  "no sequence is bound twice within one context")
+
+// ------------------------------------------------- standing down for typing
+
+function byId(id) {
+  return keymap.BINDINGS.filter(function (b) { return b.id === id })[0]
+}
+
+// Derived from the key, never declared. The guard that used to be written by
+// hand on every line is the guard that was forgotten on nine text fields.
+assert.strictEqual(keymap.suppressedByTyping(byId("archive"), "e"), true,
+  "a bare letter must not fire into a text field")
+assert.strictEqual(keymap.suppressedByTyping(byId("open"), "Return"), true,
+  "Return is a bare key: it belongs to the field being typed in")
+assert.strictEqual(keymap.suppressedByTyping(byId("cursorDown"), "Down"), true,
+  "the arrows move the caret while typing")
+assert.strictEqual(keymap.suppressedByTyping(byId("markRead"), "Shift+I"), true,
+  "Shift+I is what typing a capital I looks like, so Shift is not a modifier here")
+assert.strictEqual(keymap.suppressedByTyping(byId("goInbox"), "g,i"), true,
+  "a chord of bare keys is still bare")
+assert.strictEqual(keymap.suppressedByTyping(byId("refresh"), "F5"), false,
+  "F5 is not a character")
+assert.strictEqual(keymap.suppressedByTyping(byId("back"), "Escape"), false,
+  "Escape is the one bare key that must survive typing")
+
+// Per key, not per row. This is what lets one Search row hold both `/`, which
+// has to stand down inside a field, and Ctrl+K, whose whole purpose is reaching
+// search from inside one. Deciding by row would have forced them apart and put
+// two identical lines in the help sheet.
+const search = byId("search")
+assert.strictEqual(keymap.suppressedByTyping(search, "/"), true,
+  "a bare slash is a character someone is typing")
+assert.strictEqual(keymap.suppressedByTyping(search, "Ctrl+K"), false,
+  "Ctrl+K is unreachable by typing, so it stays live in the same row")
+
+// ------------------------------------------------------------------ enabling
+
+const archive = byId("archive")
+assert.strictEqual(keymap.isEnabled(archive, "e", "list", false, false), true)
+assert.strictEqual(keymap.isEnabled(archive, "e", "reader", false, false), true)
+assert.strictEqual(keymap.isEnabled(archive, "e", "page", false, false), false,
+  "a settings form is a form; e is not archive there")
+assert.strictEqual(keymap.isEnabled(archive, "e", "compose", false, false), false)
+assert.strictEqual(keymap.isEnabled(archive, "e", "list", true, false), false,
+  "typing stands it down")
+assert.strictEqual(keymap.isEnabled(archive, "e", "list", false, true), false,
+  "an overlay stands it down")
+
+assert.strictEqual(keymap.isEnabled(search, "/", "list", true, false), false,
+  "the bare key of a mixed row stands down")
+assert.strictEqual(keymap.isEnabled(search, "Ctrl+K", "list", true, false), true,
+  "while its modified key, in the same row, does not")
+
+const back = byId("back")
+assert.strictEqual(keymap.isEnabled(back, "Escape", "page", true, true), true,
+  "Escape dismisses the overlay and leaves the field, so it survives both")
+
+const help = byId("help")
+assert.strictEqual(keymap.isEnabled(help, "Ctrl+?", "list", false, true), true,
+  "the sheet's own key has to close the sheet")
+assert.strictEqual(keymap.isEnabled(help, "?", "list", false, true), true,
+  "and so does the bare one: an overlay is not a text field")
+
+// The zoom keys used to be live everywhere, including on a settings form.
+const zoomIn = byId("zoomIn")
+assert.strictEqual(keymap.isEnabled(zoomIn, "Ctrl+=", "reader", false, false), true)
+assert.strictEqual(keymap.isEnabled(zoomIn, "Ctrl+=", "page", false, false), false,
+  "there is no message body to size on a form")
+
+// ------------------------------------------------------------ what renders
+
+const groups = keymap.helpGroups()
+const rowCount = groups.reduce(function (n, g) { return n + g.rows.length }, 0)
+assert.strictEqual(rowCount, keymap.BINDINGS.length,
+  "the help sheet shows every binding — it cannot drift from the table again")
+groups.forEach(function (group) {
+  assert.ok(group.name, "a group is named")
+  group.rows.forEach(function (row) {
+    assert.ok(row.keys, "a help row shows its keys")
+    assert.ok(row.action, "a help row says what the keys do")
+  })
+})
+
+assert.strictEqual(keymap.displayFor(byId("cursorUp")), "k / Up",
+  "keys read as themselves unless the row overrides it")
+assert.strictEqual(keymap.displayFor(byId("cursorDown")), "j / k",
+  "the pair reads as a pair where one line stands for both")
+
+const listHints = keymap.hintsFor("list")
+deepEqual(listHints.map(function (h) { return h.label }),
+  ["move", "open", "archive", "compose"],
+  "the status bar offers what the list can do")
+const composeHints = keymap.hintsFor("compose")
+deepEqual(composeHints.map(function (h) { return h.label }),
+  ["send", "close"],
+  "Escape discards a draft, so it says close rather than back")
+deepEqual(keymap.hintsFor("page").map(function (h) { return h.label }),
+  ["back"],
+  "a form's whole keyboard contract is leaving it")
+
+console.log("test_keymap.js ok")

--- a/tests/test_keymap.js
+++ b/tests/test_keymap.js
@@ -128,4 +128,27 @@ deepEqual(keymap.hintsFor("page").map(function (h) { return h.label }),
   ["back"],
   "a form's whole keyboard contract is leaving it")
 
+// ------------------------------------------------- one entry per sequence
+
+// A Shortcut binds one sequence, so the router needs the table flattened. It
+// also needs each sequence to carry its own row, since `enabled` is decided per
+// key: the two halves of the Search row disagree while the user is typing.
+const listSequences = keymap.sequencesFor("list")
+const searchRows = listSequences.filter(function (r) { return r.id === "search" })
+assert.strictEqual(searchRows.length, 2, "/ and Ctrl+K arrive separately")
+deepEqual(searchRows.map(function (r) { return r.sequence }), ["/", "Ctrl+K"])
+assert.strictEqual(
+  keymap.isEnabled(searchRows[0].binding, searchRows[0].sequence, "list", true, false), false)
+assert.strictEqual(
+  keymap.isEnabled(searchRows[1].binding, searchRows[1].sequence, "list", true, false), true)
+
+const expectedCount = keymap.bindingsFor("list").reduce(
+  function (n, b) { return n + b.keys.length }, 0)
+assert.strictEqual(listSequences.length, expectedCount,
+  "every key of every row in the context is present")
+listSequences.forEach(function (row) {
+  assert.ok(row.id && row.sequence && row.binding,
+    "each entry carries its id, its sequence, and the row it came from")
+})
+
 console.log("test_keymap.js ok")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -181,4 +181,37 @@ assert.strictEqual(model.pluralize(0, "message"), "0 messages")
   assert.strictEqual(model.notificationTitle(null), "New message")
 }
 
+// ------------------------------------------------------------- list cursor
+
+// The cursor moves relative to itself. It used to be anchored to `selectedId`
+// — the message the reader has open — which pinned it: nothing is open in list
+// view, so every step resolved to row 0, and in the reader the anchor never
+// advanced, so the cursor moved once and then stopped.
+{
+  const rows = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }]
+
+  assert.strictEqual(model.cursorAfterOffset(rows, "", 1), "a",
+    "with no cursor yet, j starts at the top")
+  assert.strictEqual(model.cursorAfterOffset(rows, "", -1), "d",
+    "with no cursor yet, k starts at the bottom")
+
+  // The regression this exists for: pressing j repeatedly keeps moving.
+  assert.strictEqual(model.cursorAfterOffset(rows, "a", 1), "b")
+  assert.strictEqual(model.cursorAfterOffset(rows, "b", 1), "c")
+  assert.strictEqual(model.cursorAfterOffset(rows, "c", 1), "d")
+  assert.strictEqual(model.cursorAfterOffset(rows, "d", 1), "d",
+    "the last row is where moving down stops")
+
+  assert.strictEqual(model.cursorAfterOffset(rows, "c", -1), "b")
+  assert.strictEqual(model.cursorAfterOffset(rows, "a", -1), "a",
+    "the first row is where moving up stops")
+
+  assert.strictEqual(model.cursorAfterOffset([], "a", 1), "",
+    "an empty list has nowhere to go")
+  assert.strictEqual(model.cursorAfterOffset(rows, "gone", 1), "a",
+    "a cursor whose message left the list starts over rather than sticking")
+  assert.strictEqual(model.cursorAfterOffset(rows, "a", 0), "a",
+    "a zero step is a no-op, not a jump to the top")
+}
+
 console.log("test_model.js ok")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -214,4 +214,44 @@ assert.strictEqual(model.pluralize(0, "message"), "0 messages")
     "a zero step is a no-op, not a jump to the top")
 }
 
+// --------------------------------------------------- keeping the cursor seen
+
+// The list is a Column in a Flickable rather than a ListView — the panel
+// already owns a scroller — so there is no positionViewAtIndex, and keyboard
+// movement has to say where the scroller goes itself.
+{
+  // A 100-tall viewport over 500 of content, rows 20 tall, 4px of margin.
+  const view = 100
+  const content = 500
+  const pad = 4
+
+  assert.strictEqual(
+    model.contentYToReveal(0, view, 40, 20, content, pad), 0,
+    "a row already on screen does not move the list under the reader")
+
+  assert.strictEqual(
+    model.contentYToReveal(0, view, 90, 20, content, pad), 14,
+    "a row off the bottom scrolls just far enough, plus the margin")
+
+  assert.strictEqual(
+    model.contentYToReveal(200, view, 180, 20, content, pad), 176,
+    "a row off the top scrolls back to it, plus the margin")
+
+  assert.strictEqual(
+    model.contentYToReveal(10, view, 0, 20, content, pad), 0,
+    "the top of the list is as far up as it goes: no negative offset")
+
+  assert.strictEqual(
+    model.contentYToReveal(380, view, 480, 20, content, pad), 400,
+    "the bottom clamps to the last screenful rather than scrolling past it")
+
+  assert.strictEqual(
+    model.contentYToReveal(0, view, 40, 300, content, pad), 36,
+    "a row taller than the viewport shows its top rather than its bottom")
+
+  assert.strictEqual(
+    model.contentYToReveal(0, 500, 40, 20, 400, pad), 0,
+    "content shorter than the viewport never scrolls")
+}
+
 console.log("test_model.js ok")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -254,4 +254,39 @@ assert.strictEqual(model.pluralize(0, "message"), "0 messages")
     "content shorter than the viewport never scrolls")
 }
 
+
+// ------------------------------------------- the cursor outliving its message
+
+// Two ways a cursor stops pointing at anything: the row it is on is acted on
+// and leaves, or the whole list is replaced under it by a mailbox switch, a
+// search, or a refresh. Both used to leave the cursor on a message that is no
+// longer there, and cursorAfterOffset restarts at the top from that — so one
+// archive sent the next j back to the first row.
+{
+  const rows = [{ id: "a" }, { id: "b" }, { id: "c" }]
+
+  // Acting on a row: the cursor takes the row's place, which is the one below.
+  assert.strictEqual(model.cursorAfterRemoval(rows, "a"), "b")
+  assert.strictEqual(model.cursorAfterRemoval(rows, "b"), "c")
+  // Except at the end, where there is nothing below and the one above is where
+  // the eye already is.
+  assert.strictEqual(model.cursorAfterRemoval(rows, "c"), "b")
+  assert.strictEqual(model.cursorAfterRemoval([{ id: "only" }], "only"), "",
+    "emptying the list leaves no cursor to hold")
+  assert.strictEqual(model.cursorAfterRemoval(rows, "gone"), "",
+    "a cursor that is already adrift has no neighbour to inherit")
+  assert.strictEqual(model.cursorAfterRemoval([], "a"), "")
+
+  // A list replaced underneath: keep the cursor if its message survived the
+  // reload, otherwise start at the top.
+  assert.strictEqual(model.cursorAfterReload(rows, "b"), "b",
+    "a refresh that kept the message keeps the cursor")
+  assert.strictEqual(model.cursorAfterReload(rows, "gone"), "a",
+    "a mailbox switch lands on the first row rather than nowhere")
+  assert.strictEqual(model.cursorAfterReload(rows, ""), "a",
+    "and so does a list arriving for the first time")
+  assert.strictEqual(model.cursorAfterReload([], "b"), "",
+    "an empty mailbox has no row to sit on")
+}
+
 console.log("test_model.js ok")

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -79,6 +79,12 @@ if awk '
   fail "ImapSetupPage assigns the non-existent IconTextButton.hoverColor property"
 fi
 
+# A trigger holds a selected style while what it opened is on screen. The bar
+# icon is the only trigger the window has, so without this there is nothing on
+# screen saying which icon put it there.
+grep -q 'windowOpen' BarWidget.qml \
+  || fail "the bar icon must show an active style while the window is open"
+
 # Quickshell's FloatingWindow is a proxy window and does not forward
 # activeFocusItem, so `window.activeFocusItem` is undefined and the typing
 # guard silently passes for every key. The attached property is the one that

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -85,6 +85,15 @@ fi
 grep -q 'windowOpen' BarWidget.qml \
   || fail "the bar icon must show an active style while the window is open"
 
+# The mouse must not move the keyboard's cursor. Qt re-reports hover when
+# content moves under a still pointer, and the list scrolls to follow the
+# keyboard — so a hover that wrote cursorId pulled it back to whatever the mouse
+# was resting on, and j and k stuck on a few rows. A row shows its own hover
+# (MessageRow.hot); that is the whole of what hover is for here.
+if grep -n 'onRowHovered' App.qml; then
+  fail "hovering a row must not move the keyboard cursor"
+fi
+
 # The context owns the keyboard. Every context that is not text entry parks the
 # focus on a plain Item, because forceActiveFocus on the focus scope itself is a
 # no-op — it re-elects the scope's current focus item, which is the field being

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -84,6 +84,14 @@ fi
 # screen saying which icon put it there.
 grep -q 'windowOpen' BarWidget.qml \
   || fail "the bar icon must show an active style while the window is open"
+# As a selected fill, the way every other selected control here is drawn. The
+# bar's own `active` recolours the glyph from the theme's `bar.active`, which
+# falls back to `urgent` — a warning colour for a window simply being open.
+grep -q 'selectedFillFor' BarWidget.qml \
+  || fail "the bar icon's open state must use the selected fill, not a glyph colour"
+if grep -vE '^[[:space:]]*//' BarWidget.qml | grep -n 'activeColor'; then
+  fail "BarWidget must not paint its glyph with the bar's urgent-derived activeColor"
+fi
 
 # The mouse must not move the keyboard's cursor. Qt re-reports hover when
 # content moves under a still pointer, and the list scrolls to follow the

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -85,15 +85,18 @@ fi
 grep -q 'windowOpen' BarWidget.qml \
   || fail "the bar icon must show an active style while the window is open"
 
-# Quickshell's FloatingWindow is a proxy window and does not forward
-# activeFocusItem, so `window.activeFocusItem` is undefined and the typing
-# guard silently passes for every key. The attached property is the one that
-# works. This is invisible at runtime — nothing warns — so it is asserted here.
-if grep -vE '^[[:space:]]*//' App.qml | grep -n '[^A-Za-z]window\.activeFocusItem'; then
-  fail "App.qml must read Window.activeFocusItem (attached), not window.activeFocusItem"
+# The context owns the keyboard. Every context that is not text entry parks the
+# focus on a plain Item, because forceActiveFocus on the focus scope itself is a
+# no-op — it re-elects the scope's current focus item, which is the field being
+# left, so a dismissed compose field goes on swallowing every bare key. Nothing
+# warns about this: the keys simply stop arriving.
+grep -q 'onKeyContextChanged' App.qml \
+  || fail "the key context must move the keyboard when it changes"
+grep -q 'function parkKeyboard' App.qml \
+  || fail "App.qml must park the keyboard on a plain Item, not on the focus scope"
+if grep -vE '^[[:space:]]*//' App.qml | grep -n 'focusScope\.forceActiveFocus'; then
+  fail "forceActiveFocus on the focus scope re-elects the field being left; park the keyboard instead"
 fi
-grep -q 'Window\.activeFocusItem' App.qml \
-  || fail "App.qml must decide typing from the window's active focus item"
 
 # A component that declares `focus: true` owns the window's focus even while it
 # is invisible, and an owner that accepts keys is a sink for everything routed

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -79,6 +79,16 @@ if awk '
   fail "ImapSetupPage assigns the non-existent IconTextButton.hoverColor property"
 fi
 
+# Quickshell's FloatingWindow is a proxy window and does not forward
+# activeFocusItem, so `window.activeFocusItem` is undefined and the typing
+# guard silently passes for every key. The attached property is the one that
+# works. This is invisible at runtime — nothing warns — so it is asserted here.
+if grep -vE '^[[:space:]]*//' App.qml | grep -n '[^A-Za-z]window\.activeFocusItem'; then
+  fail "App.qml must read Window.activeFocusItem (attached), not window.activeFocusItem"
+fi
+grep -q 'Window\.activeFocusItem' App.qml \
+  || fail "App.qml must decide typing from the window's active focus item"
+
 # A component that declares `focus: true` owns the window's focus even while it
 # is invisible, and an owner that accepts keys is a sink for everything routed
 # by focus rather than by Shortcut. ComposeView is instantiated whether or not

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -79,6 +79,17 @@ if awk '
   fail "ImapSetupPage assigns the non-existent IconTextButton.hoverColor property"
 fi
 
+# A component that declares `focus: true` owns the window's focus even while it
+# is invisible, and an owner that accepts keys is a sink for everything routed
+# by focus rather than by Shortcut. ComposeView is instantiated whether or not
+# anyone is writing, so an unconditional focus there swallowed every Escape in
+# the window. Focus must follow "in use".
+grep -q '^  focus: root.opened$' components/ComposeView.qml \
+  || fail "ComposeView must own the focus only while it is open"
+if grep -rn '^\s*focus: true\s*$' components/ComposeView.qml; then
+  fail "ComposeView must not hold the focus unconditionally"
+fi
+
 # The IMAP server disclosure always reserves an icon slot. Both names selected
 # by its state must have a drawing, or the slot is blank in one or both states.
 for icon in chevronRight chevronDown; do


### PR DESCRIPTION
Shortcuts were intermittent. Three symptoms were reported and each turned out
to be its own root cause, all reproduced before anything was changed.

## What was broken

**`j`/`k` moved once and stopped.** `selectOffset` anchored movement on
`selectedId` — the message the reader has open — while `moveCursor` only ever
wrote `cursorId`. Nothing is open in the list, so every step resolved to row 0.

**`Esc` worked only sometimes.** `ComposeView` declared `focus: true`
unconditionally, and Qt does not exclude invisible items from owning the focus.
It was the window's `activeFocusItem` at all times and swallowed every Escape.
Letter shortcuts were unaffected because they are `Qt.WindowShortcut` and do not
travel by focus — that asymmetry is what made it look random.

**The list never followed the cursor.** It is a `Column` in a `Flickable`, not a
`ListView`, so there is no `positionViewAtIndex` — and nothing had replaced it.

Then, from use: `j`/`k` sticking near the mouse, the cursor jumping to the top
after an archive, `o` and `Enter` doing nothing in the reader, and a reply from
a list row opening a draft with no recipient and nothing quoted.

## The design

The keyboard belongs to the application and the context says what a key means
where — actions are scoped, the way a TUI or GPUI scopes them.

- One table, `keys/Keymap.js`. The shortcut sheet and the status hints render
  from it. Three hand-written copies used to exist and had already drifted: the
  sheet listed `Esc` twice, was missing `u` and `?`, and carried a mouse gesture
  among the keys.
- `components/KeyRouter.qml` turns the table into `Shortcut`s and reports an id;
  `App.qml` answers with one `runShortcut`. `Escape` is a row like any other, so
  it no longer depends on who holds the focus.
- **The context owns the keyboard.** Changing it moves the focus — to whatever
  that context types into, or parked on a plain `Item`. Keeping context and
  focus as two things kept in step by hand is the bug this replaces.
- That removes the typing guard entirely. A text-entry context binds no bare key
  but `Escape`, and Qt already gives a visible field its own keys.
- Cursor movement, the row it lands on after the list changes under it, and
  where the scroller goes now all live in `account/Model.js`, under node tests.

Documented in `docs/KEYS.md`, whose table is asserted against `Keymap.js` — a
document restating a list is exactly the fourth copy this work spent itself
removing.

## Four Qt behaviours this is shaped around

Each was found by running the code, not reading it, and each had already cost a
bug. All four are pinned by tests now.

- A `Repeater` builds no `Shortcut`s — a `Shortcut` is a `QtObject` and a
  `Repeater` builds only `Item`s, so it creates nothing and every key goes dead.
- `FloatingWindow` does not forward `activeFocusItem`; the attached
  `Window.activeFocusItem` is the one that works. The window form reads
  `undefined`, which is falsy, so it passes every guard built on it silently.
- `forceActiveFocus()` on a `FocusScope` is a no-op — it re-elects that scope's
  current focus item, which is the field you are trying to leave.
- A window `Shortcut` beats a focused item's `Keys` handler, so a local handler
  looks live and never runs. `SearchBar` had one.

And one thing that was assumed to be a problem and is not: Qt already gives a
focused `TextInput` the bare keys before any `Shortcut` sees them, so typing an
IMAP host never did archive mail. The guard removed here had never been holding
that line.

## Also

- `tests/qml/` is new — focus ownership cannot be tested without a focus scope,
  and a focus scope needs the QML engine. Offscreen, so it needs no compositor.
- The bar icon shows a selected fill while the window is open, using the same
  `Style.selectedFillFor` the in-window menu button uses rather than the bar's
  `activeColor`, which falls back to `urgent`.
- `Up`/`Down`, `u`, and `?` are bound; `r`/`a`/`f` and `o`/`Enter` work from the
  list and the reader both.

## Testing

`make validate` passes: node tests, source regressions, `qmllint`, and
`omarchy plugin validate`. 22 QML tests, and every new decision has node
coverage. Each guard added to `test_source.sh` was verified to actually fail
when the mistake is reintroduced.

Not covered headlessly: real key delivery inside the real window — QtTest cannot
instantiate the app's components, which bottom out on the shell's `Color`
singleton. Worth pressing by hand: `j`/`k` with the pointer resting over the
list, `Esc` out of a reply then `j`, and `r` from a list row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)