### PR TITLE
Edit and delete calendar events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ three directories away from the client that calls it.
 | `providers/` | Everything that differs between mail services: a description per provider, the registry over them, the protocol each speaks, and the pair of objects — signs in, fetches — that each needs. |
 | `account/` | One mailbox and the list of them. `MailAccount.qml`, `Accounts.js`, and the rules in `Model.js` about what a list does after an action. |
 | `cache/` | What a query result and a message body are kept in, and the two objects that keep them. |
+| `calendar/` | The calendars an account serves and their events: the sources in `Sources.js`, the rules in `Calendar.js`, the controller that reads and writes them, and the range cache. |
 | `message/` | A message's own content: parsing it (`Message.js`) and making it safe to draw (`Html.js`). |
 | `components/` | Views. They draw what they are given and decide nothing. |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,6 +275,11 @@ key. What matters while working:
   is world-readable.
 - Anything that could carry a credential passes through `OAuth.redact` before
   it can reach a label.
+- **CalDAV credentials go only to the configured source's own origin.** A
+  server-written event `href` is resolved against the collection and refused
+  when its scheme, host or port differs — `Calendar.caldavEventUrl` is the
+  one place that decides, and the controller judges it before the keyring is
+  touched.
 - **Every request that crosses the network is given up on eventually, and in
   QML that costs a `Timer`.** Qt's QML `XMLHttpRequest` has no `timeout` and no
   `ontimeout`: the properties do not exist, and assigning one reads back

--- a/App.qml
+++ b/App.qml
@@ -646,6 +646,27 @@ Item {
     settingsVisible = true
   }
 
+  // A delete asks first, and asks naming the target. Only the confirmation
+  // reaches the controller, with the event the dialog named.
+  function requestEventDelete(sourceId, event) {
+    if (!event) return
+    confirmDeleteDialog.openFor({
+      kind: "event",
+      name: String(event.summary || "Untitled event"),
+      message: "This event will be permanently deleted.",
+      sourceId: String(sourceId || ""),
+      event: event
+    })
+  }
+
+  function confirmDelete(request) {
+    if (!service) return
+    if (request.kind === "event" && request.event) {
+      service.calendarController.deleteEvent(request.sourceId, request.event)
+      calendarView.closeDetail()
+    }
+  }
+
   FloatingWindow {
     id: window
     visible: root.opened
@@ -1160,6 +1181,8 @@ Item {
             onCreateAt: function(startMs) { eventComposer.beginAt(startMs) }
             onCopyRequested: function(text) { root.copyText(text) }
             onOpenRequested: function(url) { Qt.openUrlExternally(url) }
+            onEditRequested: function(sourceId, event) { eventComposer.beginEdit(sourceId, event) }
+            onDeleteRequested: function(sourceId, event) { root.requestEventDelete(sourceId, event) }
           }
         }
 
@@ -1441,6 +1464,18 @@ Item {
         popupBorderColor: root.popupBorder
         panelFontFamily: root.fontFamily
         onConfirmed: function(request) { root.confirmAccountRemoval(request) }
+      }
+
+      ConfirmDeleteDialog {
+        id: confirmDeleteDialog
+        anchors.fill: parent
+        textColor: root.foreground
+        dimColor: root.dim
+        dangerColor: root.danger
+        popupBackgroundColor: root.popupBackground
+        popupBorderColor: root.popupBorder
+        panelFontFamily: root.fontFamily
+        onConfirmed: function(request) { root.confirmDelete(request) }
       }
 
       MessageMenu {

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/CalendarEventComposer.qml \
 	components/CalendarEventDetail.qml \
 	components/CalendarPalette.qml \
+	components/ConfirmDeleteDialog.qml \
 	components/SetupPage.qml \
 	components/ShortcutHelp.qml \
 	calendar/CalendarController.qml calendar/CalendarCache.qml \
@@ -99,6 +100,7 @@ test-shell:
 	bash tests/test_attachment.sh
 	bash tests/test_calendar_transport.sh
 	bash tests/test_calendar_write.sh
+	bash tests/test_calendar_delete.sh
 	bash tests/test_release_notes.sh
 
 # Focus ownership and key routing cannot be tested without a focus scope, and a

--- a/README.md
+++ b/README.md
@@ -281,9 +281,10 @@ thousand of them, evicted least-recently-used.
 - The access token exists only in memory.
 - Signing out clears the keyring entry.
 
-The app asks for `gmail.modify` and `gmail.send`. `gmail.modify` covers reading,
-labelling, archiving and trashing, and deliberately **cannot** delete anything
-permanently.
+The app asks for `gmail.modify`, `gmail.send` and `calendar.events`.
+`gmail.modify` covers reading, labelling, archiving and trashing, and
+deliberately **cannot** delete anything permanently. `calendar.events` reads
+calendars and writes events.
 
 ## Development
 

--- a/calendar/Cache.js
+++ b/calendar/Cache.js
@@ -1,9 +1,10 @@
 .pragma library
 
-// Version 2 adds the Google item id required by event update and delete.
-// Version 1 ranges cannot recover it from their iCal UID or provider URL, so
-// they are invalidated and fetched again instead of restoring unwritable rows.
-var VERSION = 2
+// Version 2 added the Google item id required by update and delete; version 3
+// adds the original CalDAV resource required to preserve fields during PUT.
+// Older ranges cannot recover either value, so they are fetched again instead
+// of restoring rows that are unwritable or unsafe to edit.
+var VERSION = 3
 var MAX_RANGES = 8
 var MAX_EVENTS = 2500
 

--- a/calendar/Cache.js
+++ b/calendar/Cache.js
@@ -1,6 +1,9 @@
 .pragma library
 
-var VERSION = 1
+// Version 2 adds the Google item id required by event update and delete.
+// Version 1 ranges cannot recover it from their iCal UID or provider URL, so
+// they are invalidated and fetched again instead of restoring unwritable rows.
+var VERSION = 2
 var MAX_RANGES = 8
 var MAX_EVENTS = 2500
 

--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -322,6 +322,10 @@ function eventsFromCaldav(xml, sourceId, rangeStart, rangeEnd) {
     for (var j = 0; j < events.length; j++) {
       events[j].sourceId = String(sourceId || "")
       events[j].href = responses[i].href
+      // A CalDAV update replaces this entire resource. Keep the source so the
+      // writer can change the fields it owns without dropping everything it
+      // does not model, such as alarms, attendees and server extensions.
+      events[j].calendarData = responses[i].data
       out.push(events[j])
     }
   }
@@ -453,6 +457,19 @@ function veventLines(uid, sequence, stampMs, fields, rule, allDay) {
   return lines
 }
 
+function editableEventLines(sequence, stampMs, fields, allDay) {
+  var lines = ["DTSTAMP:" + icsUtc(stampMs), "SEQUENCE:" + sequence]
+  if (allDay === true)
+    lines.push("DTSTART;VALUE=DATE:" + icsDate(fields.start),
+      "DTEND;VALUE=DATE:" + icsDate(fields.end))
+  else
+    lines.push("DTSTART:" + icsUtc(fields.start), "DTEND:" + icsUtc(fields.end))
+  lines.push("SUMMARY:" + icsText(fields.title))
+  if (fields.description !== "") lines.push("DESCRIPTION:" + icsText(fields.description))
+  if (fields.location !== "") lines.push("LOCATION:" + icsText(fields.location))
+  return lines
+}
+
 function googleEventBody(fields, allDay) {
   var body = {
     summary: fields.title, description: fields.description, location: fields.location
@@ -523,10 +540,16 @@ function updateEvent(fields, existing, nowMs) {
   if (!checked.ok) return checked
   var sequence = Math.max(0, Math.floor(Number(event.sequence) || 0)) + 1
   var allDay = !!(event.start && event.start.allDay)
+  var stampMs = Number(nowMs) || Date.now()
+  var original = String(event.calendarData || "")
+  var rewritten = original === "" ? "" : Ics.rewriteEvent(original, uid,
+    editableEventLines(sequence, stampMs, checked, allDay),
+    ["DTSTAMP", "SEQUENCE", "DTSTART", "DTEND", "DURATION", "SUMMARY",
+      "DESCRIPTION", "LOCATION"])
   return {
     ok: true, uid: uid,
-    ics: veventLines(uid, sequence, Number(nowMs) || Date.now(), checked, "",
-      allDay).join("\r\n"),
+    ics: rewritten !== "" ? rewritten
+      : veventLines(uid, sequence, stampMs, checked, "", allDay).join("\r\n"),
     google: googleEventBody(checked, allDay)
   }
 }

--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -391,6 +391,14 @@ function icsUtc(ms) {
   return new Date(Number(ms)).toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z")
 }
 
+// A date-only stamp is the local calendar day: the ms of an all-day boundary
+// is local midnight, so the fields are read back off the local clock and no
+// timezone can move the written date.
+function icsDate(ms) {
+  var date = new Date(Number(ms))
+  return date.getFullYear() + two(date.getMonth() + 1) + two(date.getDate())
+}
+
 function recurrenceRule(raw) {
   var value = raw || {}
   if (value.enabled !== true) return { ok: true, rule: "" }
@@ -427,12 +435,17 @@ function validateEventFields(fields) {
     description: String(value.description || ""), location: String(value.location || "") }
 }
 
-function veventLines(uid, sequence, stampMs, fields, rule) {
+function veventLines(uid, sequence, stampMs, fields, rule, allDay) {
   var lines = ["BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:-//Omamail//Calendar//EN",
     "BEGIN:VEVENT", "UID:" + uid, "DTSTAMP:" + icsUtc(stampMs)]
   if (sequence > 0) lines.push("SEQUENCE:" + sequence)
-  lines.push("DTSTART:" + icsUtc(fields.start), "DTEND:" + icsUtc(fields.end),
-    "SUMMARY:" + icsText(fields.title))
+  // An all-day event is dates with an exclusive end, never midnight times.
+  if (allDay === true)
+    lines.push("DTSTART;VALUE=DATE:" + icsDate(fields.start),
+      "DTEND;VALUE=DATE:" + icsDate(fields.end))
+  else
+    lines.push("DTSTART:" + icsUtc(fields.start), "DTEND:" + icsUtc(fields.end))
+  lines.push("SUMMARY:" + icsText(fields.title))
   if (fields.description !== "") lines.push("DESCRIPTION:" + icsText(fields.description))
   if (fields.location !== "") lines.push("LOCATION:" + icsText(fields.location))
   if (rule !== "") lines.push("RRULE:" + rule)
@@ -440,12 +453,20 @@ function veventLines(uid, sequence, stampMs, fields, rule) {
   return lines
 }
 
-function googleEventBody(fields) {
-  return {
-    summary: fields.title, description: fields.description, location: fields.location,
-    start: { dateTime: new Date(fields.start).toISOString() },
-    end: { dateTime: new Date(fields.end).toISOString() }
+function googleEventBody(fields, allDay) {
+  var body = {
+    summary: fields.title, description: fields.description, location: fields.location
   }
+  // Google keeps the same distinction: an all-day event is start.date to the
+  // exclusive end date, a timed one is dateTime.
+  if (allDay === true) {
+    body.start = { date: isoDate(new Date(fields.start)) }
+    body.end = { date: isoDate(new Date(fields.end)) }
+  } else {
+    body.start = { dateTime: new Date(fields.start).toISOString() }
+    body.end = { dateTime: new Date(fields.end).toISOString() }
+  }
+  return body
 }
 
 function createEvent(fields, nowMs) {
@@ -482,8 +503,10 @@ function writeRefusal(source, event) {
 // An edit rewrites the event on its own identity: the UID names it, and the
 // bumped SEQUENCE tells every copy of it which write is newer. Recurrence is
 // not editable here — the Google patch omits the key so the server keeps the
-// rule, and a recurring CalDAV event never reaches this function because the
-// detail draws no Edit for one.
+// rule, and a recurring CalDAV event is refused by writeRefusal before this
+// runs. Which shape the event has is likewise not a question an edit answers:
+// an all-day event stays VALUE=DATE and a Google date, a timed one stays a
+// date-time, so a title-only change cannot turn one into the other.
 function updateEvent(fields, existing, nowMs) {
   var event = existing || {}
   var uid = String(event.uid || "")
@@ -491,10 +514,12 @@ function updateEvent(fields, existing, nowMs) {
   var checked = validateEventFields(fields)
   if (!checked.ok) return checked
   var sequence = Math.max(0, Math.floor(Number(event.sequence) || 0)) + 1
+  var allDay = !!(event.start && event.start.allDay)
   return {
     ok: true, uid: uid,
-    ics: veventLines(uid, sequence, Number(nowMs) || Date.now(), checked, "").join("\r\n"),
-    google: googleEventBody(checked)
+    ics: veventLines(uid, sequence, Number(nowMs) || Date.now(), checked, "",
+      allDay).join("\r\n"),
+    google: googleEventBody(checked, allDay)
   }
 }
 

--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -552,12 +552,15 @@ function urlOrigin(url) {
 // full URL or as a path against the host the collection lives on. An absolute
 // href is accepted only on the collection's own origin: anything else would
 // send this calendar's credentials to a server that merely named an address
-// in an answer.
+// in an answer. Raw whitespace is refused outright — a URL's spaces arrive
+// percent-encoded, and the resolved address becomes one quoted line of the
+// transport's curl config, where a line break would write more options.
 function caldavEventUrl(sourceUrl, event) {
   var base = String(sourceUrl || "")
   var origin = urlOrigin(base)
   if (origin === "") return ""
   var href = String(event && event.href || "")
+  if (/\s/.test(href)) return ""
   if (/^https:\/\//i.test(href) || href.substring(0, 2) === "//") {
     var candidate = href.substring(0, 2) === "//" ? "https:" + href : href
     return urlOrigin(candidate) === origin ? candidate : ""

--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -489,13 +489,16 @@ function createEvent(fields, nowMs) {
 // its exceptions and its exclusions; rewriting that file from the fields the
 // composer edits would drop the parts it keeps no model of, so the operation
 // is refused before anything is written — the same judgement the button rule
-// makes upstream. Creation asks with no event: only the source's own rules
+// makes upstream. A modified occurrence carries no RRULE of its own, only a
+// RECURRENCE-ID, but its href is still the series' shared file, so it answers
+// the same way. Creation asks with no event: only the source's own rules
 // apply.
 function writeRefusal(source, event) {
   if (!source) return "Choose a calendar"
   if (source.readOnly === true) return "This calendar is read-only"
   if (source.kind !== "caldav") return ""
-  if (String(event && event.recurrenceRule || "") !== "")
+  if (String(event && event.recurrenceRule || "") !== ""
+      || Number(event && event.recurrenceIdMs) > 0)
     return "Recurring CalDAV events can only be changed in a full calendar client"
   return ""
 }

--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -356,6 +356,11 @@ function eventsFromGoogle(payload, sourceId) {
       !!(item.end && item.end.date && !item.end.dateTime))
     out.push({
       method: "", uid: String(item.iCalUID || item.id || ""),
+      // The write URL needs the item's own id, not the iCalUID: with
+      // singleEvents=true an expanded occurrence carries an instance id, and
+      // patching or deleting it does exactly what Google Calendar does to one
+      // occurrence of a series.
+      googleId: String(item.id || ""),
       sequence: Math.max(0, Math.floor(Number(item.sequence) || 0)),
       summary: String(item.summary || "Untitled event"),
       description: String(item.description || ""), location: String(item.location || ""),
@@ -410,7 +415,7 @@ function recurrenceIntervalUnit(frequency, interval) {
   return Number(interval) === 1 ? unit : unit + "s"
 }
 
-function createEvent(fields, nowMs) {
+function validateEventFields(fields) {
   var value = fields || {}
   var title = String(value.title || "").trim()
   var start = Number(value.startMs)
@@ -418,28 +423,87 @@ function createEvent(fields, nowMs) {
   if (title === "") return { ok: false, error: "Add an event title" }
   if (!isFinite(start) || !isFinite(end)) return { ok: false, error: "Add valid start and end times" }
   if (end <= start) return { ok: false, error: "End time must be after start time" }
-  var recurrence = recurrenceRule(value.recurrence)
+  return { ok: true, title: title, start: start, end: end,
+    description: String(value.description || ""), location: String(value.location || "") }
+}
+
+function veventLines(uid, sequence, stampMs, fields, rule) {
+  var lines = ["BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:-//Omamail//Calendar//EN",
+    "BEGIN:VEVENT", "UID:" + uid, "DTSTAMP:" + icsUtc(stampMs)]
+  if (sequence > 0) lines.push("SEQUENCE:" + sequence)
+  lines.push("DTSTART:" + icsUtc(fields.start), "DTEND:" + icsUtc(fields.end),
+    "SUMMARY:" + icsText(fields.title))
+  if (fields.description !== "") lines.push("DESCRIPTION:" + icsText(fields.description))
+  if (fields.location !== "") lines.push("LOCATION:" + icsText(fields.location))
+  if (rule !== "") lines.push("RRULE:" + rule)
+  lines.push("END:VEVENT", "END:VCALENDAR", "")
+  return lines
+}
+
+function googleEventBody(fields) {
+  return {
+    summary: fields.title, description: fields.description, location: fields.location,
+    start: { dateTime: new Date(fields.start).toISOString() },
+    end: { dateTime: new Date(fields.end).toISOString() }
+  }
+}
+
+function createEvent(fields, nowMs) {
+  var checked = validateEventFields(fields)
+  if (!checked.ok) return checked
+  var recurrence = recurrenceRule((fields || {}).recurrence)
   if (!recurrence.ok) return recurrence
   var uid = "omamail-" + Math.floor(Number(nowMs) || Date.now())
-  var description = String(value.description || "")
-  var location = String(value.location || "")
-  var lines = ["BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:-//Omamail//Calendar//EN",
-    "BEGIN:VEVENT", "UID:" + uid, "DTSTAMP:" + icsUtc(nowMs || Date.now()),
-    "DTSTART:" + icsUtc(start), "DTEND:" + icsUtc(end), "SUMMARY:" + icsText(title)]
-  if (description !== "") lines.push("DESCRIPTION:" + icsText(description))
-  if (location !== "") lines.push("LOCATION:" + icsText(location))
-  if (recurrence.rule !== "") lines.push("RRULE:" + recurrence.rule)
-  lines.push("END:VEVENT", "END:VCALENDAR", "")
   var result = {
-    ok: true, uid: uid, ics: lines.join("\r\n"),
-    google: {
-      summary: title, description: description, location: location,
-      start: { dateTime: new Date(start).toISOString() },
-      end: { dateTime: new Date(end).toISOString() }
-    }
+    ok: true, uid: uid,
+    ics: veventLines(uid, 0, Number(nowMs) || Date.now(), checked, recurrence.rule).join("\r\n"),
+    google: googleEventBody(checked)
   }
   if (recurrence.rule !== "") result.google.recurrence = ["RRULE:" + recurrence.rule]
   return result
+}
+
+// An edit rewrites the event on its own identity: the UID names it, and the
+// bumped SEQUENCE tells every copy of it which write is newer. Recurrence is
+// not editable here — the Google patch omits the key so the server keeps the
+// rule, and a recurring CalDAV event never reaches this function because the
+// detail draws no Edit for one.
+function updateEvent(fields, existing, nowMs) {
+  var event = existing || {}
+  var uid = String(event.uid || "")
+  if (uid === "") return { ok: false, error: "The event has no identity to update" }
+  var checked = validateEventFields(fields)
+  if (!checked.ok) return checked
+  var sequence = Math.max(0, Math.floor(Number(event.sequence) || 0)) + 1
+  return {
+    ok: true, uid: uid,
+    ics: veventLines(uid, sequence, Number(nowMs) || Date.now(), checked, "").join("\r\n"),
+    google: googleEventBody(checked)
+  }
+}
+
+function googleEventUrl(eventId) {
+  return "https://www.googleapis.com/calendar/v3/calendars/primary/events/"
+    + encodeURIComponent(String(eventId || ""))
+}
+
+// A REPORT answers with the event's own href, which the server may write as a
+// full URL or as a path against the host the collection lives on.
+function caldavEventUrl(sourceUrl, event) {
+  var href = String(event && event.href || "")
+  if (/^https:\/\//i.test(href)) return href
+  var base = String(sourceUrl || "")
+  var host = /^(https:\/\/[^/]+)/i.exec(base)
+  if (!host) return ""
+  if (href.charAt(0) === "/") return host[1] + href
+  if (href !== "") {
+    var collection = base.charAt(base.length - 1) === "/" ? base : base + "/"
+    return collection + href
+  }
+  var uid = String(event && event.uid || "")
+  if (uid === "") return ""
+  var root = base.charAt(base.length - 1) === "/" ? base : base + "/"
+  return root + encodeURIComponent(uid) + ".ics"
 }
 
 function compareEvents(left, right) {

--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -497,8 +497,13 @@ function writeRefusal(source, event) {
   if (!source) return "Choose a calendar"
   if (source.readOnly === true) return "This calendar is read-only"
   if (source.kind !== "caldav") return ""
+  // A RECURRENCE-ID too malformed to parse leaves recurrenceIdMs at 0, but
+  // the event's href still names the series' shared file — the raw line the
+  // parser kept answers for it.
+  var rawRecurrenceId = event && event.source
+    ? String(event.source.recurrenceId || "") : ""
   if (String(event && event.recurrenceRule || "") !== ""
-      || Number(event && event.recurrenceIdMs) > 0)
+      || Number(event && event.recurrenceIdMs) > 0 || rawRecurrenceId !== "")
     return "Recurring CalDAV events can only be changed in a full calendar client"
   return ""
 }

--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -463,6 +463,22 @@ function createEvent(fields, nowMs) {
   return result
 }
 
+// Whether a write can run against this source at all. A read-only calendar
+// refuses every write. A recurring CalDAV event is one ICS holding a rule,
+// its exceptions and its exclusions; rewriting that file from the fields the
+// composer edits would drop the parts it keeps no model of, so the operation
+// is refused before anything is written — the same judgement the button rule
+// makes upstream. Creation asks with no event: only the source's own rules
+// apply.
+function writeRefusal(source, event) {
+  if (!source) return "Choose a calendar"
+  if (source.readOnly === true) return "This calendar is read-only"
+  if (source.kind !== "caldav") return ""
+  if (String(event && event.recurrenceRule || "") !== "")
+    return "Recurring CalDAV events can only be changed in a full calendar client"
+  return ""
+}
+
 // An edit rewrites the event on its own identity: the UID names it, and the
 // bumped SEQUENCE tells every copy of it which write is newer. Recurrence is
 // not editable here — the Google patch omits the key so the server keeps the

--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -487,15 +487,38 @@ function googleEventUrl(eventId) {
     + encodeURIComponent(String(eventId || ""))
 }
 
+// The scheme and authority of an HTTPS URL. Anything else — http, a bare
+// path, junk — has no authority here, because a write address is HTTPS or
+// nothing.
+function urlAuthority(url) {
+  var match = /^(https):\/\/([^\/?#]+)/i.exec(String(url || ""))
+  return match ? match[1].toLowerCase() + "://" + match[2] : ""
+}
+
+// scheme://host:port with the port made explicit and the case-insensitive
+// parts folded, so two spellings of the same origin compare equal.
+function urlOrigin(url) {
+  var match = /^(https):\/\/([^\/?#:]+)(?::(\d+))?/i.exec(String(url || ""))
+  if (!match) return ""
+  return match[1].toLowerCase() + "://" + match[2].toLowerCase() + ":"
+    + (match[3] ? String(Number(match[3])) : "443")
+}
+
 // A REPORT answers with the event's own href, which the server may write as a
-// full URL or as a path against the host the collection lives on.
+// full URL or as a path against the host the collection lives on. An absolute
+// href is accepted only on the collection's own origin: anything else would
+// send this calendar's credentials to a server that merely named an address
+// in an answer.
 function caldavEventUrl(sourceUrl, event) {
-  var href = String(event && event.href || "")
-  if (/^https:\/\//i.test(href)) return href
   var base = String(sourceUrl || "")
-  var host = /^(https:\/\/[^/]+)/i.exec(base)
-  if (!host) return ""
-  if (href.charAt(0) === "/") return host[1] + href
+  var origin = urlOrigin(base)
+  if (origin === "") return ""
+  var href = String(event && event.href || "")
+  if (/^https:\/\//i.test(href) || href.substring(0, 2) === "//") {
+    var candidate = href.substring(0, 2) === "//" ? "https:" + href : href
+    return urlOrigin(candidate) === origin ? candidate : ""
+  }
+  if (href.charAt(0) === "/") return urlAuthority(base) + href
   if (href !== "") {
     var collection = base.charAt(base.length - 1) === "/" ? base : base + "/"
     return collection + href

--- a/calendar/CalendarController.qml
+++ b/calendar/CalendarController.qml
@@ -59,6 +59,8 @@ Item {
   readonly property var contextSources: Sources.forAccount(availableSources, accountId)
   readonly property var sourceGroups: Sources.groupByAccount(
     contextSources, service ? service.accountSummaries : [])
+  // The composer offers only calendars a write can run against.
+  readonly property var writableSourceGroups: Sources.writableGroups(sourceGroups)
 
   onAccountIdChanged: {
     if (!rangeStart || !rangeEnd || !eventCache.loaded) return
@@ -127,7 +129,8 @@ Item {
   function createEvent(sourceId, fields) {
     if (creatingEvent || eventWriting) return
     var source = findSource(sourceId)
-    if (!source) { eventCreated(false, "Choose a calendar"); return }
+    var refusal = Calendar.writeRefusal(source, null)
+    if (refusal !== "") { eventCreated(false, refusal); return }
     var built = Calendar.createEvent(fields, Date.now())
     if (!built.ok) { eventCreated(false, built.error); return }
     eventSource = source
@@ -152,22 +155,10 @@ Item {
     if (ok && rangeStart && rangeEnd) refresh(rangeStart, rangeEnd)
   }
 
-  // A recurring CalDAV event is one ICS holding a rule, its exceptions and its
-  // exclusions. Rewriting that file from the fields this panel edits would
-  // drop the parts it keeps no model of, so the operation is refused before
-  // anything is written — the same judgement the button rule makes upstream.
-  function caldavWriteRefusal(source, event) {
-    if (source.kind !== "caldav") return ""
-    if (String(event && event.recurrenceRule || "") !== "")
-      return "Recurring CalDAV events can only be changed in a full calendar client"
-    return ""
-  }
-
   function updateEvent(sourceId, event, fields) {
     if (creatingEvent || eventWriting) return
     var source = findSource(sourceId)
-    if (!source) { eventUpdated(false, "Choose a calendar"); return }
-    var refusal = caldavWriteRefusal(source, event)
+    var refusal = Calendar.writeRefusal(source, event)
     if (refusal !== "") { eventUpdated(false, refusal); return }
     var built = Calendar.updateEvent(fields, event, Date.now())
     if (!built.ok) { eventUpdated(false, built.error); return }
@@ -183,8 +174,7 @@ Item {
   function deleteEvent(sourceId, event) {
     if (creatingEvent || eventWriting) return
     var source = findSource(sourceId)
-    if (!source) { eventDeleted(false, "Choose a calendar"); return }
-    var refusal = caldavWriteRefusal(source, event)
+    var refusal = Calendar.writeRefusal(source, event)
     if (refusal !== "") { eventDeleted(false, refusal); return }
     writeOp = "delete"
     writeSource = source

--- a/calendar/CalendarController.qml
+++ b/calendar/CalendarController.qml
@@ -50,6 +50,9 @@ Item {
   property var writeSource: null
   property var writeEvent: null
   property var writeDraft: null
+  // The address the current CalDAV write goes to, judged before the keyring
+  // is touched and carried to the writer that runs after it.
+  property string writeUrl: ""
   property bool eventWriting: false
   readonly property var availableSources: Sources.withGoogleAccounts(
     sourceList, service ? service.accountSummaries : [])
@@ -200,6 +203,7 @@ Item {
     writeSource = null
     writeEvent = null
     writeDraft = null
+    writeUrl = ""
     eventRequest = null
     eventRequestTimedOut = false
     if (op === "delete") eventDeleted(ok, String(error || ""))
@@ -243,7 +247,16 @@ Item {
     })
   }
 
+  // The address is judged before the keyring is touched: a write URL that
+  // does not resolve to the source's own origin stops the operation here,
+  // not after a password has been read for it.
   function startCaldavWrite() {
+    var url = Calendar.caldavEventUrl(writeSource ? writeSource.url : "", writeEvent)
+    if (url === "") {
+      finishWrite(false, "The event's address is outside this calendar's server")
+      return
+    }
+    writeUrl = url
     caldavWritePasswordLookup.command = ["secret-tool", "lookup"]
       .concat(Sources.keyringAttributes(writeSource.id))
     caldavWritePasswordLookup.running = true
@@ -682,12 +695,9 @@ Item {
         root.finishWrite(false, "Set this calendar's password in Settings")
         return
       }
-      var url = Calendar.caldavEventUrl(root.writeSource ? root.writeSource.url : "",
-        root.writeEvent)
-      if (url === "") {
-        root.finishWrite(false, "This event has no address to write against")
-        return
-      }
+      // The URL was resolved and judged in startCaldavWrite, before this
+      // lookup ran; here it is only read back.
+      var url = root.writeUrl
       var credentials = root.writeSource.username + ":" + password
       if (root.writeOp === "delete") {
         eventDeleter.command = [root.pluginDir + "/scripts/calendar-delete.sh"]

--- a/calendar/CalendarController.qml
+++ b/calendar/CalendarController.qml
@@ -198,6 +198,12 @@ Item {
     eventRequestTimedOut = false
     if (op === "delete") eventDeleted(ok, String(error || ""))
     else eventUpdated(ok, String(error || ""))
+    // A delete is asked for from the detail, not the composer, so nothing
+    // else is listening: the failure has to land on the view's own banner.
+    if (!ok) {
+      lastError = String(error || "Could not write the event")
+      lastErrorKind = ""
+    }
     if (ok && rangeStart && rangeEnd) refresh(rangeStart, rangeEnd)
   }
 

--- a/calendar/CalendarController.qml
+++ b/calendar/CalendarController.qml
@@ -127,12 +127,15 @@ Item {
   }
 
   function createEvent(sourceId, fields) {
-    if (creatingEvent || eventWriting) return
+    if (creatingEvent || eventWriting) {
+      eventCreated(false, "Another event change is still in progress")
+      return false
+    }
     var source = findSource(sourceId)
     var refusal = Calendar.writeRefusal(source, null)
-    if (refusal !== "") { eventCreated(false, refusal); return }
+    if (refusal !== "") { eventCreated(false, refusal); return false }
     var built = Calendar.createEvent(fields, Date.now())
-    if (!built.ok) { eventCreated(false, built.error); return }
+    if (!built.ok) { eventCreated(false, built.error); return false }
     eventSource = source
     eventDraft = built
     creatingEvent = true
@@ -142,6 +145,7 @@ Item {
         .concat(Sources.keyringAttributes(source.id))
       eventPasswordLookup.running = true
     }
+    return true
   }
 
   function finishEvent(ok, error) {
@@ -156,12 +160,15 @@ Item {
   }
 
   function updateEvent(sourceId, event, fields) {
-    if (creatingEvent || eventWriting) return
+    if (creatingEvent || eventWriting) {
+      eventUpdated(false, "Another event change is still in progress")
+      return false
+    }
     var source = findSource(sourceId)
     var refusal = Calendar.writeRefusal(source, event)
-    if (refusal !== "") { eventUpdated(false, refusal); return }
+    if (refusal !== "") { eventUpdated(false, refusal); return false }
     var built = Calendar.updateEvent(fields, event, Date.now())
-    if (!built.ok) { eventUpdated(false, built.error); return }
+    if (!built.ok) { eventUpdated(false, built.error); return false }
     writeOp = "update"
     writeSource = source
     writeEvent = event
@@ -169,13 +176,17 @@ Item {
     eventWriting = true
     if (source.kind === "google") startGoogleWrite()
     else startCaldavWrite()
+    return true
   }
 
   function deleteEvent(sourceId, event) {
-    if (creatingEvent || eventWriting) return
+    if (creatingEvent || eventWriting) {
+      eventDeleted(false, "Another event change is still in progress")
+      return false
+    }
     var source = findSource(sourceId)
     var refusal = Calendar.writeRefusal(source, event)
-    if (refusal !== "") { eventDeleted(false, refusal); return }
+    if (refusal !== "") { eventDeleted(false, refusal); return false }
     writeOp = "delete"
     writeSource = source
     writeEvent = event
@@ -183,6 +194,7 @@ Item {
     eventWriting = true
     if (source.kind === "google") startGoogleWrite()
     else startCaldavWrite()
+    return true
   }
 
   function finishWrite(ok, error) {

--- a/calendar/CalendarController.qml
+++ b/calendar/CalendarController.qml
@@ -43,6 +43,14 @@ Item {
   property var eventDraft: null
   property var eventRequest: null
   property bool eventRequestTimedOut: false
+  // One write at a time, create or otherwise: the password lookup, the writer
+  // and the deadline all hold one operation's state, so update and delete
+  // share this guard with create rather than growing their own.
+  property string writeOp: ""
+  property var writeSource: null
+  property var writeEvent: null
+  property var writeDraft: null
+  property bool eventWriting: false
   readonly property var availableSources: Sources.withGoogleAccounts(
     sourceList, service ? service.accountSummaries : [])
   readonly property var contextSources: Sources.forAccount(availableSources, accountId)
@@ -58,6 +66,8 @@ Item {
   signal passwordSaved(bool ok, string error)
   signal calendarSaved(bool ok, string error)
   signal eventCreated(bool ok, string error)
+  signal eventUpdated(bool ok, string error)
+  signal eventDeleted(bool ok, string error)
 
   readonly property string configPath: {
     var home = Quickshell.env("XDG_CONFIG_HOME") || (Quickshell.env("HOME") + "/.config")
@@ -103,13 +113,17 @@ Item {
       values.map(function(source) { return String(source.id || "") }))
   }
 
-  function createEvent(sourceId, fields) {
-    if (creatingEvent) return
+  function findSource(sourceId) {
     var values = contextSources.sources
-    var source = null
     for (var i = 0; i < values.length; i++) {
-      if (values[i] && values[i].id === String(sourceId)) { source = values[i]; break }
+      if (values[i] && values[i].id === String(sourceId)) return values[i]
     }
+    return null
+  }
+
+  function createEvent(sourceId, fields) {
+    if (creatingEvent || eventWriting) return
+    var source = findSource(sourceId)
     if (!source) { eventCreated(false, "Choose a calendar"); return }
     var built = Calendar.createEvent(fields, Date.now())
     if (!built.ok) { eventCreated(false, built.error); return }
@@ -133,6 +147,106 @@ Item {
     eventRequestTimedOut = false
     eventCreated(ok, String(error || ""))
     if (ok && rangeStart && rangeEnd) refresh(rangeStart, rangeEnd)
+  }
+
+  // A recurring CalDAV event is one ICS holding a rule, its exceptions and its
+  // exclusions. Rewriting that file from the fields this panel edits would
+  // drop the parts it keeps no model of, so the operation is refused before
+  // anything is written — the same judgement the button rule makes upstream.
+  function caldavWriteRefusal(source, event) {
+    if (source.kind !== "caldav") return ""
+    if (String(event && event.recurrenceRule || "") !== "")
+      return "Recurring CalDAV events can only be changed in a full calendar client"
+    return ""
+  }
+
+  function updateEvent(sourceId, event, fields) {
+    if (creatingEvent || eventWriting) return
+    var source = findSource(sourceId)
+    if (!source) { eventUpdated(false, "Choose a calendar"); return }
+    var refusal = caldavWriteRefusal(source, event)
+    if (refusal !== "") { eventUpdated(false, refusal); return }
+    var built = Calendar.updateEvent(fields, event, Date.now())
+    if (!built.ok) { eventUpdated(false, built.error); return }
+    writeOp = "update"
+    writeSource = source
+    writeEvent = event
+    writeDraft = built
+    eventWriting = true
+    if (source.kind === "google") startGoogleWrite()
+    else startCaldavWrite()
+  }
+
+  function deleteEvent(sourceId, event) {
+    if (creatingEvent || eventWriting) return
+    var source = findSource(sourceId)
+    if (!source) { eventDeleted(false, "Choose a calendar"); return }
+    var refusal = caldavWriteRefusal(source, event)
+    if (refusal !== "") { eventDeleted(false, refusal); return }
+    writeOp = "delete"
+    writeSource = source
+    writeEvent = event
+    writeDraft = null
+    eventWriting = true
+    if (source.kind === "google") startGoogleWrite()
+    else startCaldavWrite()
+  }
+
+  function finishWrite(ok, error) {
+    var op = writeOp
+    eventDeadline.stop()
+    eventWriting = false
+    writeOp = ""
+    writeSource = null
+    writeEvent = null
+    writeDraft = null
+    eventRequest = null
+    eventRequestTimedOut = false
+    if (op === "delete") eventDeleted(ok, String(error || ""))
+    else eventUpdated(ok, String(error || ""))
+    if (ok && rangeStart && rangeEnd) refresh(rangeStart, rangeEnd)
+  }
+
+  function startGoogleWrite() {
+    var eventId = String(writeEvent && writeEvent.googleId || "")
+    if (eventId === "") { finishWrite(false, "This event has no Google id to write against"); return }
+    service.withGoogleAccessToken(writeSource.accountId, function(token, error) {
+      if (!token) { root.finishWrite(false, error); return }
+      var request = new XMLHttpRequest()
+      root.eventRequest = request
+      root.eventRequestTimedOut = false
+      if (root.writeOp === "delete") {
+        request.open("DELETE", Calendar.googleEventUrl(eventId))
+      } else {
+        request.open("PATCH", Calendar.googleEventUrl(eventId))
+        request.setRequestHeader("Content-Type", "application/json")
+      }
+      request.setRequestHeader("Authorization", "Bearer " + token)
+      request.onreadystatechange = function() {
+        if (request.readyState !== XMLHttpRequest.DONE) return
+        eventDeadline.stop()
+        root.eventRequest = null
+        var timedOut = root.eventRequestTimedOut
+        root.eventRequestTimedOut = false
+        if (request.status < 200 || request.status >= 300) {
+          root.finishWrite(false, timedOut
+            ? "The Google Calendar event request timed out"
+            : Calendar.googleResponseError(request.status, request.responseText))
+          return
+        }
+        root.finishWrite(true, "")
+      }
+      eventDeadline.restart()
+      if (root.writeOp === "delete") request.send()
+      else request.send(JSON.stringify(root.writeDraft.google))
+      token = ""
+    })
+  }
+
+  function startCaldavWrite() {
+    caldavWritePasswordLookup.command = ["secret-tool", "lookup"]
+      .concat(Sources.keyringAttributes(writeSource.id))
+    caldavWritePasswordLookup.running = true
   }
 
   function createGoogleEvent() {
@@ -555,6 +669,63 @@ Item {
     onExited: function(exitCode) {
       root.finishEvent(exitCode === 0,
         exitCode === 0 ? "" : String(eventWriteError.text || "Could not create the event"))
+    }
+  }
+
+  Process {
+    id: caldavWritePasswordLookup
+    stdout: StdioCollector { id: writePasswordOutput; waitForEnd: true }
+    stderr: StdioCollector { waitForEnd: true }
+    onExited: function(exitCode) {
+      var password = String(writePasswordOutput.text || "").trim()
+      if (exitCode !== 0 || password === "") {
+        root.finishWrite(false, "Set this calendar's password in Settings")
+        return
+      }
+      var url = Calendar.caldavEventUrl(root.writeSource ? root.writeSource.url : "",
+        root.writeEvent)
+      if (url === "") {
+        root.finishWrite(false, "This event has no address to write against")
+        return
+      }
+      var credentials = root.writeSource.username + ":" + password
+      if (root.writeOp === "delete") {
+        eventDeleter.command = [root.pluginDir + "/scripts/calendar-delete.sh"]
+        eventDeleter.requestLine = Mail.encodeBase64(url) + " "
+          + Mail.encodeBase64(credentials) + "\n"
+        eventDeleter.running = true
+      } else {
+        caldavEventUpdater.command = [root.pluginDir + "/scripts/calendar-write.sh"]
+        caldavEventUpdater.requestLine = Mail.encodeBase64(url) + " "
+          + Mail.encodeBase64(credentials) + " " + Mail.encodeBase64(root.writeDraft.ics) + "\n"
+        caldavEventUpdater.running = true
+      }
+      password = ""
+      credentials = ""
+    }
+  }
+
+  Process {
+    id: caldavEventUpdater
+    property string requestLine: ""
+    stdinEnabled: true
+    stderr: StdioCollector { id: eventUpdateError; waitForEnd: true }
+    onStarted: { write(requestLine); requestLine = "" }
+    onExited: function(exitCode) {
+      root.finishWrite(exitCode === 0,
+        exitCode === 0 ? "" : String(eventUpdateError.text || "Could not update the event"))
+    }
+  }
+
+  Process {
+    id: eventDeleter
+    property string requestLine: ""
+    stdinEnabled: true
+    stderr: StdioCollector { id: eventDeleteError; waitForEnd: true }
+    onStarted: { write(requestLine); requestLine = "" }
+    onExited: function(exitCode) {
+      root.finishWrite(exitCode === 0,
+        exitCode === 0 ? "" : String(eventDeleteError.text || "Could not delete the event"))
     }
   }
 

--- a/calendar/Sources.js
+++ b/calendar/Sources.js
@@ -166,10 +166,11 @@ function withGoogleAccounts(list, accountSummaries) {
       name: trimmed(account.email || account.label || "Google Calendar"),
       accountId: accountId,
       enabled: saved ? saved.enabled !== false : true,
-      // A Google calendar accepts writes through the API, so nothing is
-      // stamped here: readOnly names a calendar that refuses writes, which a
-      // hand-configured source can carry from calendars.json.
-      readOnly: saved ? saved.readOnly === true : false,
+      // A Google calendar accepts writes through the API. Older versions
+      // persisted readOnly on these synthesized sources, so it must not be
+      // inherited: keeping the stamp would hide Edit and Delete after an
+      // upgrade. Hand-configured CalDAV sources still keep their own flag.
+      readOnly: false,
       colorKey: saved ? saved.colorKey : Palette.defaultKey("google:" + accountId)
     })
   }

--- a/calendar/Sources.js
+++ b/calendar/Sources.js
@@ -166,7 +166,10 @@ function withGoogleAccounts(list, accountSummaries) {
       name: trimmed(account.email || account.label || "Google Calendar"),
       accountId: accountId,
       enabled: saved ? saved.enabled !== false : true,
-      readOnly: true,
+      // A Google calendar accepts writes through the API, so nothing is
+      // stamped here: readOnly names a calendar that refuses writes, which a
+      // hand-configured source can carry from calendars.json.
+      readOnly: saved ? saved.readOnly === true : false,
       colorKey: saved ? saved.colorKey : Palette.defaultKey("google:" + accountId)
     })
   }
@@ -247,6 +250,28 @@ function groupByAccount(list, accountSummaries) {
     group.calendars.push(remaining)
   }
   return groups
+}
+
+// A calendar a write can be offered on. A read-only source still draws its
+// events; it is not offered as somewhere to put one.
+function writable(source) {
+  return !!source && source.readOnly !== true
+}
+
+// The picker groups with the read-only calendars left out, and a group left
+// empty by that left out too.
+function writableGroups(groups) {
+  var values = Array.isArray(groups) ? groups : []
+  var out = []
+  for (var i = 0; i < values.length; i++) {
+    var group = values[i] || {}
+    var calendars = (Array.isArray(group.calendars) ? group.calendars : [])
+      .filter(function(source) { return writable(source) })
+    if (calendars.length === 0) continue
+    out.push({ id: group.id, providerLabel: group.providerLabel,
+      accountLabel: group.accountLabel, calendars: calendars })
+  }
+  return out
 }
 
 function calendarEditorUrl(list) {

--- a/components/CalendarEventComposer.qml
+++ b/components/CalendarEventComposer.qml
@@ -19,6 +19,12 @@ Rectangle {
   property string selectedSourceId: ""
   property bool recurring: false
   property string recurrenceFrequency: "WEEKLY"
+  // Set while an existing event is being changed rather than a new one made.
+  // The calendar picker and the recurrence section stand down then: the event
+  // stays on the calendar that owns it, and the rule is the server's to keep.
+  property var editingEvent: null
+  property string editingSourceId: ""
+  readonly property bool editing: editingEvent !== null
   color: root.backgroundColor
 
   function localDate(date) {
@@ -38,6 +44,8 @@ Rectangle {
     if (!(isFinite(requested) && requested > 0))
       start.setMinutes(Math.ceil(start.getMinutes() / 30) * 30, 0, 0)
     var end = new Date(start.getTime() + 3600000)
+    editingEvent = null
+    editingSourceId = ""
     titleField.text = ""
     dateField.text = localDate(start)
     startField.text = localTime(start)
@@ -55,16 +63,41 @@ Rectangle {
     Qt.callLater(titleField.forceActiveFocus)
   }
 
+  function beginEdit(sourceId, event) {
+    if (!event || !event.start) return
+    var start = new Date(Number(event.start.ms))
+    var end = event.end ? new Date(Number(event.end.ms)) : new Date(start.getTime() + 3600000)
+    editingEvent = event
+    editingSourceId = String(sourceId || "")
+    titleField.text = String(event.summary || "")
+    dateField.text = localDate(start)
+    startField.text = localTime(start)
+    endField.text = localTime(end)
+    locationField.text = String(event.location || "")
+    notesField.text = String(event.description || "")
+    intervalField.text = "1"
+    countField.text = ""
+    recurring = false
+    resultText.text = ""
+    selectedSourceId = editingSourceId
+    opened = true
+    Qt.callLater(titleField.forceActiveFocus)
+  }
+
   function begin() { beginAt(0) }
 
-  function close() { opened = false }
+  function close() {
+    opened = false
+    editingEvent = null
+    editingSourceId = ""
+  }
   function takeFocus() { titleField.forceActiveFocus() }
 
   function submit() {
     if (!controller) return
     var start = new Date(dateField.text + "T" + startField.text + ":00")
     var end = new Date(dateField.text + "T" + endField.text + ":00")
-    controller.createEvent(selectedSourceId, {
+    var fields = {
       title: titleField.text,
       startMs: start.getTime(),
       endMs: end.getTime(),
@@ -76,7 +109,9 @@ Rectangle {
         interval: intervalField.text,
         count: countField.text
       }
-    })
+    }
+    if (editing) controller.updateEvent(editingSourceId, editingEvent, fields)
+    else controller.createEvent(selectedSourceId, fields)
   }
 
   CalendarPalette {
@@ -111,7 +146,7 @@ Rectangle {
       }
 
       Text {
-        text: "Create event"
+        text: root.editing ? "Edit event" : "Create event"
         color: root.textColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.heading
@@ -120,6 +155,7 @@ Rectangle {
       }
 
       Text {
+        visible: !root.editing
         text: "CALENDAR"
         color: root.dimColor
         font.family: root.panelFontFamily
@@ -129,7 +165,7 @@ Rectangle {
       }
 
       Repeater {
-        model: root.controller ? root.controller.sourceGroups : []
+        model: root.editing ? [] : (root.controller ? root.controller.sourceGroups : [])
 
         delegate: Column {
           id: sourceGroup
@@ -225,6 +261,7 @@ Rectangle {
       }
 
       IconTextButton {
+        visible: !root.editing
         text: "Make recurring"
         iconName: root.recurring ? "check" : ""
         selected: root.recurring
@@ -236,7 +273,7 @@ Rectangle {
 
       Column {
         width: parent.width
-        visible: root.recurring
+        visible: root.recurring && !root.editing
         spacing: Style.space(8)
 
         Text {
@@ -341,12 +378,17 @@ Rectangle {
         spacing: Style.space(6)
 
         IconTextButton {
-          text: root.controller && root.controller.creatingEvent ? "Creating" : "Create event"
-          iconName: "plus"
+          text: {
+            if (root.editing)
+              return root.controller && root.controller.eventWriting ? "Saving" : "Save changes"
+            return root.controller && root.controller.creatingEvent ? "Creating" : "Create event"
+          }
+          iconName: root.editing ? "check" : "plus"
           foreground: root.textColor
           accent: root.accentColor
           fontFamily: root.panelFontFamily
-          enabled: root.controller && !root.controller.creatingEvent
+          enabled: root.controller && (root.editing
+            ? !root.controller.eventWriting : !root.controller.creatingEvent)
           onClicked: root.submit()
         }
 
@@ -375,6 +417,10 @@ Rectangle {
   Connections {
     target: root.controller
     function onEventCreated(ok, error) {
+      if (ok) root.close()
+      else resultText.text = error
+    }
+    function onEventUpdated(ok, error) {
       if (ok) root.close()
       else resultText.text = error
     }

--- a/components/CalendarEventComposer.qml
+++ b/components/CalendarEventComposer.qml
@@ -25,6 +25,10 @@ Rectangle {
   property var editingEvent: null
   property string editingSourceId: ""
   readonly property bool editing: editingEvent !== null
+  // An all-day event is edited as the dates it spans; the time fields stand
+  // down, because writing them back would turn the event into a timed one.
+  readonly property bool editingAllDay: editing
+    && !!(editingEvent.start && editingEvent.start.allDay)
   color: root.backgroundColor
 
   function localDate(date) {
@@ -73,6 +77,10 @@ Rectangle {
     dateField.text = localDate(start)
     startField.text = localTime(start)
     endField.text = localTime(end)
+    // The stored all-day end is the exclusive midnight after the last shown
+    // day, so the field shows a millisecond before it.
+    endDateField.text = event.start.allDay && event.end
+      ? localDate(new Date(Number(event.end.ms) - 1)) : localDate(end)
     locationField.text = String(event.location || "")
     notesField.text = String(event.description || "")
     intervalField.text = "1"
@@ -97,6 +105,13 @@ Rectangle {
     if (!controller) return
     var start = new Date(dateField.text + "T" + startField.text + ":00")
     var end = new Date(dateField.text + "T" + endField.text + ":00")
+    if (editingAllDay) {
+      start = new Date(dateField.text + "T00:00:00")
+      var lastDay = new Date(endDateField.text + "T00:00:00")
+      // The written end is exclusive: the midnight after the last shown day,
+      // reached by date fields so a daylight-saving boundary cannot shift it.
+      end = new Date(lastDay.getFullYear(), lastDay.getMonth(), lastDay.getDate() + 1)
+    }
     var fields = {
       title: titleField.text,
       startMs: start.getTime(),
@@ -146,7 +161,8 @@ Rectangle {
       }
 
       Text {
-        text: root.editing ? "Edit event" : "Create event"
+        text: root.editingAllDay ? "Edit event · All day"
+          : root.editing ? "Edit event" : "Create event"
         color: root.textColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.heading
@@ -221,14 +237,25 @@ Rectangle {
 
         TextField {
           id: dateField
-          width: (parent.width - parent.spacing * 2) * 0.5
+          width: root.editingAllDay ? (parent.width - parent.spacing) * 0.5
+            : (parent.width - parent.spacing * 2) * 0.5
           foreground: root.textColor
           font.family: root.panelFontFamily
-          placeholderText: "YYYY-MM-DD"
+          placeholderText: root.editingAllDay ? "First day (YYYY-MM-DD)" : "YYYY-MM-DD"
+        }
+
+        TextField {
+          id: endDateField
+          visible: root.editingAllDay
+          width: (parent.width - parent.spacing) * 0.5
+          foreground: root.textColor
+          font.family: root.panelFontFamily
+          placeholderText: "Last day (YYYY-MM-DD)"
         }
 
         TextField {
           id: startField
+          visible: !root.editingAllDay
           width: (parent.width - parent.spacing * 2) * 0.25
           foreground: root.textColor
           font.family: root.panelFontFamily
@@ -237,6 +264,7 @@ Rectangle {
 
         TextField {
           id: endField
+          visible: !root.editingAllDay
           width: (parent.width - parent.spacing * 2) * 0.25
           foreground: root.textColor
           font.family: root.panelFontFamily

--- a/components/CalendarEventComposer.qml
+++ b/components/CalendarEventComposer.qml
@@ -25,6 +25,10 @@ Rectangle {
   property var editingEvent: null
   property string editingSourceId: ""
   readonly property bool editing: editingEvent !== null
+  // Set when this form's own write is in flight. A completion is answered only
+  // while it is: a write the user cancelled out of — Escape, then a newer
+  // edit — must not close or report into this one.
+  property bool writePending: false
   // An all-day event is edited as the dates it spans; the time fields stand
   // down, because writing them back would turn the event into a timed one.
   readonly property bool editingAllDay: editing
@@ -50,6 +54,7 @@ Rectangle {
     var end = new Date(start.getTime() + 3600000)
     editingEvent = null
     editingSourceId = ""
+    writePending = false
     titleField.text = ""
     dateField.text = localDate(start)
     startField.text = localTime(start)
@@ -73,6 +78,7 @@ Rectangle {
     var end = event.end ? new Date(Number(event.end.ms)) : new Date(start.getTime() + 3600000)
     editingEvent = event
     editingSourceId = String(sourceId || "")
+    writePending = false
     titleField.text = String(event.summary || "")
     dateField.text = localDate(start)
     startField.text = localTime(start)
@@ -125,6 +131,7 @@ Rectangle {
         count: countField.text
       }
     }
+    writePending = true
     if (editing) controller.updateEvent(editingSourceId, editingEvent, fields)
     else controller.createEvent(selectedSourceId, fields)
   }
@@ -444,15 +451,18 @@ Rectangle {
 
   Connections {
     target: root.controller
-    // A completion can belong to a write the user already cancelled out of:
-    // a closed composer shows nothing and must not close a newer edit.
+    // A completion is answered only while this form's own write is in flight:
+    // one the user cancelled out of belongs to no edit, and its failure is
+    // already on the view's banner.
     function onEventCreated(ok, error) {
-      if (!root.opened) return
+      if (!root.writePending) return
+      root.writePending = false
       if (ok) root.close()
       else resultText.text = error
     }
     function onEventUpdated(ok, error) {
-      if (!root.opened) return
+      if (!root.writePending) return
+      root.writePending = false
       if (ok) root.close()
       else resultText.text = error
     }

--- a/components/CalendarEventComposer.qml
+++ b/components/CalendarEventComposer.qml
@@ -57,8 +57,8 @@ Rectangle {
     recurring = false
     recurrenceFrequency = "WEEKLY"
     resultText.text = ""
-    var sources = controller ? controller.contextSources.sources : []
-    selectedSourceId = sources.length ? String(sources[0].id) : ""
+    var groups = controller ? controller.writableSourceGroups : []
+    selectedSourceId = groups.length ? String(groups[0].calendars[0].id) : ""
     opened = true
     Qt.callLater(titleField.forceActiveFocus)
   }
@@ -165,7 +165,7 @@ Rectangle {
       }
 
       Repeater {
-        model: root.editing ? [] : (root.controller ? root.controller.sourceGroups : [])
+        model: root.editing ? [] : (root.controller ? root.controller.writableSourceGroups : [])
 
         delegate: Column {
           id: sourceGroup

--- a/components/CalendarEventComposer.qml
+++ b/components/CalendarEventComposer.qml
@@ -109,6 +109,10 @@ Rectangle {
 
   function submit() {
     if (!controller) return
+    // Create, update and delete share one controller write slot. Do not mark
+    // this form pending unless that slot is free: otherwise an older write's
+    // completion could be mistaken for this form's and close it.
+    if (controller.creatingEvent || controller.eventWriting) return
     var start = new Date(dateField.text + "T" + startField.text + ":00")
     var end = new Date(dateField.text + "T" + endField.text + ":00")
     if (editingAllDay) {
@@ -414,16 +418,17 @@ Rectangle {
 
         IconTextButton {
           text: {
-            if (root.editing)
-              return root.controller && root.controller.eventWriting ? "Saving" : "Save changes"
-            return root.controller && root.controller.creatingEvent ? "Creating" : "Create event"
+            var busy = root.controller
+              && (root.controller.creatingEvent || root.controller.eventWriting)
+            if (root.editing) return busy ? "Saving" : "Save changes"
+            return busy ? "Creating" : "Create event"
           }
           iconName: root.editing ? "check" : "plus"
           foreground: root.textColor
           accent: root.accentColor
           fontFamily: root.panelFontFamily
-          enabled: root.controller && (root.editing
-            ? !root.controller.eventWriting : !root.controller.creatingEvent)
+          enabled: root.controller && !root.controller.creatingEvent
+            && !root.controller.eventWriting
           onClicked: root.submit()
         }
 

--- a/components/CalendarEventComposer.qml
+++ b/components/CalendarEventComposer.qml
@@ -444,11 +444,15 @@ Rectangle {
 
   Connections {
     target: root.controller
+    // A completion can belong to a write the user already cancelled out of:
+    // a closed composer shows nothing and must not close a newer edit.
     function onEventCreated(ok, error) {
+      if (!root.opened) return
       if (ok) root.close()
       else resultText.text = error
     }
     function onEventUpdated(ok, error) {
+      if (!root.opened) return
       if (ok) root.close()
       else resultText.text = error
     }

--- a/components/CalendarEventDetail.qml
+++ b/components/CalendarEventDetail.qml
@@ -16,6 +16,8 @@ Rectangle {
   required property string panelFontFamily
 
   signal closed()
+  signal editRequested(string sourceId, var event)
+  signal deleteRequested(string sourceId, var event)
 
   readonly property var source: {
     var sources = controller && controller.availableSources
@@ -26,6 +28,13 @@ Rectangle {
     }
     return null
   }
+  // The button rule: an operation that cannot really run is not drawn. Google
+  // writes against the item id; CalDAV against the event's href, and a
+  // recurring one is one ICS with state this panel does not re-serialize.
+  readonly property bool canWrite: !!root.source && !!event
+    && (root.source.kind === "google"
+      ? String(event.googleId || "") !== ""
+      : String(event.href || "") !== "" && String(event.recurrenceRule || "") === "")
   readonly property color eventColor: calendarPalette.colorFor(
     source ? source.colorKey : "accent")
   readonly property string meetingLink: httpLink(event ? event.meetLink : "")
@@ -165,9 +174,29 @@ Rectangle {
 
       Flow {
         visible: root.meetingLink !== "" || root.locationLink !== ""
-          || root.providerLink !== ""
+          || root.providerLink !== "" || root.canWrite
         width: parent.width
         spacing: Style.space(7)
+
+        IconTextButton {
+          visible: root.canWrite
+          text: "Edit..."
+          iconName: "compose"
+          foreground: root.textColor
+          accent: root.eventColor
+          fontFamily: root.panelFontFamily
+          onClicked: root.editRequested(String(root.event.sourceId || ""), root.event)
+        }
+
+        IconTextButton {
+          visible: root.canWrite
+          text: "Delete..."
+          iconName: "trash"
+          foreground: root.urgentColor
+          accent: root.urgentColor
+          fontFamily: root.panelFontFamily
+          onClicked: root.deleteRequested(String(root.event.sourceId || ""), root.event)
+        }
 
         IconTextButton {
           visible: root.meetingLink !== ""

--- a/components/CalendarEventDetail.qml
+++ b/components/CalendarEventDetail.qml
@@ -32,14 +32,16 @@ Rectangle {
   // The button rule: an operation that cannot really run is not drawn. A
   // read-only calendar draws neither button. Google writes against the item
   // id; CalDAV against the event's href, a recurring one is one ICS with
-  // state this panel does not re-serialize, and an href that resolves outside
-  // the source's own origin is refused by the same rule the controller
-  // applies before any credential is read.
+  // state this panel does not re-serialize — and a modified occurrence
+  // carries only a RECURRENCE-ID, but its href is the series' shared file —
+  // and an href that resolves outside the source's own origin is refused by
+  // the same rule the controller applies before any credential is read.
   readonly property bool canWrite: !!root.source && !!event
     && root.source.readOnly !== true
     && (root.source.kind === "google"
       ? String(event.googleId || "") !== ""
       : String(event.href || "") !== "" && String(event.recurrenceRule || "") === ""
+        && Number(event.recurrenceIdMs || 0) <= 0
         && Calendar.caldavEventUrl(root.source.url, event) !== "")
   readonly property color eventColor: calendarPalette.colorFor(
     source ? source.colorKey : "accent")

--- a/components/CalendarEventDetail.qml
+++ b/components/CalendarEventDetail.qml
@@ -29,12 +29,14 @@ Rectangle {
     }
     return null
   }
-  // The button rule: an operation that cannot really run is not drawn. Google
-  // writes against the item id; CalDAV against the event's href, a recurring
-  // one is one ICS with state this panel does not re-serialize, and an href
-  // that resolves outside the source's own origin is refused by the same
-  // rule the controller applies before any credential is read.
+  // The button rule: an operation that cannot really run is not drawn. A
+  // read-only calendar draws neither button. Google writes against the item
+  // id; CalDAV against the event's href, a recurring one is one ICS with
+  // state this panel does not re-serialize, and an href that resolves outside
+  // the source's own origin is refused by the same rule the controller
+  // applies before any credential is read.
   readonly property bool canWrite: !!root.source && !!event
+    && root.source.readOnly !== true
     && (root.source.kind === "google"
       ? String(event.googleId || "") !== ""
       : String(event.href || "") !== "" && String(event.recurrenceRule || "") === ""

--- a/components/CalendarEventDetail.qml
+++ b/components/CalendarEventDetail.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import qs.Commons
 import qs.Ui
+import "../calendar/Calendar.js" as Calendar
 
 Rectangle {
   id: root
@@ -29,12 +30,15 @@ Rectangle {
     return null
   }
   // The button rule: an operation that cannot really run is not drawn. Google
-  // writes against the item id; CalDAV against the event's href, and a
-  // recurring one is one ICS with state this panel does not re-serialize.
+  // writes against the item id; CalDAV against the event's href, a recurring
+  // one is one ICS with state this panel does not re-serialize, and an href
+  // that resolves outside the source's own origin is refused by the same
+  // rule the controller applies before any credential is read.
   readonly property bool canWrite: !!root.source && !!event
     && (root.source.kind === "google"
       ? String(event.googleId || "") !== ""
-      : String(event.href || "") !== "" && String(event.recurrenceRule || "") === "")
+      : String(event.href || "") !== "" && String(event.recurrenceRule || "") === ""
+        && Calendar.caldavEventUrl(root.source.url, event) !== "")
   readonly property color eventColor: calendarPalette.colorFor(
     source ? source.colorKey : "accent")
   readonly property string meetingLink: httpLink(event ? event.meetLink : "")

--- a/components/CalendarEventDetail.qml
+++ b/components/CalendarEventDetail.qml
@@ -42,6 +42,7 @@ Rectangle {
       ? String(event.googleId || "") !== ""
       : String(event.href || "") !== "" && String(event.recurrenceRule || "") === ""
         && Number(event.recurrenceIdMs || 0) <= 0
+        && String(event.source && event.source.recurrenceId || "") === ""
         && Calendar.caldavEventUrl(root.source.url, event) !== "")
   readonly property color eventColor: calendarPalette.colorFor(
     source ? source.colorKey : "accent")

--- a/components/CalendarView.qml
+++ b/components/CalendarView.qml
@@ -33,6 +33,8 @@ Item {
   signal createAt(double startMs)
   signal copyRequested(string text)
   signal openRequested(string url)
+  signal editRequested(string sourceId, var event)
+  signal deleteRequested(string sourceId, var event)
 
   CalendarPalette {
     id: calendarPalette
@@ -505,5 +507,12 @@ Item {
     dimColor: root.dimColor
     panelFontFamily: root.panelFontFamily
     onClosed: root.closeDetail()
+    // Editing replaces the detail: the composer covers the view, and the
+    // event it rewrites is not the one these labels would go on showing.
+    onEditRequested: function(sourceId, event) {
+      root.closeDetail()
+      root.editRequested(sourceId, event)
+    }
+    onDeleteRequested: function(sourceId, event) { root.deleteRequested(sourceId, event) }
   }
 }

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -325,7 +325,10 @@ DropArea {
   }
 
   function submit() {
-    if (!service) return
+    // The send key is answered by action id, and the compose keyboard context
+    // also covers the calendar event form — a composer that is not open must
+    // not answer it, or a draft parked for the undo window would send twice.
+    if (!opened || !service) return
     if (forwardAttachmentsLoading || forwardAttachmentError !== "") return
     var accepted = service.send(({
       from: root.fromEmail,

--- a/components/ConfirmDeleteDialog.qml
+++ b/components/ConfirmDeleteDialog.qml
@@ -1,0 +1,92 @@
+import QtQuick
+import QtQuick.Controls as QQC
+import qs.Commons
+import qs.Ui
+
+// The one confirmation for destructive writes. A calendar event is gone for
+// good once the server says so, so it asks first: the opener names the target
+// in the request, and only the answer here reaches the controller.
+Item {
+  id: root
+
+  required property color textColor
+  required property color dimColor
+  required property color dangerColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
+  required property string panelFontFamily
+  property var request: null
+  readonly property bool opened: dialog.opened
+
+  signal confirmed(var request)
+
+  anchors.fill: parent
+  z: 80
+
+  function openFor(value) {
+    request = value
+    if (request) dialog.open()
+  }
+
+  function close() { dialog.close() }
+
+  QQC.Popup {
+    id: dialog
+    anchors.centerIn: parent
+    width: Math.min(Style.space(360), parent.width - Style.space(32))
+    padding: Style.space(18)
+    modal: true
+    focus: true
+    closePolicy: QQC.Popup.CloseOnEscape
+    onClosed: root.request = null
+    background: Rectangle {
+      radius: Style.cornerRadius
+      color: root.popupBackgroundColor
+      border.width: 1
+      border.color: root.popupBorderColor
+    }
+    contentItem: Column {
+      spacing: Style.space(14)
+
+      Text {
+        width: parent.width
+        textFormat: Text.PlainText
+        text: "Delete \"" + String(root.request ? root.request.name : "") + "\"?"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.heading
+        font.bold: true
+        wrapMode: Text.Wrap
+      }
+      Text {
+        width: parent.width
+        textFormat: Text.PlainText
+        text: String(root.request ? root.request.message : "")
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        wrapMode: Text.Wrap
+      }
+      Row {
+        anchors.right: parent.right
+        spacing: Style.space(8)
+        Button {
+          text: "Cancel"
+          foreground: root.textColor
+          bordered: false
+          onClicked: dialog.close()
+        }
+        Button {
+          text: "Delete"
+          foreground: root.dangerColor
+          bordered: false
+          onClicked: {
+            var value = root.request
+            dialog.close()
+            if (value) root.confirmed(value)
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,6 +83,7 @@ Modules are grouped by responsibility rather than language or file type:
 - `providers/` owns service descriptions, authentication, protocol behavior, capabilities, and normalization into the shared Gmail-shaped resource.
 - `account/` owns accounts, a mailbox, and list behavior after actions.
 - `cache/` owns stored query results and message bodies.
+- `calendar/` owns event sources, the range cache, and event reads and writes.
 - `message/` owns parsing, sanitizing, calendar data, and other decisions about a message's content.
 - `keys/` owns the action and binding declaration.
 - `components/` owns views and reusable interaction primitives.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -44,7 +44,7 @@ guided by an in-app four-step walkthrough.
 - Authorization Code + PKCE, loopback redirect `http://127.0.0.1:9481/oauth2callback`
 - Listener is a single-shot `socat`; the browser does the rest
 - Scopes: `gmail.modify` (read, label, archive, trash — cannot permanently
-  delete) and `gmail.send`
+  delete), `gmail.send` and `calendar.events` (read calendars, write events)
 - Refresh token → GNOME Keyring via `secret-tool`, keyed by client and account
 - Client id/secret → `~/.config/omamail/credentials.json`, mode 0600.
   Not plugin settings: `shell.json` is world-readable.
@@ -60,6 +60,8 @@ guided by an in-app four-step walkthrough.
 - Actions: read/unread, star, archive, trash, untrash, report spam, mark all read
 - Compose, reply, reply-all, forward
 - Calendar invitations: full meeting detail, RSVP, and one-click Meet join
+- Calendar: month and week views over Google Calendar and CalDAV, with event
+  create, edit and delete
 - One-click unsubscribe from mailing lists that support it
 - Search using Gmail's own operator syntax
 - Unread badge in the bar; merged desktop notification for new mail

--- a/message/Calendar.js
+++ b/message/Calendar.js
@@ -191,6 +191,64 @@ function parse(text) {
   return root
 }
 
+// Replace selected top-level properties in the one VEVENT named by UID while
+// leaving every other line alone. CalDAV PUT replaces the whole resource, so
+// rebuilding a small event from parsed fields would erase alarms, attendees,
+// timezone definitions and server extensions the editor never showed. Nested
+// components such as VALARM are deliberately outside the replacement depth.
+function rewriteEvent(text, uid, replacementLines, propertyNames) {
+  var lines = unfoldLines(text)
+  var wantedUid = String(uid || "")
+  var matches = []
+  var start = -1
+  var depth = 0
+  var foundUid = ""
+  for (var i = 0; i < lines.length; i++) {
+    var parsed = parseProperty(lines[i])
+    if (!parsed) continue
+    if (start < 0 && parsed.name === "BEGIN"
+        && String(parsed.value || "").toUpperCase() === "VEVENT") {
+      start = i
+      depth = 1
+      foundUid = ""
+      continue
+    }
+    if (start < 0) continue
+    if (parsed.name === "BEGIN") { depth++; continue }
+    if (parsed.name === "END") {
+      if (depth === 1 && String(parsed.value || "").toUpperCase() === "VEVENT") {
+        if (foundUid === wantedUid) matches.push({ start: start, end: i })
+        start = -1
+        depth = 0
+        foundUid = ""
+      } else {
+        depth--
+      }
+      continue
+    }
+    if (depth === 1 && parsed.name === "UID") foundUid = unescapeText(parsed.value).trim()
+  }
+  if (matches.length !== 1) return ""
+
+  var replace = {}
+  var names = Array.isArray(propertyNames) ? propertyNames : []
+  for (var n = 0; n < names.length; n++) replace[String(names[n]).toUpperCase()] = true
+  var target = matches[0]
+  var out = lines.slice(0, target.start + 1)
+  depth = 1
+  for (var lineIndex = target.start + 1; lineIndex < target.end; lineIndex++) {
+    var property = parseProperty(lines[lineIndex])
+    if (property && property.name === "BEGIN") depth++
+    if (!(property && depth === 1 && replace[property.name] === true))
+      out.push(lines[lineIndex])
+    if (property && property.name === "END") depth--
+  }
+  var additions = Array.isArray(replacementLines) ? replacementLines : []
+  for (var addition = 0; addition < additions.length; addition++) out.push(additions[addition])
+  out.push(lines[target.end])
+  return out.concat(lines.slice(target.end + 1)).join("\r\n") + "\r\n"
+}
+
 function childNamed(component, name) {
   var children = component && Array.isArray(component.children) ? component.children : []
   var wanted = String(name || "").toUpperCase()

--- a/scripts/calendar-delete.sh
+++ b/scripts/calendar-delete.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# The CalDAV delete verb, kept apart from calendar-write.sh the way that one is
+# kept apart from calendar-transport.sh: one script, one method. Fields cross
+# base64-encoded on one line of stdin, so a password never reaches the process
+# table, and the config goes to curl's own stdin rather than to a file on disk.
+set -eu
+
+fail() { printf '%s\n' "$1" >&2; exit 2; }
+decode() { printf '%s' "$1" | base64 -d 2>/dev/null || fail 'calendar-delete.sh: bad base64 field'; }
+escape() { printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
+
+IFS= read -r line || fail 'calendar-delete.sh: no request on stdin'
+# shellcheck disable=SC2086
+set -- $line
+[ $# -eq 2 ] || fail 'calendar-delete.sh: expected URL and credentials'
+url=$(decode "$1")
+credentials=$(decode "$2")
+case "$url" in https://*) ;; *) fail 'calendar-delete.sh: CalDAV requires HTTPS' ;; esac
+
+build_config() {
+  printf 'url = "%s"\n' "$(escape "$url")"
+  printf 'noproxy = "*"\n'
+  printf 'user = "%s"\n' "$(escape "$credentials")"
+  printf 'request = "DELETE"\n'
+  printf 'proto = "=https"\n'
+  printf 'proto-redir = "=https"\n'
+}
+
+build_config | curl --config - --silent --show-error --fail-with-body \
+  --max-time 60 --connect-timeout 20 >/dev/null

--- a/scripts/calendar-delete.sh
+++ b/scripts/calendar-delete.sh
@@ -15,6 +15,14 @@ set -- $line
 [ $# -eq 2 ] || fail 'calendar-delete.sh: expected URL and credentials'
 url=$(decode "$1")
 credentials=$(decode "$2")
+# Each decoded field becomes one quoted line of the curl config; a line break
+# in one would smuggle in more options, so it is refused before curl runs.
+# (The newline is a literal: command substitution would strip it.)
+nl='
+'
+cr=$(printf '\r')
+case $url in *"$nl"* | *"$cr"*) fail 'calendar-delete.sh: URL may not span lines' ;; esac
+case $credentials in *"$nl"* | *"$cr"*) fail 'calendar-delete.sh: credentials may not span lines' ;; esac
 case "$url" in https://*) ;; *) fail 'calendar-delete.sh: CalDAV requires HTTPS' ;; esac
 
 build_config() {

--- a/scripts/calendar-write.sh
+++ b/scripts/calendar-write.sh
@@ -12,6 +12,14 @@ set -- $line
 url=$(decode "$1")
 credentials=$(decode "$2")
 event=$(decode "$3")
+# Each decoded field becomes one quoted line of the curl config; a line break
+# in one would smuggle in more options, so it is refused before curl runs.
+# (The newline is a literal: command substitution would strip it.)
+nl='
+'
+cr=$(printf '\r')
+case $url in *"$nl"* | *"$cr"*) fail 'calendar-write.sh: URL may not span lines' ;; esac
+case $credentials in *"$nl"* | *"$cr"*) fail 'calendar-write.sh: credentials may not span lines' ;; esac
 case "$url" in https://*) ;; *) fail 'calendar-write.sh: CalDAV requires HTTPS' ;; esac
 
 umask 077

--- a/tests/qml/imports/Quickshell/Io/FileView.qml
+++ b/tests/qml/imports/Quickshell/Io/FileView.qml
@@ -1,0 +1,14 @@
+import QtQuick
+
+QtObject {
+  property string path: ""
+  property bool watchChanges: false
+  property bool printErrors: false
+  signal loaded()
+  signal fileChanged()
+  signal loadFailed()
+
+  function reload() {}
+  function text() { return "" }
+  function setText(_value) {}
+}

--- a/tests/qml/imports/Quickshell/Io/qmldir
+++ b/tests/qml/imports/Quickshell/Io/qmldir
@@ -1,3 +1,4 @@
 module Quickshell.Io
+FileView 1.0 FileView.qml
 Process 1.0 Process.qml
 StdioCollector 1.0 StdioCollector.qml

--- a/tests/qml/imports/qs/Commons/Style.qml
+++ b/tests/qml/imports/qs/Commons/Style.qml
@@ -5,7 +5,7 @@ QtObject {
   readonly property real cornerRadius: 2
   readonly property real normalBorderWidth: 1
   readonly property var font: ({
-    family: "monospace", body: 14, bodySmall: 13, caption: 11,
+    family: "monospace", title: 22, heading: 18, body: 14, bodySmall: 13, caption: 11,
     icon: 16, iconSmall: 14
   })
   readonly property var spacing: ({

--- a/tests/qml/tst_calendar_event_composer.qml
+++ b/tests/qml/tst_calendar_event_composer.qml
@@ -1,0 +1,78 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../../components" as Omamail
+
+Item {
+  width: 900
+  height: 600
+
+  QtObject {
+    id: eventController
+    property bool creatingEvent: false
+    property bool eventWriting: false
+    property int createCalls: 0
+    property int updateCalls: 0
+    property var writableSourceGroups: [{
+      id: "google:me@example.com", providerLabel: "Google", accountLabel: "me@example.com",
+      calendars: [{ id: "google:me@example.com", name: "me@example.com", colorKey: "accent" }]
+    }]
+
+    signal eventCreated(bool ok, string error)
+    signal eventUpdated(bool ok, string error)
+
+    function createEvent(_sourceId, _fields) {
+      if (creatingEvent || eventWriting) return false
+      createCalls++
+      creatingEvent = true
+      return true
+    }
+
+    function updateEvent(_sourceId, _event, _fields) {
+      if (creatingEvent || eventWriting) return false
+      updateCalls++
+      eventWriting = true
+      return true
+    }
+  }
+
+  Omamail.CalendarEventComposer {
+    id: composer
+    anchors.fill: parent
+    controller: eventController
+    textColor: Qt.rgba(1, 1, 1, 1)
+    backgroundColor: Qt.rgba(0.06, 0.06, 0.06, 1)
+    accentColor: Qt.rgba(1, 0.5, 0, 1)
+    urgentColor: Qt.rgba(1, 0.2, 0.2, 1)
+    dimColor: Qt.rgba(0.67, 0.67, 0.67, 1)
+    panelFontFamily: "monospace"
+  }
+
+  TestCase {
+    name: "CalendarEventComposer"
+    when: windowShown
+
+    function init() {
+      eventController.creatingEvent = false
+      eventController.eventWriting = false
+      eventController.createCalls = 0
+      eventController.updateCalls = 0
+      composer.close()
+      composer.writePending = false
+    }
+
+    function test_old_update_completion_does_not_close_a_new_create_form() {
+      eventController.eventWriting = true
+      composer.beginAt(new Date(2026, 7, 25, 9, 0).getTime())
+
+      composer.submit()
+      compare(eventController.createCalls, 0)
+      compare(composer.writePending, false,
+        "a busy controller did not accept this form's write")
+
+      eventController.eventWriting = false
+      eventController.eventUpdated(true, "")
+      compare(composer.opened, true,
+        "the old update completion belongs to the cancelled form")
+    }
+  }
+}

--- a/tests/test_calendar_cache.js
+++ b/tests/test_calendar_cache.js
@@ -18,6 +18,17 @@ assert.deepStrictEqual(JSON.parse(JSON.stringify(cache.load("not json"))),
 assert.deepStrictEqual(JSON.parse(JSON.stringify(cache.load(cache.serialize(store)))),
   JSON.parse(JSON.stringify(store)))
 
+// Version 1 calendar ranges predate googleId. Restoring one would make every
+// cached Google event look unwritable until a refresh happened to replace it,
+// so the schema change invalidates those ranges instead of drawing a calendar
+// whose Edit... and Delete... controls silently disappear.
+const versionOne = JSON.stringify({ version: 1, ranges: {
+  old: { events: [{ uid: "legacy", sourceId: "google:a@example.com" }] }
+} })
+assert.deepStrictEqual(JSON.parse(JSON.stringify(cache.load(versionOne))),
+  JSON.parse(JSON.stringify(cache.emptyStore())),
+  "a cache without Google item ids must be refreshed rather than restored")
+
 for (let i = 0; i < 20; i++)
   store = cache.putRange(store, "a@example.com", i * 1000, (i + 1) * 1000, [first], i + 20)
 assert.ok(Object.keys(store.ranges).length <= cache.MAX_RANGES)

--- a/tests/test_calendar_delete.sh
+++ b/tests/test_calendar_delete.sh
@@ -28,4 +28,12 @@ if printf '%s %s\n' "$(b64 'http://calendar.example/a.ics')" "$(b64 'me:secret')
   echo 'calendar-delete.sh: plain HTTP must be refused' >&2
   exit 1
 fi
+# A decoded field becomes one quoted line of the curl config, so an address
+# carrying a line break is refused before curl is ever invoked.
+if printf '%s %s\n' "$(printf 'https://calendar.example/a.ics\noutput = "/tmp/x"' | base64 -w0)" \
+  "$(b64 'me:secret')" \
+  | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-delete.sh" 2>/dev/null; then
+  echo 'calendar-delete.sh: a URL that spans lines must be refused' >&2
+  exit 1
+fi
 echo 'calendar-delete.sh ok'

--- a/tests/test_calendar_delete.sh
+++ b/tests/test_calendar_delete.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+project_dir=$(cd "$(dirname "$0")/.." && pwd)
+work=$(mktemp -d /tmp/omamail-calendar-delete-test.XXXXXX)
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/bin"
+cat > "$work/bin/curl" <<'SH'
+#!/bin/sh
+config=$(cat)
+printf '%s' "$config" > "$CALENDAR_DELETE_CONFIG"
+SH
+chmod +x "$work/bin/curl"
+b64() { printf '%s' "$1" | base64 -w0; }
+export CALENDAR_DELETE_CONFIG="$work/config"
+printf '%s %s\n' "$(b64 'https://calendar.example/dav/me/a.ics')" \
+  "$(b64 'me:secret')" \
+  | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-delete.sh"
+grep -q 'request = "DELETE"' "$work/config"
+grep -q 'url = "https://calendar.example/dav/me/a.ics"' "$work/config"
+grep -q 'user = "me:secret"' "$work/config"
+if grep -q 'upload-file' "$work/config"; then
+  echo 'calendar-delete.sh: a delete carries no body' >&2
+  exit 1
+fi
+# A non-HTTPS address is refused before curl is ever invoked.
+if printf '%s %s\n' "$(b64 'http://calendar.example/a.ics')" "$(b64 'me:secret')" \
+  | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-delete.sh" 2>/dev/null; then
+  echo 'calendar-delete.sh: plain HTTP must be refused' >&2
+  exit 1
+fi
+echo 'calendar-delete.sh ok'

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -256,6 +256,36 @@ assert.strictEqual(feed.updateEvent({ title: "x", startMs: 1, endMs: 2 }, {}, 1)
 assert.strictEqual(feed.updateEvent({ title: "", startMs: 1, endMs: 2 },
   { uid: "u" }, 1).error, "Add an event title")
 
+// A CalDAV update replaces the whole resource, so fields this editor does not
+// draw must survive a change to the ones it does. In particular, editing the
+// title must not remove the organiser, attendees, alarms, timezone rules or a
+// server extension from the VEVENT it puts back.
+const preservedXml = [
+  '<?xml version="1.0"?>',
+  '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">',
+  '<d:response><d:href>/cal/preserved.ics</d:href><d:propstat><d:prop>',
+  '<c:calendar-data>BEGIN:VCALENDAR\r\nVERSION:2.0\r\n',
+  'BEGIN:VTIMEZONE\r\nTZID:Custom/Office\r\nEND:VTIMEZONE\r\n',
+  'BEGIN:VEVENT\r\nUID:preserved\r\nDTSTART:20260824T080000Z\r\n',
+  'DTEND:20260824T090000Z\r\nSUMMARY:Before\r\n',
+  'ORGANIZER:mailto:owner@example.com\r\nATTENDEE:mailto:guest@example.com\r\n',
+  'X-SERVER-FIELD:keep-me\r\nBEGIN:VALARM\r\nACTION:DISPLAY\r\n',
+  'TRIGGER:-PT15M\r\nEND:VALARM\r\nEND:VEVENT\r\nEND:VCALENDAR',
+  '</c:calendar-data></d:prop></d:propstat></d:response></d:multistatus>'
+].join("")
+const preservedEvent = feed.eventsFromCaldav(preservedXml, "work")[0]
+const preservedUpdate = feed.updateEvent({
+  title: "After", startMs: Date.UTC(2026, 7, 24, 8, 0),
+  endMs: Date.UTC(2026, 7, 24, 9, 0), location: "", description: ""
+}, preservedEvent, 5678)
+assert.ok(preservedUpdate.ics.indexOf("SUMMARY:After") > 0)
+assert.ok(preservedUpdate.ics.indexOf("SUMMARY:Before") < 0)
+assert.ok(preservedUpdate.ics.indexOf("ORGANIZER:mailto:owner@example.com") > 0)
+assert.ok(preservedUpdate.ics.indexOf("ATTENDEE:mailto:guest@example.com") > 0)
+assert.ok(preservedUpdate.ics.indexOf("BEGIN:VALARM") > 0)
+assert.ok(preservedUpdate.ics.indexOf("X-SERVER-FIELD:keep-me") > 0)
+assert.ok(preservedUpdate.ics.indexOf("BEGIN:VTIMEZONE") > 0)
+
 // A write is refused where it cannot really run: no source, a read-only
 // calendar of any kind, or a recurring CalDAV event whose ICS state this
 // client does not re-serialize. A recurring Google event edits fine — the

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -336,6 +336,17 @@ assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me/",
   { href: "//dav.example/cal/me/a.ics" }),
   "https://dav.example/cal/me/a.ics",
   "a scheme-relative href on the same host resolves")
+
+// Raw whitespace is refused: a URL's spaces arrive percent-encoded, and the
+// resolved address becomes one quoted line of the transport's curl config,
+// where a line break would write more options.
+assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me/",
+  { href: "https://dav.example/cal/me/a.ics\noutput = elsewhere" }), "",
+  "a line break in an absolute href is refused")
+assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me/",
+  { href: "/cal/me/a.ics\r\nnext" }), "", "same for a path href")
+assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me/",
+  { href: "a b.ics" }), "", "a raw space is not a URL")
 assert.ok(googleUrl.indexOf("singleEvents=true") > 0)
 assert.ok(googleUrl.indexOf("orderBy=startTime") > 0)
 assert.ok(googleUrl.indexOf("timeMin=2026-08-01T00%3A00%3A00.000Z") > 0)

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -273,6 +273,26 @@ assert.strictEqual(feed.writeRefusal({ kind: "google" }, null), "")
 assert.strictEqual(feed.writeRefusal({ kind: "google" },
   { recurrenceRule: "FREQ=WEEKLY" }), "")
 
+// An all-day event is edited as the dates it spans: the ICS keeps VALUE=DATE
+// with an exclusive end, the Google body carries date and never dateTime, and
+// a title-only change cannot turn it into midnight-to-midnight times.
+const allDayUpdate = feed.updateEvent({
+  title: "Conference, day one moved", startMs: new Date(2026, 7, 24).getTime(),
+  endMs: new Date(2026, 7, 26).getTime()
+}, { uid: "conf-1", sequence: 1,
+  start: { ms: new Date(2026, 7, 24).getTime(), allDay: true } }, 0)
+assert.ok(allDayUpdate.ok)
+assert.ok(allDayUpdate.ics.indexOf("DTSTART;VALUE=DATE:20260824") > 0)
+assert.ok(allDayUpdate.ics.indexOf("DTEND;VALUE=DATE:20260826") > 0,
+  "the exclusive end stays the day after the last one shown")
+assert.ok(allDayUpdate.ics.indexOf("SEQUENCE:2") > 0)
+assert.ok(allDayUpdate.ics.indexOf("DTSTART:") < 0,
+  "no date-time is written for an all-day event")
+assert.deepStrictEqual(JSON.parse(JSON.stringify(allDayUpdate.google)), {
+  summary: "Conference, day one moved", description: "", location: "",
+  start: { date: "2026-08-24" }, end: { date: "2026-08-26" }
+})
+
 // The CalDAV write address is the event's own href, resolved the way the
 // server wrote it: absolute, absolute-path, or relative to the collection.
 assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me/",

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -268,6 +268,11 @@ assert.strictEqual(feed.writeRefusal({ kind: "google", readOnly: true }, null),
 assert.strictEqual(feed.writeRefusal({ kind: "caldav" },
   { recurrenceRule: "FREQ=WEEKLY" }),
   "Recurring CalDAV events can only be changed in a full calendar client")
+// A modified occurrence carries a RECURRENCE-ID but no RRULE — and its href
+// is the series' shared file, so writing it would rewrite the whole series.
+assert.strictEqual(feed.writeRefusal({ kind: "caldav" },
+  { recurrenceIdMs: new Date(2026, 7, 24).getTime() }),
+  "Recurring CalDAV events can only be changed in a full calendar client")
 assert.strictEqual(feed.writeRefusal({ kind: "caldav" }, null), "")
 assert.strictEqual(feed.writeRefusal({ kind: "google" }, null), "")
 assert.strictEqual(feed.writeRefusal({ kind: "google" },

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -173,10 +173,14 @@ const google = feed.eventsFromGoogle({ items: [{
 }] }, "google:me")
 assert.strictEqual(google.length, 1)
 assert.strictEqual(google[0].uid, "g1")
+assert.strictEqual(google[0].googleId, "g1",
+  "the write URL needs the item id, separate from the iCalUID")
 assert.strictEqual(google[0].sourceId, "google:me")
 assert.strictEqual(google[0].start.ms, Date.parse("2026-08-24T10:00:00+02:00"))
 const googleUrl = feed.googleEventsUrl(Date.UTC(2026, 7, 1), Date.UTC(2026, 8, 1))
 assert.ok(googleUrl.indexOf("https://www.googleapis.com/calendar/v3/calendars/primary/events?") === 0)
+assert.strictEqual(feed.googleEventUrl("g1_20260824T080000Z"),
+  "https://www.googleapis.com/calendar/v3/calendars/primary/events/g1_20260824T080000Z")
 
 const created = feed.createEvent({
   title: "Planning", startMs: Date.UTC(2026, 7, 24, 8, 0),
@@ -219,6 +223,53 @@ assert.strictEqual(feed.createEvent({ title: "", startMs: 1, endMs: 2 }, 1).erro
   "Add an event title")
 assert.strictEqual(feed.createEvent({ title: "x", startMs: 2, endMs: 1 }, 1).error,
   "End time must be after start time")
+
+// An edit keeps the event's identity and tells every copy which write is new.
+const updated = feed.updateEvent({
+  title: "Planning, moved", startMs: Date.UTC(2026, 7, 24, 10, 0),
+  endMs: Date.UTC(2026, 7, 24, 11, 0), location: "", description: "Weekly plan"
+}, { uid: "omamail-1234", sequence: 0 }, 5678)
+assert.strictEqual(updated.ok, true)
+assert.strictEqual(updated.uid, "omamail-1234")
+assert.ok(updated.ics.indexOf("UID:omamail-1234") > 0)
+assert.ok(updated.ics.indexOf("SEQUENCE:1") > 0,
+  "a rewrite bumps the sequence so older copies yield")
+assert.ok(updated.ics.indexOf("DTSTART:20260824T100000Z") > 0)
+assert.ok(updated.ics.indexOf("SUMMARY:Planning\\, moved") > 0,
+  "ical text escapes what the field carries")
+assert.ok(updated.ics.indexOf("RRULE") < 0,
+  "recurrence is not editable here, so none is written")
+assert.ok(updated.ics.indexOf("LOCATION") < 0, "a cleared field leaves the ICS")
+assert.deepStrictEqual(JSON.parse(JSON.stringify(updated.google)), {
+  summary: "Planning, moved", description: "Weekly plan", location: "",
+  start: { dateTime: "2026-08-24T10:00:00.000Z" },
+  end: { dateTime: "2026-08-24T11:00:00.000Z" }
+})
+assert.ok(!("recurrence" in updated.google),
+  "omitting recurrence from the patch is what keeps the server's rule")
+const bumpedAgain = feed.updateEvent({
+  title: "x", startMs: 1, endMs: 2
+}, { uid: "u", sequence: 4 }, 1)
+assert.ok(bumpedAgain.ics.indexOf("SEQUENCE:5") > 0)
+assert.strictEqual(feed.updateEvent({ title: "x", startMs: 1, endMs: 2 }, {}, 1).error,
+  "The event has no identity to update")
+assert.strictEqual(feed.updateEvent({ title: "", startMs: 1, endMs: 2 },
+  { uid: "u" }, 1).error, "Add an event title")
+
+// The CalDAV write address is the event's own href, resolved the way the
+// server wrote it: absolute, absolute-path, or relative to the collection.
+assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me/",
+  { href: "https://dav.example/cal/me/a.ics" }),
+  "https://dav.example/cal/me/a.ics")
+assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me/",
+  { href: "/cal/me/a.ics" }), "https://dav.example/cal/me/a.ics")
+assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me/",
+  { href: "a.ics" }), "https://dav.example/cal/me/a.ics")
+assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me",
+  { href: "", uid: "omamail-1" }), "https://dav.example/cal/me/omamail-1.ics")
+assert.strictEqual(feed.caldavEventUrl("http://dav.example/cal/me/",
+  { href: "/cal/me/a.ics" }), "", "CalDAV writes stay on HTTPS")
+assert.strictEqual(feed.caldavEventUrl("", { href: "", uid: "" }), "")
 assert.ok(googleUrl.indexOf("singleEvents=true") > 0)
 assert.ok(googleUrl.indexOf("orderBy=startTime") > 0)
 assert.ok(googleUrl.indexOf("timeMin=2026-08-01T00%3A00%3A00.000Z") > 0)

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -256,6 +256,23 @@ assert.strictEqual(feed.updateEvent({ title: "x", startMs: 1, endMs: 2 }, {}, 1)
 assert.strictEqual(feed.updateEvent({ title: "", startMs: 1, endMs: 2 },
   { uid: "u" }, 1).error, "Add an event title")
 
+// A write is refused where it cannot really run: no source, a read-only
+// calendar of any kind, or a recurring CalDAV event whose ICS state this
+// client does not re-serialize. A recurring Google event edits fine — the
+// server keeps the rule and one occurrence is patched.
+assert.strictEqual(feed.writeRefusal(null, null), "Choose a calendar")
+assert.strictEqual(feed.writeRefusal({ kind: "caldav", readOnly: true }, null),
+  "This calendar is read-only")
+assert.strictEqual(feed.writeRefusal({ kind: "google", readOnly: true }, null),
+  "This calendar is read-only")
+assert.strictEqual(feed.writeRefusal({ kind: "caldav" },
+  { recurrenceRule: "FREQ=WEEKLY" }),
+  "Recurring CalDAV events can only be changed in a full calendar client")
+assert.strictEqual(feed.writeRefusal({ kind: "caldav" }, null), "")
+assert.strictEqual(feed.writeRefusal({ kind: "google" }, null), "")
+assert.strictEqual(feed.writeRefusal({ kind: "google" },
+  { recurrenceRule: "FREQ=WEEKLY" }), "")
+
 // The CalDAV write address is the event's own href, resolved the way the
 // server wrote it: absolute, absolute-path, or relative to the collection.
 assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me/",

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -273,6 +273,11 @@ assert.strictEqual(feed.writeRefusal({ kind: "caldav" },
 assert.strictEqual(feed.writeRefusal({ kind: "caldav" },
   { recurrenceIdMs: new Date(2026, 7, 24).getTime() }),
   "Recurring CalDAV events can only be changed in a full calendar client")
+// A RECURRENCE-ID too malformed to parse leaves recurrenceIdMs at 0; the raw
+// line still answers for it, because the href names the series' shared file.
+assert.strictEqual(feed.writeRefusal({ kind: "caldav" },
+  { recurrenceIdMs: 0, source: { recurrenceId: "RECURRENCE-ID:not-a-date" } }),
+  "Recurring CalDAV events can only be changed in a full calendar client")
 assert.strictEqual(feed.writeRefusal({ kind: "caldav" }, null), "")
 assert.strictEqual(feed.writeRefusal({ kind: "google" }, null), "")
 assert.strictEqual(feed.writeRefusal({ kind: "google" },

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -270,6 +270,30 @@ assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me",
 assert.strictEqual(feed.caldavEventUrl("http://dav.example/cal/me/",
   { href: "/cal/me/a.ics" }), "", "CalDAV writes stay on HTTPS")
 assert.strictEqual(feed.caldavEventUrl("", { href: "", uid: "" }), "")
+
+// An absolute href is accepted only on the collection's own origin: anything
+// else would send this calendar's credentials to a server that merely named
+// an address in an answer.
+assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me/",
+  { href: "https://other.example/cal/me/a.ics" }), "",
+  "a cross-origin href is refused before credentials go anywhere")
+assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me/",
+  { href: "https://dav.example.evil.com/a.ics" }), "",
+  "a host that merely starts with the source's is another origin")
+assert.strictEqual(feed.caldavEventUrl("https://dav.example:8443/cal/me/",
+  { href: "https://dav.example/cal/me/a.ics" }), "",
+  "a different port is a different origin")
+assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me/",
+  { href: "https://dav.example:443/cal/me/a.ics" }),
+  "https://dav.example:443/cal/me/a.ics",
+  "the default port spelled out is still the same origin")
+assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me/",
+  { href: "//other.example/a.ics" }), "",
+  "a scheme-relative href still names its own host")
+assert.strictEqual(feed.caldavEventUrl("https://dav.example/cal/me/",
+  { href: "//dav.example/cal/me/a.ics" }),
+  "https://dav.example/cal/me/a.ics",
+  "a scheme-relative href on the same host resolves")
 assert.ok(googleUrl.indexOf("singleEvents=true") > 0)
 assert.ok(googleUrl.indexOf("orderBy=startTime") > 0)
 assert.ok(googleUrl.indexOf("timeMin=2026-08-01T00%3A00%3A00.000Z") > 0)

--- a/tests/test_calendar_sources.js
+++ b/tests/test_calendar_sources.js
@@ -93,6 +93,8 @@ hiddenGoogle = sources.withGoogleAccounts(hiddenGoogle, [
 ])
 assert.strictEqual(hiddenGoogle.sources[1].enabled, false,
   "discovering an account must not undo its saved visibility")
+assert.strictEqual(hiddenGoogle.sources[1].readOnly, false,
+  "a legacy synthesized Google source must not keep its old read-only stamp")
 
 const visibility = sources.setEnabled(hiddenGoogle, "google:me@gmail.com", true)
 assert.strictEqual(visibility.sources[1].enabled, true)

--- a/tests/test_calendar_sources.js
+++ b/tests/test_calendar_sources.js
@@ -52,6 +52,24 @@ const withGoogle = sources.withGoogleAccounts(list, [
 assert.strictEqual(withGoogle.sources.length, 2)
 assert.strictEqual(withGoogle.sources[1].id, "google:me@gmail.com")
 assert.strictEqual(withGoogle.sources[1].accountId, "me@gmail.com")
+assert.strictEqual(withGoogle.sources[1].readOnly, false,
+  "a Google calendar accepts writes through the API")
+assert.ok(sources.writable(withGoogle.sources[1]))
+
+let readOnlyList = sources.add(list, {
+  id: "caldav:shared-example-team", kind: "caldav", name: "Team",
+  url: "https://shared.example/dav/team/", username: "me", readOnly: true
+})
+assert.strictEqual(sources.writable(readOnlyList.sources[1]), false,
+  "a read-only calendar is not somewhere a write can be offered")
+assert.strictEqual(sources.load(sources.serialize(readOnlyList)).sources[1].readOnly,
+  true, "the read-only flag survives a config round trip")
+const writableGroups = sources.writableGroups(sources.groupByAccount(readOnlyList, [
+  { id: "me@gmail.com", email: "me@gmail.com", provider: "gmail", signedIn: true }
+]))
+assert.strictEqual(writableGroups.length, 1)
+assert.strictEqual(JSON.stringify(writableGroups[0].calendars.map(function (source) { return source.id })),
+  JSON.stringify(["nextcloud-personal"]), "the read-only calendar leaves the creation picker")
 assert.strictEqual(withGoogle.sources[1].name, "me@gmail.com",
   "Google calendar errors must identify the full account address")
 const forMe = sources.forAccount(sources.withGoogleAccounts(list, [

--- a/tests/test_calendar_write.sh
+++ b/tests/test_calendar_write.sh
@@ -20,4 +20,12 @@ printf '%s %s %s\n' "$(b64 'https://calendar.example/dav/me/a.ics')" \
   | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-write.sh"
 grep -q 'request = "PUT"' "$work/config"
 test "$(cat "$work/event")" = 'BEGIN:VCALENDAR'
+# A decoded field becomes one quoted line of the curl config, so an address
+# carrying a line break is refused before curl is ever invoked.
+if printf '%s %s %s\n' "$(printf 'https://calendar.example/a.ics\noutput = "/tmp/x"' | base64 -w0)" \
+  "$(b64 'me:secret')" "$(b64 'BEGIN:VCALENDAR')" \
+  | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-write.sh" 2>/dev/null; then
+  echo 'calendar-write.sh: a URL that spans lines must be refused' >&2
+  exit 1
+fi
 echo 'calendar-write.sh ok'

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -294,8 +294,8 @@ service = Path("Service.qml").read_text()
 if "accountId: root.calendarAccountId" not in service:
     raise SystemExit("test_source.sh: the visible Calendar must follow the displayed account")
 composer = Path("components/CalendarEventComposer.qml").read_text()
-if "controller.contextSources.sources" not in composer or "controller.sourceGroups" not in composer:
-    raise SystemExit("test_source.sh: event creation must offer only the current account calendars")
+if "controller.writableSourceGroups" not in composer:
+    raise SystemExit("test_source.sh: event creation must offer only writable calendars of the current account")
 PY
 grep -q 'text: "Create event\.\.\."' App.qml \
   || fail "calendar mode needs a Create event... header action"


### PR DESCRIPTION
Events were create-only. The calendar detail now edits and deletes them, with the rules those operations need enforced before any credential moves.

**What you can do**

- Edit... / Delete... on an event, drawn only where the operation is real. Google writes go to PATCH/DELETE on the item id — with `singleEvents=true`, changing or removing one occurrence of a series does what Google Calendar does. CalDAV writes go to PUT/DELETE on the event's own `href`, through the new `calendar-delete.sh`.
- Edit an all-day event as the dates it spans: the composer shows first/last day instead of time fields, and the write stays `DTSTART;VALUE=DATE` with an exclusive `DTEND` in ICS, `start.date`/`end.date` in Google's body. A title-only edit can no longer turn an all-day event into midnight-to-midnight times.
- Deletes confirm first, naming the event, through one dialog.

**Where it refuses**

- A recurring CalDAV event is one ICS holding a rule, its exceptions and its exclusions; this client does not re-serialize that state, so it refuses — and an occurrence carrying a RECURRENCE-ID answers the same way (parsed or not), because its `href` is the series' shared file.
- A read-only calendar draws no Edit/Delete, refuses writes in the controller, and is not offered in the creation picker. Synthesized Google sources are writable even when an older config persisted their former read-only stamp.
- A server-written `href` is resolved against its collection and accepted only on the same scheme, host and port — judged before the keyring is touched — and carries no raw whitespace, since the address becomes one quoted line of the transport's curl config.

**What a write preserves**

- A CalDAV PUT rewrites only the editable properties in the matching standalone VEVENT. Organizer, attendees, alarms, timezone definitions and server extension fields survive unchanged.
- Calendar cache schema changes invalidate ranges that lack the Google item id or original CalDAV resource instead of restoring events that cannot be edited safely.
- Create, update and delete share one write gate. A form becomes pending only when no older event write owns the controller, so an old completion cannot close a newer form.

**Invariants**: every decision lives in `.pragma library` JS with node tests (`caldavEventUrl`, `writeRefusal`, date-only serialization and CalDAV resource preservation); every new request gets the Timer-plus-abort deadline Qt's XHR makes necessary; a failed write surfaces on the view's banner; a completion is answered only by the form that started the write.

One drive-by, predating this branch: `ComposeView.submit` never checked it was open, so `Ctrl+Return` in the event form could re-queue a draft parked for the undo window and send it twice. One guard closes it.

**Verification**: `make test` and `make validate` pass on the rebased branch on the Qt the plugin runs on — node, shell and 81 offscreen QML tests, qmllint, and `omarchy plugin validate`.
