### PR TITLE
Read a message at a readable size

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,9 +213,15 @@ key. What matters while working:
   is world-readable.
 - Anything that could carry a credential passes through `OAuth.redact` before
   it can reach a label.
-- Remote images in a message body are blocked until the reader asks for them,
-  and asking covers one message. Qt's rich text engine really does fetch them,
-  so rendering one fires every tracking pixel in the message.
+- Remote images in a message body are blocked until the reader asks for them.
+  Qt's rich text engine really does fetch them, so rendering one fires every
+  tracking pixel in the message, and the fetch tells the host that this address
+  opened this message at this moment.
+- The answer is a standing one, off until it is given. Asking per message meant
+  answering the same question on every newsletter and remembering none of it,
+  so the cost of asking fell on somebody who had already decided. The notice's
+  button says "Always show", because that is what it does, and Settings is the
+  one place that turns it back off.
 
 ## Html.js
 

--- a/App.qml
+++ b/App.qml
@@ -67,13 +67,15 @@ Item {
   // mail, not for one message.
   property bool plainTextForced: false
   // Reading zoom for the message body only. The window's own chrome follows
-  // the theme's font scale, which is Omarchy's to set, not this app's.
-  property real bodyZoom: 1.0
+  // the theme's font scale, which is Omarchy's to set, not this app's. The
+  // service holds it because it is written to disk: a size somebody reached for
+  // is theirs until they change it, not until they close the window.
+  readonly property real bodyZoom: service ? service.bodyZoom : 1.0
   // 0 means "proportional"; anything else is a width somebody dragged to.
   property real listWidth: 0
 
   function zoomBy(step) {
-    bodyZoom = Math.max(0.6, Math.min(2.5, Math.round((bodyZoom + step) * 20) / 20))
+    if (service) service.setBodyZoom(Model.zoomAfterStep(service.bodyZoom, step))
   }
   property bool shortcutHelpVisible: false
   property bool setupVisible: false
@@ -303,7 +305,7 @@ Item {
     if (id === "switchAccount") return accountSwitcher.openCentered()
     if (id === "zoomIn") return zoomBy(0.1)
     if (id === "zoomOut") return zoomBy(-0.1)
-    if (id === "zoomReset") { bodyZoom = 1.0; return }
+    if (id === "zoomReset") { if (service) service.setBodyZoom(1.0); return }
     if (id === "refresh") {
       if (service) service.refresh()
       return

--- a/App.qml
+++ b/App.qml
@@ -63,9 +63,10 @@ Item {
 
   property string currentView: "list"
   property string cursorId: ""
-  // Kept across messages: somebody who wants plain text wants it for their
-  // mail, not for one message.
-  property bool plainTextForced: false
+  // Kept across messages, and across the window being closed: somebody who
+  // wants plain text wants it for their mail, not for one message. The service
+  // holds it because that is what writes it to disk.
+  readonly property bool plainTextForced: !!service && service.plainTextForced
   // Reading zoom for the message body only. The window's own chrome follows
   // the theme's font scale, which is Omarchy's to set, not this app's. The
   // service holds it because it is written to disk: a size somebody reached for
@@ -135,7 +136,10 @@ Item {
     opened = true
     if (service) service.windowOpen = true
     if (payload.mailbox && service) service.selectMailbox(String(payload.mailbox))
-    if (payload.compose === true) startCompose("new")
+    if (payload.compose === true) {
+      composeReturnView = currentView
+      startCompose("new")
+    }
     // The list is usually already loaded by the time the window is summoned —
     // the service keeps running while it is shut — so waiting for the next
     // change to seat the cursor leaves the first j with nowhere to move from.
@@ -205,6 +209,12 @@ Item {
   // draft in the same breath addressed nobody and quoted nothing, which is what
   // the list row's own Reply menu did. Held until the fetch lands instead.
   property string pendingComposeMode: ""
+  // Where the draft was raised from, so that leaving it goes back there.
+  // Answering from the list opens the message being answered — that is the
+  // reply's doing, not somewhere the reader asked to be — so closing the draft
+  // has to leave the message with it. Anything raised while reading stays in
+  // the reader, which is where it came from.
+  property string composeReturnView: ""
 
   function startCompose(mode) {
     if (!service) return
@@ -217,13 +227,29 @@ Item {
     compose.begin(next, service.selectedMessage, service.selectedBody.text)
   }
 
+  function resumeHeldCompose() {
+    if (pendingComposeMode === "" || !service || !service.selectedMessage) return
+    var mode = pendingComposeMode
+    pendingComposeMode = ""
+    startCompose(mode)
+  }
+
   // Answering from the list opens what is being answered first, the way the
   // row's own menu does. Anything already open is left alone: re-selecting it
   // would throw away the body that is on screen and fetch it again.
   function composeFromCursor(mode) {
     if (!service || cursorId === "") return
+    composeReturnView = currentView
     if (service.selectedId !== cursorId) openMessage(cursorId)
     startCompose(mode)
+  }
+
+  // A draft closed by its own Back, by Escape, by Discard, or by having been
+  // sent. All four are the same question: where was this raised from.
+  function leaveCompose() {
+    var from = composeReturnView
+    composeReturnView = ""
+    if (from === "list" && currentView === "reader") backToList()
   }
 
   // Acting on the open message closes it: it is about to leave this list.
@@ -298,7 +324,10 @@ Item {
     if (id === "reply") return composeFromCursor("reply")
     if (id === "replyAll") return composeFromCursor("replyAll")
     if (id === "forward") return composeFromCursor("forward")
-    if (id === "compose") return startCompose("new")
+    if (id === "compose") {
+      composeReturnView = currentView
+      return startCompose("new")
+    }
     if (id === "send") return compose.submit()
     if (id === "search") return searchBar.focusField()
     if (id === "goMailbox") return goSlot(Keymap.slotFor(id, sequence))
@@ -350,16 +379,20 @@ Item {
     // search, a refresh that dropped things. A cursor whose message survived
     // keeps its place; one whose message is gone would be unfindable, and an
     // unfindable cursor sends the next j to the top of the list.
-    // The message a held draft was waiting for. Selecting one clears the body
-    // and refills it from the network, so this fires twice: the guard is the
-    // summary, which is null until the fetch lands.
-    function onSelectedBodyChanged() {
-      if (root.pendingComposeMode === "") return
-      if (!root.service || !root.service.selectedMessage) return
-      var mode = root.pendingComposeMode
-      root.pendingComposeMode = ""
-      root.startCompose(mode)
-    }
+    // The message a held draft was waiting for. Both halves have to have
+    // landed: the summary carries the addresses and the subject, and the body
+    // is what gets quoted — so whichever of them arrives last is what starts
+    // the draft, and `Qt.callLater` is what lets the fetch finish assigning the
+    // rest before either is believed.
+    //
+    // Watching the body alone was not enough, and the case it missed was every
+    // message that had been opened before. Those paint from the cache, so the
+    // body changes while the summary is still null; when the summary lands the
+    // markup has not changed, so the body is not written a second time and
+    // nothing fires again. Reply, reply-all and forward raised from the list
+    // opened the message and stopped there.
+    function onSelectedBodyChanged() { Qt.callLater(root.resumeHeldCompose) }
+    function onSelectedMessageChanged() { Qt.callLater(root.resumeHeldCompose) }
 
     function onMessagesChanged() {
       root.cursorId = Model.cursorAfterReload(
@@ -693,7 +726,10 @@ Item {
             hoverColor: root.foreground
             fontFamily: root.fontFamily
             enabled: root.ready
-            onClicked: root.startCompose("new")
+            onClicked: {
+              root.composeReturnView = root.currentView
+              root.startCompose("new")
+            }
           }
 
         }
@@ -875,11 +911,15 @@ Item {
           zoom: root.bodyZoom
           showBack: root.compact
           forcePlainText: root.plainTextForced
-          onTogglePlainTextRequested: root.plainTextForced = !root.plainTextForced
+          onTogglePlainTextRequested: if (root.service)
+            root.service.setPlainTextForced(!root.service.plainTextForced)
           onZoomRequested: function(step) { root.zoomBy(step) }
-          onZoomResetRequested: root.bodyZoom = 1.0
+          onZoomResetRequested: if (root.service) root.service.setBodyZoom(1.0)
           onBackRequested: root.backToList()
-          onComposeRequested: function(mode) { root.startCompose(mode) }
+          onComposeRequested: function(mode) {
+            root.composeReturnView = root.currentView
+            root.startCompose(mode)
+          }
           onActionRequested: function(action) {
             if (root.service && root.service.selectedId !== "") {
               root.cursorId = root.service.selectedId
@@ -901,6 +941,7 @@ Item {
           dimColor: root.dim
           dimmerColor: root.dimmer
           panelFontFamily: root.fontFamily
+          onClosed: root.leaveCompose()
         }
 
         // Setup takes the whole body: there is nothing else to look at until
@@ -1156,6 +1197,7 @@ Item {
         dimColor: root.dim
         panelFontFamily: root.fontFamily
         onComposeRequested: function(mode, id) {
+          root.composeReturnView = root.currentView
           root.openMessage(id)
           root.startCompose(mode)
         }

--- a/Service.qml
+++ b/Service.qml
@@ -4,6 +4,7 @@ import Quickshell.Io
 import "account"
 
 import "account/Accounts.js" as Accounts
+import "account/Model.js" as Model
 import "providers/Registry.js" as Provider
 
 // Every mailbox on this machine, and whichever one is on screen.
@@ -299,20 +300,38 @@ Item {
   // the window cannot recompute lives here.
 
   property bool sidebarCollapsed: false
+  // Somebody who needed the text bigger needs it bigger for their mail, not for
+  // the message that made them reach for it.
+  property real bodyZoom: 1.0
   property bool windowPrefsLoaded: false
   property string windowWritePayload: ""
 
   function applyWindowPrefs(raw) {
     var parsed = null
     try { parsed = JSON.parse(String(raw || "")) } catch (e) { parsed = null }
-    if (parsed && typeof parsed === "object")
+    if (parsed && typeof parsed === "object") {
       sidebarCollapsed = parsed.sidebarCollapsed === true
+      bodyZoom = Model.clampZoom(parsed.bodyZoom)
+    }
     windowPrefsLoaded = true
   }
 
+  // A toggle is written the moment it is made; a zoom is dragged, and Ctrl and
+  // the wheel walk through a dozen values in a second. So the first change goes
+  // out immediately and anything arriving while that write is still running
+  // waits for the scrolling to stop — dropping those, which is what a bare
+  // `running` guard does, loses the one value the user settled on.
   function saveWindowPrefs() {
-    if (!windowPrefsLoaded || windowWriter.running) return
-    windowWritePayload = JSON.stringify({ sidebarCollapsed: sidebarCollapsed })
+    if (!windowPrefsLoaded) return
+    if (windowWriter.running) {
+      windowPrefsSettling.restart()
+      return
+    }
+    windowPrefsSettling.stop()
+    windowWritePayload = JSON.stringify({
+      sidebarCollapsed: sidebarCollapsed,
+      bodyZoom: bodyZoom
+    })
     windowWriter.command = [pluginDir + "/scripts/config-store.sh", "window.json"]
     windowWriter.running = true
   }
@@ -321,6 +340,13 @@ Item {
     var next = value === true
     if (next === sidebarCollapsed) return
     sidebarCollapsed = next
+    saveWindowPrefs()
+  }
+
+  function setBodyZoom(value) {
+    var next = Model.clampZoom(value)
+    if (next === bodyZoom) return
+    bodyZoom = next
     saveWindowPrefs()
   }
   signal duplicateAccount(string email)
@@ -577,6 +603,12 @@ Item {
     onLoaded: root.applyWindowPrefs(text())
     // No file yet is the ordinary first-run state, not an error.
     onLoadFailed: root.applyWindowPrefs("")
+  }
+
+  Timer {
+    id: windowPrefsSettling
+    interval: 500
+    onTriggered: root.saveWindowPrefs()
   }
 
   Process {

--- a/Service.qml
+++ b/Service.qml
@@ -301,8 +301,17 @@ Item {
 
   property bool sidebarCollapsed: false
   // Somebody who needed the text bigger needs it bigger for their mail, not for
-  // the message that made them reach for it.
+  // the message that made them reach for it. The same goes for reading it as
+  // plain text: that is a way of reading mail, not a way of reading one.
   property real bodyZoom: 1.0
+  property bool plainTextForced: false
+  // Off until somebody says otherwise, and then it stays said. Loading a
+  // remote image tells its host that this address opened this message, at this
+  // moment — the reason the answer was once asked for one message at a time.
+  // Asked for every message, it is a decision somebody makes once and should
+  // not be asked to make again on the next one; the switch that turns it on is
+  // in Settings, which is also the only place that can turn it back off.
+  property bool alwaysShowImages: false
   property bool windowPrefsLoaded: false
   property string windowWritePayload: ""
 
@@ -312,6 +321,8 @@ Item {
     if (parsed && typeof parsed === "object") {
       sidebarCollapsed = parsed.sidebarCollapsed === true
       bodyZoom = Model.clampZoom(parsed.bodyZoom)
+      plainTextForced = parsed.plainTextForced === true
+      alwaysShowImages = parsed.alwaysShowImages === true
     }
     windowPrefsLoaded = true
   }
@@ -330,7 +341,9 @@ Item {
     windowPrefsSettling.stop()
     windowWritePayload = JSON.stringify({
       sidebarCollapsed: sidebarCollapsed,
-      bodyZoom: bodyZoom
+      bodyZoom: bodyZoom,
+      plainTextForced: plainTextForced,
+      alwaysShowImages: alwaysShowImages
     })
     windowWriter.command = [pluginDir + "/scripts/config-store.sh", "window.json"]
     windowWriter.running = true
@@ -348,6 +361,23 @@ Item {
     if (next === bodyZoom) return
     bodyZoom = next
     saveWindowPrefs()
+  }
+
+  function setPlainTextForced(value) {
+    var next = value === true
+    if (next === plainTextForced) return
+    plainTextForced = next
+    saveWindowPrefs()
+  }
+
+  function setAlwaysShowImages(value) {
+    var next = value === true
+    if (next === alwaysShowImages) return
+    alwaysShowImages = next
+    saveWindowPrefs()
+    // The message on screen is the one the answer was given about, so it
+    // answers now rather than at the next message.
+    if (next && current) current.showRemoteImages()
   }
   signal duplicateAccount(string email)
 
@@ -475,7 +505,9 @@ Item {
   function loadMore() { if (current) current.loadMore() }
   function select(id) { if (current) current.select(id) }
   function clearSelection() { if (current) current.clearSelection() }
-  function showRemoteImages() { if (current) current.showRemoteImages() }
+  // The notice's own button, which is the switch: what it turns on is every
+  // message, and it says so.
+  function showRemoteImages() { setAlwaysShowImages(true) }
   function rsvp(response) { if (current) current.rsvp(response) }
   function unsubscribe() { if (current) current.unsubscribe() }
   function cursorOffset(cursorId, delta) {
@@ -579,6 +611,9 @@ Item {
       // only the first one may claim it.
       mayAdoptLegacyToken: index === 0 && (!entry || entry.provider === "gmail")
       settings: root.settings
+      // Every mailbox obeys the one answer: it is about what the reader is
+      // willing to tell a sender, not about which account the mail came to.
+      alwaysShowImages: root.alwaysShowImages
 
       onAccountIdentified: function(email) { root.nameAccount(index, email) }
       onReadyChanged: root.recount()

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -607,10 +607,19 @@ Item {
     bodyCache.read(messageId, function(cached) {
       if (serial !== root.detailSerial) return
       if (root.detailLive || !cached) return
-      root.selectedBody = { text: cached.text, source: cached.source }
-      root.renderSource(cached.html)
+      // The text is read out of the cached markup rather than taken off the
+      // disk beside it, on the same grounds the document is: what the cache
+      // holds is the sender's HTML, so a fix to how a message reads reaches
+      // every message already there instead of only the ones fetched after it.
+      // Both readings come off the one parse, and the picture list comes with
+      // them — a marker and the list it points into have to be numbered by the
+      // same walk or a marker opens somebody else's picture.
+      var reread = root.renderSource(cached.html, cached.source === "html")
+      root.selectedBody = reread.plainText
+        ? ({ text: reread.plainText.text, source: "html" })
+        : ({ text: cached.text, source: cached.source })
       root.selectedAttachments = cached.attachments
-      root.selectedImages = cached.images
+      root.selectedImages = reread.plainText ? reread.plainText.images : cached.images
       // The invitation and the unsubscribe offer are read out of the same
       // fetch as the body and never change either, so a message opened before
       // shows its card at the same moment it shows its text rather than a
@@ -650,9 +659,13 @@ Item {
       root.selectedAttachments = Mail.attachments(payload.payload)
       root.selectedInvite = Calendar.fromPayload(payload.payload)
       root.selectedUnsubscribe = Unsub.fromMessage(payload)
+      // What the reader is showing, which is not `decoded` when the cache had
+      // already painted this markup: that text came from `Mail.extractBody`'s
+      // own flattening, and its images are numbered by a different walk than
+      // the list beside it here.
       var record = ({
-        text: decoded.text,
-        source: decoded.source,
+        text: root.selectedBody.text,
+        source: root.selectedBody.source,
         html: rawHtml,
         attachments: root.selectedAttachments,
         images: root.selectedImages,

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -146,6 +146,10 @@ Item {
   // Off for every message, every time it is opened. Fetching a sender's images
   // tells them the mail was read, from which address and when, so it happens
   // only when the reader has asked — and asking covers this message alone.
+  // The window's standing answer about remote images, which is where a
+  // message starts. Off, and every message begins blocked and is asked about
+  // one at a time.
+  property bool alwaysShowImages: false
   property bool remoteImagesAllowed: false
   // The sender's images, in the order htmlToText numbers them, so a marker in
   // the plain-text body can be traced back to the picture it replaced.
@@ -589,7 +593,7 @@ Item {
     selectedHtml = ""
     selectedDocument = null
     sourceHtml = ""
-    remoteImagesAllowed = false
+    remoteImagesAllowed = alwaysShowImages
     selectedBlockedImages = 0
     selectedRemoteImages = 0
     selectedImages = []

--- a/account/Model.js
+++ b/account/Model.js
@@ -145,6 +145,37 @@ function applyLabelChange(summary, action) {
 
 // Skeleton rows replace only an empty list's first fetch. Loading another page
 // leaves useful messages in place and reports its progress at the list foot.
+// ------------------------------------------------------------- reading zoom
+//
+// The body's zoom is the one size in the window that belongs to the reader
+// rather than to the theme: Omarchy sets the font scale the chrome follows,
+// and this is somebody leaning in to one message. It is kept because it is not
+// about one message — somebody who needed the text bigger needs it bigger for
+// their mail.
+//
+// A twentieth per step, so Ctrl+scroll lands on values it can land on again
+// and a saved one reads back as what was set. The bounds are where a message
+// stops being a message: a smudge below, a poster above.
+var ZOOM_MIN = 0.6
+var ZOOM_MAX = 2.5
+var ZOOM_STEPS_PER_UNIT = 20
+
+// What a zoom read back off disk means. Anything that is not a number is a
+// file that was hand-edited or never written, and the answer to both is the
+// size it shipped at.
+function clampZoom(value) {
+  if (value === null || value === undefined || value === "") return 1
+  var zoom = Number(value)
+  if (!isFinite(zoom)) return 1
+  return Math.max(ZOOM_MIN, Math.min(ZOOM_MAX,
+    Math.round(zoom * ZOOM_STEPS_PER_UNIT) / ZOOM_STEPS_PER_UNIT))
+}
+
+function zoomAfterStep(zoom, step) {
+  var by = Number(step)
+  return clampZoom(clampZoom(zoom) + (isFinite(by) ? by : 0))
+}
+
 function showInitialListSkeleton(loading, messageCount) {
   return !!loading && Math.max(0, Number(messageCount) || 0) === 0
 }

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -154,9 +154,15 @@ Item {
     }
   }
 
+  // Every way out of a draft: this view's own Back, Discard, the window's
+  // Escape, and the send that succeeded. The window is told because only the
+  // window knows where the draft was raised from.
+  signal closed()
+
   function finish() {
     reset()
     opened = false
+    closed()
   }
 
   function submit() {

--- a/components/MessageList.qml
+++ b/components/MessageList.qml
@@ -95,13 +95,19 @@ Column {
     }
   }
 
+  // The count and the way to more of them. Inset like a row's own text rather
+  // than flush to the column: the list's left edge belongs to the selected
+  // row's fill, and a footer sitting on it reads as a row that lost its
+  // padding. The height is what puts air above and below the pair, because the
+  // column's spacing between children is two pixels.
   Item {
     width: parent.width
     visible: Model.showListFooter(root.service.messages.length)
-    implicitHeight: Style.space(30)
+    implicitHeight: Style.space(44)
 
     Text {
       anchors.left: parent.left
+      anchors.leftMargin: Style.space(14)
       anchors.verticalCenter: parent.verticalCenter
       text: root.service.resultSummary
       color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.42)
@@ -111,6 +117,7 @@ Column {
 
     Button {
       anchors.right: parent.right
+      anchors.rightMargin: Style.space(8)
       anchors.verticalCenter: parent.verticalCenter
       visible: root.service.hasMore
       text: root.service.listLoading ? "Loading…" : "Load more"

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -233,7 +233,10 @@ Item {
         && !root.remoteImagesAllowed && root.remoteImages > 0
       text: (root.remoteImages === 1 ? "1 image is blocked" : root.remoteImages + " images are blocked")
         + ": loading them tells the sender this message was opened"
-      actionLabel: "Show images"
+      // What the button does is turn them on for every message, and Settings
+      // is where that is turned back off — so it says "always" rather than
+      // letting somebody find out afterwards.
+      actionLabel: "Always show"
       textColor: root.textColor
       dimColor: root.dimColor
       accentColor: root.accentColor

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -339,7 +339,12 @@ Item {
       selectionColor: Style.selectionFillFor(root.textColor, root.accentColor)
       selectedTextColor: root.textColor
       font.family: root.panelFontFamily
-      font.pixelSize: Math.max(7, Math.round(Style.font.bodySmall * root.zoom))
+      // Body text, where the chrome around it is bodySmall: this is the one
+      // long-form thing in the window and the only one that is read rather than
+      // scanned. At bodySmall it was 11px against the 9pt — twelve — of the
+      // terminal beside it, so the message was the smallest text on a screen
+      // whose owner had already said what size they read at.
+      font.pixelSize: Math.max(7, Math.round(Style.font.body * root.zoom))
       onLinkActivated: function(link) {
         var image = Html.imageLinkIndex(link)
         if (image > 0) {

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -45,6 +45,65 @@ Column {
     font.bold: true
   }
 
+  // --------------------------------------------------------------- reading
+
+  Text {
+    text: "READING"
+    color: root.dimColor
+    font.family: root.panelFontFamily
+    font.pixelSize: Style.font.caption
+    font.letterSpacing: 1
+  }
+
+  Rectangle {
+    width: parent.width
+    implicitHeight: Math.max(imagesText.implicitHeight, imagesSwitch.implicitHeight)
+      + Style.space(16)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+
+    Column {
+      id: imagesText
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(12)
+      anchors.right: imagesSwitch.left
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(2)
+
+      Text {
+        width: parent.width
+        text: "Always show remote images"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+      }
+
+      Text {
+        width: parent.width
+        // The cost, in the words of what it actually tells whom. Off, the
+        // reader asks about each message and the answer covers that one.
+        text: "Loading an image tells its host that this address opened the "
+          + "message, and when"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+      }
+    }
+
+    ToggleSwitch {
+      id: imagesSwitch
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      checked: !!root.service && root.service.alwaysShowImages
+      foreground: root.textColor
+      accent: root.accentColor
+      onToggled: if (root.service) root.service.setAlwaysShowImages(!root.service.alwaysShowImages)
+    }
+  }
+
   // ------------------------------------------------------------- mailboxes
 
   Text {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,273 @@
+# Omamail Architecture
+
+This document describes how Omamail is divided, where state belongs, and how components communicate. It is an engineering guide rather than a product specification. `SPEC.md` says what the product promises; `DESIGN.md` says how the interface behaves and is laid out; this document says which part of the program owns each decision.
+
+Except for visual styling, GPUI and GPUI Component provide the default architectural model for Omamail. Their principles of stable identity, explicit state ownership, contextual actions, controlled values, semantic events, composable parts, behavior/presentation separation, lifecycle safety, precise vocabulary, and testable decisions apply here unless a Qt or shell constraint proves otherwise. Omamail translates those principles into QML properties, signals, JavaScript libraries, and Qt lifecycle rather than reproducing Rust APIs.
+
+Use the [GPUI Component Coding Guides](http://longbridge.github.io/gpui-component/docs/coding-guides) for the full architecture, state, lifecycle, naming, API, and testing guidance. This document keeps the Omamail module mapping and the places where QML, Qt, the shell, or the mail domain changes its application.
+
+## Architectural position
+
+Omamail is a stateful desktop application hosted as an Omarchy shell plugin. Its architecture has five layers:
+
+1. The shell entry points connect Omarchy to the application.
+2. The window composition owns window state, navigation, action dispatch, and top-level layout.
+3. Domain modules own mail, provider, cache, message, and account decisions.
+4. Interaction and layout primitives implement reusable UI behavior.
+5. Feature views compose those primitives and render data they are given.
+
+Dependencies point down this list. A view may ask the application to perform an action, but it does not acquire provider knowledge or mutate storage on its own. A provider may normalize mail into the shared message resource, but it does not know which row, popup, or page is visible.
+
+The visual system is separate from all five layers. Colors, typography, spacing, fills, radii, icons, density, and surface treatment come from the active Omarchy theme through `App.qml` and semantic component properties. GPUI Component supplies the architectural and interaction baseline, not the visual language.
+
+## Entry points and window composition
+
+The repository root contains only the QML entry points the shell loads:
+
+- `Service.qml` is the long-lived application and account host. The shell constructs it, so it declares no required properties beyond what the shell supplies. It owns state that must survive the window.
+- `BarWidget.qml` is the shell-facing trigger and settings bridge.
+- `App.qml` composes the application window. It owns visible navigation, action dispatch, focus context, non-popup surfaces, and the arrangement of the major panes.
+
+This composition boundary is shaped by the shell entry-point contract and Qt's focus and popup behavior. `App.qml` coordinates:
+
+- which page or mailbox surface is active;
+- which keyboard context owns the window;
+- where the keyboard is parked when nothing accepts text;
+- the dismissal order of pages, drafts, search, and plain overlays;
+- application-wide notices;
+- responsive composition of sidebar, list, reader, and pages.
+
+`App.qml` must not become the implementation of every one of those behaviors. It owns their state and policy; reusable mechanics belong in components or testable JavaScript modules. Composition ownership and implementation are not the same thing.
+
+## State ownership
+
+Every mutable value has one authoritative owner. Other objects receive it as input and report intent with signals or method calls.
+
+Use these lifetimes to choose that owner:
+
+| Lifetime                | Owner                                   | Examples                                                    |
+| ----------------------- | --------------------------------------- | ----------------------------------------------------------- |
+| Installation or account | service/domain storage                  | accounts, credentials, cached messages                      |
+| Across window openings  | `Service.qml` plus its store            | collapsed sidebar, reader zoom, future persisted pane sizes |
+| Current window          | `App.qml`                               | visible page, list cursor, open reader, compose mode        |
+| Open interaction        | the relevant popup or overlay component | popup selection, drag origin, submenu path                  |
+| One rendering           | the view                                | hover, pressed appearance, measured bounds                  |
+
+A value moves to a longer-lived owner only when users have expressed a preference that should survive. It does not move merely because persistence is possible. Derived state is recomputed from its source rather than stored beside it.
+
+Stable identity matters wherever state outlives a render. A mailbox, message, menu item, popup, and resizable pane must have an identity based on what it is, not on the position at which it happened to render. This is the QML equivalent of GPUI's `ElementId` and keyed state. An index is suitable only when ordering is itself the identity.
+
+### Controlled state and feedback
+
+Follow the Coding Guides' controlled-state and feedback-loop rules. In Omamail, QML property bindings carry the owner value and signals report user intent; synchronizing search text, selection, open state, or filters must not echo the owner value as a second user change. Treat a signal handler as re-entrant because it may switch the account, replace the model, close the popup, or destroy its sender.
+
+## Actions and contexts
+
+The existing keyboard architecture is the clearest GPUI-derived part of Omamail and is the model for other interactions.
+
+- `keys/Keymap.js` declares actions, bindings, and the contexts in which they mean something.
+- `components/KeyRouter.qml` turns that declaration into window shortcuts.
+- `App.qml` dispatches action identifiers to application operations.
+- `docs/KEYS.md` documents the model and the platform-specific exceptions.
+
+An action describes intent, not an input device. `archive` is the same operation whether it came from `e`, an icon, or a menu row. Components emit intent; the application decides what the intent means in the current state. This prevents parallel mouse and keyboard implementations from drifting.
+
+The context is the guard. Do not add a second collection of `enabled` tests in the key handler for conditions already expressed by the context. Capability is different: it comes from the active provider and decides whether an operation exists at all. A provider capability should remove an unavailable action from the view rather than offer an action that fails after activation.
+
+Qt Quick Controls popups intercept keys before window shortcuts. That is a platform fact, not an exception to the architecture. Popup-local navigation therefore lives on the popup content item, and the popup owns its own Escape dismissal. An application action may open a popup, but `goBack()` does not duplicate the popup's close policy. The tests in `tests/qml/tst_popup_keys.qml` preserve this boundary.
+
+## Domain modules
+
+Modules are grouped by responsibility rather than language or file type:
+
+- `providers/` owns service descriptions, authentication, protocol behavior, capabilities, and normalization into the shared Gmail-shaped resource.
+- `account/` owns accounts, a mailbox, and list behavior after actions.
+- `cache/` owns stored query results and message bodies.
+- `message/` owns parsing, sanitizing, calendar data, and other decisions about a message's content.
+- `keys/` owns the action and binding declaration.
+- `components/` owns views and reusable interaction primitives.
+
+Rules that parse, format, choose, clamp, or otherwise decide belong in `.js` libraries whenever they can. QML binds state and renders results. This is more than a testing convenience: it keeps behavior independent of compositor and widget lifecycle, in the same spirit as separating GPUI entity state from an element's layout and paint passes.
+
+Reusable behavior and presentation remain separate without introducing a framework layer merely to name that separation. JavaScript owns portable decisions and state transitions; QML components own Qt lifecycle and input mechanics; feature views supply Omamail composition; semantic properties supplied from `App.qml` carry the Omarchy presentation. This is the `gpui-base` and `gpui-component` seam expressed through the units this repository already has.
+
+Provider differences end at the provider boundary. Code above that boundary asks about capabilities and consumes the common message resource. It does not branch on provider IDs.
+
+## Vocabulary is an interface contract
+
+Follow the Coding Guides' vocabulary and API naming rules. Omamail keeps one canonical name for each mail object, command, and state across QML properties, signals, actions, sidebar rows, settings, menus, tooltips, notices, shortcuts, errors, and documentation. The project-specific distinction between `cursorId` and `selectedId` is load-bearing: the former is the keyboard position and the latter is the message shown by the reader.
+
+Review terminology in the rendered surface beside neighboring labels, not as an isolated string. When a canonical term changes, search every interface surface and document that may use it.
+
+## Components and primitives
+
+`components/` may contain two kinds of QML type:
+
+### Feature views
+
+Feature views express mail concepts: `MessageList`, `MessageReader`, `MailboxSidebar`, `ComposeView`, and account/setup pages. They compose smaller parts, expose semantic properties, and emit semantic signals.
+
+A feature view may decide how a mail concept is presented. It must not copy a general interaction algorithm just because that algorithm is currently short.
+
+### Interaction and layout primitives
+
+Primitives express reusable behavior: icon buttons, menu rows, anchored popups, overlay surfaces, split handles, and similar mechanics. Their public contract should answer:
+
+- What state is controlled by the caller, and what state is local?
+- Which semantic inputs are required?
+- Which user intents are emitted?
+- How are focus, dismissal, and geometry handled?
+- What remains true when content size or window size changes?
+
+The desired direction follows GPUI Component's separation between a component and its state object without forcing a literal state-object API onto QML. A QML primitive should usually have controlled durable state and local transient state:
+
+- the caller owns `opened`, `selected`, active identity, and persisted size;
+- the primitive owns pressed/hovered state, a drag's starting coordinates, and current measured geometry;
+- the primitive emits `activated`, `openRequested`, `dismissRequested`, or `resized`, rather than reaching into application objects.
+
+Required semantic properties are preferable to hidden dependencies on `App.qml`. Theme values must be passed from `App.qml` when a component needs them. Components do not look up mail services, account state, or sibling views through object names.
+
+## Overlay architecture
+
+Menus, the account switcher, the image popover, and shortcut help all draw above the mail panes, but they do not share one implementation or input model.
+
+`App.qml` states back-navigation precedence for the non-popup surfaces it composes. Each Qt popup owns its close policy, placement, and popup-local keys; each plain overlay participates in the application key context and `goBack()`. Feature views supply content and translate activation back into domain actions. There is no common overlay manager between them.
+
+An overlay contract includes:
+
+- the trigger or explicit anchor bounds;
+- preferred placement;
+- flip, window-edge clamp, then zero clamp;
+- placement after opening and after content size changes;
+- whether outside press dismisses it;
+- whether it takes focus;
+- initial focus and any focus restoration it performs;
+- local keyboard navigation where Qt consumes window shortcuts;
+- a stable `z` order relative to the other surfaces in the window.
+
+When a surface moves focus, its closing path must return control through the application's current key context rather than blindly focusing the item that used to be active. Where focus returns is not necessarily where an action should be dispatched.
+
+Do not infer popup ownership from coordinates or visual ancestry. A popup may be declared outside clipped row content while still belonging to that row or its trigger. Its trigger remains selected for the popup's whole visible lifetime.
+
+## Layout architecture
+
+The shell window has three semantic regions: navigation, collection, and content. Responsive layout changes how those regions are composed, not what they mean.
+
+- Wide: sidebar, message list, and reader are simultaneous panes.
+- Medium: the sidebar becomes an icon rail; list and reader remain panes.
+- Compact: mailbox tabs replace the sidebar and list/reader become navigation states rather than squeezed panes.
+
+Breakpoints are discrete modes. Components should not accumulate unrelated width tests. `App.qml` chooses the mode and passes the consequences down.
+
+Resizable panes use the same conceptual split as GPUI Component:
+
+- group state knows the axis, available bounds, pane sizes, and active handle;
+- each pane declares minimum/maximum constraints and optional preferred size;
+- each handle provides a forgiving hit target independent of its visible rule;
+- dragging changes the two adjacent allocations while preserving the group total and respecting constraints;
+- double activation may restore the computed default;
+- persistence records a user-selected size, not a transient clamped size from a smaller window.
+
+Omamail currently has one hand-built list/reader splitter. It is a valid specialization, but future split layouts should share the state and constraint rules rather than copy the drag handler.
+
+Layout state describes semantic regions and their allocation independently of the QML objects that render them. When a region is hidden, the remaining visible regions consume the released space; an invisible pane must not leave behind a slot. Restoring it reapplies its preferred allocation subject to the current bounds.
+
+This does not justify a general dock tree. Omamail has one known navigation/collection/content arrangement and three responsive modes. A tree with tab groups, arbitrary nesting, drag-to-dock, registries, or layout normalization would model operations the product does not offer. Extract the invariant—visible panes fill the available layout—not the machinery built for an IDE workspace.
+
+## Measurement and scrolling
+
+Measurement is valid only for the conditions under which it was taken. Width-dependent content is measured at the actual viewport width, not at an unconstrained sample width. A change to viewport width, font metrics, body zoom, row content, or any other input to size invalidates the cached measurement that depended on it.
+
+Every scrollable region has one owner. That owner fills the panel viewport and places its scrollbar on the panel edge. Content padding belongs inside the scroll owner; wrapping the viewport in padding moves the scrollbar away from the boundary and makes the layout hierarchy false. Avoid nested scrolling where one wheel event could plausibly belong to two regions.
+
+## Rendering and security boundaries
+
+Anything supplied by a sender is plain data unless it passes through the specific message-body renderer. Subjects, names, snippets, filenames, and labels explicitly use plain text. A reusable component cannot weaken that rule by relying on `Text.AutoText`.
+
+`message/Html.js` is a security boundary, not a presentation helper. The body cache keeps source content; the sanitizer decides what Qt may render; remote resource policy remains centralized. Component extraction must not move any of those decisions into a reader view or a generic rich-text primitive.
+
+## Testing boundaries
+
+Tests follow the ownership of behavior:
+
+- JavaScript unit tests cover parsing, formatting, state transitions, constraints, and geometry decisions.
+- QML tests cover Qt-specific focus, popup, shortcut, pointer, and lifecycle behavior.
+- source tests enforce structural and security invariants.
+- `qmllint` and plugin validation cover integration with the actual component graph.
+
+A behavior discovered by running Qt should be captured in a QML regression test. A decision expressible without Qt belongs in a JavaScript function and a node test. Do not test the same decision indirectly through several views.
+
+## Evolution rules
+
+Architecture evolves by extracting proven repetition, not by building a general component library in advance.
+
+1. State the invariant shared by at least two uses.
+2. Move the decision into a pure JavaScript function when possible.
+3. Give the primitive a semantic input/output contract.
+4. Migrate one existing use and verify behavior.
+5. Migrate the other use only when the contract still fits without feature flags that name its callers.
+
+Do not make a primitive depend on `service`, `mailbox`, `message`, or provider IDs. If it needs those concepts, it is a feature view. Do not introduce a generic abstraction whose options are merely the union of two unrelated components.
+
+Likely candidates, when implementation work calls for them, are:
+
+- one anchored popup placement rule shared by application and message menus;
+- one menu surface, separator, and row contract;
+- one split-group constraint model;
+- shared popup focus-return rules where Qt permits them;
+- shared selectable action surfaces for icon and text controls.
+
+These are directions, not a requirement for an immediate rewrite.
+
+## Translation boundary
+
+Architecture and interaction principles transfer by default; runtime machinery transfers only through an equivalent Omamail need. Translate `Entity` ownership into the appropriate service, feature view, or component property owner; translate semantic events into signals; translate controlled values into property input plus requested-change output; translate keyed identity into stable domain IDs; translate render-phase measurement into the Qt lifecycle point where resolved geometry actually exists.
+
+Do not create Rust-shaped QML APIs or shadow facilities already owned by Qt. GPUI-specific contexts, handles, and render/prepaint/paint phases explain the lifecycle problem but are not types this project needs to imitate. Qt popup key capture, focus scope behavior, object lifetime, and QML binding semantics remain authoritative for the implementation.
+
+The same distinction applies to large feature systems. Dock's pure-data layout, canonical state, stable identity, and fill-after-removal invariants apply; a Dock tree, panel registry, arbitrary tab groups, tiles, and drag-to-dock editing do not exist until Omamail offers those product operations. Virtualization's separation of model coordinates, visible range, measurement, and row rendering applies; virtual-list machinery is introduced only when the loaded-message model needs it.
+
+The visual exception is explicit. GPUI Component theme tokens, dimensions, cursor styling, animation curves, shadows, radii, and surface appearance do not transfer. Omarchy remains the visual authority.
+
+## Commit design
+
+Commits should preserve the reasoning that makes an architectural choice safe to change later. The best history in both Omamail and GPUI Component follows a consistent structure.
+
+### Subject
+
+Write an imperative, outcome-oriented subject. Describe what becomes true for the user or maintainer, not the file operation.
+
+Good:
+
+- `Keep the popup attached to the control that opened it`
+- `Restore focus after the account switcher closes`
+- `Share pane constraints between drag and restore`
+
+Weak:
+
+- `Refactor popup code`
+- `Update App.qml`
+- `Add helper`
+
+Conventional prefixes such as `fix:` or `docs:` are useful where the repository already uses them, but they do not replace a precise result.
+
+### Body
+
+Use the body to explain:
+
+1. the previous observable behavior;
+2. the cause or architectural mismatch;
+3. the invariant chosen by the change;
+4. important alternatives rejected and why;
+5. verification actually performed;
+6. known verification that could not be performed.
+
+Prefer concrete evidence over generic claims. Include measured timing, window sizes, protocol requirements, Qt behavior, or a minimal example when one of those caused the design. Explain surprising code close to the code as well; the commit records why the change happened, while the comment protects the invariant after the commit is no longer nearby.
+
+A large commit may use short sections such as `Why`, `What replaces it`, and `Verification`. A small commit should remain prose rather than imitate a pull request template. Test lists distinguish passing automated checks, manual checks, and checks unavailable in the current environment.
+
+Keep one architectural argument per commit where practical. A supporting fix belongs in the same commit when the primary change exposes it and cannot be correct without it; unrelated cleanup does not.
+
+## Documentation source
+
+Markdown prose uses one source line per paragraph. Do not hard-wrap prose to a column width. Use line breaks only for semantic structure such as headings, paragraphs, lists, tables, blockquotes, and code blocks.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,308 @@
+# Omamail Interface Design
+
+Omamail follows the Omarchy visual language and uses GPUI and GPUI Component as its default product and interaction design model. Their principles apply unless a mail-specific, Qt, or shell constraint gives a concrete reason to adapt them. This document defines that translation and the detailed behavior of the window; it does not make the application look like GPUI Component.
+
+The upstream reference is [GPUI Component Design Guides](http://longbridge.github.io/gpui-component/docs/design-guides). Read it as the general design standard; this document records Omamail's mail-specific application, Qt and shell constraints, and Omarchy visual boundary. Do not duplicate the entire upstream guide here: keep shared principles there and document only the interpretation or exception that future Omamail work needs.
+
+## Design character
+
+Omamail is a compact, keyboard-capable desktop mail client. It should feel like part of the shell rather than a web application placed inside it:
+
+- dense enough to scan quickly;
+- quiet enough for the message to remain primary;
+- explicit about state without depending on color alone;
+- predictable under keyboard, pointer, and window resizing;
+- native to the active Omarchy theme.
+
+The screenshots in `preview.png` express the visual baseline: a narrow mailbox rail, a dense list, a generous reader, monospace typography, restrained rules, and controls that appear where their actions belong.
+
+## What comes from Omarchy
+
+All visual tokens come from the active Omarchy theme:
+
+- foreground, background, accent, urgent/danger, and popup colors;
+- font family and font scale;
+- spacing and component dimensions;
+- corner radius;
+- normal, hovered, pressed, and selected fills.
+
+Semantic colors originate in `App.qml` and travel through required component properties. Muted text mixes foreground toward background. Derived fills use the shared `Style` helpers or alpha from an inherited semantic color.
+
+Do not import GPUI Component colors, shadows, radii, typography, sidebar width, or control decoration. A GPUI example may demonstrate an interaction contract; its pixels are not a design token for this application.
+
+## What comes from GPUI and GPUI Component
+
+Everything except visual styling is applicable as a design principle: task hierarchy, composition, state ownership, controlled values, stable identity, semantic actions and events, focus and keyboard behavior, overlays, measurement, scrolling, responsive layout, lifecycle safety, interface language, accessibility, error handling, and verification. The default is to translate the principle, not to decide whether it is worth learning.
+
+In particular:
+
+- actions are scoped by context;
+- controls expose selected, disabled, and open state explicitly;
+- compound components are assembled from small parts with clear roles;
+- overlays are anchored to triggers and managed above clipped content;
+- focus is captured, constrained where necessary, and restored;
+- resizable groups preserve constraints and communicate size changes;
+- stable identity keeps transient state attached to the same logical element;
+- compound controls keep trigger, surface, state, and dismissal behavior coherent.
+
+QML components should express those contracts in QML terms: properties, signals, bindings, and small JavaScript decision functions. A fluent Rust builder is not itself a pattern the interface needs to copy.
+
+## Window regions
+
+The window has a fixed hierarchy:
+
+1. Header: identity, global search, refresh, and compose.
+2. Body: navigation, collection, and content.
+3. Status bar: sidebar control, synchronization/account state, notice, and contextual key hints.
+4. Overlay layer: menus, account switcher, shortcut sheet, and other transient surfaces.
+
+The header and status bar span the whole window so the body panes read as one application. Pane separators meet those bars rather than creating independent cards.
+
+### Wide mode
+
+The sidebar, list, and reader are visible together. The reader receives the remaining width after the navigation and list panes. The message list has a computed default width and may be resized.
+
+### Medium mode
+
+The sidebar collapses to an icon rail while list and reader remain visible. Labels return through tooltips and the explicit expand control. Collapsing changes information density; it does not change which mailbox is active.
+
+### Compact mode
+
+The sidebar becomes mailbox tabs above the list. The list and reader are separate navigation states. Opening a message replaces the list; going back returns to the same cursor and scroll context.
+
+These are modes, not a continuously degrading desktop layout. A region that cannot remain useful at a width is recomposed instead of compressed into illegibility.
+
+## Region constraints
+
+Every major region defines three relationships rather than one arbitrary width:
+
+- minimum: the smallest size at which its task still works;
+- preferred: the comfortable starting size before the user expresses a preference;
+- surplus: how it grows when the window has more room.
+
+The navigation region remains subordinate, the message collection remains scannable, and the reader receives the surplus. A restored user split is clamped to the current window without overwriting the stored preference merely because this window is temporarily smaller. Hiding a region releases its whole allocation; the remaining regions fill the window with no invisible slot.
+
+## Alignment spines
+
+Each surface has a small number of shared alignment spines: the outer boundary, repeated content inset, text baseline, metadata lane, and trailing action lane. A heading, list row, skeleton, empty state, and footer at the same hierarchy level attach to the same relevant spine instead of inventing their own margins.
+
+Repeated rows reserve stable lanes for icons, labels, counts, time, badges, and actions when comparison matters. Optional content does not move the remaining text: an absent icon or action leaves its intentional lane, or the entire region consistently uses a layout without that lane. Indentation communicates real hierarchy and ends exactly when that hierarchy ends.
+
+Text of different sizes aligns by baseline when it shares a row. Icons sit in a fixed slot so different path bounds do not move labels. Comparable numbers and times share a trailing edge. Hairlines belong to one boundary owner; adjacent panes do not each draw the same separator.
+
+Equal edges and gaps are layout invariants. Verify their resolved bounds at representative window widths, body zoom levels, and display scales; do not approve alignment only by looking at a screenshot. Fix drift at the shared component, inset, or layout rule rather than adding unrelated one-pixel offsets to individual callers.
+
+A scrollbar belongs to the viewport that scrolls and sits on that region's outer edge. Text and row padding live inside the viewport; they must not inset the scrollbar into the content column. When content needs clearance from the scrollbar, reserve it deliberately inside the content rather than moving the scroll owner.
+
+## Sidebar
+
+The sidebar is a compound component with four roles:
+
+- application identity and collapse trigger;
+- primary mailboxes;
+- provider labels or folders;
+- account identity and account menu trigger.
+
+Expanded rows contain an icon, label, and optional suffix such as an unread count or visible key. Collapsed rows keep the icon and active state, while the label moves to a tooltip. The active mailbox uses fill plus persistent shape and text/icon treatment; unread additionally uses a dot and stronger weight.
+
+The collapsed state is a user preference and survives the window. It is not inferred from temporary width except when the responsive mode removes the sidebar entirely.
+
+Holding Alt reveals `1` through `0` on the same ordered rows those keys open. The visible hint and the action resolve from one data model. Pointer hover never changes the keyboard cursor.
+
+Groups may scroll when provider folders exceed the available height, but the account footer remains reachable. Header, scrolling content, and footer are layout roles rather than arbitrary children; this mirrors GPUI Component's sidebar composition while retaining Omamail's compact geometry.
+
+## Message list
+
+The list is optimized for scanning. Each row establishes, in order:
+
+- subject and time;
+- sender;
+- snippet;
+- state and quick actions.
+
+Unread state is redundant by design: dot, weight, and brighter subject. Hover is local visual feedback. Keyboard cursor and opened message remain separate states:
+
+- `cursorId` says where the next keyboard action applies;
+- `selectedId` says what the reader displays;
+- hover says only that the pointer is over a row.
+
+Selected and hovered fills extend to the list/splitter edge. Text padding is inside the row; viewport margins must not create a dead strip that breaks the relationship between row and reader.
+
+Quick actions may appear on hover or selection, but their layout space should not make text jump. Right-click first establishes the action target, then opens the contextual menu. The menu remains associated with that message even if the list changes underneath it; if the message disappears, the menu dismisses rather than acting on a new row at the same index.
+
+A critical or primary action cannot exist only on hover. Hover may reveal a faster pointer path for a secondary row action, but the same operation remains reachable through a visible command surface or the documented keyboard context. A compact row of hover icons must not replace an understandable primary action plus a menu for secondary commands.
+
+Keyboard movement reveals the cursor with the smallest necessary scroll. It does not recenter every step and the pointer does not rewrite it when content moves below a stationary mouse.
+
+## Reader
+
+The reader is the content pane and receives the most flexible width. Its hierarchy is:
+
+- subject and message-level state;
+- sender, recipients, and time;
+- notices and structured cards;
+- message body;
+- attachments;
+- persistent message actions at the bottom edge.
+
+Long-form body text follows the user's body font size and reader zoom. Chrome uses the smaller theme token. Reader zoom changes the message body, not the surrounding application.
+
+Notices form a stack with one shared component contract. A notice explains a condition and may expose one immediate action. Structured content such as an invitation is a card because it adds actions and relationships not represented by ordinary prose; routine message metadata is not boxed merely to create visual variety.
+
+Remote images remain blocked per message until requested. The visual treatment must make the blocked state and the scope of the action clear without making the notice compete with the message.
+
+Bottom actions remain attached to the reader rather than the body scroll. They are available at a stable location and correspond to the current selected message. Destructive actions use the semantic danger role and an accurate label.
+
+## Split panes
+
+The visible separator is a hairline; the pointer target is wider. A precision line should not demand precision pointing.
+
+For the list/reader split:
+
+- the list begins at a proportional default;
+- dragging creates a user-selected width;
+- list and reader minimums are enforced together;
+- the cursor changes across the whole hit target;
+- double-click restores the proportional default;
+- resizing the window may temporarily clamp the rendered width without replacing the stored preference;
+- compact mode ignores the split without destroying it.
+
+The handle should gain a subtle active treatment while dragged, derived from the theme foreground or accent. It must not introduce a permanent heavy bar.
+
+If more resizable regions are introduced, they use one group model: axis, available size, pane constraints, adjacent redistribution, and a resize event. Nested groups remain possible, but the mail window should add them only for a real independent region, not for decoration.
+
+## Buttons and action surfaces
+
+Controls describe their role through semantic state:
+
+- normal: available, not under pointer;
+- hovered: pointer target is clear;
+- pressed: activation is in progress;
+- selected: a persistent state is on, or this trigger owns an open popup;
+- disabled: visible but unavailable for a temporary reason;
+- absent: the provider does not offer the capability.
+
+Selected and pressed are not synonyms. A menu trigger stays selected from open until close even after the press has ended. A toggle uses selected for its value. A momentary action returns to normal.
+
+Icon-only actions require tooltips. The tooltip describes the action and may include the shortcut when the shortcut comes from `Keymap.js`; it must not create a second hand-maintained binding description.
+
+A control that opens another surface uses `...` in its label. An action that completes immediately does not. External navigation uses an honest label such as `Open in browser...` and may carry an external-link icon when space permits.
+
+## Menus
+
+A menu is composed from a surface, rows, separators, optional labels, and submenus. Omamail currently needs rows and separators; future variants should extend the same contract instead of making another private `MenuRow`.
+
+A menu row may have:
+
+- a label;
+- an optional leading icon or check state;
+- an optional trailing shortcut or submenu indicator;
+- enabled/disabled state;
+- semantic tone;
+- an activation signal.
+
+Columns reserve shared space across the menu. If one item has a leading icon, all labels align as though that column exists. The same applies to trailing shortcuts. Separators divide action groups; they are not padding substitutes.
+
+Menus follow these behavior rules:
+
+- the trigger remains selected while its menu is visible;
+- pointer and keyboard selection share one highlighted row;
+- disabled rows are skipped by keyboard navigation;
+- Up/Down move, Enter activates, Escape dismisses;
+- selection begins at the first available item or the action-relevant item;
+- activation dismisses before dispatching an operation that may change the underlying view;
+- destructive actions are grouped and use the danger semantic role;
+- unavailable provider capabilities are omitted rather than disabled;
+- temporary unavailability may be disabled when its reason is apparent.
+
+Menu labels describe the actual scope. `Mark these read` is correct when only loaded messages are affected. Brevity does not justify a broader promise.
+
+## Popups and positioning
+
+Contextual surfaces anchor to the control or row that caused them, not to an arbitrary pointer position unless pointer position is the semantic anchor of a context menu.
+
+Placement follows one algorithm:
+
+1. Open the popup so its contents are instantiated and measured.
+2. Place it on the preferred side of the anchor.
+3. If it overflows on that axis, flip to the opposite side.
+4. Clamp to the far window edge.
+5. Clamp to zero.
+6. Repeat placement whenever the popup size changes.
+
+For a button menu, the anchor is the trigger's edge from `mapToGlobal(0, 0)`. Where inside the control the pointer landed must not move the menu. For a row context menu, pointer position is acceptable because the requested context is spatial and the row itself may be much wider than the menu.
+
+A popup declared outside clipped row content is not visually detached from its owner: the trigger's selected state and stable anchor establish that relationship.
+
+## Overlays, modality, and focus
+
+Use the lightest surface already supported by the application that preserves the task:
+
+- menu: a short choice or command list tied to a trigger;
+- popover: richer contextual content tied to a trigger;
+- page: a substantial workflow that replaces the mail chrome while preserving the window;
+- plain overlay: non-control content such as shortcut help where application actions remain meaningful.
+
+Opening a text-entry surface changes the application key context, and that context focuses the meaningful field. A command popup focuses its content when it implements popup-local navigation under Qt Quick Controls.
+
+Closing a non-popup surface lets the application's resulting key context choose focus. A `QQC.Popup` owns its Escape behavior because Qt consumes that key before the window shortcut map. The two paths must not duplicate each other.
+
+Only the top visible surface receives pointer interaction. Non-modal popups dismiss on outside press. A plain overlay explicitly blocks or forwards pointer input according to its purpose.
+
+## Search and text entry
+
+Search occupies a stable, central place in the header. Focusing it changes the key context; bare mailbox shortcuts stop while text is being entered. Escape clears or leaves search according to the application's single `goBack()` order.
+
+Placeholder text demonstrates query shape without masquerading as existing content. Search results keep the same list row and cursor model as a mailbox so actions behave consistently.
+
+Text fields own typed characters, not application actions. Modified global actions that are valid in text-entry contexts remain routed through the central keymap.
+
+## Settings and forms
+
+Follow [Forms and settings](http://longbridge.github.io/gpui-component/docs/design-guides#forms-and-settings) for control choice, labels, help, validation, submission, and workflow sizing. In Omamail, an independent switch takes effect immediately; account and authentication work remain full pages. Privacy descriptions state what information leaves the machine, who receives it, and whether the choice covers one message, one mailbox, or every mailbox.
+
+## Interface language
+
+Follow [Interface language](http://longbridge.github.io/gpui-component/docs/design-guides#interface-language) for terminology, command labels, confirmation copy, capitalization, punctuation, errors, and localization. Omamail uses the user's mail vocabulary, keeps one term across every surface, and lets the surrounding mailbox or settings context remove redundant words without hiding an action's object, scope, or result.
+
+Project-specific rules take precedence: use three periods in `Settings...`, `Edit...`, and other commands that open another surface or require more input; an immediate command has no ellipsis. Labels must describe their real scope—`Mark these read` does not claim to affect unloaded mail—and provider capabilities that do not exist are omitted rather than explained by a failing command.
+
+## Status and feedback
+
+The status bar answers three questions without opening another surface:
+
+- Is synchronization current or working?
+- Which scope or account is active when that is otherwise hidden?
+- Which actions are immediately available in this context?
+
+Transient notices replace secondary status content rather than stacking a new bar. They expire when the information is no longer useful. Errors that require action persist or lead to the relevant page.
+
+Keyboard hints are generated from the same bindings that execute them. They are contextual and intentionally incomplete: the status bar shows the few actions useful now; the shortcut sheet shows the full map.
+
+Loading preserves layout. Skeletons approximate the structure that will replace them so panes and scroll positions do not jump. Empty states explain what is empty and offer the next relevant action; they do not decorate an otherwise self-explanatory blank pane.
+
+## Accessibility and input parity
+
+Color never carries state alone. Active, unread, selected, destructive, and disabled states also differ through shape, icon, text, weight, or label.
+
+Pointer targets are larger than fine visual marks. Keyboard navigation exposes where it will act. Focused text entry and application action contexts never silently overlap.
+
+Every operation should have one semantic implementation even when several inputs reach it. Input parity does not require every gesture to exist on every device; it requires the operation to remain reachable and to produce the same state transition.
+
+Sender-controlled strings always render as plain text outside the sanitized message body. This is both security behavior and interface behavior: a subject that resembles markup is still a subject.
+
+## Applying these rules
+
+When designing or reviewing a component, ask in order:
+
+1. Which application or domain state does it display?
+2. Which state does it own only for the current interaction?
+3. What semantic intent does it emit?
+4. Which context receives keyboard actions?
+5. What happens when it opens, closes, resizes, or loses its anchor?
+6. How does it behave in wide, medium, and compact modes?
+7. Which theme tokens does it receive from `App.qml`?
+8. Is every sender-controlled string plain text?
+9. Can its decisions be tested without rendering, and which Qt behavior still needs a QML test?
+
+A design that cannot answer these questions is not ready to become a reusable primitive. A feature-specific view may remain specific; clarity is more useful than an abstraction whose name is generic but whose contract knows one caller.

--- a/message/Html.js
+++ b/message/Html.js
@@ -779,39 +779,91 @@ function isTrackingPixel(node) {
   return false
 }
 
-// Tables past this depth become plain blocks. Two levels covers the real
-// tabular content in mail — a status table, a receipt — while the layers above
-// it are only there to centre a card in an Outlook window.
+// Grids past this depth become plain blocks. Two levels covers the real
+// tabular content in mail — a status table, a receipt — and past it Qt is
+// resolving column widths against column widths for no one's benefit.
 var KEEP_TABLE_DEPTH = 2
 var TABLE_PARTS = {
   table: true, thead: true, tbody: true, tfoot: true, tr: true, td: true, th: true
 }
 
-// Depth is what matters, not count. Qt lays tables out by resolving column
-// widths against each other, and deeply nested tables with competing widths —
-// which is exactly how notification mail is built — can keep that resolution
-// going far longer than anyone will wait. Real mail in this mailbox reaches
-// nine levels.
-function flattenTablesIn(node, limit, depth) {
-  var kept = []
+// A table in mail is either the sender's content or the sender's layout, and
+// almost all of them are the layout: a box centring a card in an Outlook
+// window. Depth cannot tell the two apart, because the layout is what wraps
+// the content — counting from the outside kept the scaffolding and flattened
+// the table that meant something. GitHub's build-status table sits three
+// tables down, and its header row came out as "Status", "Job", "Annotations"
+// on three lines of their own.
+//
+// So the question asked of a table is whether it is a **grid**: two rows that
+// each hold more than one cell. That is the whole of what a table can say that
+// a stack of blocks cannot — these cells line up with those. One row of cells
+// is a logo beside a nav, one cell is a box, and neither loses anything by
+// becoming what it already was.
+function rowsOf(node, out) {
   for (var i = 0; i < node.children.length; i++) {
     var child = node.children[i]
-    if (child.type === "text") {
-      kept.push(child)
+    if (child.type === "text") continue
+    // A nested table's rows are its own. They answer this question for it.
+    if (child.name === "table") continue
+    if (child.name === "tr") out.push(child)
+    rowsOf(child, out)
+  }
+  return out
+}
+
+function isGrid(node) {
+  var rows = rowsOf(node, [])
+  var lines = 0
+  for (var i = 0; i < rows.length; i++) {
+    var cells = 0
+    for (var j = 0; j < rows[i].children.length; j++) {
+      var cell = rows[i].children[j]
+      if (cell.type === "text") continue
+      if (cell.name === "td" || cell.name === "th") cells++
+    }
+    if (cells >= 2 && ++lines >= 2) return true
+  }
+  return false
+}
+
+// What is worth keeping off a table that was the layout is the styling that
+// rode on it, not the table semantics.
+function asBlock(node) {
+  var style = attributeValue(node, "style")
+  node.name = "div"
+  node.attrs = style === "" ? [] : [{ name: "style", value: style }]
+}
+
+// The parts belonging to this table, which stops at a nested one: that table
+// has been asked its own question already, and those rows and cells are its.
+function flattenPartsOf(node) {
+  for (var i = 0; i < node.children.length; i++) {
+    var child = node.children[i]
+    if (child.type === "text" || child.name === "table") continue
+    flattenPartsOf(child)
+    if (TABLE_PARTS[child.name] === true) asBlock(child)
+  }
+}
+
+// Depth is what the limit counts, and it counts grids: the boxes on the way
+// down are not tables by the time this returns, and charging them against a
+// budget meant for competing column widths is what put the budget on the
+// wrong two levels in the first place.
+function flattenTablesIn(node, limit, depth) {
+  for (var i = 0; i < node.children.length; i++) {
+    var child = node.children[i]
+    if (child.type === "text") continue
+    if (child.name !== "table") {
+      flattenTablesIn(child, limit, depth)
       continue
     }
-    var childDepth = child.name === "table" ? depth + 1 : depth
-    flattenTablesIn(child, limit, childDepth)
-    if (TABLE_PARTS[child.name] === true && childDepth > limit) {
-      // The layers above a real table exist to position it, so what is worth
-      // keeping is the styling that rode on them, not the table semantics.
-      var style = attributeValue(child, "style")
-      child.name = "div"
-      child.attrs = style === "" ? [] : [{ name: "style", value: style }]
-    }
-    kept.push(child)
+    var keep = depth < limit && isGrid(child)
+    flattenTablesIn(child, limit, keep ? depth + 1 : depth)
+    if (keep) continue
+    flattenPartsOf(child)
+    asBlock(child)
   }
-  node.children = kept
 }
 
 // ================================================================ sanitize
@@ -833,7 +885,19 @@ var MAX_TABLE_DEPTH = 4
 // every element in the document, which on a large message is most of the work.
 var HANDLER_ATTRIBUTE = /^on[a-z]+$/
 
+// The sender centres a 600px card in the middle of a wide window. This reader
+// is a panel of left-aligned text beside a left-aligned list, and the same
+// mail kept centred in it comes out as a column of short lines adrift — the
+// window is the card. Every other alignment is something the panel can honour:
+// a column of numbers reads right, and Arabic reads from the other end.
+//
+// A cell is the exception, because a column lining up is the one thing a grid
+// is kept for.
+var CENTRED = /^center\b/i
+var ALIGNED_BY_COLUMN = { td: true, th: true }
+
 function cleanAttributes(node, keepColors, declarations) {
+  var uncentre = ALIGNED_BY_COLUMN[node.name] !== true
   var attrs = node.attrs
   var kept = attrs
   var dropped = false
@@ -847,6 +911,7 @@ function cleanAttributes(node, keepColors, declarations) {
     // trip through a mail client.
     else if (name.charCodeAt(0) === 111 && HANDLER_ATTRIBUTE.test(name)) drop = true
     else if (name === "href" && !safeHref(attr.value)) drop = true
+    else if (uncentre && name === "align" && CENTRED.test(String(attr.value))) drop = true
 
     if (drop && !dropped) {
       dropped = true
@@ -862,6 +927,7 @@ function cleanAttributes(node, keepColors, declarations) {
   for (var j = 0; j < declarations.length; j++) {
     var declaration = declarations[j]
     if (!keepColors && COLOUR_DECLARATIONS[declaration.name] === true) continue
+    if (uncentre && declaration.name === "text-align" && CENTRED.test(declaration.value)) continue
     if (/url\s*\(/i.test(declaration.value)
       && /url\s*\(/i.test(decodeReferences(declaration.value))) continue
     survivors.push(declaration)
@@ -884,9 +950,10 @@ function cleanAttributes(node, keepColors, declarations) {
 // a box with nothing on it around a single box is that box, and an inline
 // element with nothing on it is nothing at all.
 var TRANSPARENT_INLINE = { span: true, font: true, small: true, big: true }
-// Not <center>: Qt honours it, and a card that was centred would come out
-// against the left edge. A container only counts as plain when it carries no
-// meaning of its own — which is the whole test being applied here.
+// <center> is here because it arrives as a <div>: `clean` renames it, on the
+// same grounds that take `text-align:center` off everything but a cell. A
+// container only counts as plain when it carries no meaning of its own — which
+// is the whole test being applied here.
 var PLAIN_CONTAINER = {
   div: true, section: true, article: true, aside: true,
   header: true, footer: true, main: true, nav: true
@@ -989,6 +1056,9 @@ function sanitize(html, options) {
         continue
       }
       if (DROPPED_ELEMENTS[child.name] === true) continue
+      // <center> is the same instruction spelled as an element, and Qt honours
+      // it. As a plain box it is one more wrapper for `collapse` to fold away.
+      if (child.name === "center") child.name = "div"
 
       // The style attribute is the only one worth parsing, and it is parsed
       // once per element: whether the sender marked this hidden and what
@@ -1185,12 +1255,25 @@ function fitDeclaration(declaration, node, fit) {
     if (name === "padding" || name === "margin")
       return { name: name, value: withoutSides(declaration.value) }
   }
-  if (fit.widths && name === "width" && SIZED_ELEMENTS[node.name] === true) {
-    var pixels = declaration.value.match(/^(\d+)px$/i)
-    if (pixels && Number(pixels[1]) > fit.limit) return null
+  if (fit.widths) {
+    if (name === "width" && SIZED_ELEMENTS[node.name] === true) {
+      var pixels = declaration.value.match(/^(\d+)px$/i)
+      if (pixels && Number(pixels[1]) > fit.limit) return null
+    }
+    // Qt honours this and the reader has nowhere to scroll to, so a line the
+    // sender promised would not wrap is a line that runs off the panel and is
+    // not read. Wrapping is the half of that promise the reader can keep.
+    if (name === "white-space" && /^nowrap\b/i.test(declaration.value)) return null
   }
   return declaration
 }
+
+// Splitting an element's declarations to fit them is most of what a relayout
+// costs, and a relayout happens on every drag of the splitter. Everything the
+// width pass can change says one of two words, so the string is asked before
+// it is parsed. The gutter pass has no such tell — padding, margin and their
+// four sides — and skips the question.
+var FITTABLE_DECLARATION = /width|nowrap/i
 
 // The attribute list an element is written with. The node keeps its own: this
 // is the reader fitting a message to the window it happens to be, and the same
@@ -1200,7 +1283,15 @@ function fitAttributes(node, fit) {
   if (attrs.length === 0) return attrs
   var isImage = fit.heights && node.name === "img"
   var isSized = fit.widths && SIZED_ELEMENTS[node.name] === true
-  if (!isImage && !isSized && !fit.sides) return attrs
+  if (!isImage && !isSized && !fit.sides) {
+    if (!fit.widths) return attrs
+    // Anything can carry white-space:nowrap, so the fast path out of here has
+    // to ask every element about it — and asks with a substring test, because
+    // splitting the declarations of a document that has none is the whole cost
+    // of a relayout for nothing.
+    var carried = attributeOf(node, "style")
+    if (carried === null || String(carried.value).indexOf("nowrap") < 0) return attrs
+  }
 
   var out = null
   for (var i = 0; i < attrs.length; i++) {
@@ -1214,7 +1305,8 @@ function fitAttributes(node, fit) {
     if (isImage && attr.name === "height") replacement = null
     else if (isSized && attr.name === "width" && /^\d+$/.test(String(attr.value))
       && Number(attr.value) > fit.limit) replacement = null
-    else if (attr.name === "style" && attr.value !== null && attr.value !== undefined) {
+    else if (attr.name === "style" && attr.value !== null && attr.value !== undefined
+      && (fit.sides || FITTABLE_DECLARATION.test(String(attr.value)))) {
       var declarations = splitDeclarations(attr.value)
       var kept = []
       var changed = false
@@ -1277,7 +1369,11 @@ function documentFor(bodyHtml, colors) {
   // No parse at all when the caller kept the document: this is rebuilt on every
   // relayout, and the body it is built from has not changed.
   var root = documentTree(bodyHtml)
-  var fit = fitting(true, palette.compact === true, palette.compact === true, maxImage)
+  // The gutters go only when the window is too narrow to spare them, because a
+  // wide one reads better with the sender's own spacing. A width the window
+  // cannot hold goes at every width: there is no horizontal scroll here, so
+  // what overflows is not read at all.
+  var fit = fitting(true, palette.compact === true, maxImage >= MIN_IMAGE_WIDTH, maxImage)
 
   return "<html><head><style type=\"text/css\">"
     + "body{color:" + foreground + ";background-color:" + background + ";}"
@@ -1320,15 +1416,34 @@ var BLOCK_ELEMENTS = {
 // The markers and `imageSources` are numbered by the same walk over the same
 // tree, so the two lists line up position for position. They have to: a marker
 // that disagrees with the list opens somebody else's picture.
+// A run of spaces, tabs and newlines in the source is one space, which is what
+// HTML says it is and what the renderer would have done with it. Kept as
+// written, a template's indentation arrives as gaps in the middle of a
+// sentence — a bank statement came out with its greeting a hand's width from
+// the name it greeted.
+var SOURCE_WHITESPACE = /[ \t\r\n\f]+/g
+
+// A cell ends a line the way a paragraph does, even though a cell is not a
+// block. Without it a row's label and its figure run together into one word,
+// and a statement is nothing but rows.
+var CELL_ELEMENTS = { td: true, th: true }
+
 function flatten(node, state) {
   for (var i = 0; i < node.children.length; i++) {
     var child = node.children[i]
     if (child.type === "text") {
-      if (!child.raw) state.text += decodeReferences(child.text)
+      // Collapsed before the references are decoded, not after: the run in the
+      // source is the template's formatting, while &nbsp;&nbsp; is the sender
+      // spacing something out by hand and decodes to spaces of its own.
+      if (!child.raw) state.text += decodeReferences(child.text.replace(SOURCE_WHITESPACE, " "))
       continue
     }
     if (DROPPED_ELEMENTS[child.name] === true) continue
     if (child.name === "img") {
+      // A beacon is not a picture. Numbered, it becomes a marker offering to
+      // open a 1x1 gif in the middle of the message it was hidden inside — and
+      // the statements that fall back to text are the ones carrying dozens.
+      if (isTrackingPixel(child)) continue
       state.images.push(imageSourceOf(child))
       state.text += "[image " + state.images.length + "]"
       continue
@@ -1339,7 +1454,9 @@ function flatten(node, state) {
     }
     if (child.name === "li") state.text += "• "
     flatten(child, state)
-    if (BLOCK_ELEMENTS[child.name] === true) state.text += "\n"
+    if (BLOCK_ELEMENTS[child.name] === true || CELL_ELEMENTS[child.name] === true) {
+      state.text += "\n"
+    }
   }
   return state
 }
@@ -1352,7 +1469,13 @@ function imageSourceOf(node) {
 function readTree(root) {
   var state = flatten(root, { text: "", images: [] })
   state.text = state.text
-    .replace(/[ \t]+\n/g, "\n")
+    .replace(/[^\S\n]+\n/g, "\n")
+    // A line does not start where the markup was indented. Every box a block
+    // sits inside contributes a space of its own on the way down, so a heading
+    // four tables deep arrived four spaces in — and two spaces are two
+    // non-breaking spaces by the time this is drawn, which is a ragged left
+    // edge down the whole message. The sender indented markup, not text.
+    .replace(/\n[^\S\n]+/g, "\n")
     .replace(/\n{3,}/g, "\n\n")
     .replace(/^\s+|\s+$/g, "")
   return state
@@ -1362,6 +1485,35 @@ function readTree(root) {
 // the pictures those numbers point at.
 function readPlainText(html) {
   return readTree(parse(html))
+}
+
+// Mail is padded with characters that draw nothing. A sender wants the inbox's
+// preview line to end where their first sentence does, so they fill the rest of
+// it with soft hyphens, combining grapheme joiners and zero-width spaces —
+// Linear ships three hundred and sixty of them. Every mail client's list stops
+// there, which is the point; a reader that draws them honestly gets thirty-one
+// blank lines between the greeting and the message.
+//
+// Not U+00A0: a non-breaking space is a space, and spacing is the one thing
+// somebody reading in plain text asked to see.
+var UNDRAWN_CHARACTERS = /[\u00ad\u034f\u061c\u180e\u200b-\u200f\u2060-\u2064\ufeff]/g
+
+// The rest of that padding is whitespace that does draw: figure spaces and
+// non-breaking spaces, twenty-five of each to the line. A line holding nothing
+// else holds nothing — there is no alignment to keep in a line with nothing on
+// it — so it is emptied, and then it is one of a run of blank lines rather than
+// twenty-five columns of nothing.
+var BLANK_LINE = /^[^\S\n]+$/gm
+var BLANK_RUN = /\n{3,}/g
+
+// What the sender wrote, less what nothing draws. One blank line survives a run
+// of them, because that one is a paragraph break.
+function readableText(text) {
+  return String(text === undefined || text === null ? "" : text)
+    .replace(UNDRAWN_CHARACTERS, "")
+    .replace(BLANK_LINE, "")
+    .replace(BLANK_RUN, "\n\n")
+    .replace(/^\s+|\s+$/g, "")
 }
 
 function escapeText(text) {
@@ -1385,7 +1537,7 @@ function plainTextDocument(text, colors, linkImages) {
   var foreground = String(palette.foreground || "")
   var background = String(palette.background || "")
   var link = String(palette.link || foreground)
-  var body = preserveSpacing(escapeText(text))
+  var body = preserveSpacing(escapeText(readableText(text)))
   if (linkImages) {
     body = body.replace(/\[image (\d+)\]/g, function(match, index) {
       return "<a href=\"" + IMAGE_LINK_PREFIX + index + "\">" + match + "</a>"

--- a/tests/test_html.js
+++ b/tests/test_html.js
@@ -115,13 +115,13 @@ const html = load("message/Html.js")
     + "<p>copy</p><img src=\"http://127.0.0.1/x.png\" width=\"90\">"
     + "<img src=\"https://cdn.example.com/real.png\" width=\"90\">"
   const asked = html.sanitize(body, { withPlainText: true })
-  // Numbered off the sender's own tree, before anything is dropped: a message's
-  // third picture is its third picture whether or not the first two were a
-  // beacon and a request to the machine itself.
-  assert.strictEqual(asked.plainText.text, "[image 1]copy\n[image 2][image 3]")
+  // Numbered off the sender's own tree, before the image policy is applied: a
+  // message's second picture is its second picture whether or not the first was
+  // a request to the machine itself. A beacon is the one thing not counted —
+  // it is not a picture, and a marker offering to open one would fire it.
+  assert.strictEqual(asked.plainText.text, "copy\n[image 1][image 2]")
   deepEqual(asked.plainText.images, [
-    "https://track.example.com/p.gif", "http://127.0.0.1/x.png",
-    "https://cdn.example.com/real.png"])
+    "http://127.0.0.1/x.png", "https://cdn.example.com/real.png"])
   // ...while the document itself keeps none of them.
   assert.strictEqual(asked.images, 0)
   assert.ok(asked.html.indexOf("127.0.0.1") < 0)
@@ -140,18 +140,31 @@ const html = load("message/Html.js")
 {
   // A stack of empty wrappers is the innermost thing in it.
   assert.strictEqual(html.sanitize("<div><div><div><p>hi</p></div></div></div>").html, "<p>hi</p>")
-  assert.strictEqual(html.sanitize("<div><table><tr><td>x</td></tr></table></div>").html,
-    "<table><tr><td>x</td></tr></table>")
+  const table = "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>"
+  assert.strictEqual(html.sanitize("<div>" + table + "</div>").html, table)
   // An inline element carrying nothing is nothing.
   assert.strictEqual(html.sanitize("<p><span>a</span>b<font>c</font></p>").html, "<p>abc</p>")
 
   // Anything the wrapper carries is a reason it is there.
   assert.strictEqual(html.sanitize("<div style=\"padding:8px\"><p>hi</p></div>").html,
     "<div style=\"padding:8px\"><p>hi</p></div>")
-  assert.strictEqual(html.sanitize("<div align=\"center\"><p>hi</p></div>").html,
-    "<div align=\"center\"><p>hi</p></div>")
-  // Qt honours <center>, so a card that was centred must not come out left.
-  assert.strictEqual(html.sanitize("<center><p>hi</p></center>").html, "<center><p>hi</p></center>")
+  // Centring is not one of those reasons. The sender centres a 600px card in
+  // the middle of a wide window; the reader is a panel of left-aligned text
+  // beside a left-aligned list, and a newsletter kept centred there comes out
+  // as a column of short lines adrift in it.
+  assert.strictEqual(html.sanitize("<div align=\"center\"><p>hi</p></div>").html, "<p>hi</p>")
+  assert.strictEqual(html.sanitize("<center><p>hi</p></center>").html, "<p>hi</p>")
+  assert.strictEqual(html.sanitize("<p style=\"text-align:center;font-size:9px\">hi</p>").html,
+    "<p style=\"font-size:9px\">hi</p>")
+  // Every other alignment is the sender saying something the panel can honour:
+  // a column of numbers reads right, and Arabic reads from the other end.
+  assert.ok(html.sanitize("<p style=\"text-align:right\">9.00</p>").html
+    .indexOf("text-align:right") > 0)
+  // And a cell keeps even centring: a column lining up is the one thing a grid
+  // is kept for.
+  assert.ok(html.sanitize("<table><tr><th align=\"center\">a</th><th>b</th></tr>"
+    + "<tr><td style=\"text-align:center\">c</td><td>d</td></tr></table>").html
+    .indexOf("text-align:center") > 0)
   // <b> is not <span>: it says something with no attributes at all.
   assert.strictEqual(html.sanitize("<p><b>bold</b></p>").html, "<p><b>bold</b></p>")
 
@@ -195,6 +208,37 @@ const html = load("message/Html.js")
   deepEqual(html.readPlainText("<div title=\"<img src=ghost.png>\">real</div>"),
     { text: "real", images: [] })
   deepEqual(html.readPlainText(""), { text: "", images: [] })
+
+  // HTML collapses a run of whitespace and so does this: a template's
+  // indentation is not the sender spacing anything out, and kept it arrives as
+  // gaps in the middle of sentences.
+  assert.strictEqual(html.readPlainText("<p>Dear\n     Sir,\n  hello</p>").text,
+    "Dear Sir, hello")
+  // A non-breaking space is spacing the sender asked for, and survives.
+  assert.strictEqual(html.readPlainText("a&nbsp;&nbsp;b").text, "a  b")
+
+  // A cell ends a line. Without that a statement's labels and its figures come
+  // out run together on one line each, which is the shape the fallback exists
+  // to avoid.
+  assert.strictEqual(
+    html.readPlainText("<table><tr><td>Period</td><td>2026/07</td></tr>"
+      + "<tr><td>Due</td><td>2026/08/03</td></tr></table>").text,
+    "Period\n2026/07\n\nDue\n2026/08/03")
+
+  // A line does not start where the markup was indented. Every nested tag a
+  // block sits inside contributes a space of its own, so a heading four boxes
+  // down arrived four spaces in — and a run of two is two non-breaking spaces
+  // by the time the fallback is drawn, which is a ragged left edge down the
+  // whole message. The sender indented markup, not text.
+  assert.strictEqual(
+    html.readPlainText("<div>\n  <div>\n    <p>\n      Heading\n    </p>\n  </div>\n</div>").text,
+    "Heading")
+  assert.strictEqual(html.readPlainText("<p>a</p>\n\n   <p>  b</p>").text, "a\nb")
+
+  // A beacon is not a picture, and a marker offering to open one is noise in
+  // the middle of the message it was hidden inside.
+  deepEqual(html.readPlainText("<img src=\"p.gif\" width=\"1\"><img src=\"a.png\">"),
+    { text: "[image 1]", images: ["a.png"] })
 }
 
 // ------------------------------------------------------------- stripping
@@ -215,7 +259,8 @@ assert.strictEqual(html.sanitize("<meta charset='utf-8'>body").html, "body")
 // mail is still table-and-inline-style HTML written for Outlook, which is
 // exactly the subset Qt renders.
 // Layout survives; the sender's palette does not (see the theming block).
-const table = "<table><tr><td style=\"padding:6px\"><b>Total</b></td></tr></table>"
+const table = "<table><tr><td>Item</td><td style=\"padding:6px\"><b>Total</b></td></tr>"
+  + "<tr><td>Tea</td><td>2.00</td></tr></table>"
 assert.strictEqual(html.sanitize(table).html, table)
 assert.strictEqual(html.sanitize("<a href=\"https://example.com\">link</a>").html,
   "<a href=\"https://example.com\">link</a>")
@@ -443,22 +488,41 @@ assert.strictEqual(html.tableDepth(null), 0)
 // Sibling tables are not nesting.
 assert.strictEqual(html.tableDepth("<table></table><table></table>"), 1)
 
-// A shallow table is real tabular content and survives untouched.
-const shallow = "<table><tr><td>Status</td><td>Job</td></tr></table>"
-assert.strictEqual(html.flattenTables(shallow, 2), shallow)
+// A grid survives untouched however deep it sits: two rows that each hold more
+// than one cell is the sender saying "these line up", and nothing else in the
+// message says it.
+const grid = "<table><tr><th>Status</th><th>Job</th></tr><tr><td>ok</td><td>build</td></tr></table>"
+assert.strictEqual(html.flattenTables(grid, 2), grid)
+assert.strictEqual(html.flattenTables("<table><tr><td><table><tr><td>"
+  + grid + "</td></tr></table></td></tr></table>").indexOf("<th>Status</th>") > 0, true,
+  "a grid three tables down is still the message")
 
-// Past the limit the structure becomes plain blocks, keeping the content and
-// whatever styling rode on it.
+// A row of cells is not a grid: one row is how mail lays a logo out beside a
+// nav, and how GitHub centres a card. It becomes plain blocks.
+const strip = "<table><tr><td>logo</td><td>nav</td></tr></table>"
+assert.strictEqual(html.flattenTables(strip, 2).indexOf("<table"), -1)
+assert.ok(html.flattenTables(strip, 2).indexOf("logo") > 0, "the content stays")
+
+// So does a single cell, which is a box and nothing more — with whatever
+// styling rode on it.
 const deep = "<table><tr><td><table><tr><td><table><tr><td style=\"padding:4px\">deep</td></tr></table></td></tr></table></td></tr></table>"
 const flat = html.flattenTables(deep, 2)
-assert.strictEqual(html.tableDepth(flat), 2, "nothing survives past the limit")
+assert.strictEqual(html.tableDepth(flat), 0, "no layout table survives at any depth")
 assert.ok(flat.indexOf("deep") > 0, "the content stays")
 assert.ok(flat.indexOf("padding:4px") > 0, "and so does its styling")
 // Tags balance, or Qt renders the rest of the message inside a stray block.
 assert.strictEqual((flat.match(/<div/g) || []).length, (flat.match(/<\/div>/g) || []).length)
 
+// The depth cap is still the backstop, and it counts the grids that were kept
+// rather than every box on the way down.
+const grids = "<table><tr><td>a</td><td>b</td></tr><tr><td><table><tr><td>c</td><td>d</td></tr>"
+  + "<tr><td><table><tr><td>e</td><td>f</td></tr><tr><td>g</td><td>h</td></tr></table></td></tr>"
+  + "</table></td><td>i</td></tr></table>"
+assert.strictEqual(html.tableDepth(grids), 3)
+assert.strictEqual(html.tableDepth(html.flattenTables(grids, 2)), 2, "nothing survives past the limit")
+
 // sanitize flattens by default; a caller can ask for the original.
-assert.strictEqual(html.complexity(html.sanitize(deep).html).tableDepth, 2)
+assert.strictEqual(html.complexity(html.sanitize(deep).html).tableDepth, 0)
 assert.strictEqual(html.complexity(html.sanitize(deep, { keepTables: true }).html).tableDepth, 3)
 
 // The backstop still catches anything flattening cannot tame.
@@ -504,6 +568,25 @@ assert.ok(bare.indexOf("x</body>") > 0)
   assert.ok(plainDoc.indexOf("&nbsp;&nbsp;spaced") > 0, "hand-made alignment survives")
   assert.ok(plainDoc.indexOf("Hi<br>") > 0, "line breaks survive")
 
+  // A sender pads the inbox's preview line with characters that draw nothing —
+  // soft hyphens and combining grapheme joiners, hundreds of them — so the list
+  // shows one sentence and stops. Linear's text/plain is fifty lines, and
+  // thirty-one of them hold nothing but that padding: rendered honestly, a page
+  // of blank between the greeting and the message.
+  var padded = "Lead sentence.\n\n\u034f \u00ad\u034f\u2007\u00a0\u00ad\u034f\n \u00ad\u034f\n\nBody."
+  assert.strictEqual(html.readableText(padded), "Lead sentence.\n\nBody.")
+  assert.ok(html.plainTextDocument(padded, {}, false).indexOf("Lead sentence.<br><br>Body.") > 0)
+  // One blank line is a paragraph break and stays one.
+  assert.strictEqual(html.readableText("a\n\nb"), "a\n\nb")
+  assert.strictEqual(html.readableText("a\n\n\n\n\nb"), "a\n\nb")
+  // A line the sender indented is still indented, and a single break is single.
+  assert.strictEqual(html.readableText("a\n  b"), "a\n  b")
+  // Spacing inside a line that says something is the sender aligning it.
+  assert.strictEqual(html.readableText("Name\u00a0\u00a0Jane"), "Name\u00a0\u00a0Jane")
+  // A zero-width space inside a word is padding too, and the word closes up.
+  assert.strictEqual(html.readableText("un\u200bsubscribe"), "unsubscribe")
+  assert.strictEqual(html.readableText(null), "")
+
   // A message that shipped its own text/plain part never had images in it.
   assert.ok(html.plainTextDocument("[image 1]", {}, false).indexOf("<a ") < 0,
     "markers are left alone when the text is the sender's own")
@@ -546,8 +629,9 @@ assert.ok(bare.indexOf("x</body>") > 0)
   // narrow pass must not leave its marks on the wide one that follows.
   // Only the table carries 600: a width on an image is the picture's own and is
   // clamped by the stylesheet's max-width instead.
-  var fitted = "<table width=\"600\"><tr><td style=\"padding:4px 30px\">"
-    + "<img src=\"a.png\" width=\"540\" height=\"200\"></td></tr></table>"
+  var fitted = "<table width=\"600\"><tr><td>a</td><td>b</td></tr>"
+    + "<tr><td style=\"padding:4px 30px\">"
+    + "<img src=\"a.png\" width=\"540\" height=\"200\"></td><td>c</td></tr></table>"
   var narrow = html.documentFor(fitted, { maxImageWidth: 380, compact: true })
   var roomy = html.documentFor(fitted, { maxImageWidth: 800, compact: true })
   assert.ok(narrow.indexOf('width="600"') < 0, "600 does not fit in 380")
@@ -557,6 +641,11 @@ assert.ok(bare.indexOf("x</body>") > 0)
     "and the same width twice is the same document")
   // Uncompacted, the sender's gutters are their own again.
   assert.ok(html.documentFor(fitted, { maxImageWidth: 380 }).indexOf("padding:4px 30px") > 0)
+  // A width the window cannot hold is given up at every window, though: the
+  // reader has no horizontal scroll, so what overflows is simply not read.
+  assert.ok(html.documentFor(fitted, { maxImageWidth: 380 }).indexOf('width="600"') < 0)
+  assert.ok(html.documentFor(fitted, { maxImageWidth: 800 }).indexOf('width="600"') > 0,
+    "and one that fits is the sender's own")
   assert.ok(html.documentFor(fitted, { maxImageWidth: 380 }).indexOf('height="200"') < 0,
     "heights come out at every width")
 
@@ -567,6 +656,16 @@ assert.ok(bare.indexOf("x</body>") > 0)
     html.documentFor(built.html, { maxImageWidth: 380, compact: true }))
   assert.strictEqual(html.documentFor(built.document, { maxImageWidth: 800, compact: true })
     .indexOf('width="600"') > 0, true, "and it is still good at the next width")
+
+  // Qt honours white-space:nowrap, and the reader has nowhere to scroll to. A
+  // heading the sender promised would stay on one line is a heading cut off at
+  // the panel's edge — Cloudflare's Chinese subject ran a third of the way past
+  // it. Wrapping is what the reader can honour.
+  var nowrap = "<p style=\"white-space:nowrap;font-size:28px\">a long heading</p>"
+  assert.ok(html.relaxFixedWidths(nowrap, 380).indexOf("nowrap") < 0)
+  assert.ok(html.relaxFixedWidths(nowrap, 380).indexOf("font-size:28px") > 0,
+    "and nothing else about the line changes")
+  assert.ok(html.documentFor(nowrap, { maxImageWidth: 380 }).indexOf("nowrap") < 0)
 
   var relaxed = html.relaxFixedWidths(
     '<table width="600"><td width="100" style="width:640px">x</td></table>', 380)

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -339,3 +339,23 @@ assert.strictEqual(model.wrappedIndex(0, 1, 0), 0, "and no mailboxes must not di
 assert.strictEqual(model.wrappedIndex(-1, 1, 3), 0)
 
 console.log("test_model.js ok")
+
+// ------------------------------------------------------------- reading zoom
+
+// A step lands on a twentieth, so the same scroll back returns to where it was
+// and a saved zoom reads back as the one that was set.
+assert.strictEqual(model.zoomAfterStep(1, 0.1), 1.1)
+assert.strictEqual(model.zoomAfterStep(1.1, -0.1), 1)
+assert.strictEqual(model.zoomAfterStep(1.37, 0), 1.35)
+// The bounds hold however hard the wheel is turned.
+assert.strictEqual(model.zoomAfterStep(2.5, 0.1), 2.5)
+assert.strictEqual(model.zoomAfterStep(0.6, -0.1), 0.6)
+assert.strictEqual(model.zoomAfterStep(99, 0), 2.5)
+
+// What comes back off disk is a file somebody could have edited by hand, and
+// the answer to anything that is not a number is the size it shipped at.
+assert.strictEqual(model.clampZoom(undefined), 1)
+assert.strictEqual(model.clampZoom(null), 1)
+assert.strictEqual(model.clampZoom("nonsense"), 1)
+assert.strictEqual(model.clampZoom(0), 0.6, "but zero is a number, and clamps")
+assert.strictEqual(model.clampZoom("1.5"), 1.5, "including one written as text")


### PR DESCRIPTION
Ten screenshots of messages that did not read right, which turned out to be four
causes. Every one was reproduced by rendering the real body out of the cache on
this machine through Qt at the reader's own width, and checked the same way
afterwards.

## The table that meant something was the one being flattened

`flattenTablesIn` counted depth from the outside and kept two levels. In mail
the layout is what wraps the content, so the two it kept were the boxes
centring a card in an Outlook window and the one it flattened was the message:
GitHub's build status arrived as **Status**, **Job**, **Annotations** on three
lines of their own.

It now asks whether a table is a **grid** — two rows that each hold more than
one cell — which is the whole of what a table can say that a stack of blocks
cannot.

| | before | after |
|---|---|---|
| GitHub Actions | header cells on three lines | a table, with the row under the header |
| Linear release note | 4888px tall, a word to the line | 613px |
| Longbridge statement | one character to the line | prose |
| Google verification code | heavy borders round the title | none — it was a layout table, and its colours had been stripped |

## Three more things the panel cannot honour

- **`white-space:nowrap`** — there is nowhere to scroll to. A Chinese subject
  ran a third of the way past the window's edge. A width wider than the window
  now goes at every window, not only a narrow one, for the same reason.
- **Centring, on everything but a cell** — the sender centres 600px of card in
  a wide window; here that is a column of short lines adrift in a panel of
  otherwise left-aligned text. A cell keeps its alignment, because a column
  lining up is what a grid is kept for.
- **Padding characters that draw nothing** — senders fill the inbox's preview
  line with soft hyphens and combining grapheme joiners so it stops at their
  first sentence. Linear ships 360 of them, and 31 of that message's 50 lines
  held nothing at all.

## The plain-text fallback reads like text

A run of source whitespace is one space, a line does not start where the markup
was indented, a cell ends a line, a beacon is not a picture, and a run of blank
lines is one blank line. Checked against **82 real bodies** out of the cache
here: not one visible character changed, and 56 of them got shorter.

## Two bugs found on the way

- The cache held the extracted text beside the markup, so a message opened
  before kept whatever the build that first fetched it made of it — and that
  text's image markers were numbered by a different walk than the picture list
  beside them, so `[image 3]` could open the fourth picture. Both readings now
  come off the one parse of the cached markup.
- `saveWindowPrefs` dropped a save that arrived while a previous one was still
  running. A sidebar toggle rarely notices; Ctrl and the wheel walk through a
  dozen values a second, and the one most likely to be dropped is the one the
  reader settled on.

## The right-click menu's replies went nowhere

Reply, reply all and forward from the list's menu open the message first and
hold the draft until it arrives — and for any message that had been opened
before, they held it forever. Those paint from the body cache, so the body
changes while the summary is still null; when the network answers, the markup
is the one the cache already rendered, so the body is not written again and the
signal the wait was watching never fires twice. From the outside it looked like
the menu item doing nothing but navigating to the reader.

Whichever half arrives last starts the draft now.

## And the size it is all read at

The body was `bodySmall` (11px) beside a terminal at 9pt, which is twelve — the
one long-form thing in the window was the smallest text on the screen. It is
`body` now, and the zoom that answers the rest of the question is kept in
`window.json` beside the sidebar's state instead of lasting until the window
closes.

Two more answers stop being forgotten: plain text (which lasted until the window
closed) and remote images (which lasted until the next message). Images are the
one with a cost, so the question changes rather than only where its answer is
kept — the notice's button says **Always show** because that is what it now
does, Settings grows a Reading section that turns it back off, and off is still
the default. AGENTS.md carries the new rule and why the old one went.

The list's footer is inset like the rows above it, too.

## Verification

`make test` and `make validate` green. New coverage in `tests/test_html.js`
(grids, fitting, centring, the plain-text reading) and `tests/test_model.js`
(the zoom bounds and what a hand-edited file means).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
