### PR TITLE
Retry saved Gmail sessions after transient refresh failures

### DIFF
--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -295,6 +295,7 @@ Item {
       toolsPresent: auth.toolsPresent || !auth.toolsChecked,
       credentialsPresent: auth.credentialsPresent,
       signingIn: auth.loginBusy,
+      recoveringSession: auth.recoveringSession || false,
       signedIn: auth.loggedIn
     })
   }

--- a/account/Model.js
+++ b/account/Model.js
@@ -30,6 +30,7 @@ function setupState(status) {
   if (!value.toolsPresent) return "tools_missing"
   if (!value.credentialsPresent) return "no_credentials"
   if (value.signingIn) return "signing_in"
+  if (value.recoveringSession) return "reconnecting"
   if (!value.signedIn) return "signed_out"
   return "ready"
 }
@@ -63,6 +64,7 @@ function setupHeadline(state, provider, authKind) {
     if (authKind === "cli") return "Waiting for " + name + "…"
     return "Waiting for Google…"
   }
+  if (state === "reconnecting") return "Reconnecting to " + name + "…"
   if (state === "signed_out") return "Sign in to " + name
   return ""
 }
@@ -102,6 +104,8 @@ function setupDetail(state, missingTools, reason, provider, authKind) {
       return "The HEY CLI is installed but signed out. Sign in to let it read this mailbox."
     return "Your OAuth client is ready. Sign in to let it read this mailbox."
   }
+  if (state === "reconnecting")
+    return "The saved session is intact. Omamail will retry automatically when the network is available."
   return ""
 }
 
@@ -119,6 +123,7 @@ function setupActionLabel(state, provider, authKind) {
     return "Set up the OAuth client..."
   }
   if (state === "signing_in") return "Cancel"
+  if (state === "reconnecting") return ""
   if (state === "signed_out") return "Sign in to " + providerName(provider) + "..."
   return ""
 }

--- a/providers/AuthManager.qml
+++ b/providers/AuthManager.qml
@@ -58,6 +58,12 @@ Item {
   property string grantedScope: ""
   property bool loggedIn: false
   property bool sessionChecked: false
+  // True after the keyring yielded a refresh token, even while a temporary
+  // network failure prevents it from becoming an access token. This is not a
+  // signed-out account: the saved grant is still the route back to ready.
+  property bool savedSessionPresent: false
+  readonly property bool recoveringSession: savedSessionPresent && !loggedIn
+  property int refreshRetryAttempt: 0
   property bool loginBusy: false
   property bool refreshBusy: false
   property bool credentialsWriteBusy: false
@@ -73,6 +79,8 @@ Item {
   property var tokenWaiters: []
   property string lookupPurpose: ""
   property bool lookupHandled: false
+  property var lookupAttributes: []
+  property var savedTokenAttributes: []
   // One lookup at a time, whichever of the two processes is carrying it.
   readonly property bool lookupRunning: secretLookup.running || legacySearch.running
   property string keyringWriteToken: ""
@@ -147,6 +155,7 @@ Item {
   function restoreSession() {
     sessionChecked = false
     if (!credentialsPresent) {
+      savedSessionPresent = false
       sessionChecked = true
       resetMemorySession()
       return
@@ -186,6 +195,9 @@ Item {
       // A different client means a different keyring entry and a different
       // grant; whatever is in memory belongs to the old one.
       resetMemorySession()
+      savedSessionPresent = false
+      refreshRetryAttempt = 0
+      refreshRetry.stop()
       sessionChecked = false
       if (Credentials.isConfigured(loaded)) restoreSession()
       else sessionChecked = true
@@ -228,8 +240,8 @@ Item {
     lookupHandled = false
     triedLegacyLookup = false
     secretLookupStage = 0
-    secretLookup.command = ["secret-tool", "lookup"].concat(
-      Credentials.keyringAttributes(clientId, accountId))
+    lookupAttributes = Credentials.refreshTokenAttributes(clientId, accountId, 0)
+    secretLookup.command = ["secret-tool", "lookup"].concat(lookupAttributes)
     secretLookup.running = true
   }
 
@@ -262,6 +274,7 @@ Item {
       legacySearch.running = true
       return
     }
+    lookupAttributes = attributes
     secretLookup.command = ["secret-tool", "lookup"].concat(attributes)
     secretLookup.running = true
   }
@@ -281,6 +294,7 @@ Item {
       return
     }
     lookupHandled = false
+    lookupAttributes = legacyAttributes
     secretLookup.command = ["secret-tool", "lookup"].concat(legacyAttributes)
     secretLookup.running = true
   }
@@ -296,11 +310,14 @@ Item {
     var purpose = lookupPurpose
     lookupPurpose = ""
     if (!token) {
+      savedSessionPresent = false
       resetMemorySession()
       sessionChecked = true
       if (purpose === "request") finishWaiters("", "Sign in to Gmail first")
       return
     }
+    savedSessionPresent = true
+    savedTokenAttributes = lookupAttributes.slice()
     renamedAttributesToClear = secretLookupStage >= 2
       ? (secretLookupStage === 3
         ? Credentials.renamedLegacyKeyringAttributes(clientId)
@@ -339,10 +356,11 @@ Item {
     keyringStore.running = true
   }
 
-  function clearStoredToken() {
+  function clearStoredToken(attributes) {
     if (keyringClear.running || !clientId) return
-    keyringClear.command = ["secret-tool", "clear"].concat(
-      Credentials.keyringAttributes(clientId, accountId))
+    var selected = attributes && attributes.length
+      ? attributes : Credentials.keyringAttributes(clientId, accountId)
+    keyringClear.command = ["secret-tool", "clear"].concat(selected)
     keyringClear.running = true
   }
 
@@ -421,9 +439,17 @@ Item {
       if (!result.ok) {
         root.resetMemorySession()
         root.lastError = root.safeError(result.error)
-        // A revoked or expired grant is never coming back. Dropping it here
-        // means the panel offers "Sign in" instead of retrying forever.
-        if (result.invalidGrant) root.clearStoredToken()
+        if (OAuth.refreshFailureDisposition(result) === "signed_out") {
+          // A revoked or expired grant is never coming back. Dropping it here
+          // means the panel offers "Sign in" instead of retrying forever.
+          root.savedSessionPresent = false
+          refreshRetry.stop()
+          root.clearStoredToken(root.savedTokenAttributes)
+        } else {
+          // The keyring token is still valid evidence of a saved session. Keep
+          // it and retry until the network can exchange it for an access token.
+          root.scheduleRefreshRetry()
+        }
         if (purpose === "request") root.finishWaiters("", root.lastError)
         else root.sessionUnavailable(root.lastError)
         return
@@ -441,6 +467,9 @@ Item {
     accessTokenExpiresAt = Date.now() + result.expiresIn * 1000
     if (result.scope) grantedScope = result.scope
     loggedIn = true
+    savedSessionPresent = true
+    refreshRetryAttempt = 0
+    refreshRetry.stop()
     lastError = ""
     if (result.refreshToken) storeRefreshToken(result.refreshToken)
   }
@@ -463,6 +492,13 @@ Item {
     exchangingCode = false
     pkceGenerator.command = [pluginDir + "/scripts/pkce.sh"]
     pkceGenerator.running = true
+  }
+
+  function scheduleRefreshRetry() {
+    if (!savedSessionPresent || refreshRetry.running) return
+    refreshRetry.interval = OAuth.refreshRetryDelay(refreshRetryAttempt)
+    refreshRetryAttempt++
+    refreshRetry.start()
   }
 
   function handlePkce(raw) {
@@ -591,6 +627,9 @@ Item {
 
   function logout() {
     cancelLogin()
+    refreshRetry.stop()
+    refreshRetryAttempt = 0
+    savedSessionPresent = false
     resetMemorySession()
     sessionChecked = true
     grantedScope = ""
@@ -680,6 +719,12 @@ Item {
     id: authTimeout
     interval: 180000
     onTriggered: root.failLogin("Google sign-in took too long. Please try again")
+  }
+
+  Timer {
+    id: refreshRetry
+    repeat: false
+    onTriggered: root.restoreSession()
   }
 
   Process {

--- a/providers/Credentials.js
+++ b/providers/Credentials.js
@@ -387,6 +387,16 @@ function renamedLegacyKeyringAttributes(clientId) {
   return attributes
 }
 
+// The restore stages are also the locations an invalid grant must be removed
+// from. Returning the exact attribute vector keeps lookup and cleanup from
+// drifting apart as old storage names are retired.
+function refreshTokenAttributes(clientId, accountId, stage) {
+  if (stage === 1) return legacyKeyringAttributes(clientId)
+  if (stage === 2) return renamedKeyringAttributes(clientId, accountId)
+  if (stage === 3) return renamedLegacyKeyringAttributes(clientId)
+  return keyringAttributes(clientId, accountId)
+}
+
 // An omitted attribute is a wildcard too, not just an empty one. secret-tool
 // matches any item carrying *at least* the attributes it was asked for, so
 // both lookups above that leave "account" out match the account-keyed entries

--- a/providers/OAuth.js
+++ b/providers/OAuth.js
@@ -185,6 +185,21 @@ function parseTokenResponse(status, text, previousRefreshToken) {
   }
 }
 
+// A saved grant stops being a session only when Google says the grant itself
+// is invalid. Timeouts, transport failures and server errors leave it intact
+// and must be retried when the network is usable again.
+function refreshFailureDisposition(result) {
+  return result && result.invalidGrant ? "signed_out" : "retry"
+}
+
+// Start quickly for a network transition, then back off to one request every
+// five minutes during a longer outage. A successful refresh resets the caller's
+// attempt counter.
+function refreshRetryDelay(attempt) {
+  var count = Math.max(0, Math.floor(Number(attempt)) || 0)
+  return Math.min(300000, 5000 * Math.pow(2, count))
+}
+
 // A grant is only useful if it came back with everything the panel needs. A
 // user who unticks a checkbox on Google's consent screen gets a working token
 // with a scope set that silently breaks half the actions.

--- a/tests/test_credentials.js
+++ b/tests/test_credentials.js
@@ -194,6 +194,18 @@ deepEqual(credentials.renamedLegacyKeyringAttributes(sharedClient), [
   "client-id", sharedClient
 ])
 
+// A rejected token must be cleared from the exact lookup stage that produced
+// it. Clearing only the canonical entry leaves a legacy token to be found and
+// rejected again on every restart.
+deepEqual(credentials.refreshTokenAttributes(sharedClient, "me@example.com", 0),
+  credentials.keyringAttributes(sharedClient, "me@example.com"))
+deepEqual(credentials.refreshTokenAttributes(sharedClient, "me@example.com", 1),
+  credentials.legacyKeyringAttributes(sharedClient))
+deepEqual(credentials.refreshTokenAttributes(sharedClient, "me@example.com", 2),
+  credentials.renamedKeyringAttributes(sharedClient, "me@example.com"))
+deepEqual(credentials.refreshTokenAttributes(sharedClient, "me@example.com", 3),
+  credentials.renamedLegacyKeyringAttributes(sharedClient))
+
 // --------------------------------------------- looking before the leap
 //
 // Why the legacy read counts before it asks is in Credentials.js. What it has

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -12,12 +12,17 @@ assert.strictEqual(model.setupState({ toolsPresent: false }), "tools_missing")
 assert.strictEqual(model.setupState({ toolsPresent: true, credentialsPresent: false }), "no_credentials")
 assert.strictEqual(model.setupState({ toolsPresent: true, credentialsPresent: true, signedIn: false }), "signed_out")
 assert.strictEqual(model.setupState({ toolsPresent: true, credentialsPresent: true, signingIn: true }), "signing_in")
+assert.strictEqual(model.setupState({ toolsPresent: true, credentialsPresent: true,
+  recoveringSession: true, signedIn: false }), "reconnecting")
 assert.strictEqual(model.setupState({ toolsPresent: true, credentialsPresent: true, signedIn: true }), "ready")
 assert.strictEqual(model.setupState(null), "tools_missing")
 
 // Missing tools have to be named. "Something is missing" is not actionable.
 assert.ok(model.setupDetail("tools_missing", ["socat", "secret-tool"]).indexOf("socat, secret-tool") > 0)
 assert.strictEqual(model.setupHeadline("ready"), "")
+assert.strictEqual(model.setupHeadline("reconnecting"), "Reconnecting to Gmail…")
+assert.ok(model.setupDetail("reconnecting").indexOf("retry automatically") > 0)
+assert.strictEqual(model.setupActionLabel("reconnecting"), "")
 assert.strictEqual(model.setupHeadline("signed_out"), "Sign in to Gmail",
   "an account with no provider recorded is a Gmail account")
 assert.strictEqual(model.setupHeadline("signed_out", "IMAP"), "Sign in to IMAP")

--- a/tests/test_oauth.js
+++ b/tests/test_oauth.js
@@ -104,6 +104,21 @@ assert.strictEqual(revoked.error, "Google rejected the saved session. Sign in ag
 assert.strictEqual(oauth.parseTokenResponse(500, "<html>", "").ok, false)
 assert.strictEqual(oauth.parseTokenResponse(200, "{}", "").ok, false, "no access_token is a failure")
 
+// A network outage did not revoke the saved grant. Treating every failed
+// refresh as signed out strands a valid keyring token until the shell restarts.
+assert.strictEqual(oauth.refreshFailureDisposition({ ok: false, invalidGrant: false }), "retry",
+  "temporary refresh failures keep trying the saved session")
+assert.strictEqual(oauth.refreshFailureDisposition({ ok: false, invalidGrant: true }), "signed_out",
+  "only a rejected grant requires another sign-in")
+
+// Retries start promptly, then back off so a long outage does not hammer the
+// token endpoint forever. The cap keeps recovery bounded when the network
+// eventually returns.
+assert.strictEqual(oauth.refreshRetryDelay(0), 5000)
+assert.strictEqual(oauth.refreshRetryDelay(1), 10000)
+assert.strictEqual(oauth.refreshRetryDelay(6), 300000)
+assert.strictEqual(oauth.refreshRetryDelay(100), 300000)
+
 // --------------------------------------------------------------- scopes
 
 deepEqual(


### PR DESCRIPTION
## What changed

- Keep a saved Gmail refresh token after timeouts, transport failures, and temporary Google errors instead of presenting the mailbox as signed out.
- Retry the token exchange after five seconds with exponential backoff capped at five minutes, and return the mailbox to ready as soon as an access token is available.
- Show a reconnecting state while the saved session is recovering.
- Clear a token only when Google explicitly returns `invalid_grant`, including tokens found in legacy and renamed keyring locations.

## Why

A refresh token in the keyring and a usable access token in memory are different states. A network failure can prevent the latter without invalidating the former, so session recovery now preserves that distinction. The keyring entry remains authoritative until Google rejects the grant; transient failures schedule another exchange instead of requiring a new sign-in.

## Verification

- `NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost make validate`
- 36 QML tests passed
- Independent code review found no remaining Critical or Important issues