### PR TITLE
Ask a folder for a window of itself rather than for all of it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,14 @@ key. What matters while working:
   the end of one response into the middle of the next — which is also how a
   message body could forge a response of its own. Base64 keeps one character
   per octet, so counting characters is counting octets.
+- **A response line has a ceiling, and it is curl's.** libcurl assembles one
+  ping-pong line in a 64 KiB buffer (`DYN_PINGPPONG_CMD`) and abandons the whole
+  request with `CURLE_TOO_LARGE` when a line outgrows it — which `UID SEARCH
+  ALL` does on any mailbox past about ten thousand messages, because a server
+  answers SEARCH on one line however many matched. Nothing may ask a folder a
+  question whose answer is unbounded: `searchPlan` cuts the mailbox into windows
+  of message sequence numbers first, which is what a listing pays a `STATUS`
+  for.
 - `BODY.PEEK`, never `BODY`. Reading a list must not mark the mailbox seen, and
   that is the most common way a hand-rolled IMAP client ruins a mailbox.
 - `UID EXPUNGE`, never bare `EXPUNGE`: the latter removes every `\Deleted`

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -200,9 +200,12 @@ Item {
 
   // ---------------------------------------------------------------- reads
 
-  // IMAP has no page token: SEARCH answers with every matching UID at once. So
-  // the "token" is an offset into that answer, and the count it reports is
-  // exact rather than the estimate Gmail returns.
+  // IMAP has no page token, so the "token" is an offset and the page is a
+  // window of the folder rather than a slice of a reply that carried all of it.
+  // How big the folder is decides what may be asked of it — a SEARCH the size
+  // of a mailbox is a response line curl refuses to hold — so the size is asked
+  // for first. STATUS is one command against a mailbox nothing has selected,
+  // which is why it is its own request rather than a section of the next one.
   //
   // Newest first, which is the order the list is read in and the reverse of the
   // order UIDs are assigned in.
@@ -219,8 +222,15 @@ Item {
         return
       }
       var folder = root.folderFor(parsed.folder)
-      root.run(folder, [Imap.searchCommand(Imap.normalizeCriteria(parsed.criteria))],
-        function(text, error) {
+      root.run("", [Imap.statusCommand(folder)], function(statusText, statusError) {
+        if (handle.aborted) return
+        if (statusError) {
+          if (typeof callback === "function") callback(null, statusError)
+          return
+        }
+        var plan = Imap.searchPlan(Imap.normalizeCriteria(parsed.criteria),
+          Imap.parseStatus(statusText).messages, offset, limit)
+        root.run(folder, plan.commands, function(text, error) {
           if (handle.aborted) return
           if (typeof callback !== "function") return
           if (error) {
@@ -230,18 +240,25 @@ Item {
           var uids = Imap.parseSearch(text)
           // Ascending from the server; the newest message has the highest UID.
           uids.reverse()
-          var page = uids.slice(offset, offset + limit)
+          // A window that ends at "*" answers with anything delivered since
+          // STATUS counted, so the page is taken from the front of what came
+          // back rather than assumed to be all of it.
+          var page = uids.slice(plan.offset, plan.offset + limit)
           var ids = []
           for (var i = 0; i < page.length; i++) ids.push(Imap.messageId(page[i], folder))
+          // What STATUS counted when the page is a window of the folder, and
+          // what came back when the server had to search for it.
+          var estimate = plan.estimate > 0 ? plan.estimate : uids.length
           callback({
             ids: ids,
             // IMAP has no server-side conversation id. Threading falls back to
             // References, which is what every other IMAP client does.
             threadIds: [],
-            nextPageToken: offset + limit < uids.length ? String(offset + limit) : "",
-            estimate: uids.length
+            nextPageToken: offset + limit < estimate ? String(offset + limit) : "",
+            estimate: estimate
           }, "")
         }, handle)
+      }, handle)
     })
     return handle
   }

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -364,10 +364,68 @@ function sequenceSet(uids) {
 // a hand-rolled IMAP client ruins a mailbox.
 var LIST_HEADERS = "HEADER.FIELDS (FROM TO CC SUBJECT DATE MESSAGE-ID REPLY-TO LIST-UNSUBSCRIBE)"
 
-function searchCommand(criteria) {
+// curl is the transport, and it assembles one response line in a 64 KiB buffer
+// (`DYN_PINGPPONG_CMD`, lib/curlx/dynbuf.h). A server answers SEARCH on a
+// single untagged line however many messages matched, so `UID SEARCH ALL`
+// against a large folder produces a line curl will not hold: it abandons the
+// request with CURLE_TOO_LARGE and the folder shows "A value or data field grew
+// larger than allowed" where its mail should be. An INBOX of around ten
+// thousand messages is enough to reach it.
+//
+// So a folder is asked for a window of itself. A window is a range of message
+// sequence numbers rather than of UIDs, which is what makes it expressible
+// before a single UID is known: RFC 9051 6.4.9 has a bare sequence set inside
+// UID SEARCH select by sequence number while the numbers that come back are
+// still UIDs.
+//
+// 4096 messages per window. A UID is at most 4294967295, so ten digits and a
+// separator bound one answer at 11 octets, and 4096 of them behind "* SEARCH "
+// is 45065 — inside the buffer with room for a server that spaces its reply
+// differently.
+var SEARCH_WINDOW = 4096
+
+// The last window of a mailbox ends at "*" rather than at the count STATUS
+// reported. Mail delivered between the two commands lands past a fixed end, and
+// a list that calls itself newest first would open without it.
+function searchWindow(low, high, count, criteria) {
+  return "UID SEARCH " + low + ":" + (high >= count ? "*" : String(high))
+    + (criteria === "" ? "" : " " + criteria)
+}
+
+// What to ask a folder for, given how many messages STATUS says it holds.
+// `offset` is where the reply has to be sliced and `estimate` how many messages
+// match, or 0 when only the reply itself can say.
+//
+// Without criteria the folder's own order is the answer, so one window is the
+// page: the newest messages sit at the end of the sequence, the count is what
+// STATUS already reported, and nothing but the page crosses the wire. With
+// criteria the server has to be asked, so the mailbox is walked whole — one
+// window at a time, and `parseSearch` reads every SEARCH line in the reply, so
+// the windows are one connection and one answer.
+function searchPlan(criteria, total, offset, limit) {
+  var count = Math.max(0, Math.floor(Number(total)) || 0)
   var text = trimmed(criteria)
-  // ALL rather than an empty criteria list, which is a syntax error.
-  return "UID SEARCH " + (text === "" ? "ALL" : text)
+  var from = Math.max(0, Math.floor(Number(offset)) || 0)
+  var size = Math.max(1, Math.floor(Number(limit)) || 1)
+  var commands = []
+  var low = 1
+  var high = 0
+
+  if (count === 0) return { commands: commands, offset: 0, estimate: 0 }
+
+  if (text === "") {
+    high = count - from
+    if (high < 1) return { commands: commands, offset: 0, estimate: count }
+    low = Math.max(1, high - size + 1)
+    commands.push(searchWindow(low, high, count, ""))
+    return { commands: commands, offset: 0, estimate: count }
+  }
+
+  for (low = 1; low <= count; low += SEARCH_WINDOW) {
+    high = Math.min(count, low + SEARCH_WINDOW - 1)
+    commands.push(searchWindow(low, high, count, text))
+  }
+  return { commands: commands, offset: from, estimate: 0 }
 }
 
 function summaryFetchCommand(uids) {

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -175,9 +175,36 @@ assert.strictEqual(imap.sequenceSet(null), "")
 
 // ---------------------------------------------------------------- commands
 
-assert.strictEqual(imap.searchCommand("UNSEEN"), "UID SEARCH UNSEEN")
-assert.strictEqual(imap.searchCommand(""), "UID SEARCH ALL",
-  "empty criteria is a syntax error; ALL is what it means")
+// curl holds one response line in a 64 KiB buffer and a server answers SEARCH
+// on one line however many messages matched, so nothing may ask a folder a
+// question whose answer is unbounded. Without criteria the page is one window
+// of the folder's own order and nothing else crosses the wire.
+const newest = imap.searchPlan("", 1000, 0, 25)
+deepEqual(newest.commands, ["UID SEARCH 976:*"])
+assert.strictEqual(newest.offset, 0, "the window is the page; there is nothing to skip")
+assert.strictEqual(newest.estimate, 1000, "STATUS counted the folder, so the reply need not")
+
+// The newest window ends at "*" so that mail delivered since STATUS counted is
+// in it. Every other window ends where it was asked to.
+deepEqual(imap.searchPlan("", 1000, 25, 25).commands, ["UID SEARCH 951:975"])
+deepEqual(imap.searchPlan("", 1000, 995, 25).commands, ["UID SEARCH 1:5"],
+  "the oldest page stops at the first message rather than below it")
+deepEqual(imap.searchPlan("", 1000, 1000, 25).commands, [], "past the end asks nothing")
+deepEqual(imap.searchPlan("", 0, 0, 25).commands, [], "an empty folder asks nothing")
+
+// With criteria the server has to be asked, so the mailbox is walked whole —
+// one window at a time, and `parseSearch` reads every SEARCH line as one answer.
+const searched = imap.searchPlan("UNSEEN", 9000, 0, 25)
+deepEqual(searched.commands, [
+  "UID SEARCH 1:4096 UNSEEN",
+  "UID SEARCH 4097:8192 UNSEEN",
+  "UID SEARCH 8193:* UNSEEN"
+])
+assert.strictEqual(searched.estimate, 0, "only the reply knows how many matched")
+assert.strictEqual(imap.searchPlan("UNSEEN", 30, 25, 25).offset, 25,
+  "a searched page is sliced out of the matches, not out of the folder")
+deepEqual(imap.searchPlan("UNSEEN", 30, 0, 25).commands, ["UID SEARCH 1:* UNSEEN"],
+  "a folder smaller than one window is one command")
 
 // BODY.PEEK, never BODY: reading the list must not mark the mailbox seen.
 const summaryFetch = imap.summaryFetchCommand([7, 9])
@@ -249,6 +276,9 @@ deepEqual(imap.parseFetch(spoofed).map((m) => m.uid), [3],
 // ------------------------------------------------------------------ SEARCH
 
 deepEqual(imap.parseSearch("* SEARCH 1 4 9\r\nA1 OK SEARCH completed\r\n"), [1, 4, 9])
+// One window per SEARCH, one reply for the lot: a searched folder arrives as
+// several SEARCH lines and they are one answer.
+deepEqual(imap.parseSearch("* SEARCH 1 4\r\n* SEARCH 9\r\nA1 OK\r\n"), [1, 4, 9])
 deepEqual(imap.parseSearch("* SEARCH\r\nA1 OK\r\n"), [], "nothing matched")
 deepEqual(imap.parseSearch("A1 OK SEARCH completed\r\n"), [],
   "a server may answer with no SEARCH line at all")


### PR DESCRIPTION
Hi,

This PR comes out of a problem I ran into syncing a mailbox with more than 9k messages: the Inbox would only ever show the curl error `a value or data field grew larger than allowed`, while Unread and the other folders kept working.

Full disclosure: this PR was entirely generated with Claude Code. I have read through it, but I have not tested it against a real account. I am posting it in the hope that the code is sound, or that it at least helps toward a fix.

-----

An IMAP account whose INBOX holds more than about ten thousand messages opened the Inbox on "A value or data field grew larger than allowed" and no mail at all, while Unread, Flagged and search kept working on the same account.

That sentence is libcurl's. curl is the transport, and it assembles one ping-pong response line in a 64 KiB buffer (`DYN_PINGPPONG_CMD` in lib/curlx/dynbuf.h); a line that outgrows it fails the whole request with CURLE_TOO_LARGE, exit code 100. A server answers SEARCH on a single untagged line however many messages matched, so `UID SEARCH ALL` against a large mailbox is exactly that line: ten thousand UIDs at six octets each is already past the buffer. `responseError` maps curl's documented exit codes and passes anything else through, so what reached the panel was curl's own words. Unread, Flagged and a text search escaped it only because few messages match them.

The invariant is that nothing may ask a folder a question whose answer is unbounded. `searchPlan` cuts the mailbox into windows of message sequence numbers, which RFC 9051 6.4.9 makes expressible before a single UID is known: a bare sequence set inside UID SEARCH selects by sequence number while the numbers that come back are still UIDs. Windows hold 4096 messages, because a UID is at most ten digits and a separator, so 4096 of them behind "* SEARCH " is 45065 octets.

Without criteria the folder's own order is the answer, so one window is the page and nothing but the page crosses the wire — where a listing used to download every identifier in the mailbox to display twenty-five of them. With criteria the server has to be asked, so the mailbox is walked whole, one window at a time and all of them on one connection; the windows arrive as several SEARCH lines and `parseSearch` already read every one of them as a single answer.

The newest window ends at "*" rather than at the count STATUS reported, so mail delivered between the two commands is in the list rather than past the end of it, and the page is taken from the front of what came back rather than assumed to be all of it.

What replaces it: the size of a folder stops being something the client derives by downloading every UID in it and becomes something it asks for. A listing therefore costs one `STATUS` before the search — one command against a mailbox nothing has selected, which is why it is its own request rather than a section of the next one. That is one extra connection per page load, paid back immediately on any folder large enough for the old listing to be slow and on every folder large enough for it to fail.

Rejected: raising curl's buffer, which is a compile-time constant in libcurl and not reachable from a config file; and windowing only the criteria-free listing, which leaves Unread and Flagged one large mailbox away from the same error.

Verification: `make test-js` and `make test-shell` pass, with new cases in tests/test_imap.js covering the newest page, a later page, the oldest page, a page past the end, an empty folder, a folder smaller than one window, and the multi-window ladder a criteria search produces. `make qml-check` exits 0 with the same three pre-existing warnings on ImapClient.qml as before the change, and `omarchy plugin validate .` passes. `make test-qml` could not be run here: qmltestrunner is not installed on this machine. Not verified against a mailbox of the failing size; the reproduction is a single curl request,
`curl --url imaps://host/INBOX --user ... --request "UID SEARCH ALL"`, which exits 100 on such an account and exits 0 for every window this change asks for instead.