### PR TITLE
Generate the default cloud project id without killing the script

### DIFF
--- a/scripts/google-cloud-setup.sh
+++ b/scripts/google-cloud-setup.sh
@@ -47,9 +47,12 @@ if ! gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/nu
 fi
 
 # Project ids are globally unique, so a fixed default would collide for the
-# second person who runs this.
+# second person who runs this. Read a fixed three bytes rather than piping an
+# endless `tr </dev/urandom` into `head`: there `head` closes the pipe first,
+# `tr` dies of SIGPIPE, and under `pipefail` the whole script exits 141 without
+# printing anything.
 if [[ -z $project_id ]]; then
-  project_id="omamail-$(tr -dc 'a-z0-9' </dev/urandom | head -c 6)"
+  project_id="omamail-$(od -An -tx1 -N3 /dev/urandom | tr -d ' \n')"
 fi
 
 if gcloud projects describe "$project_id" >/dev/null 2>&1; then


### PR DESCRIPTION
`scripts/google-cloud-setup.sh` run without `--project` — the way the README suggests it — exited immediately, silently, and did nothing.

The default id came from `tr -dc 'a-z0-9' </dev/urandom | head -c 6`. The left side of that pipe never ends: /dev/urandom is endless, so as soon as `head` has its six bytes and closes the pipe, `tr` writes again and is killed by SIGPIPE. `set -euo pipefail` turns that 141 into the exit status of the assignment, and the script is gone before it prints anything. It reproduces every time.

The fix reads a fixed three bytes and hexes them: `od -An -tx1 -N3 /dev/urandom | tr -d ' \n'`. The input is finite, so nothing has to be killed to stop reading it, and the suffix is always six characters instead of however many survived the filter. Bounding the input while keeping `… | head -c 6` at the end, as the report suggested, would work too, but leaves the same shape in place and can come up short of six.

Verification: the old line reproduced at exit 141 five times out of five under `set -euo pipefail`; 200 ids from the new one all match `^omamail-[0-9a-f]{6}$` with the script's own flags set; `bash -n` and `--help` pass; `make test-shell` passes. The `gcloud` calls themselves are untouched and were not run.

Fixes #30