### PR TITLE
app: Unify mail workflows around desktop interaction rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,14 @@ key. What matters while working:
   get big are never the source, so the ceiling is the rule rather than a list of
   banned paths.
 
+## Commits and pull requests
+
+- Follow the GPUI Component title style for pull requests: `<scope>: <Imperative outcome>`. Use a stable module or subsystem name for the lowercase scope; use `app` when one application-level change honestly spans several UI modules.
+- Derive the pull request title from the final `base...HEAD` diff. Do not copy the first commit subject when later commits have broadened or changed the outcome.
+- Rewrite the pull request description whenever its scope changes. It states the user-visible results, the architectural reason and invariants, and the verification actually performed; it does not preserve a chronological list of implementation attempts.
+- Commit subjects remain imperative and outcome-oriented. A commit without one honest dominant scope may remain unprefixed; a conventional prefix never substitutes for a precise result.
+- Markdown prose uses one source line per paragraph. Do not hard-wrap prose to a column width.
+
 ## Releasing
 
 - `scripts/bump.sh 0.2.0` is the whole of it: it sets the manifest version,

--- a/App.qml
+++ b/App.qml
@@ -6,6 +6,7 @@ import qs.Commons
 import qs.Ui
 
 import "account/Model.js" as Model
+import "account/Accounts.js" as Accounts
 import "keys/Keymap.js" as Keymap
 import "components"
 
@@ -35,6 +36,8 @@ Item {
   // foundational palette currently calls that source `urgent`; keeping the
   // mapping here stops account pages from confusing urgency with danger.
   readonly property color danger: Color.urgent
+  readonly property color popupBackground: Color.popups.background
+  readonly property color popupBorder: Color.popups.border
   // Mixed toward the ground rather than Qt.darker: on a light theme darkening
   // an almost-black foreground makes secondary text heavier than body text.
   readonly property color dim: Qt.rgba(
@@ -430,6 +433,7 @@ Item {
     ProviderPicker {
       textColor: root.foreground
       dimColor: root.dim
+      accentColor: root.accent
       panelFontFamily: root.fontFamily
       canLeave: root.anyReady
       onBackRequested: {
@@ -462,6 +466,7 @@ Item {
       textColor: root.foreground
       dimColor: root.dim
       dangerColor: root.danger
+      accentColor: root.accent
       panelFontFamily: root.fontFamily
       canLeave: root.anyReady
       accountCount: root.service ? root.service.accountCount : 1
@@ -478,6 +483,7 @@ Item {
       textColor: root.foreground
       dimColor: root.dim
       dangerColor: root.danger
+      accentColor: root.accent
       panelFontFamily: root.fontFamily
       canLeave: root.anyReady
       accountCount: root.service ? root.service.accountCount : 1
@@ -508,6 +514,15 @@ Item {
   function removeCurrentAccountFromEditor() {
     if (!service || service.accountCount <= 1) return
     var index = service.indexOfActiveAccount()
+    if (index < 0) return
+    var values = service.accountSummaries || []
+    var request = Accounts.removalRequest({ accounts: values }, index)
+    if (request) accountRemovalDialog.openFor(request)
+  }
+
+  function confirmAccountRemoval(request) {
+    if (!service) return
+    var index = Accounts.confirmRemoval({ accounts: service.accountSummaries || [] }, request)
     if (index < 0) return
     service.removeAccountAt(index)
     accountDraftOpen = false
@@ -709,7 +724,7 @@ Item {
             visible: !root.showPage
             iconName: "refresh"
             tooltipText: root.service && root.service.listLoading
-              ? "Checking for mail…" : "Check mail · F5"
+              ? "Checking for mail" : "Check mail · F5"
             foreground: root.dim
             hoverColor: root.foreground
             fontFamily: root.fontFamily
@@ -786,6 +801,7 @@ Item {
           anchors.margins: Style.space(14)
           visible: root.compact && !root.showPage && !root.composing && root.currentView === "list"
           textColor: root.foreground
+          accentColor: root.accent
           panelFontFamily: root.fontFamily
           // The account's own mailboxes, not a fixed set: this row and the
           // sidebar it replaces on a narrow window must offer the same ones.
@@ -907,6 +923,8 @@ Item {
           linkColor: root.link
           dimColor: root.dim
           dimmerColor: root.dimmer
+          popupBackgroundColor: root.popupBackground
+          popupBorderColor: root.popupBorder
           panelFontFamily: root.fontFamily
           zoom: root.bodyZoom
           showBack: root.compact
@@ -940,6 +958,8 @@ Item {
           accentColor: root.accent
           dimColor: root.dim
           dimmerColor: root.dimmer
+          popupBackgroundColor: root.popupBackground
+          popupBorderColor: root.popupBorder
           panelFontFamily: root.fontFamily
           onClosed: root.leaveCompose()
         }
@@ -1062,7 +1082,7 @@ Item {
           foreground: root.dim
           hoverColor: root.foreground
           iconSize: Style.font.iconSmall
-          size: Style.space(20)
+          size: Style.space(24)
           fontFamily: root.fontFamily
           onClicked: root.toggleSidebar()
         }
@@ -1085,10 +1105,8 @@ Item {
           text: {
             if (!root.service) return "Not connected"
             if (!root.ready) return "Not connected"
-            if (root.compact)
-              return root.service.accountEmail + " · " + root.service.inboxUnread + " unread"
-            return Model.statusSummary(root.service.syncedLabel,
-              root.service.resultSummary, root.service.listLoading)
+            if (root.compact) return root.service.accountEmail
+            return Model.statusSummary(root.service.syncedLabel)
           }
           color: root.dim
           font.family: root.fontFamily
@@ -1135,6 +1153,7 @@ Item {
           visible: !statusBar.hasNotice && !root.compact
           textColor: root.foreground
           dimColor: root.dimmer
+          accentColor: root.accent
           panelFontFamily: root.fontFamily
           hints: Keymap.hintsFor(focusScope.keyContext)
         }
@@ -1146,6 +1165,8 @@ Item {
         id: appMenu
         anchors.fill: parent
         textColor: root.foreground
+        popupBackgroundColor: root.popupBackground
+        popupBorderColor: root.popupBorder
         panelFontFamily: root.fontFamily
         signedIn: root.ready
         accountCount: root.service ? root.service.accountCount : 1
@@ -1172,6 +1193,8 @@ Item {
         accentColor: root.accent
         urgentColor: root.urgent
         dimColor: root.dim
+        popupBackgroundColor: root.popupBackground
+        popupBorderColor: root.popupBorder
         panelFontFamily: root.fontFamily
         accounts: root.service ? root.service.accountSummaries : []
         onAccountChosen: function(index) {
@@ -1189,12 +1212,26 @@ Item {
         }
       }
 
+      AccountRemovalDialog {
+        id: accountRemovalDialog
+        anchors.fill: parent
+        textColor: root.foreground
+        dimColor: root.dim
+        dangerColor: root.danger
+        popupBackgroundColor: root.popupBackground
+        popupBorderColor: root.popupBorder
+        panelFontFamily: root.fontFamily
+        onConfirmed: function(request) { root.confirmAccountRemoval(request) }
+      }
+
       MessageMenu {
         id: rowMenu
         service: root.service
         textColor: root.foreground
         urgentColor: root.urgent
         dimColor: root.dim
+        popupBackgroundColor: root.popupBackground
+        popupBorderColor: root.popupBorder
         panelFontFamily: root.fontFamily
         onComposeRequested: function(mode, id) {
           root.composeReturnView = root.currentView

--- a/App.qml
+++ b/App.qml
@@ -616,6 +616,7 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         height: Style.space(48)
+        visible: !root.composing
 
         // Identity first, controls after, with a rule between them: the mark
         // and the name say what this window is, and everything to their right
@@ -690,7 +691,8 @@ Item {
             width: Math.min(Style.space(340), parent.width)
             // Below this it is a slot too small to type in; the shortcut still
             // works and reopens it as the window grows.
-            visible: !root.showPage && parent.width >= Style.space(120)
+            visible: !root.showPage && !root.composing
+              && parent.width >= Style.space(120)
           textColor: root.foreground
           accentColor: root.accent
           panelFontFamily: root.fontFamily
@@ -721,7 +723,7 @@ Item {
           // own, and it stays on the left with the mark.
           IconButton {
             anchors.verticalCenter: parent.verticalCenter
-            visible: !root.showPage
+            visible: !root.showPage && !root.composing
             iconName: "refresh"
             tooltipText: root.service && root.service.listLoading
               ? "Checking for mail" : "Check mail · F5"
@@ -734,7 +736,7 @@ Item {
 
           IconButton {
             anchors.verticalCenter: parent.verticalCenter
-            visible: !root.showPage
+            visible: !root.showPage && !root.composing
             iconName: "send"
             tooltipText: "Compose · c"
             foreground: root.dim
@@ -760,7 +762,7 @@ Item {
 
       Item {
         id: body
-        anchors.top: header.bottom
+        anchors.top: header.visible ? header.bottom : parent.top
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: statusBar.top
@@ -925,6 +927,7 @@ Item {
           dimmerColor: root.dimmer
           popupBackgroundColor: root.popupBackground
           popupBorderColor: root.popupBorder
+          leadingBoundaryOverlap: listSplitter.visible ? listSplitter.width : 0
           panelFontFamily: root.fontFamily
           zoom: root.bodyZoom
           showBack: root.compact

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/ListSkeleton.qml \
 	components/MessageRow.qml \
 	components/MessageMenu.qml \
+	components/MenuActionRow.qml components/MenuSeparatorLine.qml \
 	components/KeyRouter.qml \
 	components/ActionIcon.qml \
 	components/IconButton.qml \
@@ -28,6 +29,7 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/SearchBar.qml \
 	components/AppMenu.qml \
 	components/AccountSwitcher.qml \
+	components/AccountRemovalDialog.qml \
 	components/BackBar.qml \
 	components/UserBar.qml \
 	components/SettingsPage.qml \
@@ -52,6 +54,7 @@ test-js:
 	node tests/test_model.js
 	node tests/test_keymap.js
 	node tests/test_accounts.js
+	node tests/test_menu.js
 	node tests/test_provider.js
 	node tests/test_imap.js
 

--- a/account/Accounts.js
+++ b/account/Accounts.js
@@ -240,6 +240,29 @@ function removeAt(list, index) {
   return source
 }
 
+// The request is an immutable description of the row the user saw. Keeping
+// both its id and position lets confirmation reject a stale request instead of
+// deleting whichever account later moved into the same row.
+function removalRequest(list, index) {
+  var values = Array.isArray((list || {}).accounts) ? list.accounts : []
+  if (values.length <= 1) return null
+  var at = Math.floor(Number(index))
+  if (!isFinite(at) || at < 0 || at >= values.length) return null
+  var entry = values[at] || {}
+  if (!entry.id) return null
+  return { id: String(entry.id || ""), email: String(entry.email || ""), index: at }
+}
+
+function confirmRemoval(list, request) {
+  if (!request) return -1
+  var values = Array.isArray((list || {}).accounts) ? list.accounts : []
+  var at = Math.floor(Number(request.index))
+  if (!isFinite(at) || at < 0 || at >= values.length) return -1
+  var entry = values[at] || {}
+  var id = String(request.id || "")
+  return id !== "" && String(entry.id || "") === id ? at : -1
+}
+
 function discardDraftAt(list, index) {
   var source = copyList(list)
   var at = Math.floor(Number(index))

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -243,7 +243,7 @@ Item {
   property int syncTick: 0
   readonly property string syncedLabel: {
     var ignored = syncTick
-    if (listLoading) return "Checking for mail…"
+    if (listLoading) return "Checking for mail"
     if (lastSyncedMs <= 0) return ""
     var ago = Mail.relativeTime(new Date(lastSyncedMs), new Date())
     return ago === "now" ? "Synced just now" : "Synced " + ago + " ago"

--- a/account/Model.js
+++ b/account/Model.js
@@ -426,13 +426,8 @@ function resultSummary(list, estimate, hasMore) {
   return shown + " of about " + total
 }
 
-function statusSummary(syncLabel, resultLabel, loading) {
-  var sync = String(syncLabel || "")
-  var result = String(resultLabel || "")
-  if (loading) return sync
-  if (!sync) return result
-  if (!result) return sync
-  return sync + "  ·  " + result
+function statusSummary(syncLabel) {
+  return String(syncLabel || "")
 }
 
 function truncate(text, limit) {

--- a/components/AccountRemovalDialog.qml
+++ b/components/AccountRemovalDialog.qml
@@ -1,0 +1,89 @@
+import QtQuick
+import QtQuick.Controls as QQC
+import qs.Commons
+import qs.Ui
+
+Item {
+  id: root
+
+  required property color textColor
+  required property color dimColor
+  required property color dangerColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
+  required property string panelFontFamily
+  property var request: null
+  readonly property bool opened: dialog.opened
+
+  signal confirmed(var request)
+
+  anchors.fill: parent
+  z: 80
+
+  function openFor(value) {
+    request = value
+    if (request) dialog.open()
+  }
+
+  function close() { dialog.close() }
+
+  QQC.Popup {
+    id: dialog
+    anchors.centerIn: parent
+    width: Math.min(Style.space(360), parent.width - Style.space(32))
+    padding: Style.space(18)
+    modal: true
+    focus: true
+    closePolicy: QQC.Popup.CloseOnEscape
+    onClosed: root.request = null
+    background: Rectangle {
+      radius: Style.cornerRadius
+      color: root.popupBackgroundColor
+      border.width: 1
+      border.color: root.popupBorderColor
+    }
+    contentItem: Column {
+      spacing: Style.space(14)
+
+      Text {
+        width: parent.width
+        textFormat: Text.PlainText
+        text: "Remove " + String(root.request ? root.request.email : "") + "?"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.heading
+        font.bold: true
+        wrapMode: Text.Wrap
+      }
+      Text {
+        width: parent.width
+        textFormat: Text.PlainText
+        text: "This mailbox will be removed from Omamail."
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        wrapMode: Text.Wrap
+      }
+      Row {
+        anchors.right: parent.right
+        spacing: Style.space(8)
+        Button {
+          text: "Cancel"
+          foreground: root.textColor
+          bordered: false
+          onClicked: dialog.close()
+        }
+        Button {
+          text: "Remove"
+          foreground: root.dangerColor
+          bordered: false
+          onClicked: {
+            var value = root.request
+            dialog.close()
+            if (value) root.confirmed(value)
+          }
+        }
+      }
+    }
+  }
+}

--- a/components/AccountSwitcher.qml
+++ b/components/AccountSwitcher.qml
@@ -3,14 +3,14 @@ import QtQuick.Controls as QQC
 import qs.Commons
 import qs.Ui
 import "../account/Model.js" as Model
+import "Menu.js" as Menu
 
 // The list of mailboxes, opened from the user bar.
 //
 // Switching is meant to be instant, which it is because every account keeps its
-// own cache — so this shows each one's unread count even while you are looking
-// at another, and says which is being checked right now. An account that has
-// not finished signing in is listed too, because otherwise a half-added
-// mailbox becomes invisible and unfixable.
+// own cache. It says which is being checked right now and keeps a mailbox that
+// has not finished signing in visible, because otherwise a half-added mailbox
+// becomes invisible and unfixable.
 Item {
   id: root
 
@@ -18,6 +18,8 @@ Item {
   required property color accentColor
   required property color urgentColor
   required property color dimColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
   required property string panelFontFamily
 
   // [{ id, email, label, unread, active, signedIn, busy, error }]
@@ -59,15 +61,9 @@ Item {
   function place() {
     if (!menu.visible) return
     var tall = menu.height > 0 ? menu.height : menu.implicitHeight
-    var x = Math.max(0, Math.min(anchorX, root.width - menu.width))
-    var y = anchorY
-    // Below the click by preference, above it if that would overflow, and
-    // pinned to the bottom edge if the menu is taller than the room either way.
-    if (y + tall > root.height) y = anchorY - tall
-    if (y + tall > root.height) y = root.height - tall
-    if (y < 0) y = 0
-    menu.x = x
-    menu.y = y
+    var placed = Menu.position(anchorX, anchorY, menu.width, tall, root.width, root.height)
+    menu.x = placed.x
+    menu.y = placed.y
   }
 
   // Opened from a menu rather than from a click on the rail, so there is no
@@ -120,9 +116,9 @@ Item {
     }
     background: Rectangle {
       radius: Style.cornerRadius
-      color: Color.popups.background
+      color: root.popupBackgroundColor
       border.width: 1
-      border.color: Color.popups.border
+      border.color: root.popupBorderColor
     }
 
     // The one place in this window that answers keys itself, and the reason is
@@ -203,8 +199,8 @@ Item {
           Column {
             anchors.left: rowAvatar.right
             anchors.leftMargin: Style.space(9)
-            anchors.right: rowCount.left
-            anchors.rightMargin: Style.space(6)
+            anchors.right: parent.right
+            anchors.rightMargin: Style.space(10)
             anchors.verticalCenter: parent.verticalCenter
             spacing: Style.space(1)
 
@@ -231,8 +227,8 @@ Item {
               text: {
                 if (row.modelData.error !== undefined && row.modelData.error !== "")
                   return row.modelData.error
-                if (!row.modelData.signedIn) return "Not signed in"
-                if (row.modelData.busy) return "Checking…"
+                if (!row.modelData.signedIn) return "Signed out"
+                if (row.modelData.busy) return "Checking"
                 // Only when it says something the address does not.
                 var name = String(row.modelData.label || "")
                 return name !== "" && row.modelData.email.indexOf(name) !== 0 ? name : ""
@@ -245,20 +241,7 @@ Item {
             }
           }
 
-          Text {
-            id: rowCount
-            anchors.right: parent.right
-            anchors.rightMargin: Style.space(10)
-            anchors.verticalCenter: parent.verticalCenter
-            visible: row.modelData.unread > 0
-            text: row.modelData.unread > 999 ? "999+" : row.modelData.unread
-            color: root.accentColor
-            font.family: root.panelFontFamily
-            font.pixelSize: Style.font.caption
-            font.bold: true
-          }
-
-          HoverHandler { id: rowHover; cursorShape: Qt.PointingHandCursor }
+          HoverHandler { id: rowHover }
           TapHandler {
             onTapped: {
               menu.close()
@@ -322,7 +305,7 @@ Item {
       elide: Text.ElideRight
     }
 
-    HoverHandler { id: plainHover; cursorShape: Qt.PointingHandCursor }
+    HoverHandler { id: plainHover }
     TapHandler { onTapped: plainRow.activated() }
   }
 }

--- a/components/AppMenu.qml
+++ b/components/AppMenu.qml
@@ -2,12 +2,15 @@ import QtQuick
 import QtQuick.Controls as QQC
 import qs.Commons
 import qs.Ui
+import "Menu.js" as Menu
 
 // Links out, plus the handful of actions that have no natural home on screen.
 Item {
   id: root
 
   required property color textColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
   required property string panelFontFamily
   property bool signedIn: false
   // The rail carries the switcher, and the rail is gone at a narrow window —
@@ -24,6 +27,9 @@ Item {
   // Where the menu was asked to appear, kept because it cannot be placed yet.
   property real anchorX: 0
   property real anchorY: 0
+  property int cursorIndex: -1
+  readonly property var menuRows: [markRow, webRow, switchRow, settingsRow,
+    shortcutsRow, projectRow, authorRow]
 
   function openAt(sceneX, sceneY) {
     var local = root.mapFromGlobal(sceneX, sceneY)
@@ -41,14 +47,20 @@ Item {
   function place() {
     if (!menu.visible) return
     var tall = menu.height > 0 ? menu.height : menu.implicitHeight
-    var x = Math.max(0, Math.min(anchorX, root.width - menu.width))
-    var y = anchorY
-    if (y + tall > root.height) y = anchorY - tall
-    if (y + tall > root.height) y = root.height - tall
-    if (y < 0) y = 0
-    menu.x = x
-    menu.y = y
+    var placed = Menu.position(anchorX, anchorY, menu.width, tall, root.width, root.height)
+    menu.x = placed.x
+    menu.y = placed.y
   }
+
+  function selectableRows() {
+    var values = []
+    for (var i = 0; i < menuRows.length; i++) values.push({
+      selectable: true, visible: menuRows[i].visible, enabled: menuRows[i].enabled
+    })
+    return values
+  }
+  function moveCursor(step) { cursorIndex = Menu.nextSelectable(selectableRows(), cursorIndex, step) }
+  function runCursor() { if (cursorIndex >= 0) menuRows[cursorIndex].activated() }
 
   function close() { menu.close() }
 
@@ -84,18 +96,34 @@ Item {
     focus: true
     closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
     onHeightChanged: root.place()
-    onOpened: root.place()
+    onOpened: {
+      root.cursorIndex = Menu.firstSelectable(root.selectableRows())
+      root.place()
+    }
     background: Rectangle {
       radius: Style.cornerRadius
-      color: Color.popups.background
+      color: root.popupBackgroundColor
       border.width: 1
-      border.color: Color.popups.border
+      border.color: root.popupBorderColor
     }
     contentItem: Column {
       id: menuItems
       spacing: Style.space(2)
 
+      focus: true
+      Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_J || event.key === Qt.Key_Down) {
+          root.moveCursor(1); event.accepted = true
+        } else if (event.key === Qt.Key_K || event.key === Qt.Key_Up) {
+          root.moveCursor(-1); event.accepted = true
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter
+            || event.key === Qt.Key_O) {
+          root.runCursor(); event.accepted = true
+        }
+      }
+
       MenuRow {
+        id: markRow
         // "These" and not "all": it marks the messages that are loaded, which
         // is what you are looking at, not every message the mailbox holds.
         text: "Mark these read"
@@ -103,79 +131,59 @@ Item {
         onActivated: { menu.close(); root.markAllReadRequested() }
       }
       MenuRow {
-        text: "Open in Gmail"
+        id: webRow
+        text: "Open web inbox..."
         enabled: root.signedIn
         onActivated: { menu.close(); root.openWebRequested() }
       }
 
-      Separator {}
+      MenuSeparatorLine {
+        width: menu.width - menu.leftPadding - menu.rightPadding
+        lineColor: root.textColor
+      }
 
       MenuRow {
+        id: switchRow
         text: "Switch account..."
         visible: root.accountCount > 1
         onActivated: { menu.close(); root.switchAccountRequested() }
       }
       MenuRow {
+        id: settingsRow
         text: "Settings..."
         onActivated: { menu.close(); root.setupRequested() }
       }
 
-      Separator {}
+      MenuSeparatorLine {
+        width: menu.width - menu.leftPadding - menu.rightPadding
+        lineColor: root.textColor
+      }
 
       MenuRow {
-        text: "Shortcuts"
+        id: shortcutsRow
+        text: "Keyboard shortcuts..."
         onActivated: { menu.close(); root.shortcutsRequested() }
       }
       MenuRow {
-        text: "GitHub"
+        id: projectRow
+        text: "Project on GitHub..."
         onActivated: { menu.close(); root.projectRequested() }
       }
       MenuRow {
-        text: "Twitter"
+        id: authorRow
+        text: "Author on X..."
         onActivated: { menu.close(); root.authorRequested() }
       }
     }
   }
 
-  component Separator: Item {
-    width: menu.width - menu.leftPadding - menu.rightPadding
-    implicitHeight: Style.space(7)
-    PanelSeparator {
-      anchors.verticalCenter: parent.verticalCenter
-      width: parent.width
-      foreground: root.textColor
-    }
-  }
-
   // `enabled` is Item's own, and it already stops the handlers below from
   // firing, so a disabled row only has to look disabled.
-  component MenuRow: Rectangle {
-    id: row
-    required property string text
-    signal activated()
-
+  component MenuRow: MenuActionRow {
     width: menu.width - menu.leftPadding - menu.rightPadding
-    implicitHeight: Style.spacing.popupRowHeight
-    radius: Style.cornerRadius
-    opacity: row.enabled ? 1.0 : 0.4
-    color: hover.hovered
-      ? Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.08)
-      : "transparent"
-
-    Text {
-      anchors.left: parent.left
-      anchors.leftMargin: Style.space(9)
-      anchors.right: parent.right
-      anchors.rightMargin: Style.space(9)
-      anchors.verticalCenter: parent.verticalCenter
-      text: row.text
-      color: root.textColor
-      font.family: root.panelFontFamily
-      font.pixelSize: Style.font.bodySmall
-      elide: Text.ElideRight
-    }
-
-    HoverHandler { id: hover; cursorShape: Qt.PointingHandCursor }
-    TapHandler { onTapped: row.activated() }
+    textColor: root.textColor
+    panelFontFamily: root.panelFontFamily
+    collection: root.menuRows
+    cursorIndex: root.cursorIndex
   }
 }

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -216,10 +216,7 @@ Item {
 
     Row {
       id: titleRow
-      anchors.left: backBar.right
-      anchors.leftMargin: Style.space(16)
-      anchors.right: parent.right
-      anchors.rightMargin: Style.space(18)
+      anchors.horizontalCenter: parent.horizontalCenter
       anchors.verticalCenter: parent.verticalCenter
       spacing: Style.space(10)
 
@@ -283,9 +280,11 @@ Item {
         text: root.fromEmail
         foreground: root.textColor
         accent: root.accentColor
+        background: Style.normalFillFor(root.textColor, root.accentColor)
         bordered: true
         fontFamily: root.panelFontFamily
         fontSize: Style.font.bodySmall
+        verticalPadding: Style.spacing.inputPaddingY
         leftAlign: true
         selected: fromMenu.opened
         enabled: root.fromAliases.length > 1

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -29,7 +29,6 @@ Item {
   readonly property int formInset: Style.space(18)
   readonly property int formLabelWidth: Style.space(52)
   readonly property int formLabelGap: Style.space(10)
-  readonly property int fieldContentInset: formInset + formLabelWidth + formLabelGap
 
   property bool opened: false
   property string mode: "new"
@@ -217,8 +216,8 @@ Item {
 
     Row {
       id: titleRow
-      anchors.left: parent.left
-      anchors.leftMargin: root.fieldContentInset
+      anchors.left: backBar.right
+      anchors.leftMargin: Style.space(16)
       anchors.right: parent.right
       anchors.rightMargin: Style.space(18)
       anchors.verticalCenter: parent.verticalCenter
@@ -284,6 +283,7 @@ Item {
         text: root.fromEmail
         foreground: root.textColor
         accent: root.accentColor
+        bordered: true
         fontFamily: root.panelFontFamily
         fontSize: Style.font.bodySmall
         leftAlign: true

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -22,6 +22,8 @@ Item {
   required property color accentColor
   required property color dimColor
   required property color dimmerColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
   required property string panelFontFamily
 
   property bool opened: false
@@ -489,9 +491,9 @@ Item {
     onOpened: root.placeFromMenu()
     background: Rectangle {
       radius: Style.cornerRadius
-      color: Color.popups.background
+      color: root.popupBackgroundColor
       border.width: 1
-      border.color: Color.popups.border
+      border.color: root.popupBorderColor
     }
 
     contentItem: ListView {
@@ -544,7 +546,7 @@ Item {
           }
         }
 
-        HoverHandler { id: fromHover; cursorShape: Qt.PointingHandCursor }
+        HoverHandler { id: fromHover }
         TapHandler { onTapped: root.chooseFrom(fromRow.modelData.email) }
       }
     }
@@ -612,7 +614,7 @@ Item {
       IconTextButton {
         iconName: "send"
         tooltipText: "Send · Ctrl+Enter"
-        text: root.service && root.service.sending ? "Sending…" : "Send"
+        text: root.service && root.service.sending ? "Sending" : "Send"
         foreground: root.textColor
         fontFamily: root.panelFontFamily
         enabled: !!root.service && !root.service.sending

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -26,6 +26,11 @@ Item {
   required property color popupBorderColor
   required property string panelFontFamily
 
+  readonly property int formInset: Style.space(18)
+  readonly property int formLabelWidth: Style.space(52)
+  readonly property int formLabelGap: Style.space(10)
+  readonly property int fieldContentInset: formInset + formLabelWidth + formLabelGap
+
   property bool opened: false
   property string mode: "new"
   property string threadId: ""
@@ -41,16 +46,10 @@ Item {
   }
 
   readonly property string title: {
-    if (mode === "reply") return "REPLY"
-    if (mode === "replyAll") return "REPLY ALL"
-    if (mode === "forward") return "FORWARD"
-    return "NEW MESSAGE"
-  }
-  readonly property string iconName: {
-    if (mode === "reply") return "reply"
-    if (mode === "replyAll") return "replyAll"
-    if (mode === "forward") return "forward"
-    return "unread"
+    if (mode === "reply") return "Reply"
+    if (mode === "replyAll") return "Reply all"
+    if (mode === "forward") return "Forward"
+    return "New message"
   }
 
   function reset() {
@@ -195,25 +194,21 @@ Item {
 
   // ----------------------------------------------------------- header
   //
-  // There is no client-side titlebar under Hyprland, so the window has to
-  // say what it is itself.
+  // One compact title band. Back is the exit path and the title names the
+  // draft; splitting them into two stacked bands gave one short decision the
+  // hierarchy of a whole settings page.
   Item {
     id: head
     anchors.top: parent.top
     anchors.left: parent.left
     anchors.right: parent.right
-    height: backBar.implicitHeight + Style.space(14) + titleRow.implicitHeight
-      + Style.space(24)
+    height: Style.space(44)
 
-    // Its own line, level with the reader's and the setup page's. Sharing a
-    // line with the title made it read as part of the title on this page and
-    // as a page control on the others.
     BackBar {
       id: backBar
       anchors.left: parent.left
       anchors.leftMargin: Style.space(14)
-      anchors.top: parent.top
-      anchors.topMargin: Style.space(12)
+      anchors.verticalCenter: parent.verticalCenter
       textColor: root.textColor
       dimColor: root.dimColor
       panelFontFamily: root.panelFontFamily
@@ -223,36 +218,17 @@ Item {
     Row {
       id: titleRow
       anchors.left: parent.left
-      anchors.leftMargin: Style.space(14)
+      anchors.leftMargin: root.fieldContentInset
       anchors.right: parent.right
       anchors.rightMargin: Style.space(18)
-      anchors.top: backBar.bottom
-      anchors.topMargin: Style.space(14)
+      anchors.verticalCenter: parent.verticalCenter
       spacing: Style.space(10)
-
-      ActionIcon {
-        anchors.verticalCenter: parent.verticalCenter
-        name: root.iconName
-        iconSize: Style.font.icon
-        color: root.textColor
-      }
 
       PanelSectionHeader {
         anchors.verticalCenter: parent.verticalCenter
         text: root.title
         foreground: root.textColor
         fontFamily: root.panelFontFamily
-      }
-
-      Text {
-        anchors.verticalCenter: parent.verticalCenter
-        visible: root.mode !== "new"
-        textFormat: Text.PlainText
-        text: subjectField.text
-        color: root.dimmerColor
-        font.family: root.panelFontFamily
-        font.pixelSize: Style.font.caption
-        elide: Text.ElideRight
       }
     }
 
@@ -281,9 +257,9 @@ Item {
       Text {
         id: fromLabel
         anchors.left: parent.left
-        anchors.leftMargin: Style.space(18)
+        anchors.leftMargin: root.formInset
         anchors.verticalCenter: parent.verticalCenter
-        width: Style.space(52)
+        width: root.formLabelWidth
         horizontalAlignment: Text.AlignRight
         text: "From"
         color: root.dimColor
@@ -301,7 +277,7 @@ Item {
           ? Style.font.iconSmall + Style.spacing.controlGap : 0
 
         anchors.left: fromLabel.right
-        anchors.leftMargin: Style.space(10)
+        anchors.leftMargin: root.formLabelGap
         anchors.verticalCenter: parent.verticalCenter
         width: Math.min(implicitWidth + trailing,
           parent.width - fromLabel.width - Style.space(46))
@@ -347,9 +323,9 @@ Item {
       Text {
         id: toLabel
         anchors.left: parent.left
-        anchors.leftMargin: Style.space(18)
+        anchors.leftMargin: root.formInset
         anchors.verticalCenter: parent.verticalCenter
-        width: Style.space(52)
+        width: root.formLabelWidth
         horizontalAlignment: Text.AlignRight
         text: "To"
         color: root.dimColor
@@ -372,7 +348,7 @@ Item {
       TextField {
         id: toField
         anchors.left: toLabel.right
-        anchors.leftMargin: Style.space(10)
+        anchors.leftMargin: root.formLabelGap
         anchors.right: ccToggle.left
         anchors.rightMargin: Style.space(8)
         anchors.verticalCenter: parent.verticalCenter
@@ -403,9 +379,9 @@ Item {
       Text {
         id: ccLabel
         anchors.left: parent.left
-        anchors.leftMargin: Style.space(18)
+        anchors.leftMargin: root.formInset
         anchors.verticalCenter: parent.verticalCenter
-        width: Style.space(52)
+        width: root.formLabelWidth
         horizontalAlignment: Text.AlignRight
         text: "Cc"
         color: root.dimColor
@@ -416,7 +392,7 @@ Item {
       TextField {
         id: ccField
         anchors.left: ccLabel.right
-        anchors.leftMargin: Style.space(10)
+        anchors.leftMargin: root.formLabelGap
         anchors.right: parent.right
         anchors.rightMargin: Style.space(18)
         anchors.verticalCenter: parent.verticalCenter
@@ -445,9 +421,9 @@ Item {
       Text {
         id: subjectLabel
         anchors.left: parent.left
-        anchors.leftMargin: Style.space(18)
+        anchors.leftMargin: root.formInset
         anchors.verticalCenter: parent.verticalCenter
-        width: Style.space(52)
+        width: root.formLabelWidth
         horizontalAlignment: Text.AlignRight
         text: "Subject"
         color: root.dimColor
@@ -458,7 +434,7 @@ Item {
       TextField {
         id: subjectField
         anchors.left: subjectLabel.right
-        anchors.leftMargin: Style.space(10)
+        anchors.leftMargin: root.formLabelGap
         anchors.right: parent.right
         anchors.rightMargin: Style.space(18)
         anchors.verticalCenter: parent.verticalCenter
@@ -630,15 +606,6 @@ Item {
       }
     }
 
-    Text {
-      anchors.right: parent.right
-      anchors.rightMargin: Style.space(18)
-      anchors.verticalCenter: parent.verticalCenter
-      text: "Ctrl+Enter sends · Esc closes"
-      color: root.dimmerColor
-      font.family: root.panelFontFamily
-      font.pixelSize: Style.font.caption
-    }
   }
 
 }

--- a/components/IconButton.qml
+++ b/components/IconButton.qml
@@ -49,7 +49,6 @@ Rectangle {
     id: mouse
     anchors.fill: parent
     hoverEnabled: true
-    cursorShape: Qt.PointingHandCursor
     onClicked: root.clicked()
   }
 

--- a/components/IconButton.qml
+++ b/components/IconButton.qml
@@ -5,7 +5,7 @@ import qs.Ui
 // A drawn icon on the kit's shared hover/cursor surface. qs.Ui's
 // PanelActionButton takes a font glyph, and this app's icons are Canvas paths,
 // so this is that button with the glyph swapped for an ActionIcon.
-Rectangle {
+Item {
   id: root
 
   property string iconName: ""
@@ -21,6 +21,7 @@ Rectangle {
   property bool selected: false
   property real iconSize: Style.font.icon
   property real size: Math.max(Style.space(24), iconSize + Style.spacing.sm * 2)
+  property real visualInset: Style.space(2)
   property string fontFamily: Style.font.family
 
   signal clicked()
@@ -31,11 +32,16 @@ Rectangle {
   implicitHeight: size
   width: size
   height: size
-  radius: Style.cornerRadius
   opacity: enabled ? 1.0 : 0.4
-  color: mouse.pressed ? Style.pressedFillFor(root.foreground, root.accent)
-    : (root.selected ? Style.selectedFillFor(root.foreground, root.accent)
-      : (hot ? Style.hoverFillFor(root.foreground, root.accent) : "transparent"))
+
+  Rectangle {
+    anchors.fill: parent
+    anchors.margins: root.visualInset
+    radius: Style.cornerRadius
+    color: mouse.pressed ? Style.pressedFillFor(root.foreground, root.accent)
+      : (root.selected ? Style.selectedFillFor(root.foreground, root.accent)
+        : (root.hot ? Style.hoverFillFor(root.foreground, root.accent) : "transparent"))
+  }
 
   ActionIcon {
     anchors.centerIn: parent

--- a/components/IconTextButton.qml
+++ b/components/IconTextButton.qml
@@ -70,7 +70,6 @@ Rectangle {
     id: mouse
     anchors.fill: parent
     hoverEnabled: true
-    cursorShape: Qt.PointingHandCursor
     onClicked: root.clicked()
   }
 

--- a/components/ImagePopover.qml
+++ b/components/ImagePopover.qml
@@ -15,6 +15,8 @@ Item {
 
   required property color textColor
   required property color dimColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
   required property string panelFontFamily
 
   property string source: ""
@@ -61,9 +63,9 @@ Item {
 
     background: Rectangle {
       radius: Style.cornerRadius
-      color: Color.popups.background
+      color: root.popupBackgroundColor
       border.width: 1
-      border.color: Color.popups.border
+      border.color: root.popupBorderColor
     }
 
     Column {
@@ -93,7 +95,7 @@ Item {
           visible: root.refused || picture.status !== Image.Ready
           text: root.refused
             ? "That image is not on the public internet, so it was not fetched"
-            : (picture.status === Image.Error ? "That image could not be loaded" : "Loading…")
+            : (picture.status === Image.Error ? "That image could not be loaded" : "Loading")
           color: root.dimColor
           font.family: root.panelFontFamily
           font.pixelSize: Style.font.bodySmall

--- a/components/ImapSetupPage.qml
+++ b/components/ImapSetupPage.qml
@@ -18,6 +18,7 @@ Column {
   required property color textColor
   required property color dimColor
   required property color dangerColor
+  required property color accentColor
   required property string panelFontFamily
   property bool canLeave: false
   property int accountCount: 1
@@ -164,9 +165,9 @@ Column {
     visible: root.toolsMissing
     implicitHeight: missingText.implicitHeight + Style.space(20)
     radius: Style.cornerRadius
-    color: Style.normalFillFor(root.textColor, Color.accent)
+    color: Style.normalFillFor(root.textColor, root.accentColor)
     border.width: 1
-    border.color: Style.hoverBorderFor(root.textColor, Color.accent)
+    border.color: Style.hoverBorderFor(root.textColor, root.accentColor)
 
     Text {
       id: missingText
@@ -256,7 +257,7 @@ Column {
       width: parent.width
       visible: text !== ""
       text: ""
-      color: Color.urgent
+      color: root.dangerColor
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.caption
       wrapMode: Text.WordWrap
@@ -365,7 +366,7 @@ Column {
 
     Button {
       visible: !root.signedIn
-      text: root.busy ? "Checking…" : "Connect the mailbox"
+      text: root.busy ? "Checking" : "Connect the mailbox"
       enabled: !root.busy && addressField.text.trim() !== "" && passwordField.text !== ""
       foreground: root.textColor
       bordered: true

--- a/components/KeyHints.qml
+++ b/components/KeyHints.qml
@@ -15,6 +15,7 @@ Row {
 
   required property color textColor
   required property color dimColor
+  required property color accentColor
   required property string panelFontFamily
 
   // [{ key: "j / k", label: "move" }, ...]
@@ -37,7 +38,7 @@ Row {
         radius: Style.cornerRadius
         // Fill only. An outline as well made these read as buttons you could
         // press, which drew far more attention than a hint deserves.
-        color: Style.normalFillFor(root.textColor, Color.accent)
+        color: Style.normalFillFor(root.textColor, root.accentColor)
 
         Text {
           id: cap

--- a/components/MailboxSidebar.qml
+++ b/components/MailboxSidebar.qml
@@ -269,7 +269,7 @@ Item {
       color: root.accentColor
     }
 
-    HoverHandler { id: hover; cursorShape: Qt.PointingHandCursor }
+    HoverHandler { id: hover }
     TapHandler { onTapped: entry.activated() }
 
     // The tooltip is how the rail stays usable while collapsed, and it carries

--- a/components/MailboxTabs.qml
+++ b/components/MailboxTabs.qml
@@ -11,6 +11,7 @@ Flickable {
   id: root
 
   required property color textColor
+  required property color accentColor
   required property string panelFontFamily
   property string current: "inbox"
   // Provider-specific, and handed down rather than looked up: this row must
@@ -79,7 +80,7 @@ Flickable {
     radius: Style.cornerRadius
     color: "transparent"
     border.width: 1
-    border.color: Style.normalBorderFor(root.textColor, Color.accent)
+    border.color: Style.normalBorderFor(root.textColor, root.accentColor)
 
     Row {
       id: chips

--- a/components/Menu.js
+++ b/components/Menu.js
@@ -1,0 +1,32 @@
+.pragma library
+
+function selectable(entry) {
+  return !!entry && entry.selectable !== false && entry.visible !== false && entry.enabled !== false
+}
+
+function firstSelectable(entries) {
+  var values = Array.isArray(entries) ? entries : []
+  for (var i = 0; i < values.length; i++) if (selectable(values[i])) return i
+  return -1
+}
+
+function nextSelectable(entries, current, step) {
+  var values = Array.isArray(entries) ? entries : []
+  if (values.length === 0) return -1
+  var direction = Number(step) < 0 ? -1 : 1
+  var at = Math.floor(Number(current))
+  if (!isFinite(at) || at < 0 || at >= values.length) at = direction > 0 ? -1 : 0
+  for (var i = 0; i < values.length; i++) {
+    at = (at + direction + values.length) % values.length
+    if (selectable(values[at])) return at
+  }
+  return -1
+}
+
+function position(anchorX, anchorY, width, height, containerWidth, containerHeight) {
+  var x = Math.max(0, Math.min(Number(anchorX), Number(containerWidth) - Number(width)))
+  var y = Number(anchorY)
+  if (y + height > containerHeight) y = y - height
+  if (y + height > containerHeight) y = containerHeight - height
+  return { x: Math.max(0, x), y: Math.max(0, y) }
+}

--- a/components/MenuActionRow.qml
+++ b/components/MenuActionRow.qml
@@ -1,0 +1,41 @@
+import QtQuick
+import qs.Commons
+import qs.Ui
+
+Rectangle {
+  id: root
+
+  required property string text
+  required property color textColor
+  required property string panelFontFamily
+  property color tone: textColor
+  property var collection: []
+  property int cursorIndex: -1
+  readonly property bool selected: collection.indexOf(root) === cursorIndex
+
+  signal activated()
+
+  implicitHeight: Style.spacing.popupRowHeight
+  radius: Style.cornerRadius
+  opacity: enabled ? 1.0 : 0.4
+  color: hover.hovered || selected
+    ? Qt.rgba(textColor.r, textColor.g, textColor.b, 0.08)
+    : "transparent"
+
+  Text {
+    anchors.left: parent.left
+    anchors.leftMargin: Style.space(9)
+    anchors.right: parent.right
+    anchors.rightMargin: Style.space(9)
+    anchors.verticalCenter: parent.verticalCenter
+    textFormat: Text.PlainText
+    text: root.text
+    color: root.tone
+    font.family: root.panelFontFamily
+    font.pixelSize: Style.font.bodySmall
+    elide: Text.ElideRight
+  }
+
+  HoverHandler { id: hover }
+  TapHandler { onTapped: root.activated() }
+}

--- a/components/MenuSeparatorLine.qml
+++ b/components/MenuSeparatorLine.qml
@@ -1,0 +1,16 @@
+import QtQuick
+import qs.Commons
+import qs.Ui
+
+Item {
+  id: root
+
+  required property color lineColor
+  implicitHeight: Style.space(7)
+
+  PanelSeparator {
+    anchors.verticalCenter: parent.verticalCenter
+    width: parent.width
+    foreground: root.lineColor
+  }
+}

--- a/components/MessageList.qml
+++ b/components/MessageList.qml
@@ -95,32 +95,20 @@ Column {
     }
   }
 
-  // The count and the way to more of them. Inset like a row's own text rather
-  // than flush to the column: the list's left edge belongs to the selected
-  // row's fill, and a footer sitting on it reads as a row that lost its
-  // padding. The height is what puts air above and below the pair, because the
-  // column's spacing between children is two pixels.
+  // Pagination is the only thing this footer needs to say. A result estimate
+  // promoted an unreliable server number into interface hierarchy it did not
+  // deserve, and repeated it again in the window status line.
   Item {
     width: parent.width
-    visible: Model.showListFooter(root.service.messages.length)
-    implicitHeight: Style.space(44)
-
-    Text {
-      anchors.left: parent.left
-      anchors.leftMargin: Style.space(14)
-      anchors.verticalCenter: parent.verticalCenter
-      text: root.service.resultSummary
-      color: Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.42)
-      font.family: root.panelFontFamily
-      font.pixelSize: Style.font.caption
-    }
+    visible: root.service.hasMore
+    implicitHeight: Style.space(40)
 
     Button {
       anchors.right: parent.right
       anchors.rightMargin: Style.space(8)
       anchors.verticalCenter: parent.verticalCenter
       visible: root.service.hasMore
-      text: root.service.listLoading ? "Loading…" : "Load more"
+      text: root.service.listLoading ? "Loading" : "Load more"
       foreground: root.textColor
       bordered: false
       fontSize: Style.font.caption

--- a/components/MessageMenu.qml
+++ b/components/MessageMenu.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls as QQC
 import qs.Commons
 import qs.Ui
+import "Menu.js" as Menu
 
 // The list's right-click menu. It is a Popup rather than a child of the row
 // because the list scrolls inside a clipping Flickable, which would cut the
@@ -13,9 +14,16 @@ Item {
   required property color textColor
   required property color urgentColor
   required property color dimColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
   required property string panelFontFamily
 
   property string messageId: ""
+  property real anchorX: 0
+  property real anchorY: 0
+  property int cursorIndex: -1
+  readonly property var menuRows: [replyRow, replyAllRow, forwardRow, archiveRow,
+    trashRow, spamRow, readRow, starRow, browserRow]
   readonly property bool opened: menu.opened
   readonly property var summary: {
     if (!service || messageId === "") return null
@@ -36,14 +44,28 @@ Item {
     root.messageId = String(id || "")
     if (!root.summary) return
     var local = root.mapFromGlobal(sceneX, sceneY)
-    // Flip rather than overflow: a menu opened near the bottom edge would
-    // otherwise render half off-window.
-    menu.x = Math.max(0, Math.min(local.x, root.width - menu.width))
-    menu.y = local.y + menu.implicitHeight > root.height
-      ? Math.max(0, local.y - menu.implicitHeight)
-      : local.y
+    anchorX = local.x
+    anchorY = local.y
     menu.open()
   }
+
+  function place() {
+    if (!menu.visible) return
+    var tall = menu.height > 0 ? menu.height : menu.implicitHeight
+    var placed = Menu.position(anchorX, anchorY, menu.width, tall, root.width, root.height)
+    menu.x = placed.x
+    menu.y = placed.y
+  }
+
+  function selectableRows() {
+    var values = []
+    for (var i = 0; i < menuRows.length; i++) values.push({
+      selectable: true, visible: menuRows[i].visible, enabled: menuRows[i].enabled
+    })
+    return values
+  }
+  function moveCursor(step) { cursorIndex = Menu.nextSelectable(selectableRows(), cursorIndex, step) }
+  function runCursor() { if (cursorIndex >= 0) menuRows[cursorIndex].activated() }
 
   function close() { menu.close() }
 
@@ -67,57 +89,88 @@ Item {
     modal: false
     focus: true
     closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
+    onHeightChanged: root.place()
+    onOpened: {
+      root.cursorIndex = Menu.firstSelectable(root.selectableRows())
+      root.place()
+    }
     background: Rectangle {
       radius: Style.cornerRadius
-      color: Color.popups.background
+      color: root.popupBackgroundColor
       border.width: 1
-      border.color: Color.popups.border
+      border.color: root.popupBorderColor
     }
 
     contentItem: Column {
       id: rows
       spacing: Style.space(2)
 
-      MenuRow { text: "Reply"; onActivated: root.compose("reply") }
-      MenuRow { text: "Reply all"; onActivated: root.compose("replyAll") }
-      MenuRow { text: "Forward"; onActivated: root.compose("forward") }
+      focus: true
+      Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_J || event.key === Qt.Key_Down) {
+          root.moveCursor(1); event.accepted = true
+        } else if (event.key === Qt.Key_K || event.key === Qt.Key_Up) {
+          root.moveCursor(-1); event.accepted = true
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter
+            || event.key === Qt.Key_O) {
+          root.runCursor(); event.accepted = true
+        }
+      }
 
-      Separator {}
+      MenuRow { id: replyRow; text: "Reply"; onActivated: root.compose("reply") }
+      MenuRow { id: replyAllRow; text: "Reply all"; onActivated: root.compose("replyAll") }
+      MenuRow { id: forwardRow; text: "Forward"; onActivated: root.compose("forward") }
+
+      MenuSeparatorLine {
+        width: menu.width - menu.leftPadding - menu.rightPadding
+        lineColor: root.textColor
+      }
 
       // Hidden rather than disabled where the provider has no such verb. IMAP
       // archives by moving to a folder that may not exist, and has no junk
       // verb the server learns anything from — a "Report spam" that quietly
       // meant "move to a folder" would be a promise this cannot keep.
       MenuRow {
+        id: archiveRow
         visible: !root.service || root.service.canArchive
         text: "Archive"
         onActivated: root.run("archive")
       }
-      MenuRow { text: "Move to trash"; tone: root.urgentColor; onActivated: root.run("trash") }
+      MenuRow { id: trashRow; text: "Move to trash"; tone: root.urgentColor; onActivated: root.run("trash") }
       MenuRow {
+        id: spamRow
         visible: !root.service || root.service.canReportSpam
         text: "Report spam"
         tone: root.urgentColor
         onActivated: root.run("spam")
       }
 
-      Separator {}
+      MenuSeparatorLine {
+        width: menu.width - menu.leftPadding - menu.rightPadding
+        lineColor: root.textColor
+      }
 
       MenuRow {
+        id: readRow
         text: root.summary && root.summary.unread ? "Mark as read" : "Mark as unread"
         onActivated: root.run(root.summary && root.summary.unread ? "markRead" : "markUnread")
       }
       MenuRow {
+        id: starRow
         visible: !root.service || root.service.canStar
         text: root.summary && root.summary.starred ? "Unstar" : "Star"
         onActivated: root.run(root.summary && root.summary.starred ? "unstar" : "star")
       }
 
-      Separator {}
+      MenuSeparatorLine {
+        width: menu.width - menu.leftPadding - menu.rightPadding
+        lineColor: root.textColor
+      }
 
       // Only where there is a web mailbox to open. An IMAP account has no
       // address this plugin could know.
       MenuRow {
+        id: browserRow
         visible: !root.service || root.service.canOpenOnWeb
         text: "Open in browser..."
         tone: root.dimColor
@@ -130,43 +183,11 @@ Item {
     }
   }
 
-  component Separator: Item {
+  component MenuRow: MenuActionRow {
     width: menu.width - menu.leftPadding - menu.rightPadding
-    implicitHeight: Style.space(7)
-    PanelSeparator {
-      anchors.verticalCenter: parent.verticalCenter
-      width: parent.width
-      foreground: root.textColor
-    }
-  }
-
-  component MenuRow: Rectangle {
-    id: row
-    required property string text
-    property color tone: root.textColor
-    signal activated()
-
-    width: menu.width - menu.leftPadding - menu.rightPadding
-    implicitHeight: Style.spacing.popupRowHeight
-    radius: Style.cornerRadius
-    color: hover.hovered
-      ? Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.08)
-      : "transparent"
-
-    Text {
-      anchors.left: parent.left
-      anchors.leftMargin: Style.space(9)
-      anchors.right: parent.right
-      anchors.rightMargin: Style.space(9)
-      anchors.verticalCenter: parent.verticalCenter
-      text: row.text
-      color: row.tone
-      font.family: root.panelFontFamily
-      font.pixelSize: Style.font.bodySmall
-      elide: Text.ElideRight
-    }
-
-    HoverHandler { id: hover; cursorShape: Qt.PointingHandCursor }
-    TapHandler { onTapped: row.activated() }
+    textColor: root.textColor
+    panelFontFamily: root.panelFontFamily
+    collection: root.menuRows
+    cursorIndex: root.cursorIndex
   }
 }

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -18,6 +18,8 @@ Item {
   required property color accentColor
   required property color linkColor
   required property color dimColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
   required property color dimmerColor
   required property string panelFontFamily
   property bool forcePlainText: false
@@ -408,8 +410,11 @@ Item {
     anchors.bottom: parent.bottom
     anchors.left: parent.left
     anchors.right: parent.right
-    anchors.leftMargin: root.pageInset
-    anchors.rightMargin: root.pageInset
+    // Control frames share the status bar's eight-pixel chrome inset. The
+    // page content keeps its wider reading inset; applying that to buttons as
+    // well made their glyphs sit visibly farther inward than the chrome below.
+    anchors.leftMargin: Style.space(8)
+    anchors.rightMargin: Style.space(8)
     anchors.bottomMargin: Style.space(4)
     spacing: Style.space(4)
     visible: !!root.summary
@@ -466,17 +471,17 @@ Item {
       IconButton {
         id: replyButton
         iconName: "reply"; tooltipText: "Reply · r"
-        foreground: root.textColor; fontFamily: root.panelFontFamily
+        foreground: root.dimColor; hoverColor: root.textColor; fontFamily: root.panelFontFamily
         onClicked: root.composeRequested("reply")
       }
       IconButton {
         iconName: "replyAll"; tooltipText: "Reply all · a"
-        foreground: root.textColor; fontFamily: root.panelFontFamily
+        foreground: root.dimColor; hoverColor: root.textColor; fontFamily: root.panelFontFamily
         onClicked: root.composeRequested("replyAll")
       }
       IconButton {
         iconName: "forward"; tooltipText: "Forward · f"
-        foreground: root.textColor; fontFamily: root.panelFontFamily
+        foreground: root.dimColor; hoverColor: root.textColor; fontFamily: root.panelFontFamily
         onClicked: root.composeRequested("forward")
       }
 
@@ -497,7 +502,7 @@ Item {
           anchors.centerIn: parent
           width: 1
           height: Style.space(15)
-          foreground: root.textColor
+          foreground: root.dimColor
         }
       }
 
@@ -507,12 +512,12 @@ Item {
       IconButton {
         visible: !root.service || root.service.canArchive
         iconName: "archive"; tooltipText: "Archive · e"
-        foreground: root.textColor; fontFamily: root.panelFontFamily
+        foreground: root.dimColor; hoverColor: root.textColor; fontFamily: root.panelFontFamily
         onClicked: root.actionRequested("archive")
       }
       IconButton {
         iconName: "trash"; tooltipText: "Move to trash · d"
-        foreground: root.textColor; fontFamily: root.panelFontFamily
+        foreground: root.dimColor; hoverColor: root.textColor; fontFamily: root.panelFontFamily
         onClicked: root.actionRequested("trash")
       }
 
@@ -550,6 +555,8 @@ Item {
     id: imagePopover
     textColor: root.textColor
     dimColor: root.dimColor
+    popupBackgroundColor: root.popupBackgroundColor
+    popupBorderColor: root.popupBorderColor
     panelFontFamily: root.panelFontFamily
   }
 }

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -20,6 +20,7 @@ Item {
   required property color dimColor
   required property color popupBackgroundColor
   required property color popupBorderColor
+  required property real leadingBoundaryOverlap
   required property color dimmerColor
   required property string panelFontFamily
   property bool forcePlainText: false
@@ -389,6 +390,11 @@ Item {
   Rectangle {
     id: footerBackdrop
     anchors.left: parent.left
+    // The reader begins after the splitter's forgiving hit target, while its
+    // visible rule sits at that target's leading edge. Extend only the surface
+    // boundary across the gap so the two rules meet; footer content remains
+    // aligned inside the reader and the splitter stays above it for input.
+    anchors.leftMargin: -root.leadingBoundaryOverlap
     anchors.right: parent.right
     anchors.bottom: parent.bottom
     height: footer.implicitHeight + Style.space(10)

--- a/components/MessageRow.qml
+++ b/components/MessageRow.qml
@@ -153,7 +153,7 @@ Rectangle {
       foreground: root.summary.starred ? root.accentColor : root.dimColor
       hoverColor: root.accentColor
       iconSize: Style.font.iconSmall
-      size: Style.space(20)
+      size: Style.space(24)
       fontFamily: root.panelFontFamily
       onClicked: root.starToggled()
     }
@@ -168,7 +168,7 @@ Rectangle {
       foreground: root.dimColor
       hoverColor: root.textColor
       iconSize: Style.font.iconSmall
-      size: Style.space(20)
+      size: Style.space(24)
       fontFamily: root.panelFontFamily
       onClicked: root.archiveRequested()
     }
@@ -180,7 +180,7 @@ Rectangle {
       foreground: root.dimColor
       hoverColor: root.textColor
       iconSize: Style.font.iconSmall
-      size: Style.space(20)
+      size: Style.space(24)
       fontFamily: root.panelFontFamily
       onClicked: root.trashRequested()
     }

--- a/components/ProviderPicker.qml
+++ b/components/ProviderPicker.qml
@@ -19,6 +19,7 @@ Column {
 
   required property color textColor
   required property color dimColor
+  required property color accentColor
   required property string panelFontFamily
   property bool canLeave: false
 
@@ -75,10 +76,10 @@ Column {
         implicitHeight: cardText.implicitHeight + Style.space(24)
         radius: Style.cornerRadius
         color: card.connectable && hover.hovered
-          ? Style.hoverFillFor(root.textColor, Color.accent)
-          : Style.normalFillFor(root.textColor, Color.accent)
+          ? Style.hoverFillFor(root.textColor, root.accentColor)
+          : Style.normalFillFor(root.textColor, root.accentColor)
         border.width: 1
-        border.color: Style.hoverBorderFor(root.textColor, Color.accent)
+        border.color: Style.hoverBorderFor(root.textColor, root.accentColor)
         // Not greyed out with a literal colour — the theme owns those. Reduced
         // opacity says "not available" without inventing a grey that some
         // themes render as ordinary body text.
@@ -120,7 +121,6 @@ Column {
         HoverHandler {
           id: hover
           enabled: card.connectable
-          cursorShape: Qt.PointingHandCursor
         }
 
         TapHandler {

--- a/components/ReaderBlankSlate.qml
+++ b/components/ReaderBlankSlate.qml
@@ -73,9 +73,9 @@ Item {
       horizontalAlignment: Text.AlignHCenter
       text: {
         if (!root.service) return ""
-        if (root.service.listLoading && root.service.messages.length === 0) return "Fetching the mailbox…"
+        if (root.service.listLoading && root.service.messages.length === 0) return "Fetching the mailbox"
         if (root.empty) return root.searching ? "Nothing matches that search" : "Nothing here"
-        return root.service.resultSummary + " · pick one to read it"
+        return "Pick a message to read it"
       }
       color: root.dimColor
       font.family: root.panelFontFamily

--- a/components/ReaderNotice.qml
+++ b/components/ReaderNotice.qml
@@ -55,12 +55,17 @@ Rectangle {
     visible: root.actionLabel !== ""
     enabled: !root.busy
     anchors.right: parent.right
-    anchors.rightMargin: Style.space(6)
+    anchors.rightMargin: Style.space(8)
     anchors.verticalCenter: parent.verticalCenter
+    width: implicitWidth
+    height: implicitHeight
     text: root.busy && root.busyLabel !== "" ? root.busyLabel : root.actionLabel
     foreground: root.textColor
     bordered: false
     fontSize: Style.font.caption
+    horizontalPadding: Style.space(8)
+    verticalPadding: Style.space(2)
+    focusable: true
     onClicked: root.activated()
   }
 }

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -159,7 +159,7 @@ Column {
             text: {
               if (row.modelData.error !== undefined && row.modelData.error !== "")
                 return row.modelData.error
-              if (!row.modelData.signedIn) return "Not signed in yet"
+              if (!row.modelData.signedIn) return "Signed out"
               var count = row.modelData.unread
               var unread = count === 0 ? "No unread mail"
                 : (count === 1 ? "1 unread message" : count + " unread messages")
@@ -194,10 +194,10 @@ Column {
 
   IconTextButton {
     iconName: "plus"
-    text: "Add a mailbox"
+    text: "Add a mailbox..."
     foreground: root.textColor
     fontFamily: root.panelFontFamily
-    tooltipText: "Sign in to another Gmail account"
+    tooltipText: "Add another mail account"
     onClicked: root.addRequested()
   }
 

--- a/components/SetupPage.qml
+++ b/components/SetupPage.qml
@@ -17,6 +17,7 @@ Column {
   required property color textColor
   required property color dimColor
   required property color dangerColor
+  required property color accentColor
   required property string panelFontFamily
   property bool canLeave: false
   property int accountCount: 1
@@ -134,9 +135,9 @@ Column {
     visible: root.toolsMissing
     implicitHeight: missingText.implicitHeight + Style.space(20)
     radius: Style.cornerRadius
-    color: Style.normalFillFor(root.textColor, Color.accent)
+    color: Style.normalFillFor(root.textColor, root.accentColor)
     border.width: 1
-    border.color: Style.hoverBorderFor(root.textColor, Color.accent)
+    border.color: Style.hoverBorderFor(root.textColor, root.accentColor)
 
     Text {
       id: missingText
@@ -353,7 +354,7 @@ Column {
     visible: !!root.auth && root.auth.lastError !== ""
     textFormat: Text.PlainText
     text: root.auth ? root.auth.lastError : ""
-    color: Color.urgent
+    color: root.dangerColor
     font.family: root.panelFontFamily
     font.pixelSize: Style.font.caption
     wrapMode: Text.WordWrap
@@ -422,7 +423,7 @@ Column {
         anchors.top: parent.top
         visible: !step.done
         text: step.number
-        color: step.active ? Color.accent : root.dimColor
+        color: step.active ? root.accentColor : root.dimColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.bodySmall
         font.bold: step.active
@@ -434,7 +435,7 @@ Column {
         visible: step.done
         name: "check"
         iconSize: Style.font.bodySmall
-        color: Color.accent
+        color: root.accentColor
       }
     }
 

--- a/components/UserBar.qml
+++ b/components/UserBar.qml
@@ -72,11 +72,11 @@ Rectangle {
     elide: Text.ElideMiddle
   }
 
-  HoverHandler { id: hover; cursorShape: Qt.PointingHandCursor }
+  HoverHandler { id: hover }
 
   TapHandler {
-    onTapped: function(point) {
-      var scene = root.mapToGlobal(point.position.x, point.position.y)
+    onTapped: {
+      var scene = root.mapToGlobal(0, 0)
       root.switcherRequested(scene.x, scene.y)
     }
   }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -268,6 +268,14 @@ A large commit may use short sections such as `Why`, `What replaces it`, and `Ve
 
 Keep one architectural argument per commit where practical. A supporting fix belongs in the same commit when the primary change exposes it and cannot be correct without it; unrelated cleanup does not.
 
+## Pull request design
+
+A pull request title follows the GPUI Component form `<scope>: <Imperative outcome>`. The lowercase scope names the stable module or subsystem that owns the result; use `app` for one application-level change that honestly spans several UI modules. The outcome describes what the complete change makes true rather than the work performed or the file touched.
+
+Derive the title from the final `base...HEAD` diff, not from the first commit. Later review fixes can change the actual scope, and a title that remains attached to the opening implementation gives reviewers the wrong boundary.
+
+The description is a current explanation of the complete diff rather than a chronology. It covers the user-visible results, the architectural reason and invariants, and the verification actually performed. Rewrite it when later commits materially change any of those; do not append corrections to a stale description.
+
 ## Documentation source
 
 Markdown prose uses one source line per paragraph. Do not hard-wrap prose to a column width. Use line breaks only for semantic structure such as headings, paragraphs, lists, tables, blockquotes, and code blocks.

--- a/tests/test_accounts.js
+++ b/tests/test_accounts.js
@@ -122,8 +122,28 @@ assert.strictEqual(accounts.count(settled), 3)
 
 let three = accounts.add(corrected, account("cid@example.com"))
 assert.strictEqual(accounts.count(three), 3)
-
 const beforeRemove = frozen(three)
+
+// Removing an account is destructive and happens in two steps. The first
+// step only describes the target; it never mutates the list. A stale target
+// is rejected when the confirmation is finally accepted.
+const removal = accounts.removalRequest(three, 0)
+deepEqual(removal, {
+  id: "ada@example.com",
+  email: "ADA@example.com",
+  index: 0
+})
+assert.strictEqual(frozen(three), beforeRemove)
+assert.strictEqual(accounts.removalRequest(three, -1), null)
+assert.strictEqual(accounts.removalRequest(three, 99), null)
+assert.strictEqual(accounts.removalRequest(one, 0), null,
+  "the only account cannot be removed")
+assert.strictEqual(accounts.removalRequest(bothPending, 1), null,
+  "a draft has no stable identity and is canceled rather than removed")
+assert.strictEqual(accounts.confirmRemoval(three, { id: "gone@example.com", index: 0 }), -1,
+  "confirmation must not remove whichever account later occupies a stale row")
+assert.strictEqual(accounts.confirmRemoval(three, removal), 0)
+
 let withoutBob = accounts.remove(three, "bob@example.com")
 assert.strictEqual(frozen(three), beforeRemove, "remove leaves its input alone")
 assert.strictEqual(accounts.count(withoutBob), 2)

--- a/tests/test_menu.js
+++ b/tests/test_menu.js
@@ -1,0 +1,23 @@
+const assert = require("assert")
+const { load, deepEqual } = require("./load")
+
+const menu = load("components/Menu.js")
+
+const entries = [
+  { selectable: true },
+  { selectable: false },
+  { selectable: true },
+  { selectable: false }
+]
+
+assert.strictEqual(menu.firstSelectable(entries), 0)
+assert.strictEqual(menu.firstSelectable([{ selectable: false }]), -1)
+assert.strictEqual(menu.nextSelectable(entries, 0, 1), 2)
+assert.strictEqual(menu.nextSelectable(entries, 2, 1), 0, "down wraps")
+assert.strictEqual(menu.nextSelectable(entries, 0, -1), 2, "up wraps")
+
+deepEqual(menu.position(180, 190, 80, 60, 200, 200), { x: 120, y: 130 })
+deepEqual(menu.position(10, 20, 80, 60, 200, 200), { x: 10, y: 20 })
+deepEqual(menu.position(-10, -10, 260, 240, 200, 200), { x: 0, y: 0 })
+
+console.log("menu tests passed")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -154,11 +154,9 @@ assert.strictEqual(model.resultSummary([{}, {}], 87, true), "2 of about 87")
 // Gmail's estimate can come back lower than the page it just returned.
 assert.strictEqual(model.resultSummary([{}, {}, {}], 1, true), "3 of about 3")
 
-assert.strictEqual(model.statusSummary("Checking for mail…", "25 of about 80", true),
-  "Checking for mail…", "loading status must not compete with stale pagination")
-assert.strictEqual(model.statusSummary("Synced just now", "25 messages", false),
-  "Synced just now  ·  25 messages")
-assert.strictEqual(model.statusSummary("", "No messages", false), "No messages")
+assert.strictEqual(model.statusSummary("Checking for mail"), "Checking for mail")
+assert.strictEqual(model.statusSummary("Synced just now"), "Synced just now")
+assert.strictEqual(model.statusSummary(""), "")
 
 assert.strictEqual(model.truncate("short", 20), "short")
 assert.strictEqual(model.truncate("a much longer string", 10), "a much lo…")

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -327,8 +327,14 @@ grep -q 'anchors.top: header.visible ? header.bottom : parent.top' App.qml \
 if grep -q 'text: subjectField.text' components/ComposeView.qml; then
   fail "the Compose header must not repeat the Subject field"
 fi
-grep -q 'anchors.left: backBar.right' components/ComposeView.qml \
-  || fail "the Compose title must follow the rendered Back control instead of colliding with it"
+awk '
+  /id: titleRow/ { in_title = 1 }
+  in_title && /anchors.horizontalCenter: parent.horizontalCenter/ { centered = 1 }
+  in_title && /anchors.left: backBar.right/ { follows_back = 1 }
+  in_title && /^    }/ { exit !(centered && !follows_back) }
+  END { exit !(centered && !follows_back) }
+' components/ComposeView.qml \
+  || fail "the Compose title must stay centered independently of the Back control"
 awk '
   /id: fromButton/ { in_from = 1 }
   in_from && /bordered: true/ { found = 1 }
@@ -336,6 +342,14 @@ awk '
   END { exit !found }
 ' components/ComposeView.qml \
   || fail "the From dropdown must use an outline treatment"
+awk '
+  /id: fromButton/ { in_from = 1 }
+  in_from && /background: Style.normalFillFor\(root.textColor, root.accentColor\)/ { fill = 1 }
+  in_from && /verticalPadding: Style.spacing.inputPaddingY/ { padding = 1 }
+  in_from && /^      }/ { exit !(fill && padding) }
+  END { exit !(fill && padding) }
+' components/ComposeView.qml \
+  || fail "the From dropdown must share the TextField fill and vertical sizing"
 
 # Sign out and removal are peer account actions. Removal stays last in the
 # action row instead of falling onto a detached row beneath it.

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -327,6 +327,15 @@ grep -q 'anchors.top: header.visible ? header.bottom : parent.top' App.qml \
 if grep -q 'text: subjectField.text' components/ComposeView.qml; then
   fail "the Compose header must not repeat the Subject field"
 fi
+grep -q 'anchors.left: backBar.right' components/ComposeView.qml \
+  || fail "the Compose title must follow the rendered Back control instead of colliding with it"
+awk '
+  /id: fromButton/ { in_from = 1 }
+  in_from && /bordered: true/ { found = 1 }
+  in_from && /^      }/ { exit !found }
+  END { exit !found }
+' components/ComposeView.qml \
+  || fail "the From dropdown must use an outline treatment"
 
 # Sign out and removal are peer account actions. Removal stays last in the
 # action row instead of falling onto a detached row beneath it.

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -78,6 +78,24 @@ if awk '
 ' components/ImapSetupPage.qml; then
   fail "ImapSetupPage assigns the non-existent IconTextButton.hoverColor property"
 fi
+for file in components/MessageList.qml components/ReaderBlankSlate.qml; do
+  if grep -n 'resultSummary' "$file"; then
+    fail "$file must not expose result-count estimates in the interface"
+  fi
+done
+if grep -n 'modelData\.unread' components/AccountSwitcher.qml; then
+  fail "the account switcher must identify mailboxes without count badges"
+fi
+grep -q 'mapToGlobal(0, 0)' components/UserBar.qml \
+  || fail "the account switcher must anchor to the user bar, not the click position"
+awk '
+  /id: footer$/ { in_footer = 1 }
+  in_footer && /anchors.leftMargin: Style.space\(8\)/ { left = 1 }
+  in_footer && /anchors.rightMargin: Style.space\(8\)/ { right = 1 }
+  in_footer && /spacing: Style.space\(4\)/ { exit !(left && right) }
+  END { exit !(left && right) }
+' components/MessageReader.qml \
+  || fail "the reader toolbar control frames must share the status-bar inset"
 
 # A trigger holds a selected style while what it opened is on screen. The bar
 # icon is the only trigger the window has, so without this there is nothing on
@@ -206,6 +224,83 @@ for page in components/SetupPage.qml components/ImapSetupPage.qml; do
     END { if (!in_remove) exit 1; exit !found }
   ' "$page" || fail "$page Remove account must be a danger button"
 done
+
+# Removing a mailbox is destructive. The edit pages may request it, but only a
+# confirmation owned by App may call the service after naming the target.
+grep -q 'AccountRemovalDialog {' App.qml \
+  || fail "account removal needs a confirmation dialog"
+if awk '
+  /function removeCurrentAccountFromEditor\(/ { in_remove = 1 }
+  in_remove && /service\.removeAccountAt/ { exit 0 }
+  in_remove && /^  }/ { exit 1 }
+  END { exit 1 }
+' App.qml; then
+  fail "requesting account removal must not remove it immediately"
+fi
+
+# Native desktop controls retain the arrow cursor. A pointing hand is reserved
+# for actual links such as URLs inside the message reader.
+for file in components/IconButton.qml components/IconTextButton.qml components/AppMenu.qml \
+  components/MessageMenu.qml components/AccountSwitcher.qml components/ProviderPicker.qml \
+  components/MailboxSidebar.qml components/UserBar.qml; do
+  if grep -n 'PointingHandCursor' "$file"; then
+    fail "$file uses a web-link cursor for a native control"
+  fi
+done
+
+# Labels say when an action leaves the app and use three periods for the
+# established workflow suffix. Busy state is status, not decorative prose.
+if grep -rnE 'Checking…|Fetching the mailbox…|Not signed in yet|Open in Gmail|text: "(Shortcuts|GitHub|Twitter)"' \
+  App.qml components; then
+  fail "UI copy does not follow the project action and status vocabulary"
+fi
+if grep -rnE '^[[:space:]]*(text|tooltipText):.*…' App.qml components; then
+  fail "UI labels use the project ellipsis convention (...), while progress uses state"
+fi
+grep -q 'text: "Add a mailbox\.\.\."' components/SettingsPage.qml \
+  || fail "Add a mailbox opens a workflow and needs an ellipsis"
+grep -q 'tooltipText: "Add another mail account"' components/SettingsPage.qml \
+  || fail "the add-account tooltip must be provider-neutral"
+if awk '
+  /id: accountLine/ { in_status = 1 }
+  in_status && /resultSummary/ { exit 0 }
+  in_status && /^        }/ { exit 1 }
+  END { exit 1 }
+' App.qml; then
+  fail "the window status line must not repeat the list result count"
+fi
+
+# Both action menus own navigation locally because Qt popups intercept window
+# shortcuts. Placement happens after opening and whenever content is measured.
+for file in components/AppMenu.qml components/MessageMenu.qml; do
+  grep -q 'Keys.onPressed' "$file" \
+    || fail "$file needs popup-local keyboard navigation"
+  grep -q 'onOpened:' "$file" \
+    || fail "$file must place itself after its contents exist"
+  grep -q 'onHeightChanged: root.place()' "$file" \
+    || fail "$file must re-place itself when its measured height changes"
+  grep -q 'MenuActionRow {' "$file" \
+    || fail "$file must use the shared menu-row contract"
+  if grep -q 'component MenuRow: Rectangle' "$file"; then
+    fail "$file duplicates the shared menu-row presentation"
+  fi
+done
+
+# Feature views receive semantic colours from App. Reading theme roles locally
+# makes the same concept drift between pages and prevents App from naming it.
+for file in components/AppMenu.qml components/MessageMenu.qml components/AccountSwitcher.qml \
+  components/ProviderPicker.qml components/MailboxTabs.qml components/SetupPage.qml \
+  components/ImapSetupPage.qml components/KeyHints.qml components/ImagePopover.qml \
+  components/ComposeView.qml; do
+  if grep -nE '(^|[^A-Za-z])Color\.' "$file"; then
+    fail "$file reads theme colours instead of receiving semantic roles"
+  fi
+done
+
+# Row actions must meet the compact desktop hit-target floor.
+if grep -n 'size: Style\.space(20)' components/MessageRow.qml; then
+  fail "message row actions need at least a 24px hit target"
+fi
 
 # Sign out and removal are peer account actions. Removal stays last in the
 # action row instead of falling onto a detached row beneath it.

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -156,6 +156,10 @@ done
 # row, not in a gutter that cuts every selected background short.
 grep -q 'width: listFlick\.width$' App.qml \
   || fail "message rows must reach the list column edge"
+grep -q 'leadingBoundaryOverlap: listSplitter.visible ? listSplitter.width : 0' App.qml \
+  || fail "the reader toolbar boundary must cross the splitter hit area to meet its visible rule"
+grep -q 'anchors.leftMargin: -root.leadingBoundaryOverlap' components/MessageReader.qml \
+  || fail "the reader toolbar boundary must meet the list/reader divider"
 awk '
   /id: listSplitter/ { in_splitter = 1 }
   in_splitter && /PanelSeparator[[:space:]]*\{/ { in_separator = 1 }
@@ -300,6 +304,28 @@ done
 # Row actions must meet the compact desktop hit-target floor.
 if grep -n 'size: Style\.space(20)' components/MessageRow.qml; then
   fail "message row actions need at least a 24px hit target"
+fi
+grep -q 'anchors.margins: root.visualInset' components/IconButton.qml \
+  || fail "IconButton hover fill must sit inside its hit target"
+grep -q 'verticalPadding: Style.space(2)' components/ReaderNotice.qml \
+  || fail "ReaderNotice actions must keep their visual surface inside the notice"
+grep -q 'width: implicitWidth' components/ReaderNotice.qml \
+  || fail "ReaderNotice actions need a trailing intrinsic-width lane"
+if grep -q 'Ctrl+Enter sends' components/ComposeView.qml; then
+  fail "Compose must render shortcut hints from Keymap instead of hand-writing a second copy"
+fi
+grep -q 'visible: !root.showPage && !root.composing' App.qml \
+  || fail "mailbox header commands must stand down while Compose owns the task"
+awk '
+  /id: header$/ { in_header = 1 }
+  in_header && /visible: !root.composing/ { found = 1 }
+  in_header && /id: body$/ { exit !found }
+  END { exit !found }
+' App.qml || fail "Compose must replace the mailbox header instead of stacking another one below it"
+grep -q 'anchors.top: header.visible ? header.bottom : parent.top' App.qml \
+  || fail "Compose must reclaim the space of the hidden mailbox header"
+if grep -q 'text: subjectField.text' components/ComposeView.qml; then
+  fail "the Compose header must not repeat the Subject field"
 fi
 
 # Sign out and removal are peer account actions. Removal stays last in the


### PR DESCRIPTION
## What changed

- Confirm account removal against the mailbox identity the user selected, so a stale confirmation cannot remove a different account.
- Give application and message menus shared rows, separators, selection rules, keyboard navigation, and measured popup placement.
- Anchor account switching to its trigger and remove unread counts that do not help the switching decision.
- Keep popup colors and other semantic theme roles owned by `App.qml` and passed into feature views.
- Separate list pagination, sync status, reader actions, and keyboard hints so each surface has one responsibility.
- Align the reader toolbar and its interaction surfaces with the surrounding window chrome.
- Let Compose replace the mailbox header, center its title independently of Back, use consistent form-control surfaces, and render shortcut hints only from the keymap.
- Normalize action labels, workflow punctuation, pointer behavior, and compact control hit targets.

## Design rationale

This applies the GPUI Component Design Guides to Omamail’s existing workflows without importing GPUI Component’s visual style. Stable identity protects destructive actions; popup state and geometry belong to the popup and its trigger; keyboard and pointer interaction expose the same operations; and information appears only on the surface responsible for it.

Omarchy remains the visual authority. Colors, spacing, typography, borders, and control treatment continue to come from the active system theme.

## Verification

- `make validate`
- 36 QML tests passed
- JavaScript, source, shell, transport, `qmllint`, plugin validation, and diff checks passed