### PR TITLE
Add Alt-1 .. Alt-0 to open sidebar item.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,14 @@ key. What matters while working:
 - Route keys through `KeyRouter`, never a `Keys.on...Pressed` handler: a window
   `Shortcut` beats a focused item's `Keys` handler, so a local one looks live and
   never runs. Anything `Escape` should do belongs in `goBack()`.
+- **No chords.** Qt puts a deadline on an unfinished key sequence —
+  `styleHints.keyboardInputInterval`, 400ms — so `g` then `i` half a second
+  later does nothing at all and says nothing about why. The mailboxes were
+  reached that way and are numbered now. A modifier has no deadline.
+- A held modifier is the one thing `KeyRouter` cannot own, because a modifier
+  alone cannot be a `Shortcut`. `App.qml` watches `Key_Alt` with a `Keys`
+  handler to name the rail's rows, accepts nothing, and clears on `activeFocus`
+  rather than on the release — Alt+Tab takes the release to another window.
 - `KeyRouter` builds its shortcuts with an `Instantiator`. A `Repeater` builds
   only `Item`s, so it creates no `Shortcut`s at all and every key goes dead.
 - A `QQC.Popup` with `CloseOnEscape` consumes `Escape` itself. Do not add a

--- a/App.qml
+++ b/App.qml
@@ -252,9 +252,26 @@ Item {
     backToList()
   }
 
+  // The rail as the keys see it: one numbered list, the same one the badges
+  // are drawn from, so the number beside a row and the row a number opens are
+  // the same fact rather than two.
+  readonly property var sidebarSlots: service
+    ? Model.sidebarSlots(service.mailboxes, service.labels, 10) : []
+
+  function goSlot(index) {
+    if (!service || index < 0 || index >= sidebarSlots.length) return
+    var slot = sidebarSlots[index]
+    if (slot.kind === "mailbox") return goMailbox(slot.key)
+    // Not a search: the provider decides what selecting a label means, and on
+    // IMAP it is a folder rather than a term to look for.
+    service.selectLabel(slot.name)
+    backToList()
+  }
+
   // One answer per key id. The ids come from keys/Keymap.js; adding a key is a
-  // row there and a case here, and nothing else.
-  function runShortcut(id) {
+  // row there and a case here, and nothing else. The sequence says which key of
+  // a row fired, for the rows that bind more than one meaning.
+  function runShortcut(id, sequence) {
     // The sheet is on top, so moving moves it. It is a plain overlay rather
     // than a popup, which is why its keys can come from here at all — the
     // switcher's cannot, and answers them itself.
@@ -282,10 +299,7 @@ Item {
     if (id === "compose") return startCompose("new")
     if (id === "send") return compose.submit()
     if (id === "search") return searchBar.focusField()
-    if (id === "goInbox") return goMailbox("inbox")
-    if (id === "goStarred") return goMailbox("starred")
-    if (id === "goUnread") return goMailbox("unread")
-    if (id === "goSent") return goMailbox("sent")
+    if (id === "goMailbox") return goSlot(Keymap.slotFor(id, sequence))
     if (id === "switchAccount") return accountSwitcher.openCentered()
     if (id === "zoomIn") return zoomBy(0.1)
     if (id === "zoomOut") return zoomBy(-0.1)
@@ -487,6 +501,27 @@ Item {
       // Where the window is, and the only thing that says what a key means.
       // A page is a form before it is anything else, a draft beats reading, a
       // query being typed beats the list underneath it.
+      // Holding Alt names every row on the rail, so the digits are read rather
+      // than remembered. A `Keys` handler, which bindings may not use — but a
+      // modifier on its own cannot be a `Shortcut`, so there is no binding to
+      // route and nothing for `KeyRouter` to own. It accepts nothing: whatever
+      // follows Alt still goes exactly where it went before.
+      //
+      // `activeFocus` is what clears it. Alt+Tab leaves the window with Alt
+      // down and the release lands somewhere else, so waiting for a release
+      // that is never coming would paint the numbers on permanently.
+      property bool altDown: false
+      readonly property bool altHeld: altDown && activeFocus
+        && (keyContext === "list" || keyContext === "reader")
+
+      Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_Alt) focusScope.altDown = true
+      }
+      Keys.onReleased: function(event) {
+        if (event.key === Qt.Key_Alt) focusScope.altDown = false
+      }
+      onActiveFocusChanged: if (!activeFocus) altDown = false
+
       readonly property string keyContext:
           root.showPage  ? "page"
         : root.composing ? "compose"
@@ -691,6 +726,8 @@ Item {
           dimColor: root.dim
           panelFontFamily: root.fontFamily
           switcherOpen: accountSwitcher.opened
+          slots: root.sidebarSlots
+          numbersVisible: focusScope.altHeld
           onSwitcherRequested: function(sceneX, sceneY) { accountSwitcher.openAt(sceneX, sceneY) }
           onMailboxSelected: function(key) { root.goMailbox(key) }
           // Not a search: the provider decides what selecting a label means,
@@ -1142,7 +1179,7 @@ Item {
       KeyRouter {
         context: focusScope.keyContext
         overlay: root.shortcutHelpVisible
-        onTriggered: function(id) { root.runShortcut(id) }
+        onTriggered: function(id, sequence) { root.runShortcut(id, sequence) }
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ server — including one you run yourself.
   mailbox with an address and an app password. Several accounts at once, each
   with its own inbox, cache and unread count.
 - **Keyboard-first.** `j`/`k` to move, `e` to archive, `s` to star, `r` to
-  reply, `c` to compose, `g i` for the inbox, `Alt+A` to switch mailbox, `/` to search,
-  `?` for the rest — Gmail's own shortcuts, so there is nothing new to learn.
+  reply, `c` to compose, `Alt+1`…`0` for the mailboxes — hold Alt and the rail says
+  which is which — `Alt+A` to switch account, `/` to search, `?` for the rest.
 - **Always counting.** The unread badge keeps working while the window is shut,
   for every account, with a desktop notification when new mail lands.
 - **One window.** Read, archive, star, trash, search, and answer without a
@@ -159,8 +159,8 @@ and the client itself are console-only; there is no CLI for them.
 | `c` | Compose |
 | `Ctrl+Enter` | Send |
 | `/` or `Ctrl+K` | Search |
-| `g` then `i` / `s` / `u` / `t` | Inbox, starred, unread, sent |
-| `Alt+A` | Switch mailbox |
+| `Alt+1` … `Alt+0` | The mailbox with that number on the rail |
+| `Alt+A` | Switch account |
 | `Ctrl+=` / `Ctrl+-` / `Ctrl+0` | Zoom the message body, or reset it |
 | `F5` | Check for mail |
 | `Ctrl+?` | Every shortcut |

--- a/account/Model.js
+++ b/account/Model.js
@@ -180,6 +180,44 @@ function indexById(list, id) {
   return -1
 }
 
+// The rail as one numbered list, in the order it is drawn: the provider's
+// mailboxes first, then the labels or folders the server reported. Both the
+// sidebar's badges and the keys that jump read this, so the number beside a row
+// and the row a number opens cannot disagree — describing the order twice is
+// how they would.
+//
+// Ten because the keys are digits. Past that a row simply has no number: a
+// mailbox nobody can reach by keyboard is honest, and renumbering the rail
+// every time the server reports a label would not be.
+function sidebarSlots(mailboxes, labels, limit) {
+  var max = Math.max(0, Math.floor(Number(limit) || 0))
+  var out = []
+  var boxes = Array.isArray(mailboxes) ? mailboxes : []
+  for (var i = 0; i < boxes.length && out.length < max; i++) {
+    if (!boxes[i] || !boxes[i].key) continue
+    out.push({ kind: "mailbox", key: String(boxes[i].key), name: String(boxes[i].label || "") })
+  }
+  var all = Array.isArray(labels) ? labels : []
+  for (var j = 0; j < all.length && out.length < max; j++) {
+    if (!all[j] || all[j].system) continue
+    out.push({ kind: "label", id: String(all[j].id || ""),
+      name: String(all[j].rawName || all[j].name || "") })
+  }
+  return out
+}
+
+// What a row's badge says, and 0 for a row past the tenth. One-based, because
+// the badge is read by a person rather than indexed by anything.
+function slotNumberOf(slots, kind, handle) {
+  var list = Array.isArray(slots) ? slots : []
+  for (var i = 0; i < list.length; i++) {
+    if (list[i].kind !== kind) continue
+    if (String(kind === "mailbox" ? list[i].key : list[i].id) !== String(handle)) continue
+    return i + 1
+  }
+  return 0
+}
+
 // Where the switcher's cursor lands after a step. It wraps where the message
 // list clamps, and the difference is the shape of the two things: a mailbox
 // list is long and scrolls, so running off the end has to feel like an end,

--- a/components/KeyRouter.qml
+++ b/components/KeyRouter.qml
@@ -29,7 +29,10 @@ Item {
   // consumes its own keys, so the router never sees them.
   property bool overlay: false
 
-  signal triggered(string id)
+  // The sequence travels with the id, because one row can bind several keys
+  // that differ in what they mean: `Alt+1`…`Alt+0` are one binding and ten
+  // mailboxes.
+  signal triggered(string id, string sequence)
 
   Instantiator {
     model: Keymap.sequencesFor(root.context)
@@ -38,7 +41,7 @@ Item {
       required property var modelData
       sequence: modelData.sequence
       enabled: Keymap.isEnabled(modelData.binding, root.context, root.overlay)
-      onActivated: root.triggered(modelData.id)
+      onActivated: root.triggered(modelData.id, modelData.sequence)
     }
   }
 }

--- a/components/MailboxSidebar.qml
+++ b/components/MailboxSidebar.qml
@@ -24,6 +24,11 @@ Item {
   signal mailboxSelected(string key)
   signal labelSelected(string labelId, string name)
 
+  // The numbered list App.qml also gives the keys, so a badge and the key that
+  // opens the row it sits on cannot disagree.
+  property var slots: []
+  property bool numbersVisible: false
+
   // Forwarded to the user bar, which is the control those popups hang off.
   property bool switcherOpen: false
   signal switcherRequested(real sceneX, real sceneY)
@@ -84,6 +89,7 @@ Item {
           count: 0
           selected: !!root.service && root.service.mailboxKey === modelData.key
             && root.service.searchQuery === "" && root.service.rawQuery === ""
+          slotNumber: Model.slotNumberOf(root.slots, "mailbox", modelData.key)
           onActivated: root.mailboxSelected(modelData.key)
         }
       }
@@ -120,6 +126,7 @@ Item {
           // put a single hanzi in a 16px slot, which is neither an icon nor a
           // readable name. The tooltip carries the name instead.
           icon: "label"
+          slotNumber: Model.slotNumberOf(root.slots, "label", modelData.id)
           count: modelData.unread
           selected: !!root.service && root.service.rawQuery !== ""
             && root.service.rawQuery
@@ -168,7 +175,13 @@ Item {
     property string icon: ""
     property int count: 0
     property bool selected: false
+    property int slotNumber: 0
     signal activated()
+
+    // The badge names the key, not the position: the tenth row is opened by
+    // Alt+0, so it says 0. A row past the tenth has no key and no badge.
+    readonly property bool showsNumber: root.numbersVisible && slotNumber > 0
+    readonly property string numberText: slotNumber === 10 ? "0" : String(slotNumber)
 
     width: column.width
     implicitHeight: Style.space(28)
@@ -186,13 +199,41 @@ Item {
       name: entry.icon
       iconSize: Style.font.icon
       color: entry.selected ? root.textColor : root.dimColor
+      visible: !(entry.showsNumber && root.collapsed)
+    }
+
+    // Held Alt names every row. Collapsed there is no room beside the glyph, so
+    // it stands where the glyph was; open it takes the count's place, because a
+    // 148px rail cannot hold both and the count is the one you can get back by
+    // letting go.
+    Rectangle {
+      id: slotChip
+      visible: entry.showsNumber
+      anchors.verticalCenter: parent.verticalCenter
+      anchors.horizontalCenter: root.collapsed ? parent.horizontalCenter : undefined
+      anchors.right: root.collapsed ? undefined : parent.right
+      anchors.rightMargin: root.collapsed ? 0 : Style.space(6)
+      width: Style.space(16)
+      height: width
+      radius: Style.cornerRadius
+      color: Style.selectedFillFor(root.textColor, root.accentColor)
+
+      Text {
+        anchors.centerIn: parent
+        text: entry.numberText
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        font.bold: true
+      }
     }
 
     Text {
       visible: !root.collapsed
       anchors.left: glyph.right
       anchors.leftMargin: Style.space(9)
-      anchors.right: badge.visible ? badge.left : parent.right
+      anchors.right: slotChip.visible ? slotChip.left
+        : (badge.visible ? badge.left : parent.right)
       anchors.rightMargin: Style.space(6)
       anchors.verticalCenter: parent.verticalCenter
       text: entry.label
@@ -205,7 +246,7 @@ Item {
 
     Text {
       id: badge
-      visible: entry.count > 0 && !root.collapsed
+      visible: entry.count > 0 && !root.collapsed && !entry.showsNumber
       anchors.right: parent.right
       anchors.rightMargin: Style.space(8)
       anchors.verticalCenter: parent.verticalCenter
@@ -217,7 +258,7 @@ Item {
     }
 
     Rectangle {
-      visible: entry.count > 0 && root.collapsed
+      visible: entry.count > 0 && root.collapsed && !entry.showsNumber
       anchors.right: parent.right
       anchors.rightMargin: Style.space(3)
       anchors.top: parent.top

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -99,10 +99,7 @@ used to exist, and they had.
 | `send` | `Ctrl+Return` | compose | Send |
 | `search` | `/` | mail | Search |
 | `searchAnywhere` | `Ctrl+K` | all | Search from anywhere |
-| `goInbox` | `g,i` | mail | Go to the inbox |
-| `goStarred` | `g,s` | mail | Go to starred |
-| `goUnread` | `g,u` | mail | Go to unread |
-| `goSent` | `g,t` | mail | Go to sent |
+| `goMailbox` | `Alt+1`, `Alt+2`, `Alt+3`, `Alt+4`, `Alt+5`, `Alt+6`, `Alt+7`, `Alt+8`, `Alt+9`, `Alt+0` | mail | Go to that mailbox |
 | `switchAccount` | `Alt+A` | mail | Switch account |
 | `zoomIn` | `Ctrl++`, `Ctrl+=` | reader | Zoom the message body in |
 | `zoomOut` | `Ctrl+-` | reader | Zoom the message body out |
@@ -117,6 +114,34 @@ Two rows are split on purpose. `search` keeps the bare `/` in the mailbox while
 cannot live in a text-entry context, and the modified one should. `help` is a
 mailbox action rather than a global one: the sheet lists what the mailbox
 answers to, and a draft is not a mailbox.
+
+## Why the rail is numbered and not chorded
+
+`g i`, `g s`, `g u` and `g t` used to open the mailboxes, and they were two
+problems in one row.
+
+They were a chord, and Qt puts a deadline on an unfinished one:
+`styleHints.keyboardInputInterval`, 400ms here. Press `g`, think for half a
+second, press `i`, and nothing happens — no mailbox, no error, no hint that a
+clock had been running. Measured, not guessed:
+`0ms → fires · 300ms → fires · 500ms → dead · 800ms → dead`.
+
+And they had to be memorised. Four bindings that look like nothing on screen,
+for the four places you actually go.
+
+`Alt+1`…`Alt+0` replaces both. A modifier has no deadline, and **holding Alt
+puts the digit on every row of the rail**, so there is nothing to remember —
+the rail says which key opens it. The numbers run down the rail as it is drawn,
+mailboxes first and then the server's labels, from `Model.sidebarSlots`, which
+is the same list the badges are drawn from: the number beside a row and the row
+a number opens are one fact rather than two. Past the tenth row there is simply
+no number, because there is no digit left to offer.
+
+Held Alt is the one `Keys` handler in `App.qml`, and it is not a binding — a
+modifier alone cannot be a `Shortcut`, so there is nothing to route. It accepts
+no event, so what follows Alt still goes where it always went, and it clears on
+`activeFocus` rather than on the release: Alt+Tab takes the release with it, and
+waiting for one that is not coming would paint the numbers on permanently.
 
 `Escape` is the only bare key bound everywhere, because it is the way out of
 everywhere. What it means in each place is one list in `goBack()`, in the order
@@ -194,8 +219,11 @@ different row under the still pointer, and the cursor snapped back to it — so
 ## Adding a key
 
 1. Add a row to `BINDINGS` in `keys/Keymap.js`. Name the contexts it means
-   something in — that is the guard, and there is no other.
-2. Add a case to `runShortcut` in `App.qml`.
+   something in — that is the guard, and there is no other. A `display` string
+   is how the sheet shows a range instead of enumerating every key.
+2. Add a case to `runShortcut` in `App.qml`. The second argument is the
+   sequence that fired, which is how a row of several keys tells them apart —
+   read it with `slotFor`, never by parsing the string.
 3. Add the row to the table above. The test will tell you if you forget.
 
 That is all. The shortcut sheet and the status hints pick it up on their own.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -78,7 +78,7 @@ render or are checked against it, so no second list is maintained by hand.
 
 `j`/`k` move · `Enter` or `o` open · `u` back to list · `e` archive · `d` trash ·
 `s` star · `r`/`a`/`f` reply, reply all, forward · `c` compose · `/` or `Ctrl+K`
-search · `g i` inbox · `Alt+A` switch account · `?` the reference sheet ·
+search · `Alt+1`…`0` the mailboxes · `Alt+A` switch account · `?` the reference sheet ·
 `Esc` back or close.
 
 **See `docs/KEYS.md`** for the model, the contexts, the full table, and the four

--- a/keys/Keymap.js
+++ b/keys/Keymap.js
@@ -81,14 +81,20 @@ var BINDINGS = [
   { id: "searchAnywhere", keys: ["Ctrl+K"], contexts: ANY,
     group: "Finding", label: "Search from anywhere" },
 
-  { id: "goInbox", keys: ["g,i"], contexts: MAIL,
-    group: "Going", label: "Go to the inbox" },
-  { id: "goStarred", keys: ["g,s"], contexts: MAIL,
-    group: "Going", label: "Go to starred" },
-  { id: "goUnread", keys: ["g,u"], contexts: MAIL,
-    group: "Going", label: "Go to unread" },
-  { id: "goSent", keys: ["g,t"], contexts: MAIL,
-    group: "Going", label: "Go to sent" },
+  // The rail by number, and nothing to remember: hold Alt and every row says
+  // which digit opens it. This replaced `g i` / `g s` / `g u` / `g t`, which
+  // were two problems in one row — a chord nobody recalls under pressure, and
+  // Qt's own 400ms deadline on an unfinished sequence, so half of them did
+  // nothing and said nothing about why. A modifier has no deadline.
+  //
+  // One row, ten sequences: `slotFor` reads which one fired off this row's own
+  // key list, so the `Alt+` prefix is not written down a second time.
+  { id: "goMailbox",
+    keys: ["Alt+1", "Alt+2", "Alt+3", "Alt+4", "Alt+5",
+      "Alt+6", "Alt+7", "Alt+8", "Alt+9", "Alt+0"],
+    contexts: MAIL, group: "Going", label: "Go to that mailbox",
+    display: "Alt+1…0" },
+
   // One key, not nine, and modified rather than bare. Switching mailboxes is
   // not frequent enough to spend a letter on — the bare ones are the scarce
   // thing here — and not a chord either, because it opens a list the keyboard
@@ -117,6 +123,22 @@ var BINDINGS = [
     group: "Mailbox", label: "Back, or close the window",
     hint: { reader: "back", page: "back", compose: "close", search: "leave" } }
 ]
+
+function byId(id) {
+  for (var i = 0; i < BINDINGS.length; i++) {
+    if (BINDINGS[i].id === id) return BINDINGS[i]
+  }
+  return null
+}
+
+// Which of a row's keys fired, as a zero-based position in the row's own list.
+// Derived rather than parsed: `Alt+3` is the fourth entry because the table
+// says so, and changing the row to `Ctrl+1…0` would need nothing here.
+function slotFor(id, sequence) {
+  var row = byId(id)
+  var keys = row ? row.keys || [] : []
+  return keys.indexOf(String(sequence || ""))
+}
 
 function matchesContext(binding, context) {
   if (!binding) return false
@@ -177,6 +199,9 @@ function readableSequence(sequence) {
 // separator.
 function displayFor(binding) {
   if (!binding) return ""
+  // A row of ten keys reads as a range. Enumerating them would be ten lines of
+  // sheet for one idea.
+  if (binding.display) return binding.display
   var keys = binding.keys || []
   var out = []
   for (var i = 0; i < keys.length; i++) out.push(readableSequence(keys[i]))

--- a/tests/qml/tst_keyrouter.qml
+++ b/tests/qml/tst_keyrouter.qml
@@ -13,13 +13,17 @@ Item {
   width: 300; height: 200
 
   property string lastId: ""
+  property string lastSequence: ""
   property string context: "list"
   property bool overlay: false
 
   Omamail.KeyRouter {
     context: host.context
     overlay: host.overlay
-    onTriggered: function(id) { host.lastId = id }
+    onTriggered: function(id, sequence) {
+      host.lastId = id
+      host.lastSequence = sequence
+    }
   }
 
   readonly property Item focusItem: host.Window.activeFocusItem
@@ -55,6 +59,7 @@ Item {
       host.context = "list"
       host.overlay = false
       host.lastId = ""
+      host.lastSequence = ""
       compose.opened = false
       scope.applyContextFocus()
       wait(30)
@@ -156,6 +161,28 @@ Item {
     }
 
     // Zoom is not: there is no message body to size until one is open.
+    // A row of ten keys, told apart by which one fired. No chord: Qt puts a
+    // 400ms deadline on an unfinished sequence, which is what the mailboxes
+    // used to be reached through and why half the presses did nothing.
+    function test_a_digit_names_the_mailbox_it_opens() {
+      keyClick(Qt.Key_3, Qt.AltModifier)
+      compare(host.lastId, "goMailbox")
+      compare(host.lastSequence, "Alt+3")
+    }
+
+    function test_the_tenth_mailbox_is_the_zero_key() {
+      keyClick(Qt.Key_0, Qt.AltModifier)
+      compare(host.lastId, "goMailbox")
+      compare(host.lastSequence, "Alt+0")
+    }
+
+    function test_a_digit_is_dead_in_a_draft() {
+      host.context = "compose"
+      wait(20)
+      keyClick(Qt.Key_3, Qt.AltModifier)
+      compare(host.lastId, "", "typing a number into a reply is not going anywhere")
+    }
+
     // One press, not a chord: it opens a list the keyboard then walks, so
     // getting to it should not itself be a sequence.
     function test_the_switcher_opens_on_one_press() {

--- a/tests/test_keymap.js
+++ b/tests/test_keymap.js
@@ -115,7 +115,16 @@ assert.strictEqual(keymap.readableSequence("g,i"), "g then i",
   "a chord reads as a chord, not as Qt's comma")
 assert.strictEqual(keymap.readableSequence("Escape"), "Esc")
 assert.strictEqual(keymap.readableSequence("Ctrl+Return"), "Ctrl+Enter")
-assert.strictEqual(keymap.displayFor(byId("goInbox")), "g then i")
+assert.strictEqual(keymap.displayFor(byId("goMailbox")), "Alt+1…0",
+  "ten mailbox keys are one row on the sheet, not ten")
+
+// Which key of the row fired, read off the row's own list rather than parsed.
+assert.strictEqual(keymap.slotFor("goMailbox", "Alt+1"), 0)
+assert.strictEqual(keymap.slotFor("goMailbox", "Alt+9"), 8)
+assert.strictEqual(keymap.slotFor("goMailbox", "Alt+0"), 9, "the tenth row, not the zeroth")
+assert.strictEqual(keymap.slotFor("goMailbox", "Ctrl+1"), -1)
+assert.strictEqual(keymap.slotFor("goMailbox", ""), -1)
+assert.strictEqual(keymap.slotFor("nothing", "Alt+1"), -1)
 assert.strictEqual(keymap.displayFor(byId("open")), "Enter, o")
 assert.strictEqual(keymap.displayFor(byId("back")), "Esc")
 assert.strictEqual(keymap.displayFor(byId("switchAccount")), "Alt+A")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -289,6 +289,44 @@ assert.strictEqual(model.pluralize(0, "message"), "0 messages")
     "an empty mailbox has no row to sit on")
 }
 
+// One numbered list over the rail: mailboxes first, then the labels the server
+// reported, and no number at all past the tenth row.
+{
+  const boxes = [
+    { key: "inbox", label: "Inbox" },
+    { key: "unread", label: "Unread" },
+    { key: "sent", label: "Sent" }
+  ]
+  const labels = [
+    { id: "SYS", name: "Category", rawName: "Category", system: true },
+    { id: "L1", name: "Work", rawName: "Work" },
+    { id: "L2", name: "Bills", rawName: "Bills" }
+  ]
+  const slots = model.sidebarSlots(boxes, labels, 10)
+  assert.strictEqual(slots.length, 5, "system labels are not rows and get no number")
+  assert.strictEqual(slots[0].kind, "mailbox")
+  assert.strictEqual(slots[0].key, "inbox")
+  assert.strictEqual(slots[3].kind, "label")
+  assert.strictEqual(slots[3].id, "L1")
+  assert.strictEqual(slots[3].name, "Work", "the name a provider selects a label by")
+
+  assert.strictEqual(model.slotNumberOf(slots, "mailbox", "inbox"), 1)
+  assert.strictEqual(model.slotNumberOf(slots, "mailbox", "sent"), 3)
+  assert.strictEqual(model.slotNumberOf(slots, "label", "L2"), 5)
+  assert.strictEqual(model.slotNumberOf(slots, "label", "SYS"), 0)
+  assert.strictEqual(model.slotNumberOf(slots, "mailbox", "L1"), 0,
+    "a key and an id are not the same handle")
+  assert.strictEqual(model.slotNumberOf([], "mailbox", "inbox"), 0)
+
+  // The ceiling is where a row stops having a key, not where the rail stops.
+  const many = []
+  for (let i = 0; i < 14; i++) many.push({ id: "L" + i, name: "n" + i, rawName: "n" + i })
+  assert.strictEqual(model.sidebarSlots(boxes, many, 10).length, 10)
+  assert.strictEqual(model.slotNumberOf(model.sidebarSlots(boxes, many, 10), "label", "L7"), 0,
+    "past the tenth row there is no digit left to offer")
+  assert.strictEqual(model.sidebarSlots(null, null, 10).length, 0)
+}
+
 // The switcher's cursor wraps where the message list clamps: a menu of two or
 // three rows that stopped at the bottom would make `j` do nothing on the row
 // you use most.

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -223,6 +223,18 @@ awk '
 ' components/ImapSetupPage.qml \
   || fail "IMAP Remove account must not be detached from the account action row"
 
+# A mailbox row is the selected one only when no search is standing on top of
+# it, and that guard is a continuation line. Inserting a binding between the two
+# lines silently reparented the guard onto the new property — every row on the
+# rail then numbered itself 1, and nothing failed.
+awk '
+  /selected: !!root.service && root.service.mailboxKey/ {
+    getline
+    if ($0 !~ /searchQuery/) exit 1
+  }
+' components/MailboxSidebar.qml \
+  || fail "the mailbox row's selected guard lost its search continuation line"
+
 # 5. Nothing tracked may be large. This plugin is installed by cloning it, so
 #    every megabyte in the tree is a megabyte between the user and a working
 #    mailbox — and the things that get big are never the source. A published


### PR DESCRIPTION
`g i`, `g s`, `g u` and `g t` were two problems in one row.

**They were a chord, and Qt puts a deadline on an unfinished one** — `styleHints.keyboardInputInterval`, 400ms here. Press `g`, think for half a second, press `i`, and nothing happens: no mailbox, no error, no hint that a clock had been running. Measured rather than guessed, and written into `docs/KEYS.md` so nobody rediscovers it:

```
gap between g and i:  0ms → fires   300ms → fires   500ms → dead   800ms → dead
```

**And they had to be memorised** — four bindings that look like nothing on screen, for the four places you actually go.

## What replaces them

`Alt+1`…`Alt+9` and `Alt+0` open the rail's first ten rows, and **holding Alt puts the digit on every row**, so there is nothing to remember: the rail says which key opens it. A modifier has no deadline.

The numbers run down the rail as it is drawn — the provider's mailboxes first, then the labels or folders the server reported — from `Model.sidebarSlots`, which is the same list the badges are drawn from. The number beside a row and the row a number opens are one fact rather than two descriptions of one. Past the tenth row there is no number, because there is no digit left to offer: a row nobody can reach by keyboard is honest, and renumbering the whole rail every time the server reports a label would not be. The badge names the key rather than the position, so the tenth row says `0`.

Collapsed to the 44px strip there is no room beside the glyph, so the number stands where the glyph was. Open, it takes the unread count's place — a 148px rail cannot hold both, and the count is the one you get back by letting go.

## The one `Keys` handler in `App.qml`

Held Alt is not a binding: a modifier alone cannot be a `Shortcut`, so there is nothing for `KeyRouter` to own. It accepts no event, so whatever follows Alt still goes where it went before, and it clears on `activeFocus` rather than on the release — Alt+Tab takes the release to another window, and waiting for one that is not coming would paint the numbers on permanently. AGENTS.md and `docs/KEYS.md` both carry the reason.

This also puts back the two mechanisms #10 removed — the sequence travelling with the id, and `display`. A row of several keys told apart by which one fired was the right idea; it was attached to the wrong feature. `slotFor` reads the position off the row's own key list, so the `Alt+` prefix is not written down twice.

## Test plan

- [x] `make test-js` and `make test-qml` (36 passed) green; `qmllint` exit 0
- [x] `tests/test_model.js` covers the ordering, the system-label filter, the ten-row ceiling and the handle types
- [x] `tests/test_keymap.js` covers `slotFor` and the one-row `display`
- [x] `tests/qml/tst_keyrouter.qml` fires `Alt+3` and `Alt+0`, and asserts both are dead in a draft
- [x] `tests/test_source.sh` gained a guard for the continuation line an earlier edit of this branch silently reparented — it numbered every row `1` and nothing failed
- [ ] Hold Alt with the rail open, and again collapsed to 44px
- [ ] Release Alt and confirm the unread counts come back
- [ ] Alt+Tab away with Alt held, come back, confirm no numbers are stuck on
- [ ] A mailbox with more than ten rows: the eleventh has no badge and no key

`make test-shell` is red here on `main`'s `preview.png`, which #13 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)