### PR TITLE
Preserve mailto plus signs and source release notes from PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,11 +390,13 @@ key. What matters while working:
 - Derive the pull request title from the final `base...HEAD` diff. Do not copy the first commit subject when later commits have broadened or changed the outcome.
 - **Re-derive it every time a commit is added, not only when the pull request is opened.** The rule above is easy to satisfy at creation and easy to lose afterwards — one pull request here was opened for a single fix, grew three more, and kept the first commit's subject until somebody read it and said it was wrong. The description carries the same rule for the same reason; the title needs it said out loud because a title is short enough to go on looking true.
 - Rewrite the pull request description whenever its scope changes. It states the user-visible results, the architectural reason and invariants, and the verification actually performed; it does not preserve a chronological list of implementation attempts.
+- Every pull request description includes a `## Release Notes` section whose bulleted list contains the user-visible results in language ready to publish. When a pull request has no user-visible result, the section says `- None.`; never omit it.
 - Commit subjects follow the same rule: imperative, outcome-oriented, unprefixed. A conventional prefix never substitutes for a precise result.
 - Markdown prose uses one source line per paragraph. Do not hard-wrap prose to a column width.
 
 ## Releasing
 
+- Release notes are assembled from the `## Release Notes` section of every merged pull request in the release range, then checked against the release diff for omissions. Read each final pull request description in full while doing that check: commit subjects and pull request titles are navigation, not a sufficient account of the user-visible results. If a description no longer matches its final diff, correct it before assembling the notes so every shipped feature is represented.
 - `scripts/bump.sh 0.2.0` is the whole of it: it sets the manifest version,
   commits, tags and pushes both. The release workflow refuses a tag that
   disagrees with the manifest, and by then the tag is on the remote and has to

--- a/message/Mailto.js
+++ b/message/Mailto.js
@@ -11,7 +11,7 @@
 // field. The body is allowed them — that is what a body is.
 
 function percentDecode(value) {
-  var text = String(value || "").replace(/\+/g, " ")
+  var text = String(value || "")
   try {
     return decodeURIComponent(text)
   } catch (e) {

--- a/message/Unsubscribe.js
+++ b/message/Unsubscribe.js
@@ -45,7 +45,7 @@ function entries(value) {
 // ------------------------------------------------------------------ mailto
 
 function percentDecode(value) {
-  var text = String(value || "").replace(/\+/g, " ")
+  var text = String(value || "")
   try {
     return decodeURIComponent(text)
   } catch (e) {

--- a/tests/test_mailto.js
+++ b/tests/test_mailto.js
@@ -27,8 +27,12 @@ deepEqual(mailto.parse("mailto:?bcc=hidden@example.com"),
   draft("", "", "hidden@example.com", "", ""),
   "a bcc-only link still opens a draft")
 
-assert.strictEqual(mailto.parse("mailto:jane@example.com?subject=Stop+these").subject,
-  "Stop these", "+ in a query string is a space")
+assert.strictEqual(mailto.parse("mailto:user+tag@example.com").to,
+  "user+tag@example.com", "+ is data in a mailto address, not a form-encoded space")
+assert.strictEqual(mailto.parse("mailto:jane@example.com?subject=C++").subject,
+  "C++", "+ is data in a mailto query too; spaces are percent-encoded")
+assert.strictEqual(mailto.parse("mailto:jane@example.com?subject=Stop%20these").subject,
+  "Stop these", "%20 is how a mailto query carries a space")
 assert.strictEqual(mailto.parse("mailto:jane@example.com?subject=%E4%B8%AD%E6%96%87").subject,
   "中文")
 assert.strictEqual(mailto.parse("mailto:jane@example.com?body=line%0Abreak").body,

--- a/tests/test_unsubscribe.js
+++ b/tests/test_unsubscribe.js
@@ -32,9 +32,10 @@ deepEqual(unsub.parseMailto("mailto:bye@example.com"),
   { to: "bye@example.com", subject: "Unsubscribe", body: "Unsubscribe" })
 deepEqual(unsub.parseMailto("mailto:bye@example.com?subject=Stop%20these&body=please"),
   { to: "bye@example.com", subject: "Stop these", body: "please" })
-// "+" is a space in a query string, which is where these live.
-assert.strictEqual(unsub.parseMailto("mailto:bye@example.com?subject=Stop+these").subject,
-  "Stop these")
+assert.strictEqual(unsub.parseMailto("mailto:bye+tag@example.com").to,
+  "bye+tag@example.com", "+ is data in a mailto address, not a form-encoded space")
+assert.strictEqual(unsub.parseMailto("mailto:bye@example.com?subject=C++").subject,
+  "C++", "+ is data in a mailto query too; spaces are percent-encoded")
 // Several recipients: the first is the one that unambiguously belongs here.
 assert.strictEqual(unsub.parseMailto("mailto:a@example.com,b@example.com").to, "a@example.com")
 assert.strictEqual(unsub.parseMailto("mailto:not-an-address"), null)


### PR DESCRIPTION
## What changed

- **Preserve literal plus signs in mailto links.** New-message and unsubscribe parsers no longer apply form-encoding rules to RFC 6068 URLs, so addresses such as `user+tag@example.com` and text such as `C++` remain intact while `%20` continues to decode as a space.
- **Make release notes directly extractable.** Every PR must contain a bulleted `## Release Notes` section, using `- None.` when there is no user-visible result. Releases assemble these sections across the merged PR range and check them against the release diff for omissions.

## Release Notes

- Preserve `+` characters in recipients, subjects, and bodies opened from `mailto:` links.

## Architecture and invariants

- RFC 6068 mailto values use percent encoding, not `application/x-www-form-urlencoded`; a literal `+` is data and a space is `%20`.
- PR titles and commit subjects remain navigation. Release notes come from the dedicated PR description section and are verified against the shipped diff.

## Verification

- `make validate`
- Red-green regression tests for tagged addresses and `C++` in both compose and unsubscribe mailto parsers
- `git diff --check`
