### PR TITLE
Keep message headers out of IMAP failures

### DIFF
--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -896,15 +896,30 @@ function redact(text) {
     .replace(/(password|pass|pwd)\s*[=:]\s*\S+/gi, "$1=[redacted]")
 }
 
-// Whether the tagged completion said OK. curl hides the tag from us for a
-// custom request, so this reads what it does surface.
+// Whether a tagged completion said NO or BAD. This has to inspect parsed IMAP
+// responses rather than search the whole byte string: a FETCH response holds
+// the message as a literal, and an ordinary message header such as
+// `X-Spam-Flag: NO` is not the server refusing the command.
+function failureCompletion(text) {
+  var lines = splitResponse(text)
+  for (var i = 0; i < lines.length; i++) {
+    // A response containing a literal includes the literal's own lines in this
+    // string. Only its first protocol line can be a completion, and spaces or
+    // tabs — not \s, which also crosses a newline — separate its fields.
+    var first = String(lines[i] || "").split(/\r?\n/)[0]
+    var match = first.match(/^([^+*\s]\S*)[ \t]+(NO|BAD)(?:[ \t]+(.*))?$/i)
+    if (match) return { detail: trimmed(match[3]) }
+  }
+  return null
+}
+
 function isFailure(text) {
-  return /^\S+\s+(NO|BAD)\s/im.test(String(text || ""))
+  return failureCompletion(text) !== null
 }
 
 function failureDetail(text) {
-  var match = String(text || "").match(/^\S+\s+(?:NO|BAD)\s+([\s\S]*)$/im)
-  return match ? trimmed(match[1].split(/[\r\n]/)[0]) : ""
+  var completion = failureCompletion(text)
+  return completion ? completion.detail : ""
 }
 
 // ------------------------------------------------------------- capabilities

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -499,8 +499,27 @@ assert.strictEqual(imap.isFailure("A1 OK completed\r\n"), false)
 assert.strictEqual(imap.isFailure("A1 NO [AUTHENTICATIONFAILED] nope\r\n"), true)
 assert.strictEqual(imap.isFailure("A1 BAD syntax\r\n"), true)
 assert.strictEqual(imap.isFailure("* OK still going\r\n"), false, "untagged OK is not a failure")
+assert.strictEqual(imap.isFailure("* NO [ALERT] mailbox maintenance\r\n"), false,
+  "an untagged status response is not a command failure")
 assert.strictEqual(imap.failureDetail("A1 NO [AUTHENTICATIONFAILED] Invalid credentials\r\n"),
   "[AUTHENTICATIONFAILED] Invalid credentials")
+assert.strictEqual(imap.isFailure("+ NO is continuation text\r\n"), false,
+  "a continuation response is not a tagged failure")
+
+// A fetched message is an opaque literal. This is the shape of the
+// Outlook-originated message that exposed the bug: its spam verdict was read
+// as the IMAP server saying NO, and the following header was shown as the
+// error while the successfully fetched body was discarded.
+const spamHeaders = "X-Spam-Flag: NO\r\nUI-OutboundReport: notjunk:1;M01:P0:signature\r\n\r\nbody"
+const fetchedSpamHeaders =
+  "* 1 FETCH (UID 87340 BODY[] {" + spamHeaders.length + "}\r\n" + spamHeaders + ")\r\n"
+assert.strictEqual(imap.isFailure(fetchedSpamHeaders), false,
+  "NO inside a message literal is not an IMAP failure")
+assert.strictEqual(imap.failureDetail(fetchedSpamHeaders), "")
+assert.strictEqual(imap.isFailure(fetchedSpamHeaders + "A1 NO message unavailable\r\n"), true,
+  "a real tagged failure after the literal is still reported")
+assert.strictEqual(imap.failureDetail(fetchedSpamHeaders + "A1 NO message unavailable\r\n"),
+  "message unavailable")
 
 // ------------------------------------------------------------ capabilities
 


### PR DESCRIPTION
## Summary

- inspect literal-aware IMAP response records before deciding that a request failed
- accept only tagged `NO` or `BAD` completions, not matching text inside fetched message bodies
- cover untagged statuses, continuation responses, and a fetched message carrying `X-Spam-Flag: NO`

The previous multiline regular expression searched the complete `FETCH` response. A normal message header such as `X-Spam-Flag: NO` therefore looked like an IMAP command failure, so the successfully fetched body was discarded and the reader showed “This message has no text to show”.

Fixes #42.

## Testing

- `make test` (all JavaScript and shell tests; 81 QML tests passed)
- verified against an affected multipart IMAP message containing `X-Spam-Flag: NO`

## Release Notes

- Fix IMAP messages with spam verdict headers appearing to have no readable body.
