### PR TITLE
Refuse a redirect on the one-click unsubscribe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,23 @@ key. What matters while working:
   is world-readable.
 - Anything that could carry a credential passes through `OAuth.redact` before
   it can reach a label.
+- **A gate that judges only the first address is not a gate.** `isPostableUrl`
+  and `imageSourceKind` refuse loopback, private, link-local and single-label
+  hosts — but they judge the address *the sender wrote*, and Qt's
+  `XMLHttpRequest` follows a 3xx by itself and re-sends the request, body
+  intact, wherever that answer points. Measured, not assumed: a loopback target
+  answering `302 Location: /landed` recorded the POST arriving there. So the
+  one-click unsubscribe goes out through `scripts/unsubscribe.sh`, which is
+  curl, which follows nothing unless told to — and a 3xx is reported as a list
+  that did not unsubscribe rather than as an address to chase.
+- **Remote images are the part of that which is not closed.** Qt's own image
+  loader performs those fetches and takes no policy from QML, so a sender who
+  redirects an image can still reach an address the gate would have refused.
+  What holds the line meanwhile is that nothing is fetched until the reader
+  asks. Closing it properly means fetching the bytes here — curl, no redirects
+  — and handing the renderer a `data:` URI, which is a day's work and a change
+  to the rule that the string handed over is the only control point. Do not
+  paper over it with a second check on the same first address.
 - Remote images in a message body are blocked until the reader asks for them.
   Qt's rich text engine really does fetch them, so rendering one fires every
   tracking pixel in the message, and the fetch tells the host that this address

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ test-shell:
 	bash tests/test_service_source.sh
 	bash tests/test_install.sh
 	bash tests/test_transport.sh
+	bash tests/test_unsubscribe_transport.sh
 
 # Focus ownership and key routing cannot be tested without a focus scope, and a
 # focus scope needs the QML engine. Offscreen, so it needs no compositor: the

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import Quickshell
+import Quickshell.Io
 import "../providers"
 import "../cache"
 
@@ -1089,28 +1090,95 @@ Item {
   // are checked, and it borrows the judgement that decides whether a message
   // may load a picture.
   //
+  // **Sent by curl rather than by XMLHttpRequest, because a gate that judges
+  // only the first address is not a gate.** Qt's XHR follows a 3xx by itself
+  // and re-sends the POST, body intact, wherever that answer points — measured
+  // against a loopback target, which recorded the POST arriving after a single
+  // `302`. So the address the sender wrote would be checked, and a different
+  // address entirely would be the one this machine connected to, from inside
+  // the user's own network. curl follows nothing unless told to, and
+  // `scripts/unsubscribe.sh` tells it twice not to.
+  //
   // The reply is never read beyond its status. It is a document from whoever
   // sent the mail, and the only question being asked of it is whether the
   // address is off the list.
   function postUnsubscribe(url) {
+    if (!Unsub.isPostableUrl(url)) {
+      fail("That unsubscribe address is not one this can post to")
+      return
+    }
     unsubscribing = true
-    var request = new XMLHttpRequest()
-    request.onreadystatechange = function() {
-      if (request.readyState !== XMLHttpRequest.DONE) return
+    var request = unsubscribeComponent.createObject(root, {
+      command: [pluginDir + "/scripts/unsubscribe.sh"],
+      requestLine: [Mail.encodeBase64(String(url)),
+        Mail.encodeBase64(Unsub.postContentType()),
+        Mail.encodeBase64(Unsub.postBody())].join(" ")
+    })
+    if (!request) {
+      unsubscribing = false
+      fail("The unsubscribe request could not be sent")
+      return
+    }
+    request.finished.connect(function(exitCode, status) {
       if (!root) return
+      request.destroy()
       root.unsubscribing = false
-      var status = Number(request.status) || 0
-      if (status >= 200 && status < 400) {
+      root.unsubscribeDone = ""
+      if (exitCode !== 0 || status === 0) {
+        root.fail("The unsubscribe request could not be sent")
+        return
+      }
+      if (status >= 200 && status < 300) {
         root.unsubscribeDone = "Unsubscribed from this list"
         return
       }
-      root.fail(status === 0
-        ? "The unsubscribe request could not be sent"
+      // A 3xx is a server answering a one-click request with "go and ask over
+      // there". It has not done what its own header promised, and the address
+      // it points at was never judged — so it is reported as a refusal rather
+      // than followed.
+      root.fail(status >= 300 && status < 400
+        ? "This list answered with a redirect instead of unsubscribing (" + status + ")"
         : "This list refused the unsubscribe request (" + status + ")")
+    })
+    request.running = true
+  }
+
+  // One process per request, created and destroyed around it. The same shape
+  // the mail transport uses, for the same reason: the URL crosses on stdin
+  // base64-encoded, so a header a stranger wrote never reaches the process
+  // table and nothing has to be escaped on the way.
+  Component {
+    id: unsubscribeComponent
+
+    Process {
+      id: unsubscribeProcess
+
+      property string requestLine: ""
+      signal finished(int exitCode, int status)
+
+      stdinEnabled: true
+      stdout: StdioCollector { waitForEnd: true }
+      stderr: StdioCollector { waitForEnd: true }
+
+      onStarted: {
+        // One line, because Quickshell's Process.write() never closes stdin and
+        // the script would wait forever for an EOF that does not come.
+        write(requestLine + "\n")
+        requestLine = ""
+      }
+
+      onExited: function(exitCode) {
+        // "<curl exit code> <http status>", and nothing else is read.
+        var parts = String(unsubscribeProcess.stdout.text || "").trim().split(/\s+/)
+        var code = Math.floor(Number(parts[0]))
+        var status = Math.floor(Number(parts[1]))
+        if (exitCode !== 0 || parts.length < 2 || !isFinite(code) || !isFinite(status)) {
+          unsubscribeProcess.finished(exitCode === 0 ? 1 : exitCode, 0)
+          return
+        }
+        unsubscribeProcess.finished(code, status)
+      }
     }
-    request.open("POST", url)
-    request.setRequestHeader("Content-Type", Unsub.postContentType())
-    request.send(Unsub.postBody())
   }
 
   // -------------------------------------------------------- notifications

--- a/scripts/unsubscribe.sh
+++ b/scripts/unsubscribe.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# Sends one RFC 8058 one-click unsubscribe POST, and reports what the list said.
+#
+# ## Why this is not an XMLHttpRequest
+#
+# It used to be one, and that was a hole. `Unsubscribe.isPostableUrl` judges the
+# address the *sender wrote* — https, and not loopback, private, link-local or
+# single-label. Qt's XMLHttpRequest then follows a 3xx by itself and re-sends
+# the POST, body intact, to wherever that answer points; nothing re-asks the
+# gate about the second address. Measured rather than assumed: a loopback target
+# answering `302 Location: /landed` recorded the POST arriving at `/landed`.
+#
+# curl follows nothing unless it is told to, and it is not told to here.
+# `--max-redirs 0` says the same thing a second time on purpose: the day
+# somebody adds `--location` for an unrelated reason, that line is what refuses
+# it rather than silently reopening this.
+#
+# A 3xx therefore comes back as a 3xx and the panel reports the list as *not*
+# unsubscribed. That is the honest reading — a server answering a one-click
+# request with "go and ask over there" has not done what its own header
+# promised, and RFC 8058 says the answer to this POST is a 2xx.
+#
+# ## Everything crosses on stdin, base64-encoded
+#
+# One line, three fields:
+#
+#   <b64 url> <b64 content-type> <b64 body>
+#
+# The same rule the mail transport follows, for the same reasons: the URL comes
+# out of a stranger's message and may hold quotes, spaces or backslashes; base64
+# has none of those, so the field split is a plain `set --` and there is no
+# escaping to get wrong on the way in. And the URL reaches curl through a config
+# on curl's own stdin rather than as an argument — it carries the token that
+# identifies this subscriber, and an argument would put that in the process
+# table for anyone on the machine to read.
+#
+# ## And comes back as one line
+#
+#   <curl exit code> <http status>
+#
+# Neither is a document, so neither needs encoding — and the body is never read
+# at all. It is written by whoever sent the mail, and the only question being
+# asked of it is whether the address is off the list.
+set -eu
+
+fail() {
+  printf '%s\n' "$1" >&2
+  exit 2
+}
+
+command -v curl >/dev/null 2>&1 || fail 'unsubscribe.sh: curl is not installed'
+
+decode() {
+  printf '%s' "$1" | base64 -d 2>/dev/null || fail 'unsubscribe.sh: bad base64 field'
+}
+
+# curl's config format quotes with "..." and escapes with a backslash. Only two
+# characters need it, and a URL out of a mail header may carry either.
+escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+IFS= read -r line || fail 'unsubscribe.sh: no request on stdin'
+[ -n "$line" ] || fail 'unsubscribe.sh: empty request'
+
+# The fields are base64, which contains no spaces, so splitting on them is safe
+# and needs no quoting rules.
+# shellcheck disable=SC2086
+set -- $line
+[ $# -eq 3 ] || fail 'unsubscribe.sh: usage: <b64 url> <b64 content-type> <b64 body>'
+
+url=$(decode "$1")
+content_type=$(decode "$2")
+body=$(decode "$3")
+
+# The gate that ran in `Unsubscribe.js`, run again down here where the request
+# is actually made. Two checks of one rule is the point: this one cannot be
+# skipped by a caller, and it is the last thing between a header a stranger
+# wrote and a connection this machine opens.
+case "$url" in
+  https://*) ;;
+  *) fail 'unsubscribe.sh: refusing a URL that is not https' ;;
+esac
+
+escaped_url=$(escape "$url")
+escaped_type=$(escape "$content_type")
+escaped_body=$(escape "$body")
+
+build_config() {
+  printf 'url = "%s"\n' "$escaped_url"
+  printf 'request = "POST"\n'
+  printf 'header = "Content-Type: %s"\n' "$escaped_type"
+  printf 'data-binary = "%s"\n' "$escaped_body"
+  # Not followed, said twice. `--proto` bounds the first request and
+  # `--proto-redir` the ones that would follow it, so even a curl that was
+  # somehow told to follow could not leave https.
+  printf 'max-redirs = 0\n'
+  printf 'proto = "=https"\n'
+  printf 'proto-redir = "=https"\n'
+  # The whole exchange, bounded. The XMLHttpRequest this replaces had no
+  # timeout at all: a request that was accepted and then black-holed left the
+  # button saying "unsubscribing" until the window was closed.
+  printf 'max-time = 20\n'
+  printf 'connect-timeout = 10\n'
+  printf 'silent\n'
+  printf 'show-error\n'
+  printf 'output = "/dev/null"\n'
+  printf 'write-out = "%%{http_code}"\n'
+}
+
+set +e
+status=$(build_config | curl --config - 2>/dev/null)
+code=$?
+set -e
+
+# curl writes `000` when it never got an answer at all — a refused connection, a
+# TLS failure, a timeout. That is all digits, so it survives the check below;
+# the floor is what turns it into the zero the panel reads as "not sent".
+case "$status" in
+  ''|*[!0-9]*) status=0 ;;
+esac
+[ "$status" -ge 100 ] 2>/dev/null || status=0
+
+printf '%s %s\n' "$code" "$status"

--- a/tests/bench_html.qml
+++ b/tests/bench_html.qml
@@ -5,7 +5,7 @@
 // node. Run it on the machine the shell runs on.
 import QtQml
 
-import "../Html.js" as Html
+import "../message/Html.js" as Html
 import "bench_cases.js" as Bench
 
 QtObject {

--- a/tests/bench_node.js
+++ b/tests/bench_node.js
@@ -1,7 +1,7 @@
 // The V8 half of `make bench`. See tests/bench_cases.js.
 const { load } = require("./load")
 
-const html = load("Html.js")
+const html = load("message/Html.js")
 const bench = load("tests/bench_cases.js")
 
 // Reached through plain functions rather than through the module object, so

--- a/tests/test_unsubscribe_transport.sh
+++ b/tests/test_unsubscribe_transport.sh
@@ -1,0 +1,215 @@
+#!/bin/sh
+# What unsubscribe.sh does with a one-click POST, against a server that is
+# really there.
+#
+# Two halves, and both are needed. A curl stub can assert the invocation, which
+# is what the mail transport's test does — but the bug this script exists for
+# was not in the arguments, it was in a client that chased a `302` on its own.
+# So the second half stands a loopback server up and asks it afterwards whether
+# the redirect was followed. That is the only witness that cannot be fooled by
+# reading the same config that was written.
+set -eu
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+script="$root/scripts/unsubscribe.sh"
+work=$(mktemp -d "${TMPDIR:-/tmp}/omamail-unsub-test.XXXXXX")
+trap 'rm -rf "$work"; [ -n "${server_pid:-}" ] && kill "$server_pid" 2>/dev/null; exit' EXIT INT TERM HUP
+
+failures=0
+server_pid=
+
+b64() {
+  printf '%s' "$1" | base64 | tr -d '\n'
+}
+
+ok() {
+  printf '  ok   %s\n' "$1"
+}
+
+bad() {
+  printf '  FAIL %s\n' "$1"
+  failures=$((failures + 1))
+}
+
+check() {
+  if [ "$2" = "$3" ]; then ok "$1"; else
+    bad "$1"
+    printf '         expected: %s\n' "$3"
+    printf '         actual:   %s\n' "$2"
+  fi
+}
+
+contains() {
+  if printf '%s' "$2" | grep -qF -- "$3"; then ok "$1"; else
+    bad "$1"
+    printf '         looked for: %s\n' "$3"
+  fi
+}
+
+missing() {
+  if printf '%s' "$2" | grep -qF -- "$3"; then
+    bad "$1"
+    printf '         found what must not be there: %s\n' "$3"
+  else ok "$1"; fi
+}
+
+# ------------------------------------------------------- the config it writes
+
+mkdir -p "$work/bin"
+cat > "$work/bin/curl" <<'STUB'
+#!/bin/sh
+# Keeps the config it was handed, so the assertions below are about the exact
+# bytes that would have reached the network. The script reads curl's stdout as
+# the status, so the config cannot come back that way.
+cat > "${CURL_STUB_DUMP:-/dev/null}"
+printf '200'
+STUB
+chmod +x "$work/bin/curl"
+
+wrote() {
+  CURL_STUB_DUMP="$work/config" PATH="$work/bin:$PATH" sh "$script" >/dev/null
+  cat "$work/config"
+}
+
+config=$(printf '%s %s %s\n' \
+  "$(b64 'https://lists.example.com/u/abc?token=x%20y')" \
+  "$(b64 'application/x-www-form-urlencoded')" \
+  "$(b64 'List-Unsubscribe=One-Click')" \
+  | wrote)
+
+printf 'unsubscribe.sh — the config\n'
+contains "the URL is sent as config, not as an argument" "$config" 'url = "https://lists.example.com/u/abc?token=x%20y"'
+contains "it is a POST" "$config" 'request = "POST"'
+contains "the one-click body is sent" "$config" 'data-binary = "List-Unsubscribe=One-Click"'
+contains "redirects are refused" "$config" 'max-redirs = 0'
+contains "https only, for the request" "$config" 'proto = "=https"'
+contains "and for anything it might follow" "$config" 'proto-redir = "=https"'
+contains "the exchange is bounded" "$config" 'max-time = 20'
+missing  "nothing tells curl to follow a redirect" "$config" 'location'
+
+# A quote in a URL must not end the config value it sits in.
+quoted=$(printf '%s %s %s\n' \
+  "$(b64 'https://x.example.com/a"b\c')" "$(b64 'text/plain')" "$(b64 'x=1')" \
+  | wrote)
+contains "a quote and a backslash in the URL are escaped" "$quoted" 'url = "https://x.example.com/a\"b\\c"'
+
+# ------------------------------------------------------------- what it refuses
+
+set +e
+plain=$(printf '%s %s %s\n' "$(b64 'http://lists.example.com/u/abc')" "$(b64 'text/plain')" "$(b64 'x=1')" \
+  | PATH="$work/bin:$PATH" sh "$script" 2>&1)
+plain_code=$?
+set -e
+check "a plain http address is refused" "$plain_code" "2"
+contains "and says why" "$plain" "not https"
+
+set +e
+short=$(printf '%s\n' "$(b64 'https://x.example.com/')" | PATH="$work/bin:$PATH" sh "$script" 2>&1)
+short_code=$?
+set -e
+check "a malformed request is refused" "$short_code" "2"
+
+# ------------------------------------------- and what a real server sees
+
+if ! command -v python3 >/dev/null 2>&1; then
+  printf '\n  python3 is not installed, so the live half did not run.\n'
+  [ "$failures" -eq 0 ] || exit 1
+  exit 0
+fi
+
+port=9942
+cat > "$work/target.py" <<'PY'
+import http.server, sys, threading
+followed = False
+
+class Target(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        global followed
+        if self.path == "/bounce":
+            self.send_response(302)
+            self.send_header("Location", "/landed")
+            self.end_headers()
+        elif self.path == "/landed":
+            followed = True
+            self.send_response(204)
+            self.end_headers()
+        elif self.path == "/plain":
+            self.send_response(200)
+            self.end_headers()
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_GET(self):
+        if self.path == "/verdict":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"FOLLOWED" if followed else b"NOT-FOLLOWED")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *args):
+        pass
+
+http.server.HTTPServer(("127.0.0.1", int(sys.argv[1])), Target).serve_forever()
+PY
+
+python3 "$work/target.py" "$port" &
+server_pid=$!
+# The server needs a moment, and a port that is already busy is worth saying.
+tries=0
+while ! curl -s -o /dev/null "http://127.0.0.1:$port/verdict"; do
+  tries=$((tries + 1))
+  if [ "$tries" -gt 40 ]; then
+    printf '\n  the loopback target never came up on %s, so the live half did not run.\n' "$port"
+    [ "$failures" -eq 0 ] || exit 1
+    exit 0
+  fi
+  sleep 0.1
+done
+
+printf '\nunsubscribe.sh — against a server that is really there\n'
+
+# http is refused by the script, so the live half drives curl directly with the
+# very same config the script writes, minus the https-only lines. What is being
+# tested here is the redirect policy, and that policy is scheme-independent.
+live() {
+  printf 'url = "http://127.0.0.1:%s%s"\n' "$port" "$1"
+  printf 'request = "POST"\n'
+  printf 'header = "Content-Type: application/x-www-form-urlencoded"\n'
+  printf 'data-binary = "List-Unsubscribe=One-Click"\n'
+  printf 'max-redirs = 0\n'
+  printf 'max-time = 20\n'
+  printf 'silent\n'
+  printf 'output = "/dev/null"\n'
+  printf 'write-out = "%%{http_code}"\n'
+}
+
+plain_status=$(live /plain | curl --config - 2>/dev/null)
+check "a list that answers 200 reads as unsubscribed" "$plain_status" "200"
+
+bounce_status=$(live /bounce | curl --config - 2>/dev/null)
+check "a list that answers 302 reads as 302, not as its target" "$bounce_status" "302"
+
+verdict=$(curl -s "http://127.0.0.1:$port/verdict")
+check "and the redirect target was never contacted" "$verdict" "NOT-FOLLOWED"
+
+# A request that never got an answer must read as "not sent" rather than as a
+# status. curl writes `000` for it, which is all digits and would otherwise
+# survive into the panel as a number nobody can act on.
+unreachable=$(printf '%s %s %s\n' \
+  "$(b64 'https://127.0.0.1:9') " "$(b64 'text/plain')" "$(b64 'x=1')" \
+  | sh "$script" 2>/dev/null || true)
+case "$unreachable" in
+  *" 0") ok "an unreachable list reports no status at all" ;;
+  *) bad "an unreachable list reports no status at all"; printf '         actual: %s\n' "$unreachable" ;;
+esac
+
+printf '\n'
+if [ "$failures" -eq 0 ]; then
+  printf 'unsubscribe.sh ok\n'
+else
+  printf '%s assertion(s) failed\n' "$failures"
+  exit 1
+fi


### PR DESCRIPTION
`Unsubscribe.isPostableUrl` judges the address **the sender wrote** — https, and not loopback, private, link-local or single-label. Qt's `XMLHttpRequest` then followed a `3xx` by itself and re-sent the POST, body intact, wherever that answer pointed. Nothing re-asked the gate about the second address.

## The hole

A sender controls an ordinary https host, so the gate passes. That host answers the one-click unsubscribe with `302 Location: http://192.168.1.1/…`. The request this machine actually made is the one the gate exists to refuse, made from inside the user's own network, with the user's routing, carrying a POST body.

**Measured rather than reasoned.** Under Quickshell's own engine, a loopback target answering `302 Location: /landed` recorded the POST arriving at `/landed`:

```
bounce: answered 302 -> http://127.0.0.1:9931/landed
LANDED: POST — the client followed the redirect by itself
```

## The fix

The request goes out through `scripts/unsubscribe.sh`, which is curl, which follows nothing unless it is told to. `--max-redirs 0` and `--proto-redir "=https"` say it a second time on purpose: the day somebody adds `--location` for an unrelated reason, those lines are what refuse it rather than silently reopening this.

A `3xx` now comes back as a `3xx` and reads as a list that did **not** unsubscribe. That is the honest answer — a server answering a one-click request with "go and ask over there" has not done what its own header promised, and RFC 8058 says the answer to this POST is a `2xx`.

Two things come with the move:

- **The subscriber token stays out of the process table.** The URL crosses on stdin base64-encoded and reaches curl in a config on curl's own stdin, the same rule `mail-transport.sh` follows for passwords. An argument would have put the token identifying this subscriber where anyone on the machine could read it.
- **The exchange is bounded.** The request this replaces had no timeout at all, so one that was accepted and then black-holed left the button saying "unsubscribing" until the window was closed.

## What is not closed

**Remote images.** Qt's own image loader performs those fetches and takes no policy from QML, so a sender who redirects an image can still reach an address the gate would have refused. What holds the line meanwhile is that nothing is fetched until the reader asks for it. Closing it properly means fetching the bytes here — curl, no redirects — and handing the renderer a `data:` URI, which is a day's work and a change to the rule that the string handed over is the only control point. `AGENTS.md` now records both the finding and that cost, and says not to paper over it with a second check on the same first address.

## Verification

`make validate` passes. `tests/test_unsubscribe_transport.sh` is new and runs in `make test`: it asserts the config with a curl stub, and then stands a loopback server up and asks it afterwards whether the redirect was followed. The invocation was never the thing that was wrong, so reading it back would not have caught this — the server's own record is the only witness that cannot be fooled.

Also in this branch: the benchmark loader path, which had pointed at the pre-reorganisation `Html.js` since the tree was grouped by module. `make bench` runs its V8 column again. The QML column still exits 0 printing nothing, which is a separate bug and is not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
