### PR TITLE
Add sender alias selection

### DIFF
--- a/Service.qml
+++ b/Service.qml
@@ -388,6 +388,7 @@ Item {
   readonly property var auth: current ? current.auth : null
   readonly property bool ready: !!current && current.ready
   readonly property string accountEmail: current ? current.accountEmail : ""
+  readonly property var sendAsAliases: current ? current.availableSendAsAliases : []
   readonly property string accountAddress: {
     var accounts = accountList ? accountList.accounts : []
     var index = activeIndex >= 0 ? activeIndex : indexOfActiveAccount()
@@ -449,6 +450,9 @@ Item {
   function toggleStar(id) { if (current) current.toggleStar(id) }
   function markAllRead() { if (current) current.markAllRead() }
   function send(fields) { if (current) current.send(fields) }
+  function preferredSendAs(recipients) {
+    return current ? current.preferredSendAs(recipients) : null
+  }
   function signIn() { if (current) current.signIn() }
   function cancelSignIn() { if (current) current.cancelSignIn() }
   function signOut() { if (current) current.signOut() }

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -113,6 +113,9 @@ Item {
   property string rawQuery: ""
   property var messages: []
   property var labels: []
+  property var sendAsAliases: []
+  property bool sendAsLoading: false
+  property bool sendAsLoaded: false
   property string nextPageToken: ""
   property int resultEstimate: 0
   property bool listLoading: false
@@ -161,6 +164,11 @@ Item {
 
   property var profile: null
   readonly property string accountEmail: profile ? String(profile.email || "") : ""
+  readonly property var availableSendAsAliases: {
+    if (sendAsAliases.length > 0) return sendAsAliases
+    if (accountEmail === "") return []
+    return [{ email: accountEmail, displayName: "", isPrimary: true, isDefault: true }]
+  }
   property int inboxUnread: 0
   property bool countLoading: false
 
@@ -345,6 +353,25 @@ Item {
       root.labels = result
       cacheStore.putLabels(result)
     })
+  }
+
+  // Every provider exposes the same sender-list operation. Gmail reads its
+  // configured send-as aliases; an IMAP mailbox returns its one account
+  // address. Keeping that distinction below this object lets the compose view
+  // draw one honest From control for either provider.
+  function loadSendAs() {
+    if (!ready || sendAsLoading || sendAsLoaded) return
+    sendAsLoading = true
+    api.getSendAs(function(result, error) {
+      root.sendAsLoading = false
+      if (error) return
+      root.sendAsAliases = result
+      root.sendAsLoaded = true
+    })
+  }
+
+  function preferredSendAs(recipients) {
+    return Api.preferredSendAs(availableSendAsAliases, recipients)
   }
 
   // Paints whatever the last visit to this query left behind. Switching
@@ -732,8 +759,14 @@ Item {
       fail("Add a recipient first")
       return
     }
+    var from = String(values.from || "").trim()
+    if (from !== "" && !Api.isSendAsAllowed(availableSendAsAliases, from)) {
+      fail("Choose a valid From address")
+      return
+    }
     sending = true
     api.sendMessage(Mail.buildSendPayload({
+      from: from,
       to: to,
       cc: String(values.cc || "").trim(),
       subject: String(values.subject || ""),
@@ -841,6 +874,7 @@ Item {
   function afterSignIn() {
     loadProfile()
     loadLabels()
+    loadSendAs()
     refreshCounts()
     loadMessages(false)
   }
@@ -859,6 +893,9 @@ Item {
     if (auth) auth.logout()
     messages = []
     labels = []
+    sendAsAliases = []
+    sendAsLoading = false
+    sendAsLoaded = false
     profile = null
     inboxUnread = 0
     listLoaded = false
@@ -877,6 +914,7 @@ Item {
     clearNotice()
     if (!ready) return
     loadProfile()
+    loadSendAs()
     if (!listLoaded) loadMessages(false)
     else refresh()
   }
@@ -884,6 +922,7 @@ Item {
   onReadyChanged: {
     if (!ready) return
     loadProfile()
+    loadSendAs()
     refreshCounts()
     if (!active) return
     loadLabels()
@@ -894,6 +933,7 @@ Item {
   onActiveChanged: {
     if (!active || !ready) return
     loadLabels()
+    loadSendAs()
     if (!listLoaded) loadMessages(false)
     else refresh()
   }

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -364,7 +364,17 @@ Item {
     sendAsLoading = true
     api.getSendAs(function(result, error) {
       root.sendAsLoading = false
-      if (error) return
+      // Not a notice: a sender list that did not arrive costs the user a menu,
+      // not a mailbox, and a banner over the inbox would be out of proportion.
+      // It is not silent either — failing quietly here is indistinguishable
+      // from "this account has one address", which is a question nobody could
+      // answer from the window. `sendAsLoaded` stays false, so the next time
+      // this account becomes ready or active it tries again.
+      if (error) {
+        console.warn("omamail: could not read the send-as addresses:",
+          OAuth.redact(String(error)))
+        return
+      }
       root.sendAsAliases = result
       root.sendAsLoaded = true
     })
@@ -759,14 +769,19 @@ Item {
       fail("Add a recipient first")
       return
     }
+    // The display name is read back off the alias list rather than taken from
+    // the compose form: the list is what `isSendAsAllowed` just checked, so the
+    // name on the message cannot disagree with the address that was allowed.
     var from = String(values.from || "").trim()
-    if (from !== "" && !Api.isSendAsAllowed(availableSendAsAliases, from)) {
+    var alias = from === "" ? null : Api.sendAsFor(availableSendAsAliases, from)
+    if (from !== "" && !alias) {
       fail("Choose a valid From address")
       return
     }
     sending = true
     api.sendMessage(Mail.buildSendPayload({
       from: from,
+      fromName: alias ? String(alias.displayName || "") : "",
       to: to,
       cc: String(values.cc || "").trim(),
       subject: String(values.subject || ""),

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -115,8 +115,13 @@ Item {
         ? summary.replyTo.email : summary.from.email
       threadId = summary.threadId
       inReplyTo = summary.messageId
-      if (mode === "reply" || mode === "replyAll")
-        replyRecipients = Array.isArray(summary.to) ? summary.to : []
+      // Cc as well as To: an alias is just as often the address a thread
+      // copied you on as the one it was sent to, and answering from the
+      // account's default instead is how a thread ends up split in two.
+      if (mode === "reply" || mode === "replyAll") {
+        replyRecipients = (Array.isArray(summary.to) ? summary.to : [])
+          .concat(Array.isArray(summary.cc) ? summary.cc : [])
+      }
 
       if (mode === "forward") {
         subjectField.text = "Fwd: " + summary.subject
@@ -278,14 +283,21 @@ Item {
         font.pixelSize: Style.font.caption
       }
 
+      // Sized to the address rather than to the row: a full-width trigger puts
+      // the chevron a screen away from the name it belongs to. The extra width
+      // is the room the chevron is drawn into, over the button's own trailing
+      // padding, so the two read as one control.
       Button {
         id: fromButton
+        readonly property real trailing: root.fromAliases.length > 1
+          ? Style.font.iconSmall + Style.spacing.controlGap : 0
+
         anchors.left: fromLabel.right
         anchors.leftMargin: Style.space(10)
-        anchors.right: parent.right
-        anchors.rightMargin: Style.space(18)
         anchors.verticalCenter: parent.verticalCenter
-        text: root.fromEmail + (root.fromAliases.length > 1 ? "  ▾" : "")
+        width: Math.min(implicitWidth + trailing,
+          parent.width - fromLabel.width - Style.space(46))
+        text: root.fromEmail
         foreground: root.textColor
         accent: root.accentColor
         fontFamily: root.panelFontFamily
@@ -294,6 +306,19 @@ Item {
         selected: fromMenu.opened
         enabled: root.fromAliases.length > 1
         onClicked: fromMenu.opened ? fromMenu.close() : fromMenu.open()
+
+        // The kit's own chevron is a font glyph, which at this size renders
+        // thinner than every other mark in the window. This is the app's drawn
+        // set, at the size the rest of the icons use.
+        ActionIcon {
+          anchors.right: parent.right
+          anchors.rightMargin: fromButton.horizontalPadding
+          anchors.verticalCenter: parent.verticalCenter
+          visible: root.fromAliases.length > 1
+          name: "chevronDown"
+          iconSize: Style.font.iconSmall
+          color: root.dimColor
+        }
       }
 
       PanelSeparator {

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls as QQC
 import qs.Commons
 import qs.Ui
 import "../message/Message.js" as Mail
@@ -28,6 +29,14 @@ Item {
   property string threadId: ""
   property string inReplyTo: ""
   property bool ccVisible: false
+  property string fromEmail: ""
+  property var replyRecipients: []
+  property bool fromWasChosen: false
+
+  readonly property var fromAliases: {
+    if (!root.service || !Array.isArray(root.service.sendAsAliases)) return []
+    return root.service.sendAsAliases
+  }
 
   readonly property string title: {
     if (mode === "reply") return "REPLY"
@@ -43,6 +52,7 @@ Item {
   }
 
   function reset() {
+    fromMenu.close()
     toField.text = ""
     ccField.text = ""
     subjectField.text = ""
@@ -51,6 +61,34 @@ Item {
     threadId = ""
     inReplyTo = ""
     ccVisible = false
+    fromEmail = ""
+    replyRecipients = []
+    fromWasChosen = false
+  }
+
+  function selectPreferredFrom() {
+    var choice = root.service ? root.service.preferredSendAs(replyRecipients) : null
+    fromEmail = choice ? String(choice.email || "") : ""
+  }
+
+  function chooseFrom(email) {
+    fromEmail = String(email || "")
+    fromWasChosen = true
+    fromMenu.close()
+  }
+
+  function placeFromMenu() {
+    if (!fromMenu.visible) return
+    var global = fromButton.mapToGlobal(0, 0)
+    var at = root.mapFromGlobal(global.x, global.y)
+    var tall = fromMenu.height > 0 ? fromMenu.height : fromMenu.implicitHeight
+    var x = Math.max(0, Math.min(at.x, root.width - fromMenu.width))
+    var y = at.y + fromButton.height
+    if (y + tall > root.height) y = at.y - tall
+    if (y + tall > root.height) y = root.height - tall
+    if (y < 0) y = 0
+    fromMenu.x = x
+    fromMenu.y = y
   }
 
   // Everyone on the original except this mailbox: replying to yourself is
@@ -77,6 +115,8 @@ Item {
         ? summary.replyTo.email : summary.from.email
       threadId = summary.threadId
       inReplyTo = summary.messageId
+      if (mode === "reply" || mode === "replyAll")
+        replyRecipients = Array.isArray(summary.to) ? summary.to : []
 
       if (mode === "forward") {
         subjectField.text = "Fwd: " + summary.subject
@@ -90,6 +130,8 @@ Item {
       }
       bodyEdit.text = "\n\n" + Mail.quoteBody(summary, String(bodyText || ""))
     }
+
+    selectPreferredFrom()
 
     // Focus is not placed here. Opening this changes the window's key context,
     // and the context is what moves the keyboard — one mechanism, so the two
@@ -115,6 +157,7 @@ Item {
   function submit() {
     if (!service) return
     service.send(({
+      from: root.fromEmail,
       to: toField.text,
       cc: ccField.text,
       subject: subjectField.text,
@@ -132,6 +175,10 @@ Item {
   // Escape in the window, which is why Esc looked intermittent: whether it
   // worked depended on where the user had last clicked.
   focus: root.opened
+
+  onFromAliasesChanged: {
+    if (opened && !fromWasChosen) selectPreferredFrom()
+  }
 
   // ----------------------------------------------------------- header
   //
@@ -213,6 +260,48 @@ Item {
     anchors.top: head.bottom
     anchors.left: parent.left
     anchors.right: parent.right
+
+    Item {
+      width: parent.width
+      implicitHeight: fromButton.implicitHeight + Style.space(14)
+
+      Text {
+        id: fromLabel
+        anchors.left: parent.left
+        anchors.leftMargin: Style.space(18)
+        anchors.verticalCenter: parent.verticalCenter
+        width: Style.space(52)
+        horizontalAlignment: Text.AlignRight
+        text: "From"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+      }
+
+      Button {
+        id: fromButton
+        anchors.left: fromLabel.right
+        anchors.leftMargin: Style.space(10)
+        anchors.right: parent.right
+        anchors.rightMargin: Style.space(18)
+        anchors.verticalCenter: parent.verticalCenter
+        text: root.fromEmail + (root.fromAliases.length > 1 ? "  ▾" : "")
+        foreground: root.textColor
+        accent: root.accentColor
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.bodySmall
+        leftAlign: true
+        selected: fromMenu.opened
+        enabled: root.fromAliases.length > 1
+        onClicked: fromMenu.opened ? fromMenu.close() : fromMenu.open()
+      }
+
+      PanelSeparator {
+        anchors.bottom: parent.bottom
+        width: parent.width
+        foreground: root.textColor
+      }
+    }
 
     Item {
       width: parent.width
@@ -352,6 +441,80 @@ Item {
         anchors.bottom: parent.bottom
         width: parent.width
         foreground: root.textColor
+      }
+    }
+  }
+
+  QQC.Popup {
+    id: fromMenu
+    width: Math.min(Style.space(360), root.width - Style.space(36))
+    implicitHeight: Math.min(fromRows.implicitHeight + Style.space(8), Style.space(260))
+    padding: Style.space(4)
+    modal: false
+    focus: opened
+    z: 50
+    closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
+    onHeightChanged: root.placeFromMenu()
+    onOpened: root.placeFromMenu()
+    background: Rectangle {
+      radius: Style.cornerRadius
+      color: Color.popups.background
+      border.width: 1
+      border.color: Color.popups.border
+    }
+
+    contentItem: ListView {
+      id: fromRows
+      implicitHeight: contentHeight
+      clip: true
+      model: root.fromAliases
+
+      delegate: Rectangle {
+        id: fromRow
+        required property var modelData
+
+        width: fromMenu.width - fromMenu.leftPadding - fromMenu.rightPadding
+        implicitHeight: Style.space(42)
+        radius: Style.cornerRadius
+        color: root.fromEmail.toLowerCase() === String(modelData.email || "").toLowerCase()
+          ? Style.selectedFillFor(root.textColor, root.accentColor)
+          : (fromHover.hovered
+            ? Style.hoverFillFor(root.textColor, root.accentColor) : "transparent")
+
+        Column {
+          anchors.left: parent.left
+          anchors.leftMargin: Style.space(9)
+          anchors.right: parent.right
+          anchors.rightMargin: Style.space(9)
+          anchors.verticalCenter: parent.verticalCenter
+          spacing: Style.space(1)
+
+          Text {
+            width: parent.width
+            textFormat: Text.PlainText
+            text: String(fromRow.modelData.email || "")
+            color: root.textColor
+            font.family: root.panelFontFamily
+            font.pixelSize: Style.font.bodySmall
+            font.bold: root.fromEmail.toLowerCase()
+              === String(fromRow.modelData.email || "").toLowerCase()
+            elide: Text.ElideMiddle
+          }
+
+          Text {
+            width: parent.width
+            visible: text !== ""
+            textFormat: Text.PlainText
+            text: String(fromRow.modelData.displayName || "")
+            color: root.dimColor
+            font.family: root.panelFontFamily
+            font.pixelSize: Style.font.caption
+            elide: Text.ElideRight
+          }
+        }
+
+        HoverHandler { id: fromHover; cursorShape: Qt.PointingHandCursor }
+        TapHandler { onTapped: root.chooseFrom(fromRow.modelData.email) }
       }
     }
   }

--- a/message/Message.js
+++ b/message/Message.js
@@ -738,6 +738,7 @@ function summarize(message, now) {
     replyTo: parseAddress(headerValue(message, "Reply-To")),
     messageId: headerValue(message, "Message-ID"),
     to: parseAddressList(headerValue(message, "To")),
+    cc: parseAddressList(headerValue(message, "Cc")),
     subject: subject || "(no subject)",
     snippet: decodeSnippet(message && message.snippet),
     date: date,
@@ -763,6 +764,27 @@ function summarize(message, now) {
 // not worth refusing to send over.
 function headerSafe(value) {
   return String(value === undefined || value === null ? "" : value).replace(/[\r\n]+/g, " ")
+}
+
+// A display name is a phrase, not a header value: an encoded word may not sit
+// inside quotes, and an ASCII name carrying a comma or a dot is only legal
+// quoted. `foldHeader` cannot do this, because it encodes the whole value as
+// one word — `=?UTF-8?B?...?=` wrapped around `"Name" <a@b>` is not an address.
+function encodedPhrase(text) {
+  var value = headerSafe(text).trim()
+  if (value === "") return ""
+  if (!/^[\x20-\x7e]*$/.test(value))
+    return "=?UTF-8?B?" + encodeBase64(value) + "?="
+  return '"' + value.replace(/([\\"])/g, "\\$1") + '"'
+}
+
+// Written by hand rather than through `foldHeader` for the reason above. The
+// address still loses its line breaks, so a display name cannot smuggle a
+// second header in either.
+function fromHeader(email, displayName) {
+  var address = headerSafe(email).trim()
+  var phrase = encodedPhrase(displayName)
+  return "From: " + (phrase === "" ? address : phrase + " <" + address + ">")
 }
 
 function foldHeader(name, value) {
@@ -803,7 +825,7 @@ function replySubject(subject) {
 function buildRawMessage(fields) {
   var values = fields || {}
   var lines = []
-  if (values.from) lines.push(foldHeader("From", values.from))
+  if (values.from) lines.push(fromHeader(values.from, values.fromName))
   lines.push(foldHeader("To", values.to || ""))
   if (values.cc) lines.push(foldHeader("Cc", values.cc))
   lines.push(foldHeader("Subject", values.subject || ""))

--- a/providers/GmailApi.js
+++ b/providers/GmailApi.js
@@ -221,6 +221,12 @@ function parseProfile(payload) {
 // Gmail's send-as collection includes the primary address and every custom
 // address configured under "Send mail as". Pending custom addresses cannot be
 // used yet, so they must not appear as choices in a compose window.
+//
+// Only `pending` is excluded, never "everything that is not `accepted`":
+// verification applies to custom addresses alone, so an alias that never
+// needed it — a Workspace alternate address, an alias domain — comes back with
+// the field absent, and requiring `accepted` dropped exactly the addresses
+// that were always usable.
 function parseSendAs(payload) {
   var entries = arrayValues(payload && payload.sendAs)
   var aliases = []
@@ -229,7 +235,7 @@ function parseSendAs(payload) {
     var email = String(entry.sendAsEmail || "").trim()
     var primary = entry.isPrimary === true
     var status = String(entry.verificationStatus || "").toLowerCase()
-    if (!email || (!primary && status !== "accepted")) continue
+    if (!email || (!primary && status === "pending")) continue
     aliases.push({
       email: email,
       displayName: String(entry.displayName || "").trim(),
@@ -265,14 +271,18 @@ function preferredSendAs(aliases, recipients) {
   return choices.length > 0 ? choices[0] : null
 }
 
-function isSendAsAllowed(aliases, email) {
+function sendAsFor(aliases, email) {
   var wanted = aliasEmail(email)
-  if (!wanted) return false
+  if (!wanted) return null
   var choices = Array.isArray(aliases) ? aliases : []
   for (var i = 0; i < choices.length; i++) {
-    if (aliasEmail(choices[i]) === wanted) return true
+    if (aliasEmail(choices[i]) === wanted) return choices[i]
   }
-  return false
+  return null
+}
+
+function isSendAsAllowed(aliases, email) {
+  return sendAsFor(aliases, email) !== null
 }
 
 // --------------------------------------------------------------- browsing

--- a/providers/GmailApi.js
+++ b/providers/GmailApi.js
@@ -122,6 +122,7 @@ function threadPath(id) { return "/users/me/threads/" + encode(id) }
 function labelsPath() { return "/users/me/labels" }
 function labelPath(id) { return "/users/me/labels/" + encode(id) }
 function profilePath() { return "/users/me/profile" }
+function sendAsPath() { return "/users/me/settings/sendAs" }
 function attachmentPath(messageId, attachmentId) {
   return "/users/me/messages/" + encode(messageId) + "/attachments/" + encode(attachmentId)
 }
@@ -215,6 +216,63 @@ function parseProfile(payload) {
     threadsTotal: Math.max(0, Math.floor(Number(body.threadsTotal) || 0)),
     historyId: String(body.historyId || "")
   }
+}
+
+// Gmail's send-as collection includes the primary address and every custom
+// address configured under "Send mail as". Pending custom addresses cannot be
+// used yet, so they must not appear as choices in a compose window.
+function parseSendAs(payload) {
+  var entries = arrayValues(payload && payload.sendAs)
+  var aliases = []
+  for (var i = 0; i < entries.length; i++) {
+    var entry = entries[i] || {}
+    var email = String(entry.sendAsEmail || "").trim()
+    var primary = entry.isPrimary === true
+    var status = String(entry.verificationStatus || "").toLowerCase()
+    if (!email || (!primary && status !== "accepted")) continue
+    aliases.push({
+      email: email,
+      displayName: String(entry.displayName || "").trim(),
+      isPrimary: primary,
+      isDefault: entry.isDefault === true
+    })
+  }
+  return aliases
+}
+
+function aliasEmail(alias) {
+  if (alias && typeof alias === "object")
+    return String(alias.email || alias.sendAsEmail || "").trim().toLowerCase()
+  return String(alias || "").trim().toLowerCase()
+}
+
+function preferredSendAs(aliases, recipients) {
+  var choices = Array.isArray(aliases) ? aliases : []
+  var addressed = Array.isArray(recipients) ? recipients : []
+  for (var i = 0; i < addressed.length; i++) {
+    var recipient = aliasEmail(addressed[i])
+    if (!recipient) continue
+    for (var j = 0; j < choices.length; j++) {
+      if (aliasEmail(choices[j]) === recipient) return choices[j]
+    }
+  }
+  for (var k = 0; k < choices.length; k++) {
+    if (choices[k] && choices[k].isDefault === true) return choices[k]
+  }
+  for (var p = 0; p < choices.length; p++) {
+    if (choices[p] && choices[p].isPrimary === true) return choices[p]
+  }
+  return choices.length > 0 ? choices[0] : null
+}
+
+function isSendAsAllowed(aliases, email) {
+  var wanted = aliasEmail(email)
+  if (!wanted) return false
+  var choices = Array.isArray(aliases) ? aliases : []
+  for (var i = 0; i < choices.length; i++) {
+    if (aliasEmail(choices[i]) === wanted) return true
+  }
+  return false
 }
 
 // --------------------------------------------------------------- browsing

--- a/providers/GmailApiClient.qml
+++ b/providers/GmailApiClient.qml
@@ -187,6 +187,14 @@ Item {
       })
   }
 
+  function getSendAs(callback) {
+    return request("GET", Api.sendAsPath(), null, null,
+      function(status, payload, error) {
+        if (typeof callback !== "function") return
+        callback(error ? [] : Api.parseSendAs(payload), error)
+      })
+  }
+
   // --------------------------------------------------------------- writes
 
   function modifyMessage(id, addLabelIds, removeLabelIds, callback) {

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -403,6 +403,24 @@ Item {
     return newHandle()
   }
 
+  // IMAP has no send-as settings endpoint. Its one sender is the mailbox
+  // address the user configured, returned in the same shape as Gmail aliases
+  // so everything above the provider boundary can stay provider-neutral.
+  function getSendAs(callback) {
+    if (typeof callback !== "function") return newHandle()
+    var address = String(root.email || "")
+    Qt.callLater(function() {
+      if (!root) return
+      callback(address === "" ? [] : [{
+        email: address,
+        displayName: "",
+        isPrimary: true,
+        isDefault: true
+      }], "")
+    })
+    return newHandle()
+  }
+
   // --------------------------------------------------------------- writes
 
   // `MailAccount` asks in Gmail's vocabulary whichever provider it holds, so

--- a/tests/test_gmail_api.js
+++ b/tests/test_gmail_api.js
@@ -134,12 +134,17 @@ const aliases = api.parseSendAs({
       sendAsEmail: "waiting@example.org", displayName: "Waiting", isPrimary: false,
       isDefault: false, verificationStatus: "pending"
     },
+    // A Workspace alternate address needs no verification, so Gmail sends the
+    // field back unset. Requiring "accepted" hid exactly these.
+    { sendAsEmail: "alt@example.net", displayName: "Alternate", isPrimary: false },
     { displayName: "missing address", verificationStatus: "accepted" }
   ]
 })
-assert.strictEqual(aliases.length, 2, "pending and malformed aliases are not selectable")
+assert.strictEqual(aliases.length, 3, "pending and malformed aliases are not selectable")
 assert.strictEqual(aliases[0].email, "me@example.com")
 assert.strictEqual(aliases[1].displayName, "Me at work")
+assert.strictEqual(aliases[2].email, "alt@example.net",
+  "an alias that never needed verifying is still a choice")
 assert.strictEqual(api.parseSendAs(null).length, 0)
 
 assert.strictEqual(api.preferredSendAs(aliases, [{ email: "WORK@example.net" }]).email,
@@ -154,6 +159,13 @@ assert.strictEqual(api.preferredSendAs([{ email: "only@example.com" }], []).emai
 assert.strictEqual(api.preferredSendAs([], []), null)
 assert.strictEqual(api.isSendAsAllowed(aliases, "WORK@example.net"), true)
 assert.strictEqual(api.isSendAsAllowed(aliases, "waiting@example.org"), false)
+
+// The display name that goes on the message is read back off the list, so it
+// is looked up by address and never carried alongside it.
+assert.strictEqual(api.sendAsFor(aliases, "WORK@example.net").displayName, "Me at work")
+assert.strictEqual(api.sendAsFor(aliases, "waiting@example.org"), null)
+assert.strictEqual(api.sendAsFor(aliases, ""), null)
+assert.strictEqual(api.sendAsFor(null, "me@example.com"), null)
 
 // -------------------------------------------------------------- browsing
 

--- a/tests/test_gmail_api.js
+++ b/tests/test_gmail_api.js
@@ -36,6 +36,7 @@ assert.strictEqual(api.messagePath("a/b"), "/users/me/messages/a%2Fb")
 assert.strictEqual(api.modifyPath("18f3a"), "/users/me/messages/18f3a/modify")
 assert.strictEqual(api.trashPath("18f3a"), "/users/me/messages/18f3a/trash")
 assert.strictEqual(api.labelPath("INBOX"), "/users/me/labels/INBOX")
+assert.strictEqual(api.sendAsPath(), "/users/me/settings/sendAs")
 assert.strictEqual(api.attachmentPath("m1", "a1"), "/users/me/messages/m1/attachments/a1")
 
 deepEqual(api.listQuery("in:inbox", 25, ""), { q: "in:inbox", maxResults: 25, pageToken: "" })
@@ -118,6 +119,41 @@ const profile = api.parseProfile({ emailAddress: "me@example.com", messagesTotal
 assert.strictEqual(profile.email, "me@example.com")
 assert.strictEqual(profile.historyId, "9912")
 assert.strictEqual(api.parseProfile(null).email, "")
+
+const aliases = api.parseSendAs({
+  sendAs: [
+    {
+      sendAsEmail: "me@example.com", displayName: "Me", isPrimary: true,
+      isDefault: false, verificationStatus: "accepted"
+    },
+    {
+      sendAsEmail: "work@example.net", displayName: "Me at work", isPrimary: false,
+      isDefault: true, verificationStatus: "accepted"
+    },
+    {
+      sendAsEmail: "waiting@example.org", displayName: "Waiting", isPrimary: false,
+      isDefault: false, verificationStatus: "pending"
+    },
+    { displayName: "missing address", verificationStatus: "accepted" }
+  ]
+})
+assert.strictEqual(aliases.length, 2, "pending and malformed aliases are not selectable")
+assert.strictEqual(aliases[0].email, "me@example.com")
+assert.strictEqual(aliases[1].displayName, "Me at work")
+assert.strictEqual(api.parseSendAs(null).length, 0)
+
+assert.strictEqual(api.preferredSendAs(aliases, [{ email: "WORK@example.net" }]).email,
+  "work@example.net", "a reply uses the alias to which the original was addressed")
+assert.strictEqual(api.preferredSendAs(aliases, []).email, "work@example.net",
+  "new mail uses Gmail's default send-as address")
+assert.strictEqual(api.preferredSendAs([
+  { email: "first@example.com" }, { email: "primary@example.com", isPrimary: true }
+], []).email, "primary@example.com")
+assert.strictEqual(api.preferredSendAs([{ email: "only@example.com" }], []).email,
+  "only@example.com")
+assert.strictEqual(api.preferredSendAs([], []), null)
+assert.strictEqual(api.isSendAsAllowed(aliases, "WORK@example.net"), true)
+assert.strictEqual(api.isSendAsAllowed(aliases, "waiting@example.org"), false)
 
 // -------------------------------------------------------------- browsing
 

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -238,12 +238,14 @@ assert.strictEqual(message.replySubject("RE: Invoice"), "RE: Invoice")
 assert.strictEqual(message.replySubject(""), "Re: (no subject)")
 
 const raw = message.buildRawMessage({
+  from: "work@example.net",
   to: "jane@example.com",
   subject: "你好",
   body: "Hi Jane,\n\nThanks!",
   inReplyTo: "<abc@mail.gmail.com>"
 })
 
+assert.ok(raw.indexOf("From: work@example.net\r\n") === 0)
 assert.ok(raw.indexOf("To: jane@example.com\r\n") >= 0)
 // A non-ASCII subject has to go back out as an encoded word or Gmail rejects
 // the whole raw message.
@@ -314,6 +316,7 @@ assert.strictEqual(message.extractHtml({
     "the value survives as one header line")
 
   const folded = message.buildRawMessage({
+    from: "me@example.com\r\nBcc: attacker@example.net",
     to: "friend@example.com\r\nBcc: attacker@example.net",
     subject: "hello\nX-Injected: 1",
     body: "hi"

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -183,6 +183,7 @@ const resource = {
     headers: [
       { name: "From", value: "=?UTF-8?B?" + Buffer.from("李四", "utf8").toString("base64") + "?= <li@example.com>" },
       { name: "To", value: "me@example.com" },
+      { name: "Cc", value: "team@example.com, work@example.net" },
       { name: "Subject", value: "  Invoice   for   August  " },
       { name: "Date", value: "Wed, 19 Aug 2026 14:50:00 +0000" }
     ]
@@ -195,6 +196,9 @@ assert.strictEqual(summary.threadId, "18f39")
 assert.strictEqual(summary.from.display, "李四")
 assert.strictEqual(summary.from.email, "li@example.com")
 assert.strictEqual(summary.subject, "Invoice for August", "runs of whitespace collapse")
+assert.strictEqual(summary.cc.length, 2, "Cc is carried: a reply picks its alias out of it")
+assert.strictEqual(summary.cc[1].email, "work@example.net")
+assert.strictEqual(message.summarize({ payload: { headers: [] } }, now).cc.length, 0)
 assert.strictEqual(summary.snippet, "Your receipt is attached & ready")
 assert.strictEqual(summary.time, "10m")
 assert.strictEqual(summary.unread, true)
@@ -246,6 +250,24 @@ const raw = message.buildRawMessage({
 })
 
 assert.ok(raw.indexOf("From: work@example.net\r\n") === 0)
+
+// A display name is a phrase and encodes as one. Quoted when it is ASCII —
+// an unquoted comma or dot would split the address list — and an encoded word
+// when it is not, which may never be wrapped in quotes of its own.
+assert.ok(message.buildRawMessage({
+  from: "work@example.net", fromName: "Jason Lee", to: "jane@example.com"
+}).indexOf('From: "Jason Lee" <work@example.net>\r\n') === 0)
+assert.ok(message.buildRawMessage({
+  from: "work@example.net", fromName: 'Lee, Jason "JL"', to: "jane@example.com"
+}).indexOf('From: "Lee, Jason \\"JL\\"" <work@example.net>\r\n') === 0,
+  "a quote inside the name is escaped rather than ending it")
+assert.ok(message.buildRawMessage({
+  from: "work@example.net", fromName: "李四", to: "jane@example.com"
+}).indexOf("From: =?UTF-8?B?" + Buffer.from("李四", "utf8").toString("base64")
+  + "?= <work@example.net>\r\n") === 0)
+assert.ok(message.buildRawMessage({
+  from: "work@example.net", fromName: "   ", to: "jane@example.com"
+}).indexOf("From: work@example.net\r\n") === 0, "an empty name leaves a bare address")
 assert.ok(raw.indexOf("To: jane@example.com\r\n") >= 0)
 // A non-ASCII subject has to go back out as an encoded word or Gmail rejects
 // the whole raw message.
@@ -317,6 +339,7 @@ assert.strictEqual(message.extractHtml({
 
   const folded = message.buildRawMessage({
     from: "me@example.com\r\nBcc: attacker@example.net",
+    fromName: "Me\r\nBcc: attacker@example.net",
     to: "friend@example.com\r\nBcc: attacker@example.net",
     subject: "hello\nX-Injected: 1",
     body: "hi"

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -242,4 +242,18 @@ if [ -n "$oversized" ]; then
   fail "the files above are over 128 KB; keep large assets out of the clone"
 fi
 
+# The compose form, account boundary and raw-message builder must keep the
+# selected send-as address all the way to the provider. A missing link silently
+# falls back to a default address and makes the selector lie.
+grep -q 'from: root.fromEmail' components/ComposeView.qml \
+  || fail "ComposeView must submit the selected From address"
+grep -q 'from: from' account/MailAccount.qml \
+  || fail "MailAccount must pass the selected From address to Message.js"
+grep -q 'foldHeader("From", values.from)' message/Message.js \
+  || fail "Message.js must write the selected From header"
+for client in providers/GmailApiClient.qml providers/ImapClient.qml; do
+  grep -q 'function getSendAs' "$client" \
+    || fail "$client must implement the provider-neutral sender-list operation"
+done
+
 printf 'test_source.sh ok\n'

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -249,8 +249,8 @@ grep -q 'from: root.fromEmail' components/ComposeView.qml \
   || fail "ComposeView must submit the selected From address"
 grep -q 'from: from' account/MailAccount.qml \
   || fail "MailAccount must pass the selected From address to Message.js"
-grep -q 'foldHeader("From", values.from)' message/Message.js \
-  || fail "Message.js must write the selected From header"
+grep -q 'fromHeader(values.from, values.fromName)' message/Message.js \
+  || fail "Message.js must write the selected From header, display name and all"
 for client in providers/GmailApiClient.qml providers/ImapClient.qml; do
   grep -q 'function getSendAs' "$client" \
     || fail "$client must implement the provider-neutral sender-list operation"


### PR DESCRIPTION
Adds a From picker backed by Gmail send-as aliases. New messages use the default alias, while replies prefer the address that received the original message.

<img width="828" height="450" alt="image" src="https://github.com/user-attachments/assets/7cecc9d0-0d70-4739-89df-932ed9dfd485" />

Tested with `make validate`.