### PR TITLE
List large IMAP folders without overflowing curl

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,12 @@ key. What matters while working:
   the end of one response into the middle of the next — which is also how a
   message body could forge a response of its own. Base64 keeps one character
   per octet, so counting characters is counting octets.
+- **A response line has curl's 64 KiB ceiling.** SEARCH returns every matching
+  UID on one line, so an unbounded `UID SEARCH ALL` fails around ten thousand
+  messages. A listing first takes a UID snapshot with `UID FETCH 1:* (UID)`,
+  whose response is one short line per message. Filtered searches split those
+  stable UIDs into batches of at most 4096; never replace them with message
+  sequence-number windows, which move when another client expunges mail.
 - `BODY.PEEK`, never `BODY`. Reading a list must not mark the mailbox seen, and
   that is the most common way a hand-rolled IMAP client ruins a mailbox.
 - `UID EXPUNGE`, never bare `EXPUNGE`: the latter removes every `\Deleted`

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -200,9 +200,11 @@ Item {
 
   // ---------------------------------------------------------------- reads
 
-  // IMAP has no page token: SEARCH answers with every matching UID at once. So
-  // the "token" is an offset into that answer, and the count it reports is
-  // exact rather than the estimate Gmail returns.
+  // IMAP has no page token, so the "token" is an offset into a UID snapshot.
+  // FETCH makes that snapshot one short response line per message; an ordinary
+  // SEARCH would put every UID on one line and curl refuses that line once a
+  // folder grows past roughly ten thousand messages. A filtered listing then
+  // searches bounded ranges of the stable UIDs the snapshot reported.
   //
   // Newest first, which is the order the list is read in and the reverse of the
   // order UIDs are assigned in.
@@ -219,18 +221,27 @@ Item {
         return
       }
       var folder = root.folderFor(parsed.folder)
-      root.run(folder, [Imap.searchCommand(Imap.normalizeCriteria(parsed.criteria))],
-        function(text, error) {
+      root.run(folder, [Imap.uidListCommand()], function(snapshotText, snapshotError) {
+        if (handle.aborted) return
+        if (snapshotError) {
+          if (typeof callback === "function") callback(null, snapshotError)
+          return
+        }
+
+        var snapshot = Imap.parseUidList(snapshotText)
+        var criteria = Imap.normalizeCriteria(parsed.criteria)
+
+        function finish(uids, error) {
           if (handle.aborted) return
           if (typeof callback !== "function") return
           if (error) {
             callback(null, error)
             return
           }
-          var uids = Imap.parseSearch(text)
+          var ordered = Array.isArray(uids) ? uids.slice() : []
           // Ascending from the server; the newest message has the highest UID.
-          uids.reverse()
-          var page = uids.slice(offset, offset + limit)
+          ordered.reverse()
+          var page = ordered.slice(offset, offset + limit)
           var ids = []
           for (var i = 0; i < page.length; i++) ids.push(Imap.messageId(page[i], folder))
           callback({
@@ -238,10 +249,20 @@ Item {
             // IMAP has no server-side conversation id. Threading falls back to
             // References, which is what every other IMAP client does.
             threadIds: [],
-            nextPageToken: offset + limit < uids.length ? String(offset + limit) : "",
-            estimate: uids.length
+            nextPageToken: offset + limit < ordered.length ? String(offset + limit) : "",
+            estimate: ordered.length
           }, "")
+        }
+
+        var commands = Imap.searchCommands(criteria, snapshot)
+        if (criteria === "" || commands.length === 0) {
+          finish(criteria === "" ? snapshot : [], "")
+          return
+        }
+        root.run(folder, commands, function(searchText, searchError) {
+          finish(Imap.parseSearch(searchText), searchError)
         }, handle)
+      }, handle)
     })
     return handle
   }

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -364,10 +364,50 @@ function sequenceSet(uids) {
 // a hand-rolled IMAP client ruins a mailbox.
 var LIST_HEADERS = "HEADER.FIELDS (FROM TO CC SUBJECT DATE MESSAGE-ID REPLY-TO LIST-UNSUBSCRIBE)"
 
-function searchCommand(criteria) {
+// curl holds one IMAP response line in a 64 KiB buffer. SEARCH answers with
+// every matching UID on one line, so an unbounded `UID SEARCH ALL` fails with
+// CURLE_TOO_LARGE once a folder has around ten thousand messages. FETCH puts
+// each UID on its own response line instead, which makes this the stable
+// snapshot every listing starts from.
+function uidListCommand() {
+  return "UID FETCH 1:* (UID)"
+}
+
+// A SEARCH over a known UID snapshot can be split without using message
+// sequence numbers. UIDs do not move when another client expunges a message,
+// and a message delivered after the snapshot has a UID above its last one.
+//
+// 4096 UIDs per response. A UID is at most ten digits, so the matching SEARCH
+// line stays below 45 KiB even when every UID in the batch matches. The range
+// endpoints may be far apart in a sparse mailbox, but the snapshot proves that
+// at most 4096 existing messages lie between them.
+var SEARCH_WINDOW = 4096
+
+function sortedUids(values) {
+  var list = Array.isArray(values) ? values : []
+  var found = {}
+  var out = []
+  for (var i = 0; i < list.length; i++) {
+    var uid = Math.floor(Number(list[i]))
+    if (!isFinite(uid) || uid < 1 || found[uid]) continue
+    found[uid] = true
+    out.push(uid)
+  }
+  out.sort(function(a, b) { return a - b })
+  return out
+}
+
+function searchCommands(criteria, snapshot) {
   var text = trimmed(criteria)
-  // ALL rather than an empty criteria list, which is a syntax error.
-  return "UID SEARCH " + (text === "" ? "ALL" : text)
+  var uids = sortedUids(snapshot)
+  var commands = []
+  if (text === "" || uids.length === 0) return commands
+
+  for (var i = 0; i < uids.length; i += SEARCH_WINDOW) {
+    var last = Math.min(uids.length - 1, i + SEARCH_WINDOW - 1)
+    commands.push("UID SEARCH UID " + uids[i] + ":" + uids[last] + " " + text)
+  }
+  return commands
 }
 
 function summaryFetchCommand(uids) {
@@ -516,7 +556,17 @@ function parseSearch(text) {
       if (isFinite(uid) && uid > 0) uids.push(uid)
     }
   }
-  return uids
+  return sortedUids(uids)
+}
+
+// `UID FETCH 1:* (UID)` returns one FETCH response per message. The UID is the
+// only data item it carries; sorting and de-duplicating here makes the snapshot
+// independent of the order in which a server chose to report those responses.
+function parseUidList(text) {
+  var entries = parseFetch(text)
+  var uids = []
+  for (var i = 0; i < entries.length; i++) uids.push(entries[i].uid)
+  return sortedUids(uids)
 }
 
 // Reads the value of one FETCH data item out of a response line. The items are
@@ -526,7 +576,7 @@ function fetchItem(line, name) {
   var index = line.indexOf(name)
   if (index < 0) return ""
   var rest = line.substring(index + name.length)
-  var match = rest.match(/^\s*("(?:[^"\\]|\\.)*"|\S+)/)
+  var match = rest.match(/^\s*("(?:[^"\\]|\\.)*"|[^()\s]+)/)
   return match ? match[1] : ""
 }
 

--- a/scripts/mail-transport.sh
+++ b/scripts/mail-transport.sh
@@ -110,6 +110,8 @@ if [ "$mode" = "smtp" ]; then
   printf 'url = "%s"\n' "$escaped_url"
   printf 'noproxy = "*"\n'
   printf 'user = "%s"\n' "$escaped_credentials"
+  printf 'max-time = 60\n'
+  printf 'connect-timeout = 20\n'
   printf 'mail-from = "%s"\n' "$(escape "$sender")"
   for recipient in "$@"; do
     printf 'mail-rcpt = "%s"\n' "$(escape "$(decode "$recipient")")"
@@ -137,6 +139,10 @@ else
     # Repeated because `next` resets this curl option with the rest.
     printf 'noproxy = "*"\n'
     printf 'user = "%s"\n' "$escaped_credentials"
+    # These are per-transfer options too. Keeping them in every section makes
+    # every command give up eventually, rather than only the final one.
+    printf 'max-time = 60\n'
+    printf 'connect-timeout = 20\n'
     printf 'request = "%s"\n' "$(escape "$(decode "$argument")")"
   done
 fi
@@ -153,12 +159,11 @@ fi
 # config builder's.
 set +e
 build_config "$@" | curl \
+  --fail-early \
   --config - \
   --silent \
   --show-error \
   --dump-header "$work/headers" \
-  --max-time 60 \
-  --connect-timeout 20 \
   > "$work/out" 2> "$work/err"
 status=$?
 set -e

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -175,9 +175,23 @@ assert.strictEqual(imap.sequenceSet(null), "")
 
 // ---------------------------------------------------------------- commands
 
-assert.strictEqual(imap.searchCommand("UNSEEN"), "UID SEARCH UNSEEN")
-assert.strictEqual(imap.searchCommand(""), "UID SEARCH ALL",
-  "empty criteria is a syntax error; ALL is what it means")
+assert.strictEqual(imap.uidListCommand(), "UID FETCH 1:* (UID)",
+  "a UID snapshot is one bounded FETCH response line per message")
+deepEqual(imap.searchCommands("", [1, 2, 3]), [],
+  "an unfiltered listing already has its answer in the UID snapshot")
+deepEqual(imap.searchCommands("UNSEEN", [3, 40, 9000000]), [
+  "UID SEARCH UID 3:9000000 UNSEEN"
+], "a sparse range is bounded by the number of UIDs known to exist inside it")
+
+const manyUids = []
+for (let uid = 1; uid <= 9000; uid++) manyUids.push(uid)
+deepEqual(imap.searchCommands("FLAGGED", manyUids), [
+  "UID SEARCH UID 1:4096 FLAGGED",
+  "UID SEARCH UID 4097:8192 FLAGGED",
+  "UID SEARCH UID 8193:9000 FLAGGED"
+], "no SEARCH response can contain more than 4096 UIDs")
+assert.ok(imap.searchCommands("UNSEEN", manyUids)[2].indexOf("*") < 0,
+  "mail delivered after the snapshot cannot enter its last search window")
 
 // BODY.PEEK, never BODY: reading the list must not mark the mailbox seen.
 const summaryFetch = imap.summaryFetchCommand([7, 9])
@@ -249,10 +263,16 @@ deepEqual(imap.parseFetch(spoofed).map((m) => m.uid), [3],
 // ------------------------------------------------------------------ SEARCH
 
 deepEqual(imap.parseSearch("* SEARCH 1 4 9\r\nA1 OK SEARCH completed\r\n"), [1, 4, 9])
+deepEqual(imap.parseSearch("* SEARCH 9 4\r\n* SEARCH 4 1\r\nA1 OK\r\n"), [1, 4, 9],
+  "several windows are one sorted answer without duplicates")
 deepEqual(imap.parseSearch("* SEARCH\r\nA1 OK\r\n"), [], "nothing matched")
 deepEqual(imap.parseSearch("A1 OK SEARCH completed\r\n"), [],
   "a server may answer with no SEARCH line at all")
 deepEqual(imap.parseSearch(""), [])
+
+deepEqual(imap.parseUidList(
+  "* 3 FETCH (UID 9000000)\r\n* 1 FETCH (UID 3)\r\n* 2 FETCH (UID 40)\r\n"),
+  [3, 40, 9000000], "the UID snapshot does not depend on response order")
 
 // ------------------------------------------------------------------- FETCH
 

--- a/tests/test_transport.sh
+++ b/tests/test_transport.sh
@@ -16,15 +16,30 @@ mkdir -p "$work/bin"
 cat > "$work/bin/curl" <<'STUB'
 #!/bin/sh
 header_file=
+saw_fail_early=0
 while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--dump-header" ]; then
-    header_file=$2
-    shift 2
-  else
-    shift
-  fi
+  case "$1" in
+    --dump-header)
+      header_file=$2
+      shift 2
+      ;;
+    --fail-early)
+      saw_fail_early=1
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
 done
-if [ -n "${CURL_STUB_HEADER:-}" ] && [ -n "$header_file" ]; then
+if [ "${CURL_STUB_REQUIRE_FAIL_EARLY:-0}" = "1" ] && [ "$saw_fail_early" != "1" ]; then
+  cat >/dev/null
+  exit 99
+fi
+if [ -n "${CURL_STUB_STDOUT:-}" ]; then
+  cat >/dev/null
+  printf '%s' "$CURL_STUB_STDOUT"
+elif [ -n "${CURL_STUB_HEADER:-}" ] && [ -n "$header_file" ]; then
   printf '%s' "$CURL_STUB_HEADER" > "$header_file"
   cat >/dev/null
   printf '%s' "${CURL_STUB_BODY:-}"
@@ -128,6 +143,31 @@ else
   printf '  FAIL expected 2 url lines, found %s\n' "$sections"
   failures=$(( failures + 1 ))
 fi
+max_times=$(printf '%s' "$config" | grep -c '^max-time = 60$' || true)
+connect_timeouts=$(printf '%s' "$config" | grep -c '^connect-timeout = 20$' || true)
+if [ "$max_times" = "$sections" ] && [ "$connect_timeouts" = "$sections" ]; then
+  printf '  ok   every command section has its own deadlines\n'
+else
+  printf '  FAIL expected deadlines in all %s sections, found max-time=%s connect-timeout=%s\n' \
+    "$sections" "$max_times" "$connect_timeouts"
+  failures=$(( failures + 1 ))
+fi
+
+# curl otherwise reports only the final transfer's status after --next. A
+# failed earlier SEARCH window must stop the run instead of returning a short,
+# apparently successful result assembled from the remaining windows.
+partial_reply='* SEARCH 1 2 3'
+out=$(printf '%s\n' "$multi" \
+  | CURL_STUB_REQUIRE_FAIL_EARLY=1 CURL_STUB_STDOUT="$partial_reply" CURL_STUB_EXIT=21 \
+    PATH="$work/bin:$PATH" sh "$script")
+first=$(printf '%s\n' "$out" | sed -n '1p')
+decoded=$(printf '%s\n' "$out" | sed -n '2p' | base64 -d)
+if [ "$first" = "21" ] && [ "$decoded" = "$partial_reply" ]; then
+  printf '  ok   an earlier failed section cannot be hidden by a later success\n'
+else
+  printf '  FAIL expected fail-early status 21 with the partial SEARCH response\n'
+  failures=$(( failures + 1 ))
+fi
 
 # --------------------------------------------------------------- escaping
 #
@@ -180,6 +220,8 @@ check "the first recipient is set" "$config" 'mail-rcpt = "friend@example.com"'
 check "every recipient is set" "$config" 'mail-rcpt = "other@example.com"'
 check "the body is uploaded from a file, not passed as an argument" "$config" 'upload-file = "'
 check_absent "SMTP does not emit --next sections" "$config" 'next'
+check "SMTP keeps its transfer deadline" "$config" 'max-time = 60'
+check "SMTP keeps its connection deadline" "$config" 'connect-timeout = 20'
 
 # ------------------------------------------------------------- the framing
 


### PR DESCRIPTION
## What changed

Large IMAP folders now list through a UID snapshot whose response is one short `FETCH` line per message instead of one unbounded `SEARCH` line. Unfiltered listings page directly over that snapshot. Unread, flagged, and text searches split the snapshot into stable ranges containing at most 4096 existing UIDs, so every matching `SEARCH` response remains below curl's 64 KiB line limit.

The ranges use UIDs rather than message sequence numbers. An expunge cannot move their boundaries, and mail delivered after the snapshot receives a UID beyond its last range instead of shifting the page being assembled. Sparse mailboxes remain bounded by the number of UIDs known to exist between each pair of endpoints, not by the numeric distance between them.

Reading the UID-only `FETCH` response also exposed a parser edge case: a final atom immediately before `)` included the parenthesis. FETCH atoms now stop at response syntax, and the UID snapshot test covers that shape.

This uses the libcurl diagnosis from #33 and takes a different paging route to address the sequence-number races identified in its review.

## Verification

- `make validate`
- Reproduced against a real IMAP Inbox large enough to trigger the failure: `UID SEARCH ALL` exited 100; `UID FETCH 1:* (UID)` exited 0 and returned the complete UID snapshot
- Ran a bounded filtered search across multiple batches from the same snapshot; every batch completed with exit 0
- Loaded the development checkout in the real Omarchy shell: Inbox, Unread, and Flagged rendered without curl or IMAP runtime errors
