### PR TITLE
Use the body and the read state already on disk

### DIFF
--- a/Service.qml
+++ b/Service.qml
@@ -497,6 +497,7 @@ Item {
   readonly property string unsubscribeDetail: current ? current.unsubscribeDetail : ""
   readonly property bool unsubscribing: !!current && current.unsubscribing
   readonly property bool detailLoading: !!current && current.detailLoading
+  readonly property bool detailPainted: !!current && current.detailPainted
   readonly property bool sending: !!current && current.sending
   readonly property string lastError: current ? current.lastError : ""
   readonly property string actionStatus: current ? current.actionStatus : ""

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -614,6 +614,17 @@ Item {
     unsubscribeDone = ""
     detailLoading = true
 
+    // The reader opens on what the list already knows — sender, subject, date,
+    // flags — rather than on a skeleton. The row *is* a summary, and it is the
+    // same shape the live read produces.
+    //
+    // Without this the body cache was invisible: a message opened before had
+    // its body painted from disk in a few milliseconds, and then sat behind the
+    // loading state until the network answered, because the skeleton was gated
+    // on there being no summary and only the live payload ever set one.
+    var known = Model.indexById(messages, messageId)
+    if (known >= 0) selectedMessage = messages[known]
+
     // A message that has been opened before opens from its file, usually well
     // before Gmail answers. The read is asynchronous, so the live copy can win
     // the race — in which case the cached one is simply dropped rather than
@@ -817,6 +828,7 @@ Item {
 
     if (removed) messages = Model.removeById(messages, messageId)
     else messages = Model.replaceById(messages, updated)
+    rememberList()
     if (selectedId === messageId) {
       if (removed) clearSelection()
       else selectedMessage = updated
@@ -826,6 +838,7 @@ Item {
       root.messages = removed
         ? root.messages.slice(0, index).concat([before], root.messages.slice(index))
         : Model.replaceById(root.messages, before)
+      root.rememberList()
       root.refreshCounts()
       root.fail(error)
     }
@@ -851,6 +864,23 @@ Item {
       }
       api.modifyMessage(messageId, change.add, change.remove, done)
     }
+  }
+
+  // What is on screen, written back to the query cache.
+  //
+  // An action changes `messages` and used to change nothing else, so the copy
+  // on disk still said what the mailbox looked like before it. Anything that
+  // paints from that copy — the next `loadMessages`, a mailbox switched away
+  // from and back, the window reopened — put the old state back on screen: a
+  // message read a moment ago, bold again. The live load corrects it a moment
+  // later, which is what made it look intermittent rather than broken.
+  function rememberList() {
+    if (!listLoaded || !cacheStore.loaded) return
+    cacheStore.putQuery(cacheKey, ({
+      summaries: messages,
+      estimate: resultEstimate,
+      nextPageToken: nextPageToken
+    }))
   }
 
   function actionLabel(action) {
@@ -888,11 +918,13 @@ Item {
     var next = []
     for (var j = 0; j < messages.length; j++) next.push(Model.applyLabelChange(messages[j], "markRead"))
     messages = Model.survivesAction(mailboxKey, "markRead") ? next : []
+    rememberList()
     pendingAction = "markRead"
     api.batchModify(ids, [], ["UNREAD"], function(payload, error) {
       root.pendingAction = ""
       if (error) {
         root.messages = before
+        root.rememberList()
         root.fail(error)
         return
       }

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -225,6 +225,15 @@ Item {
   readonly property string unsubscribeDetail: unsubscribeDone !== "" ? unsubscribeDone
     : Unsub.explanation(selectedUnsubscribe, canSend)
   property bool detailLoading: false
+  // Whether the reader has something to show yet, which is a different question
+  // from whether a request is still in the air. A body already on disk answers
+  // the first the moment it is read; the second stays true until the live read
+  // lands, and the status bar is right to keep saying so.
+  //
+  // They were one property, and a message HEY serves no body for — its own
+  // sign-up mail — showed the loading state for the whole round trip on every
+  // open, because nothing ever arrived to make it stop looking empty.
+  property bool detailPainted: false
   // Set once Gmail's own copy has landed, so a slower cache read knows not to
   // paint over it.
   property bool detailLive: false
@@ -613,6 +622,7 @@ Item {
     selectedUnsubscribe = null
     unsubscribeDone = ""
     detailLoading = true
+    detailPainted = false
 
     // The reader opens on what the list already knows — sender, subject, date,
     // flags — rather than on a skeleton. The row *is* a summary, and it is the
@@ -652,6 +662,10 @@ Item {
       // second later when the network agrees.
       root.selectedInvite = cached.invite
       root.selectedUnsubscribe = cached.unsubscribe
+      // Including a body that is empty, which is a real answer: this message
+      // has no text, and saying so at once beats a skeleton that waits for the
+      // network to say the same thing.
+      root.detailPainted = true
       bodyCache.touch(messageId)
     })
 
@@ -659,6 +673,7 @@ Item {
       if (serial !== root.detailSerial) return
       root.detailLoading = false
       root.detailLive = true
+      root.detailPainted = true
       if (error || !payload) {
         root.fail(error || "Could not open that message")
         return

--- a/cache/BodyCache.qml
+++ b/cache/BodyCache.qml
@@ -37,7 +37,10 @@ Item {
 
   // ------------------------------------------------------------------ read
 
+  // One FileView, so one read at a time — and the name it is for, because the
+  // callback alone cannot say which message it was waiting on.
   property var pendingCallback: null
+  property string pendingPath: ""
 
   function read(id, callback) {
     var name = Cache.bodyFileName(id)
@@ -45,17 +48,31 @@ Item {
       if (typeof callback === "function") callback(null)
       return
     }
+    // A second read replaces the first, and the first is *answered* rather than
+    // dropped. It used to be dropped: two reads in one frame — which is what a
+    // held j does — left the first caller holding a callback that never fired.
+    // Nothing waits on it forever, because the network is already on its way,
+    // but a promise silently unkept is how a cache stops being trustworthy.
+    var displaced = pendingCallback
     pendingCallback = callback
-    var wanted = directory + "/" + name
+    pendingPath = directory + "/" + name
+    if (typeof displaced === "function") displaced(null)
+
     // Setting the same path again does not reload on its own, and reopening the
     // message you just closed has to hit the file rather than the last answer.
-    if (reader.path === wanted) reader.reload()
-    else reader.path = wanted
+    if (reader.path === pendingPath) reader.reload()
+    else reader.path = pendingPath
   }
 
+  // Answered against the path that was asked for, not against whatever the
+  // FileView happens to hold. The two agree today because reassigning the path
+  // cancels the load under way — but that is a coincidence of Qt's, and this
+  // is a cache handing a message body to a reader.
   function deliver(body) {
+    if (reader.path !== pendingPath) return
     var callback = pendingCallback
     pendingCallback = null
+    pendingPath = ""
     if (typeof callback === "function") callback(body)
   }
 

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -103,9 +103,28 @@ Item {
     panelFontFamily: root.panelFontFamily
   }
 
+  // Nothing known at all, which after the reader learned to open on the list's
+  // own row is only a message that is not in the list.
   ReaderSkeleton {
     anchors.fill: parent
     visible: !root.summary && !!root.service && root.service.detailLoading
+    textColor: root.textColor
+    panelFontFamily: root.panelFontFamily
+  }
+
+  // The headers are known and the body is not, which is every message being
+  // opened for the first time. Over the body alone, so the sender and the
+  // subject stay readable while it arrives — a whole-reader skeleton would
+  // hide the very thing that just became available.
+  //
+  // `z` rather than declaration order: this has to sit above the body it
+  // stands in for, and being above it should not depend on where in the file
+  // the two happen to be written.
+  ReaderSkeleton {
+    anchors.fill: bodyFlick
+    z: 1
+    visible: !!root.summary && !!root.service && root.service.detailLoading
+      && root.bodySource === ""
     textColor: root.textColor
     panelFontFamily: root.panelFontFamily
   }

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -124,7 +124,7 @@ Item {
     anchors.fill: bodyFlick
     z: 1
     visible: !!root.summary && !!root.service && root.service.detailLoading
-      && root.bodySource === ""
+      && !root.service.detailPainted
     textColor: root.textColor
     panelFontFamily: root.panelFontFamily
   }
@@ -244,6 +244,30 @@ Item {
       accentColor: root.accentColor
       panelFontFamily: root.panelFontFamily
       onActivated: root.forceRichAnyway = true
+    }
+
+    // A message with nothing in it is a real answer, and an empty reader on its
+    // own does not look like one — it looks like something failed. HEY's own
+    // sign-up mail is the case this exists for: the CLI serves those threads
+    // with no body at all, so there is genuinely nothing to draw.
+    //
+    // Waits for the read to be done before saying it, because "no text" is only
+    // true once nothing more is coming.
+    ReaderNotice {
+      width: parent.width
+      visible: !!root.summary && !!root.service
+        && !root.service.detailLoading && root.service.detailPainted
+        && root.bodySource === "" && root.rawHtml === ""
+        && (root.service.selectedAttachments || []).length === 0
+      text: "This message has no text to show"
+      // Only where there is somewhere to go and read it. The service decides
+      // that, and the "..." is there because what it opens is a browser.
+      actionLabel: !root.service || root.service.canOpenOnWeb ? "Open on the web..." : ""
+      textColor: root.textColor
+      dimColor: root.dimColor
+      accentColor: root.accentColor
+      panelFontFamily: root.panelFontFamily
+      onActivated: if (root.service && root.summary) root.service.openInBrowser(root.summary.id)
     }
 
     // Under the heavy-document notice when both are up: one says why the

--- a/tests/test_cache.js
+++ b/tests/test_cache.js
@@ -279,4 +279,36 @@ assert.strictEqual(reloaded.version, cache.VERSION)
       invite: null, unsubscribe: null })
 }
 
+// ------------------------------------- what the cache says about a read row
+//
+// An action changes the list on screen and now writes it back here, because
+// anything that paints from this copy — the next load, a mailbox switched away
+// from and back, the window reopened — otherwise put the old state on screen: a
+// message read a moment ago, bold again. So the flags an action moves have to
+// survive the trip to disk and back.
+
+const readRow = {
+  id: "18f3a", subject: "Lunch", snippet: "Are you free",
+  from: { name: "Jane", email: "jane@example.com" }, to: [], cc: [],
+  date: new Date("2026-08-20T10:00:00Z"), time: "10:00", fullTime: "Aug 20, 2026 10:00",
+  unread: false, starred: true, inInbox: true, labelIds: ["INBOX", "STARRED"]
+}
+
+const throughDisk = cache.hydrate(
+  cache.getQuery(
+    cache.load(cache.serialize(
+      cache.putQuery(cache.emptyStore(), "k",
+        { summaries: [readRow], estimate: 1, nextPageToken: "" }, 1000))),
+    "k").summaries)[0]
+
+assert.strictEqual(throughDisk.unread, false, "a row read before the write stays read")
+assert.strictEqual(throughDisk.starred, true)
+deepEqual(throughDisk.labelIds, ["INBOX", "STARRED"])
+assert.strictEqual(throughDisk.date.getTime(), readRow.date.getTime(),
+  "and the date is a Date again, because relativeTime asks it for one")
+
+// The other way too, so this is a round trip rather than a default.
+const unreadRow = { id: "18f3b", date: new Date("2026-08-20T11:00:00Z"), unread: true }
+assert.strictEqual(cache.hydrate(cache.dehydrate([unreadRow]))[0].unread, true)
+
 console.log("test_cache.js ok")


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.97.0
Both caches were right on disk and unusable on screen. The bodies were there, the
rows were there, and opening a message read before still waited on the network
while a message read a moment ago came back bold. Four faults, all of them in the
last step — what the reader and the list do with an answer they already have.

## A message opened before still waited on the network

The reader's skeleton was gated on there being no summary, and only the live read ever set one:

```qml
ReaderSkeleton { visible: !root.summary && ... service.detailLoading }
```

So a body already on disk was painted in a few milliseconds and then sat behind the loading state until Gmail answered. The body cache was doing its work and there was no way to tell.

The row **is** a summary — the same shape the live read produces — so the reader opens on it. Sender, subject, date and flags are there at once and the cached body arrives under them. A second skeleton covers the body alone while it is on its way, because a whole-reader one would hide the very thing that just became available.

## A message read a moment ago came back bold

An action changed `messages` and nothing else. The copy in the query cache still described the mailbox as it was *before* it, so anything painting from that copy — the next `loadMessages`, a mailbox switched away from and back, the window reopened — put the old state back on screen. The live load corrected it a moment later, which is exactly why it looked intermittent rather than broken.

`rememberList` writes what is on screen back to the cache: on the optimistic update, again if it is rolled back, and on `markAllRead`. `CacheStore.scheduleSave` already debounces the file write, so this costs a timer restart rather than a save per keystroke.

## Two body reads in one frame dropped the first caller

`BodyCache` held one `pendingCallback` and a second `read()` overwrote it. Measured under Quickshell against a seeded cache directory — reading A then B in the same frame, which is what a held `j` does:

```
callback for B received: "THIS IS BODY B"
A's callback fired: false   B's callback fired: true
```

Nothing waits on it forever, because the network is already on its way. But a promise silently unkept is how a cache stops being trustworthy, and the first fix above makes this path load-bearing rather than an optimisation.

The displaced caller is answered with nothing, which reads as a miss:

```
callback for A received: null
callback for B received: "THIS IS BODY B"
PASS — both callers were answered; neither was left waiting
```

Delivery is also checked against the path that was asked for, rather than against whatever the `FileView` happens to hold. The two agree today because reassigning the path cancels the load under way — I measured that too, in both interleavings, and the body was right each time. That is a coincidence of Qt's, and this is a cache handing a message body to a reader.

## A message with no text loaded forever

HEY serves its own sign-up mail with no body: `hey threads` answers those threads with an entry carrying no `body` key at all, while every ordinary message has one. That much is upstream and right. What was ours is what the reader did with it.

A cache hit did not end the loading state. `detailLoading` was the only signal and only the live read cleared it, so the body skeleton stayed up for a whole round trip on **every** open. A message with text hid it the moment the text appeared, which is why this only ever showed on the messages that have none — and those are cached like any other, so the wait bought nothing:

```
1234004911_3a2104288623.json   text=0   html=0   source=''      <- cached, and still waited
1235277732_3a2106485185.json   text=45  html=0   source='plain'  <- cached, looked fine
```

`detailPainted` is the other half of the question: whether the reader has something to show, as against whether a request is still in the air. The status bar is right to keep saying busy while the live read finishes; the skeleton is not, once the body is on screen. A body read from disk sets it — including one that is empty, because "this message has no text" is an answer rather than an absence.

An empty reader now says so, with a way through to the web app for the mailboxes that have one.

## Verification

`make validate` passes. `tests/test_cache.js` covers what the second fix rests on: the flags an action moves survive the trip to disk and back, both ways, and the date comes back as a `Date` because `relativeTime` asks it for one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

