### PR TITLE
Save and reopen drafts without blocking compose during Undo Send

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -26,6 +26,7 @@ Item {
   property var service: null
   property bool opened: false
   property bool closingFromHost: false
+  property string draftSavedNotice: ""
 
   readonly property string pluginId: manifest && manifest.id
     ? String(manifest.id) : "omamail"
@@ -253,7 +254,7 @@ Item {
   property string composeReturnView: ""
 
   function startCompose(mode) {
-    if (!service || service.sendPending || service.sending) return
+    if (!service) return
     var next = String(mode || "new")
     if (next !== "new" && !service.selectedMessage) {
       pendingComposeMode = next
@@ -268,7 +269,6 @@ Item {
   // already open when this runs — summon delivers the payload to open().
   function openDraft(draft) {
     if (!draft) return
-    if (service && (service.sendPending || service.sending)) return
     composeReturnView = currentView
     compose.beginDraft(draft)
   }
@@ -298,10 +298,51 @@ Item {
     if (from === "list" && currentView === "reader") backToList()
   }
 
+  function saveAndLeaveCompose() {
+    if (!service || !compose.hasMeaningfulDraft()) {
+      compose.finish()
+      return
+    }
+    var saved = compose.detachForSave()
+    var fields = compose.fieldsForDraft(saved)
+    service.saveDraft(fields, function(result, error) {
+      if (!root) return
+      if (error) {
+        compose.recoverDetachedSave(saved)
+        service.fail("Could not save draft: " + String(error))
+        return
+      }
+      compose.completeDetachedSave(saved)
+      root.draftSavedNotice = "Draft saved"
+      draftSavedTimer.restart()
+      if (service.mailboxKey === "drafts") service.refresh()
+    })
+  }
+
   function undoPendingSend() {
     if (!service || !service.undoSend()) return false
-    compose.resumePendingSend()
+    if (!compose.resumePendingSend()) return true
+    var interrupted = compose.interruptedDraft
+    var fields = compose.interruptedFields()
+    if (!interrupted || !fields) return true
+    service.saveDraft(fields, function(saved, error) {
+      if (!root) return
+      if (error) {
+        service.fail("Could not save the newer draft: " + String(error))
+        return
+      }
+      if (!compose.completeInterruptedSave(interrupted)) return
+      root.draftSavedNotice = "Draft saved"
+      draftSavedTimer.restart()
+    })
     return true
+  }
+
+  Timer {
+    id: draftSavedTimer
+    interval: 4000
+    repeat: false
+    onTriggered: root.draftSavedNotice = ""
   }
 
   // Acting on the open message closes it: it is about to leave this list.
@@ -449,7 +490,7 @@ Item {
       focusScope.parkKeyboard()
     }
     else if (eventComposer.opened) eventComposer.close()
-    else if (compose.opened) compose.finish()
+    else if (compose.opened) saveAndLeaveCompose()
     else if (setupVisible) setupVisible = false
     else if (settingsVisible) settingsVisible = false
     else if (currentView === "calendar" && calendarView.detailOpen) calendarView.closeDetail()
@@ -461,7 +502,7 @@ Item {
   Connections {
     target: root.service
     ignoreUnknownSignals: true
-    function onReplySent() { compose.finish() }
+    function onReplySent() { compose.completePendingSend() }
     // Every time the list is replaced — first arrival, a mailbox switch, a
     // search, a refresh that dropped things. A cursor whose message survived
     // keeps its place; one whose message is gone would be unfindable, and an
@@ -1139,6 +1180,7 @@ Item {
           popupBorderColor: root.popupBorder
           panelFontFamily: root.fontFamily
           onClosed: root.leaveCompose()
+          onCloseRequested: root.saveAndLeaveCompose()
           onSendQueued: root.backToList()
         }
 
@@ -1289,6 +1331,21 @@ Item {
         popupBorderColor: root.popupBorder
         panelFontFamily: root.fontFamily
         onUndoRequested: root.undoPendingSend()
+      }
+
+      DraftSavedToast {
+        anchors.right: parent.right
+        anchors.rightMargin: Style.space(16)
+        anchors.bottom: statusBar.top
+        anchors.bottomMargin: Style.space(12)
+        z: 80
+        visible: root.draftSavedNotice !== ""
+        message: root.draftSavedNotice
+        textColor: root.foreground
+        accentColor: root.accent
+        popupBackgroundColor: root.popupBackground
+        popupBorderColor: root.popupBorder
+        panelFontFamily: root.fontFamily
       }
 
       // --------------------------------------------------------- status bar

--- a/App.qml
+++ b/App.qml
@@ -9,6 +9,7 @@ import "account/Model.js" as Model
 import "account/Accounts.js" as Accounts
 import "keys/Keymap.js" as Keymap
 import "message/Mailto.js" as Mailto
+import "message/Message.js" as Message
 import "components"
 import "calendar"
 
@@ -201,14 +202,23 @@ Item {
   function openMessage(id) {
     if (!service) return
     pendingComposeMode = ""
+    pendingDraftId = ""
     reader.forceRichAnyway = false
     cursorId = String(id || "")
+    if (service.mailboxKey === "drafts") {
+      composeReturnView = currentView
+      pendingDraftId = cursorId
+      service.select(cursorId)
+      Qt.callLater(root.resumeHeldDraft)
+      return
+    }
     service.select(cursorId)
     currentView = "reader"
   }
 
   function backToList() {
     pendingComposeMode = ""
+    pendingDraftId = ""
     if (service) service.clearSelection()
     currentView = "list"
     Qt.callLater(function() { focusScope.applyContextFocus() })
@@ -246,6 +256,7 @@ Item {
   // draft in the same breath addressed nobody and quoted nothing, which is what
   // the list row's own Reply menu did. Held until the fetch lands instead.
   property string pendingComposeMode: ""
+  property string pendingDraftId: ""
   // Where the draft was raised from, so that leaving it goes back there.
   // Answering from the list opens the message being answered — that is the
   // reply's doing, not somewhere the reader asked to be — so closing the draft
@@ -255,6 +266,7 @@ Item {
 
   function startCompose(mode) {
     if (!service) return
+    pendingDraftId = ""
     var next = String(mode || "new")
     if (next !== "new" && !service.selectedMessage) {
       pendingComposeMode = next
@@ -269,6 +281,7 @@ Item {
   // already open when this runs — summon delivers the payload to open().
   function openDraft(draft) {
     if (!draft) return
+    pendingDraftId = ""
     composeReturnView = currentView
     compose.beginDraft(draft)
   }
@@ -278,6 +291,16 @@ Item {
     var mode = pendingComposeMode
     pendingComposeMode = ""
     startCompose(mode)
+  }
+
+  function resumeHeldDraft() {
+    if (pendingDraftId === "" || !service) return
+    if (service.selectedId !== pendingDraftId || service.detailLoading
+        || !service.detailPainted || !service.selectedMessage) return
+    var messageId = pendingDraftId
+    pendingDraftId = ""
+    compose.beginDraft(Message.draftFields(service.selectedMessage,
+      service.selectedBody.text), messageId, service.selectedAttachments)
   }
 
   // Answering from the list opens what is being answered first, the way the
@@ -519,8 +542,14 @@ Item {
     // markup has not changed, so the body is not written a second time and
     // nothing fires again. Reply, reply-all and forward raised from the list
     // opened the message and stopped there.
-    function onSelectedBodyChanged() { Qt.callLater(root.resumeHeldCompose) }
-    function onSelectedMessageChanged() { Qt.callLater(root.resumeHeldCompose) }
+    function onSelectedBodyChanged() { Qt.callLater(function() {
+      root.resumeHeldCompose()
+      root.resumeHeldDraft()
+    }) }
+    function onSelectedMessageChanged() { Qt.callLater(function() {
+      root.resumeHeldCompose()
+      root.resumeHeldDraft()
+    }) }
 
     function onMessagesChanged() {
       root.cursorId = Model.cursorAfterReload(

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/ComposeView.qml \
 	components/RecipientSuggestions.qml \
 	components/UndoSendToast.qml \
+	components/DraftSavedToast.qml \
 	components/SearchBar.qml \
 	components/AppMenu.qml \
 	components/AccountSwitcher.qml \

--- a/Service.qml
+++ b/Service.qml
@@ -666,6 +666,16 @@ Item {
   function toggleStar(id) { if (current) current.toggleStar(id) }
   function markAllRead() { if (current) current.markAllRead() }
   function send(fields) { return current ? current.send(fields) : false }
+  function saveDraft(fields, callback) {
+    var values = fields || ({})
+    var target = String(values.accountId || "")
+    var host = target !== "" ? findAccount(target) : current
+    if (!host) {
+      if (typeof callback === "function") callback(null, "The mailbox for this draft is unavailable")
+      return null
+    }
+    return host.saveDraft(values, callback)
+  }
   function fail(text) { if (current) current.fail(text) }
   function note(text) { if (current) current.note(text) }
   function undoSend() {

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1231,6 +1231,36 @@ Item {
     return true
   }
 
+  function saveDraft(fields, callback) {
+    if (!ready || !api || typeof api.saveDraft !== "function") {
+      if (typeof callback === "function") callback(null, "The mailbox is not ready to save drafts")
+      return null
+    }
+    var values = fields || ({})
+    var from = String(values.from || "").trim()
+    var alias = from === "" ? null : Api.sendAsFor(availableSendAsAliases, from)
+    if (from !== "" && !alias) {
+      if (typeof callback === "function") callback(null, "Choose a valid From address")
+      return null
+    }
+    var payload = Mail.buildSendPayload({
+      from: from,
+      fromName: alias ? String(alias.displayName || "") : "",
+      to: String(values.to || "").trim(),
+      cc: String(values.cc || "").trim(),
+      bcc: String(values.bcc || "").trim(),
+      subject: String(values.subject || ""),
+      body: String(values.body || ""),
+      attachments: Array.isArray(values.attachments) ? values.attachments : [],
+      threadId: values.threadId,
+      inReplyTo: values.inReplyTo,
+      references: values.references
+    })
+    return api.saveDraft(payload, function(saved, error) {
+      if (typeof callback === "function") callback(saved, error)
+    })
+  }
+
   function send(fields) {
     if (!ready || sending || sendPending) return false
     var values = fields || ({})

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -95,6 +95,7 @@ DropArea {
     if (mode === "reply") return "Reply"
     if (mode === "replyAll") return "Reply all"
     if (mode === "forward") return "Forward"
+    if (mode === "draft") return "Draft"
     return "New message"
   }
 
@@ -298,6 +299,25 @@ DropArea {
       })
   }
 
+  function loadDraftAttachments(messageId, attachments) {
+    var listed = Array.isArray(attachments) ? attachments.slice() : []
+    originalAttachments = listed
+    if (!service || listed.length === 0) return
+    var serial = ++forwardLoadSerial
+    forwardAttachmentsLoading = true
+    forwardAttachmentError = ""
+    service.loadAttachments(messageId, listed, function(loaded, error) {
+      if (serial !== root.forwardLoadSerial || !root.opened || root.mode !== "draft") return
+      root.forwardAttachmentsLoading = false
+      root.forwardAttachmentError = String(error || "")
+      if (error) {
+        if (root.service && typeof root.service.fail === "function") root.service.fail(error)
+        return
+      }
+      root.draftAttachments = Array.isArray(loaded) ? loaded : []
+    })
+  }
+
   function begin(nextMode, summary, bodyText, attachments) {
     clearCurrentDraft(true)
     mode = String(nextMode || "new")
@@ -342,9 +362,12 @@ DropArea {
 
   // A mailto: link is a new message with the fields already named. Reply and
   // forward stay on `begin`; they fill from a message, not from a URL.
-  function beginDraft(draft) {
+  function beginDraft(draft, messageId, attachments) {
     begin("new", null, "", [])
     var values = draft || ({})
+    mode = String(values.mode || "new") === "draft" ? "draft" : "new"
+    threadId = String(values.threadId || "")
+    inReplyTo = String(values.inReplyTo || "")
     toField.text = String(values.to || "")
     ccField.text = String(values.cc || "")
     ccVisible = ccField.text !== ""
@@ -352,6 +375,12 @@ DropArea {
     bccVisible = bccField.text !== ""
     subjectField.text = String(values.subject || "")
     bodyEdit.text = String(values.body || "")
+    var chosenFrom = String(values.from || "")
+    if (chosenFrom !== "") {
+      fromEmail = chosenFrom
+      fromWasChosen = true
+    }
+    if (mode === "draft") loadDraftAttachments(messageId, attachments)
   }
 
   // Where the keyboard goes when composing becomes the context. A reply starts

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -33,11 +33,18 @@ DropArea {
   readonly property int formInset: Style.space(18)
   readonly property int formLabelWidth: Style.space(52)
   readonly property int formLabelGap: Style.space(10)
-  readonly property bool deliveryLocked: !!root.service
-    && (root.service.sendPending || root.service.sending)
 
   property bool opened: false
   property bool parkedForSend: false
+  // The timer owns this draft while the visible composer remains free.
+  property var pendingDraft: null
+  // Undo temporarily replaces a newer draft. Closing or resending returns here.
+  property var interruptedDraft: null
+  // A failed provider save stays reachable after Back or Escape.
+  property var recoveryDrafts: []
+  property string accountId: ""
+  property int restoreRevision: 0
+  property real restoreFlashOpacity: 0
   property string mode: "new"
   property string threadId: ""
   property string inReplyTo: ""
@@ -91,7 +98,15 @@ DropArea {
     return "New message"
   }
 
-  function reset() {
+  function forgetOwned(attachments) {
+    var owned = Array.isArray(attachments) ? attachments : []
+    for (var i = 0; i < owned.length; i++) {
+      if (owned[i] && owned[i].owned && owned[i].path)
+        enqueueAttach("forget", owned[i].path)
+    }
+  }
+
+  function clearCurrentDraft(forgetAttachments) {
     forwardLoadSerial++
     fromMenu.close()
     toField.text = ""
@@ -99,6 +114,7 @@ DropArea {
     bccField.text = ""
     subjectField.text = ""
     bodyEdit.text = ""
+    accountId = ""
     mode = "new"
     threadId = ""
     inReplyTo = ""
@@ -114,16 +130,74 @@ DropArea {
     forwardedAttachments = []
     forwardAttachmentsLoading = false
     forwardAttachmentError = ""
-    parkedForSend = false
     var owned = draftAttachments
     draftAttachments = []
     attachJobs = []
     attaching = false
     pasteInFlight = false
-    for (var i = 0; i < owned.length; i++) {
-      if (owned[i] && owned[i].owned && owned[i].path)
-        enqueueAttach("forget", owned[i].path)
-    }
+    if (forgetAttachments) forgetOwned(owned)
+  }
+
+  function snapshotDraft() {
+    return ({
+      to: toField.text,
+      cc: ccField.text,
+      bcc: bccField.text,
+      subject: subjectField.text,
+      body: bodyEdit.text,
+      accountId: accountId,
+      mode: mode,
+      threadId: threadId,
+      inReplyTo: inReplyTo,
+      ccVisible: ccVisible,
+      bccVisible: bccVisible,
+      fromEmail: fromEmail,
+      replyRecipients: replyRecipients.slice(),
+      fromWasChosen: fromWasChosen,
+      originalAttachments: originalAttachments.slice(),
+      forwardedAttachments: forwardedAttachments.slice(),
+      draftAttachments: draftAttachments.slice()
+    })
+  }
+
+  function restoreDraft(draft) {
+    var saved = draft || ({})
+    mode = String(saved.mode || "new")
+    accountId = String(saved.accountId || "")
+    threadId = String(saved.threadId || "")
+    inReplyTo = String(saved.inReplyTo || "")
+    ccVisible = saved.ccVisible === true
+    bccVisible = saved.bccVisible === true
+    fromEmail = String(saved.fromEmail || "")
+    replyRecipients = Array.isArray(saved.replyRecipients)
+      ? saved.replyRecipients.slice() : []
+    fromWasChosen = saved.fromWasChosen === true
+    originalAttachments = Array.isArray(saved.originalAttachments)
+      ? saved.originalAttachments.slice() : []
+    forwardedAttachments = Array.isArray(saved.forwardedAttachments)
+      ? saved.forwardedAttachments.slice() : []
+    draftAttachments = Array.isArray(saved.draftAttachments)
+      ? saved.draftAttachments.slice() : []
+    toField.text = String(saved.to || "")
+    ccField.text = String(saved.cc || "")
+    bccField.text = String(saved.bcc || "")
+    subjectField.text = String(saved.subject || "")
+    bodyEdit.text = String(saved.body || "")
+    opened = true
+  }
+
+  function reset() {
+    clearCurrentDraft(true)
+    forgetOwned(pendingDraft ? pendingDraft.draftAttachments : [])
+    forgetOwned(interruptedDraft ? interruptedDraft.draftAttachments : [])
+    for (var i = 0; i < recoveryDrafts.length; i++)
+      forgetOwned(recoveryDrafts[i] ? recoveryDrafts[i].draftAttachments : [])
+    pendingDraft = null
+    interruptedDraft = null
+    recoveryDrafts = []
+    parkedForSend = false
+    restoreRevision = 0
+    restoreFlashOpacity = 0
   }
 
   function selectPreferredFrom() {
@@ -138,8 +212,8 @@ DropArea {
     fromMenu.close()
     var accountId = String(row.accountId || "")
     if (accountId === "" || !root.service) return
+    root.accountId = accountId
     if (String(root.service.activeAccountId || "") === accountId) return
-    if (root.deliveryLocked) return
     if (typeof root.service.switchTo === "function") root.service.switchTo(accountId)
   }
 
@@ -225,8 +299,9 @@ DropArea {
   }
 
   function begin(nextMode, summary, bodyText, attachments) {
-    reset()
+    clearCurrentDraft(true)
     mode = String(nextMode || "new")
+    accountId = root.service ? String(root.service.activeAccountId || "") : ""
     opened = true
 
     if (summary && mode !== "new") {
@@ -294,34 +369,146 @@ DropArea {
     }
   }
 
-  // Every way out of a draft: this view's own Back, Discard, the window's
-  // Escape, and the send that succeeded. The window is told because only the
-  // window knows where the draft was raised from.
+  // The Back control asks the window to save. Discard stays local and
+  // destructive. The window owns the save because it owns the provider.
   signal closed()
+  signal closeRequested()
   signal sendQueued()
 
   function finish() {
-    reset()
+    clearCurrentDraft(true)
+    if (interruptedDraft) {
+      var held = interruptedDraft
+      interruptedDraft = null
+      restoreDraft(held)
+      return
+    }
+    if (recoveryDrafts.length > 0) {
+      var queued = recoveryDrafts.slice()
+      var recovered = queued.shift()
+      recoveryDrafts = queued
+      restoreDraft(recovered)
+      restoreRevision++
+      restoreFlash.restart()
+      return
+    }
     opened = false
     closed()
   }
 
+  function hasMeaningfulDraft() {
+    if (String(toField.text || "").trim() !== "") return true
+    if (String(ccField.text || "").trim() !== "") return true
+    if (String(bccField.text || "").trim() !== "") return true
+    if (String(subjectField.text || "").trim() !== "") return true
+    if (String(bodyEdit.text || "").trim() !== "") return true
+    return allOutgoingAttachments().length > 0
+  }
+
+  function fieldsForDraft(saved) {
+    var draft = saved || ({})
+    var attachments = []
+    var forwarded = draft.mode === "forward" && Array.isArray(draft.forwardedAttachments)
+      ? draft.forwardedAttachments : []
+    var owned = Array.isArray(draft.draftAttachments) ? draft.draftAttachments : []
+    var i
+    for (i = 0; i < forwarded.length; i++) attachments.push(forwarded[i])
+    for (i = 0; i < owned.length; i++) attachments.push(owned[i])
+    return ({
+      accountId: String(draft.accountId || ""),
+      from: String(draft.fromEmail || ""),
+      to: String(draft.to || ""),
+      cc: String(draft.cc || ""),
+      bcc: String(draft.bcc || ""),
+      subject: String(draft.subject || ""),
+      body: String(draft.body || ""),
+      attachments: attachments,
+      threadId: draft.mode === "forward" ? "" : String(draft.threadId || ""),
+      inReplyTo: draft.mode === "forward" ? "" : String(draft.inReplyTo || "")
+    })
+  }
+
+  function detachForSave() {
+    var saved = snapshotDraft()
+    clearCurrentDraft(false)
+    if (interruptedDraft) {
+      var held = interruptedDraft
+      interruptedDraft = null
+      restoreDraft(held)
+    } else {
+      opened = false
+      closed()
+    }
+    return saved
+  }
+
+  function completeDetachedSave(saved) {
+    forgetOwned(saved && saved.draftAttachments ? saved.draftAttachments : [])
+  }
+
+  function recoverDetachedSave(saved) {
+    if (!saved) return
+    if (!opened) {
+      restoreDraft(saved)
+      restoreRevision++
+      restoreFlash.restart()
+      return
+    }
+    var queued = recoveryDrafts.slice()
+    queued.push(saved)
+    recoveryDrafts = queued
+  }
+
   function parkForSend() {
+    pendingDraft = snapshotDraft()
+    clearCurrentDraft(false)
     opened = false
     parkedForSend = true
-    sendQueued()
+    if (interruptedDraft) {
+      var held = interruptedDraft
+      interruptedDraft = null
+      restoreDraft(held)
+    } else {
+      sendQueued()
+    }
   }
 
   function resumePendingSend() {
-    if (!parkedForSend) return false
+    if (!parkedForSend || !pendingDraft) return false
+    if (opened) interruptedDraft = snapshotDraft()
+    clearCurrentDraft(false)
+    var draft = pendingDraft
+    pendingDraft = null
     parkedForSend = false
-    opened = true
+    restoreDraft(draft)
+    restoreRevision++
+    restoreFlash.restart()
+    return true
+  }
+
+  function interruptedFields() {
+    var saved = interruptedDraft
+    if (!saved) return null
+    return fieldsForDraft(saved)
+  }
+
+  function completeInterruptedSave(expected) {
+    if (!interruptedDraft || interruptedDraft !== expected) return false
+    forgetOwned(interruptedDraft.draftAttachments)
+    interruptedDraft = null
+    return true
+  }
+
+  function completePendingSend() {
+    if (!parkedForSend || !pendingDraft) return false
+    forgetOwned(pendingDraft.draftAttachments)
+    pendingDraft = null
+    parkedForSend = false
     return true
   }
 
   function cancelOrFinish() {
-    if (root.service && root.service.sendPending) root.service.undoSend()
-    else finish()
+    closeRequested()
   }
 
   function submit() {
@@ -342,7 +529,7 @@ DropArea {
       threadId: root.mode === "forward" ? "" : root.threadId,
       inReplyTo: root.mode === "forward" ? "" : root.inReplyTo
     }))
-    if (accepted === true || service.sendPending || service.sending) parkForSend()
+    if (accepted === true) parkForSend()
   }
 
   function allOutgoingAttachments() {
@@ -505,6 +692,19 @@ DropArea {
   }
   onContactBookChanged: updateRecipientSuggestions()
 
+  SequentialAnimation {
+    id: restoreFlash
+    running: false
+    NumberAnimation {
+      target: root
+      property: "restoreFlashOpacity"
+      from: 0.32
+      to: 0
+      duration: 720
+      easing.type: Easing.OutCubic
+    }
+  }
+
   // ----------------------------------------------------------- header
   //
   // One compact title band. Back is the exit path and the title names the
@@ -607,7 +807,7 @@ DropArea {
         verticalPadding: Style.spacing.inputPaddingY
         leftAlign: true
         selected: fromMenu.opened
-        enabled: root.canChooseFrom && !root.deliveryLocked
+        enabled: root.canChooseFrom
         onClicked: fromMenu.opened ? fromMenu.close() : fromMenu.open()
 
         // The kit's own chevron is a font glyph, which at this size renders
@@ -668,7 +868,6 @@ DropArea {
           foreground: root.ccVisible ? root.textColor : root.dimColor
           bordered: false
           fontSize: Style.font.caption
-          enabled: !root.deliveryLocked
           onClicked: root.ccVisible = !root.ccVisible
         }
 
@@ -679,7 +878,6 @@ DropArea {
           foreground: root.bccVisible ? root.textColor : root.dimColor
           bordered: false
           fontSize: Style.font.caption
-          enabled: !root.deliveryLocked
           onClicked: root.bccVisible = !root.bccVisible
         }
       }
@@ -697,7 +895,6 @@ DropArea {
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.bodySmall
         placeholderText: "recipient@example.com"
-        enabled: !root.deliveryLocked
         onTextChanged: root.updateRecipientSuggestions()
         onActiveFocusChanged: root.updateRecipientSuggestions()
         Keys.priority: Keys.BeforeItem
@@ -778,7 +975,6 @@ DropArea {
         accent: root.accentColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.bodySmall
-        enabled: !root.deliveryLocked
         onTextChanged: root.updateRecipientSuggestions()
         onActiveFocusChanged: root.updateRecipientSuggestions()
         Keys.priority: Keys.BeforeItem
@@ -854,7 +1050,6 @@ DropArea {
         accent: root.accentColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.bodySmall
-        enabled: !root.deliveryLocked
         onTextChanged: root.updateRecipientSuggestions()
         onActiveFocusChanged: root.updateRecipientSuggestions()
         Keys.priority: Keys.BeforeItem
@@ -934,7 +1129,6 @@ DropArea {
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.bodySmall
         placeholderText: "Subject"
-        enabled: !root.deliveryLocked
         KeyNavigation.tab: bodyEdit
         onAccepted: bodyEdit.forceActiveFocus()
         Keys.priority: Keys.BeforeItem
@@ -1028,6 +1222,15 @@ DropArea {
         foreground: root.textColor
       }
     }
+  }
+
+  Rectangle {
+    objectName: "compose-fields-restore-flash"
+    anchors.fill: fields
+    z: 20
+    enabled: false
+    color: root.accentColor
+    opacity: root.restoreFlashOpacity
   }
 
   QQC.Popup {
@@ -1144,10 +1347,18 @@ DropArea {
       selectedTextColor: root.textColor
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.bodySmall
-      enabled: !root.deliveryLocked
       Keys.priority: Keys.BeforeItem
       Keys.onPressed: root.pasteKey(event)
     }
+  }
+
+  Rectangle {
+    objectName: "compose-body-restore-flash"
+    anchors.fill: bodyFlick
+    z: bodyFlick.z + 1
+    enabled: false
+    color: root.accentColor
+    opacity: root.restoreFlashOpacity
   }
 
   Item {
@@ -1238,7 +1449,6 @@ DropArea {
                 hoverColor: root.textColor
                 fontFamily: root.panelFontFamily
                 iconSize: Style.font.iconSmall
-                enabled: !root.deliveryLocked
                 onClicked: root.removeAttachment(attachItem.index)
               }
             }
@@ -1270,21 +1480,14 @@ DropArea {
       spacing: Style.space(10)
 
       IconTextButton {
-        iconName: root.service && root.service.sendPending ? "undo" : "send"
-        tooltipText: root.service && root.service.sendPending
-          ? "Undo send · Ctrl+Z" : "Send · Ctrl+Enter"
-        text: root.service && root.service.sendPending
-          ? "Undo send (" + root.service.sendSecondsRemaining + "s)"
-          : (root.service && root.service.sending ? "Sending" : "Send")
+        iconName: "send"
+        tooltipText: "Send · Ctrl+Enter"
+        text: root.service && root.service.sending ? "Sending" : "Send"
         foreground: root.textColor
         fontFamily: root.panelFontFamily
-        enabled: !!root.service && !root.service.sending
-          && (root.service.sendPending || (!root.forwardAttachmentsLoading
-            && root.forwardAttachmentError === ""))
-        onClicked: {
-          if (root.service.sendPending) root.service.undoSend()
-          else root.submit()
-        }
+        enabled: !!root.service && !root.service.sending && !root.service.sendPending
+          && !root.forwardAttachmentsLoading && root.forwardAttachmentError === ""
+        onClicked: root.submit()
       }
 
       IconTextButton {
@@ -1293,7 +1496,7 @@ DropArea {
         text: root.attaching ? "Attaching" : "Attach..."
         foreground: root.textColor
         fontFamily: root.panelFontFamily
-        enabled: !!root.service && !root.attaching && !root.deliveryLocked
+        enabled: !!root.service && !root.attaching
         onClicked: root.chooseFiles()
       }
 
@@ -1302,7 +1505,6 @@ DropArea {
         foreground: root.dimColor
         bordered: false
         fontSize: Style.font.bodySmall
-        enabled: !root.deliveryLocked
         onClicked: root.finish()
       }
     }

--- a/components/DraftSavedToast.qml
+++ b/components/DraftSavedToast.qml
@@ -1,21 +1,17 @@
 import QtQuick
 import qs.Commons
-import qs.Ui
 
 Rectangle {
   id: root
 
-  required property int secondsRemaining
+  required property string message
   required property color textColor
-  required property color dimColor
   required property color accentColor
   required property color popupBackgroundColor
   required property color popupBorderColor
   required property string panelFontFamily
 
-  signal undoRequested()
-
-  implicitWidth: content.implicitWidth + Style.space(16)
+  implicitWidth: content.implicitWidth + Style.space(20)
   implicitHeight: Math.max(content.implicitHeight + Style.space(12), Style.space(42))
   radius: Style.cornerRadius
   color: Qt.rgba(popupBackgroundColor.r, popupBackgroundColor.g,
@@ -26,28 +22,23 @@ Rectangle {
   Row {
     id: content
     anchors.centerIn: parent
-    spacing: Style.space(12)
+    spacing: Style.space(8)
+
+    Rectangle {
+      anchors.verticalCenter: parent.verticalCenter
+      width: Style.space(7)
+      height: width
+      radius: width / 2
+      color: root.accentColor
+    }
 
     Text {
-      objectName: "undo-send-message"
       anchors.verticalCenter: parent.verticalCenter
-      text: "Sending in " + root.secondsRemaining + "s"
+      text: root.message
       textFormat: Text.PlainText
       color: root.textColor
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.bodySmall
-    }
-
-    Button {
-      objectName: "undo-send-button"
-      anchors.verticalCenter: parent.verticalCenter
-      text: "Undo  Alt+Z"
-      foreground: root.accentColor
-      accent: root.accentColor
-      bordered: true
-      fontFamily: root.panelFontFamily
-      fontSize: Style.font.bodySmall
-      onClicked: root.undoRequested()
     }
   }
 }

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -141,7 +141,7 @@ Column {
 
       Text {
         width: parent.width
-        text: "Omamail waits before delivery. Press Ctrl+Z or select Undo to cancel. Set 0 to send now."
+        text: "Omamail waits before delivery. Press Alt+Z or select Undo to cancel. Set 0 to send now."
         color: root.dimColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.caption

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -108,7 +108,7 @@ used to exist, and they had.
 | `calendarWeek` | `w` | calendar | Show week view |
 | `calendarMonth` | `m` | calendar | Show month view |
 | `send` | `Ctrl+Return` | compose | Send |
-| `undoSend` | `Ctrl+Z` | mail+calendar | Undo send |
+| `undoSend` | `Alt+Z` | all | Undo send |
 | `search` | `/` | mail | Search |
 | `goMailbox` | `Ctrl+1`, `Ctrl+2`, `Ctrl+3`, `Ctrl+4`, `Ctrl+5`, `Ctrl+6`, `Ctrl+7`, `Ctrl+8`, `Ctrl+9`, `Ctrl+0` | mail | Go to that mailbox |
 | `goAccount` | `Alt+1`, `Alt+2`, `Alt+3`, `Alt+4`, `Alt+5`, `Alt+6`, `Alt+7`, `Alt+8`, `Alt+9`, `Alt+0` | mail+calendar | Go to that email account |
@@ -129,7 +129,7 @@ used to exist, and they had.
 The bare `/` stays in the mailbox because fields need it as text. `Ctrl+K`
 opens the complete key sheet from every context.
 
-The delayed-send toast does not create a keyboard context. The list, reader, or calendar keeps its normal keys while the toast is visible. `Ctrl+Z` and the toast button undo the pending send. `Escape` keeps its normal navigation meaning.
+The delayed-send toast does not create a keyboard context. The current screen keeps its normal keys while the toast is visible. A new draft, reply, or forward can open during the delay. The send button waits for the queued message, but every draft field remains editable. The toast button restores the queued message. `Alt+Z` does the same from every context. `Ctrl+Z` remains text undo while composing or searching. If another compose is open, Omamail saves it to the provider's Drafts storage before dropping its in-memory fallback. A failed save keeps that fallback. Back and `Escape` save a non-empty composition before leaving it. The explicit Discard button remains the destructive exit.
 
 ## Why the rail is numbered and not chorded
 

--- a/keys/Keymap.js
+++ b/keys/Keymap.js
@@ -89,7 +89,7 @@ var BINDINGS = [
     group: "Calendar", label: "Show month view" },
   { id: "send", keys: ["Ctrl+Return"], contexts: ["compose"],
     group: "Writing", label: "Send", hint: { compose: "send" } },
-  { id: "undoSend", keys: ["Ctrl+Z"], contexts: ["list", "reader", "calendar"],
+  { id: "undoSend", keys: ["Alt+Z"], contexts: ANY,
     survivesOverlay: true,
     group: "Writing", label: "Undo send" },
 
@@ -164,7 +164,7 @@ var BINDINGS = [
 
 // A pending send is a transient action over the screen, not a screen of its
 // own. It does not replace this context, so mailbox navigation stays live while
-// the toast offers Ctrl+Z and its button.
+// the toast offers Alt+Z and its button.
 function contextFor(state) {
   var value = state || ({})
   if (value.showPage) return "page"

--- a/message/Message.js
+++ b/message/Message.js
@@ -769,6 +769,8 @@ function summarize(message, now) {
     messageId: headerValue(message, "Message-ID"),
     to: parseAddressList(headerValue(message, "To")),
     cc: parseAddressList(headerValue(message, "Cc")),
+    bcc: parseAddressList(headerValue(message, "Bcc")),
+    inReplyTo: headerValue(message, "In-Reply-To"),
     subject: subject || "(no subject)",
     snippet: decodeSnippet(message && message.snippet),
     date: date,
@@ -782,6 +784,34 @@ function summarize(message, now) {
     isDraft: hasLabel(message, "DRAFT"),
     labelIds: labelIds(message).slice(),
     sizeEstimate: Math.max(0, Math.floor(Number(message && message.sizeEstimate) || 0))
+  }
+}
+
+function draftAddressText(addresses) {
+  var list = Array.isArray(addresses) ? addresses : []
+  var out = []
+  for (var i = 0; i < list.length; i++) {
+    var email = String(list[i] && list[i].email ? list[i].email : "").trim()
+    if (email !== "") out.push(email)
+  }
+  return out.join(", ")
+}
+
+// A full draft read has the same provider-neutral summary and body as any
+// message. Compose needs the addresses as editable text rather than row data.
+function draftFields(summary, body) {
+  var source = summary || ({})
+  var subject = String(source.subject || "")
+  return {
+    mode: "draft",
+    from: String(source.from && source.from.email ? source.from.email : ""),
+    to: draftAddressText(source.to),
+    cc: draftAddressText(source.cc),
+    bcc: draftAddressText(source.bcc),
+    subject: subject === "(no subject)" ? "" : subject,
+    body: String(body || ""),
+    threadId: String(source.threadId || ""),
+    inReplyTo: String(source.inReplyTo || "")
   }
 }
 

--- a/providers/Gmail.js
+++ b/providers/Gmail.js
@@ -73,6 +73,7 @@ var MAILBOXES = [
     query: "in:inbox is:unread -category:promotions -category:social -category:forums" },
   { key: "starred", label: "Starred", icon: "star", query: "is:starred" },
   { key: "sent", label: "Sent", icon: "send", query: "in:sent" },
+  { key: "drafts", label: "Drafts", icon: "compose", query: "in:drafts" },
   // Optional: the first to go when the row cannot hold every mailbox. Neither
   // is somewhere anyone works from — they are places you go looking for
   // something specific, and search reaches both.

--- a/providers/GmailApi.js
+++ b/providers/GmailApi.js
@@ -118,12 +118,18 @@ function trashPath(id) { return "/users/me/messages/" + encode(id) + "/trash" }
 function untrashPath(id) { return "/users/me/messages/" + encode(id) + "/untrash" }
 function batchModifyPath() { return "/users/me/messages/batchModify" }
 function sendPath() { return "/users/me/messages/send" }
+function draftsPath() { return "/users/me/drafts" }
+function draftPath(id) { return "/users/me/drafts/" + encode(id) }
 
 function sendBody(payload) {
   var source = payload || {}
   var body = { raw: String(source.raw || "") }
   if (source.threadId) body.threadId = String(source.threadId)
   return body
+}
+
+function draftBody(payload) {
+  return { message: sendBody(payload) }
 }
 function threadPath(id) { return "/users/me/threads/" + encode(id) }
 function labelsPath() { return "/users/me/labels" }

--- a/providers/GmailApiClient.qml
+++ b/providers/GmailApiClient.qml
@@ -307,4 +307,11 @@ Item {
         if (typeof callback === "function") callback(body, error)
       })
   }
+
+  function saveDraft(payload, callback) {
+    return request("POST", Api.draftsPath(), null, Api.draftBody(payload),
+      function(status, body, error) {
+        if (typeof callback === "function") callback(body, error)
+      })
+  }
 }

--- a/providers/Hey.js
+++ b/providers/Hey.js
@@ -83,6 +83,7 @@ var MAILBOXES = [
   // is no unseen box to ask for, so the client lists and filters — which is
   // also what the unread badge counts.
   { key: "unread", label: "New for you", icon: "unread", query: "box:imbox unseen" },
+  { key: "drafts", label: "Drafts", icon: "compose", query: "drafts:" },
   { key: "later", label: "Reply Later", icon: "reply", query: "box:laterbox" },
   { key: "aside", label: "Set Aside", icon: "pin", query: "box:asidebox" },
   { key: "feed", label: "The Feed", icon: "label", query: "box:feedbox" },

--- a/providers/HeyCli.js
+++ b/providers/HeyCli.js
@@ -107,6 +107,9 @@ function topicIdOf(id) {
 // selecting a mailbox.
 function parseQuery(query) {
   var text = trimmed(query)
+  if (text === "drafts:") {
+    return { kind: "drafts", box: "", label: "", text: "", unseen: false }
+  }
   if (text.indexOf("label:") === 0) {
     return { kind: "label", box: "", label: trimmed(text.slice(6)), text: "", unseen: false }
   }
@@ -178,6 +181,12 @@ function listCommand(parsed, maxResults, pageToken) {
   var limit = scanLimit(query)
   var cursor = tokenCursor(pageToken)
 
+  if (query.kind === "drafts") {
+    var drafts = ["draft", "list", "--json"]
+    if (cursor !== "") drafts = drafts.concat(["--page", cursor])
+    return drafts
+  }
+
   if (query.kind === "label") {
     var label = ["label", query.label, "--json"]
     if (limit > 0) label = label.concat(["--limit", String(limit)])
@@ -221,6 +230,16 @@ function threadCommand(id) {
   // people have, and an unknown flag fails the whole command — see
   // `unknownFlag`.
   return ["threads", topic, "--allow-partial", "--html"]
+}
+
+function draftIdOf(id) {
+  var match = /^draft:(\d+)$/.exec(trimmed(id))
+  return match ? match[1] : ""
+}
+
+function draftShowCommand(id) {
+  var draft = draftIdOf(id)
+  return draft === "" ? [] : ["draft", "show", draft, "--json"]
 }
 
 // The flag `hey` said it did not know, out of its own usage error. A release
@@ -314,6 +333,28 @@ function composeCommand(fields) {
   return command.concat(attachArgs(values.attachments))
 }
 
+// Saving has the same two shapes as sending, but a new draft needs no
+// recipient. HEY keeps the body on stdin and answers the draft id.
+function draftCommand(fields) {
+  var values = fields || {}
+  var thread = trimmed(values.threadId)
+  var command = []
+  if (thread !== "") {
+    command = ["reply", thread, "--draft"]
+  } else {
+    command = ["compose"]
+    var to = trimmed(values.to)
+    if (to !== "") command = command.concat(["--to", to])
+    command = command.concat(["--subject", String(values.subject || "")])
+    var cc = trimmed(values.cc)
+    if (cc !== "") command = command.concat(["--cc", cc])
+    var bcc = trimmed(values.bcc)
+    if (bcc !== "") command = command.concat(["--bcc", bcc])
+    command.push("--draft")
+  }
+  return command.concat(attachArgs(values.attachments))
+}
+
 function attachArgs(files) {
   var list = Array.isArray(files) ? files : []
   var out = []
@@ -369,6 +410,11 @@ function payload(text) {
     return { ok: false, data: null, error: trimmed(body.error) || "HEY refused that request" }
   }
   return { ok: true, data: body.data === undefined ? null : body.data, error: "" }
+}
+
+function envelopeNextPage(text) {
+  var body = parseJson(text, null)
+  return body && body.meta ? trimmed(body.meta.next_page) : ""
 }
 
 // Whether what came back is a thread as HTML rather than the JSON envelope.
@@ -472,6 +518,56 @@ function parseListing(data) {
   return rows
 }
 
+function parseDraftListing(data) {
+  var list = Array.isArray(data) ? data : []
+  var rows = []
+  for (var i = 0; i < list.length; i++) {
+    var entry = list[i] || {}
+    var id = trimmed(entry.id)
+    if (!/^\d+$/.test(id)) continue
+    rows.push({
+      id: "draft:" + id,
+      draftId: id,
+      subject: trimmed(entry.subject),
+      snippet: trimmed(entry.summary),
+      from: { name: "", email: "" },
+      to: [],
+      date: trimmed(entry.updated_at),
+      seen: true,
+      box: "",
+      appUrl: "",
+      isDraft: true
+    })
+  }
+  return rows
+}
+
+function draftAddresses(values) {
+  var list = Array.isArray(values) ? values : []
+  var out = []
+  for (var i = 0; i < list.length; i++) {
+    var email = trimmed(list[i])
+    if (email !== "") out.push({ name: "", email: email })
+  }
+  return out
+}
+
+function parseDraft(data) {
+  var entry = data || {}
+  var id = trimmed(entry.id)
+  return {
+    id: /^\d+$/.test(id) ? "draft:" + id : "",
+    draftId: /^\d+$/.test(id) ? id : "",
+    subject: String(entry.subject || ""),
+    body: String(entry.body || ""),
+    to: draftAddresses(entry.to),
+    cc: draftAddresses(entry.cc),
+    bcc: draftAddresses(entry.bcc),
+    date: trimmed(entry.updated_at),
+    isDraft: true
+  }
+}
+
 // What HEY offers after the page just read, in its own terms. A box and a label
 // carry an opaque cursor; a search is numbered, so the number after this one is
 // the answer.
@@ -481,6 +577,8 @@ function nextCursor(parsed, data, cursor, rowCount) {
   // its end there is nothing to continue with, because continuing would page
   // the box while the filter kept discarding.
   if (query.unseen === true) return ""
+  if (query.kind === "drafts")
+    return data && !Array.isArray(data) ? trimmed(data.next_page) : ""
   if (query.kind === "search" || query.kind === "trash") {
     if (rowCount === 0) return ""
     var page = Math.floor(Number(trimmed(cursor))) || 1

--- a/providers/HeyClient.qml
+++ b/providers/HeyClient.qml
@@ -202,6 +202,16 @@ Item {
       addressed.push(Mail.addressHeader(recipients[i].email, recipients[i].name))
     }
     if (addressed.length > 0) headers.push({ name: "To", value: addressed.join(", ") })
+    var copied = Array.isArray(known.cc) ? known.cc : []
+    var copiedHeaders = []
+    for (var c = 0; c < copied.length; c++)
+      copiedHeaders.push(Mail.addressHeader(copied[c].email, copied[c].name))
+    if (copiedHeaders.length > 0) headers.push({ name: "Cc", value: copiedHeaders.join(", ") })
+    var hidden = Array.isArray(known.bcc) ? known.bcc : []
+    var hiddenHeaders = []
+    for (var b = 0; b < hidden.length; b++)
+      hiddenHeaders.push(Mail.addressHeader(hidden[b].email, hidden[b].name))
+    if (hiddenHeaders.length > 0) headers.push({ name: "Bcc", value: hiddenHeaders.join(", ") })
     if (String(known.subject || "") !== "")
       headers.push({ name: "Subject", value: String(known.subject) })
     if (String(known.date || "") !== "")
@@ -223,13 +233,14 @@ Item {
     var labels = []
     if (!known.seen) labels.push("UNREAD")
     if (String(known.box || "") === "imbox") labels.push("INBOX")
+    if (known.isDraft === true) labels.push("DRAFT")
 
     var date = String(known.date || "")
     var stamp = date === "" ? 0 : Date.parse(date)
     return {
       id: String(id || ""),
       // HEY's own conversation id, which is what makes a thread a thread here.
-      threadId: Cli.topicIdOf(id),
+      threadId: known.isDraft === true ? "" : Cli.topicIdOf(id),
       labelIds: labels,
       internalDate: isFinite(stamp) && stamp > 0 ? String(stamp) : "",
       sizeEstimate: payload.body.size,
@@ -256,11 +267,15 @@ Item {
         callback(null, answer.error)
         return
       }
-      var found = Cli.filterRows(parsed, Cli.parseListing(answer.data))
+      var found = parsed.kind === "drafts"
+        ? Cli.parseDraftListing(answer.data)
+        : Cli.filterRows(parsed, Cli.parseListing(answer.data))
       // One of HEY's pages was read; the size the user configured decides how
       // much of it this request gets, and the token says where to carry on —
       // further into this page, or on to HEY's next one.
-      var page = Cli.pageOf(parsed, answer.data, found, maxResults, pageToken)
+      var pageData = parsed.kind === "drafts"
+        ? ({ next_page: Cli.envelopeNextPage(text) }) : answer.data
+      var page = Cli.pageOf(parsed, pageData, found, maxResults, pageToken)
       var ids = []
       for (var i = 0; i < page.rows.length; i++) {
         root.remember(page.rows[i])
@@ -351,7 +366,9 @@ Item {
       return handle
     }
 
-    var command = Cli.threadCommand(messageId)
+    var draftId = Cli.draftIdOf(messageId)
+    var command = draftId !== ""
+      ? Cli.draftShowCommand(messageId) : Cli.threadCommand(messageId)
     if (command.length === 0) {
       if (typeof callback === "function") {
         Qt.callLater(function() {
@@ -366,6 +383,17 @@ Item {
       if (typeof callback !== "function") return
       if (error) {
         callback(null, error)
+        return
+      }
+      if (draftId !== "") {
+        var draftAnswer = Cli.payload(text)
+        if (!draftAnswer.ok) {
+          callback(null, draftAnswer.error)
+          return
+        }
+        var draft = Cli.parseDraft(draftAnswer.data)
+        root.remember(draft)
+        callback(root.toMessage(messageId, draft, ({ text: draft.body, html: "" })), "")
         return
       }
       var thread = Cli.parseThread(text)
@@ -574,6 +602,37 @@ Item {
     run(command, body, function(text, error) {
       if (handle.aborted) return
       if (typeof callback === "function") callback(error ? null : {}, error)
+    }, handle)
+    return handle
+  }
+
+  function saveDraft(payload, callback) {
+    var handle = newHandle()
+    var raw = payload && payload.raw ? String(payload.raw) : ""
+    if (raw === "") {
+      if (typeof callback === "function") callback(null, "There is no draft to save")
+      return handle
+    }
+
+    var parsed = Mail.parseRfc822(Mail.decodeBase64Url(raw))
+    var body = Mail.extractBody(parsed).text
+    var files = payload && Array.isArray(payload.attachments) ? payload.attachments : []
+    var threadId = payload && payload.threadId ? Cli.topicIdOf(String(payload.threadId)) : ""
+    if (threadId === "" && payload && payload.threadId)
+      threadId = String(payload.threadId)
+
+    var command = Cli.draftCommand({
+      threadId: threadId,
+      to: Mail.headerFrom(parsed.headers, "To"),
+      cc: Mail.headerFrom(parsed.headers, "Cc"),
+      bcc: Mail.headerFrom(parsed.headers, "Bcc"),
+      subject: Mail.decodeHeaderValue(Mail.headerFrom(parsed.headers, "Subject")),
+      attachments: files
+    })
+    run(command, body, function(text, error) {
+      if (handle.aborted) return
+      var answer = error ? null : Cli.payload(text)
+      if (typeof callback === "function") callback(error ? null : (answer ? answer.data : {}), error)
     }, handle)
     return handle
   }

--- a/providers/Imap.js
+++ b/providers/Imap.js
@@ -46,6 +46,7 @@ var MAILBOXES = [
   { key: "unread", label: "Unread", icon: "unread", query: "folder:INBOX UNSEEN" },
   { key: "starred", label: "Flagged", icon: "star", query: "folder:INBOX FLAGGED" },
   { key: "sent", label: "Sent", icon: "send", query: "folder:\\Sent" },
+  { key: "drafts", label: "Drafts", icon: "compose", query: "folder:\\Drafts" },
   { key: "archive", label: "Archive", icon: "archive", query: "folder:\\Archive", optional: true },
   { key: "trash", label: "Trash", icon: "trash", query: "folder:\\Trash", optional: true }
 ]

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -573,6 +573,72 @@ Item {
 
   // ----------------------------------------------------------------- send
 
+  function saveDraft(payload, callback) {
+    var handle = newHandle()
+    var raw = payload && payload.raw ? String(payload.raw) : ""
+    if (raw === "") {
+      if (typeof callback === "function") callback(null, "There is no draft to save")
+      return handle
+    }
+
+    ensureFolders(function(folderError) {
+      if (handle.aborted) return
+      if (folderError) {
+        if (typeof callback === "function") callback(null, folderError)
+        return
+      }
+      var folder = root.special["\\drafts"] || ""
+      if (folder === "") {
+        if (typeof callback === "function")
+          callback(null, "This server did not report a Drafts folder")
+        return
+      }
+
+      root.inFlight++
+      auth.withCredentials(function(credentials, credentialError) {
+        if (!root) return
+        if (handle.aborted) {
+          root.inFlight = Math.max(0, root.inFlight - 1)
+          return
+        }
+        if (!credentials) {
+          root.inFlight = Math.max(0, root.inFlight - 1)
+          if (typeof callback === "function") callback(null, credentialError || "Not signed in")
+          return
+        }
+        var url = Imap.imapUrl(auth.settings, folder)
+        var message = Mail.decodeBase64Url(raw)
+        var fields = [Mail.encodeBase64(url), Mail.encodeBase64(credentials),
+          Mail.encodeBase64(message)]
+        var process = transportComponent.createObject(root, {
+          command: [root.transport],
+          requestLine: "imap-append " + fields.join(" ")
+        })
+        if (!process) {
+          root.inFlight = Math.max(0, root.inFlight - 1)
+          if (typeof callback === "function") callback(null, "Could not start the mail transport")
+          return
+        }
+        handle.process = process
+        process.finished.connect(function(status, out, err) {
+          if (!root) return
+          if (handle.process === process) handle.process = null
+          process.destroy()
+          root.inFlight = Math.max(0, root.inFlight - 1)
+          if (handle.aborted || typeof callback !== "function") return
+          if (status !== 0) {
+            var detail = Imap.decodeResponse(err, Mail.base64ToBytes, Mail.bytesToLatin1)
+            callback(null, Imap.responseError(status, detail, "The draft could not be saved"))
+            return
+          }
+          callback({}, "")
+        })
+        process.running = true
+      })
+    })
+    return handle
+  }
+
   // `MailAccount` builds the same payload for either provider: a base64url
   // `raw` field, because that is what Gmail's send endpoint takes. SMTP wants
   // the message itself and the envelope separately, so it is decoded back and

--- a/scripts/mail-transport.sh
+++ b/scripts/mail-transport.sh
@@ -12,6 +12,7 @@
 # One line, fields separated by spaces:
 #
 #   imap <b64 url> <b64 user:password> <b64 command> [<b64 command> ...]
+#   imap-append <b64 url> <b64 user:password> <b64 message>
 #   smtp <b64 url> <b64 user:password> <b64 from> <b64 message> <b64 rcpt> ...
 #
 # base64 rather than the values themselves, for three reasons that each bite
@@ -76,8 +77,8 @@ credentials=$(decode "$3")
 shift 3
 
 case "$mode" in
-  imap|smtp) ;;
-  *) fail 'mail-transport.sh: mode must be imap or smtp' ;;
+  imap|imap-append|smtp) ;;
+  *) fail 'mail-transport.sh: mode must be imap, imap-append or smtp' ;;
 esac
 
 # The URL is built and validated by Imap.js, which has already refused anything
@@ -120,6 +121,14 @@ if [ "$mode" = "smtp" ]; then
   # from a file rather than from a string — stdin is already carrying this
   # config. It lands in the 0700 directory the trap removes on any exit.
   printf 'upload-file = "%s"\n' "$(escape "$work/message")"
+elif [ "$mode" = "imap-append" ]; then
+  printf 'url = "%s"\n' "$escaped_url"
+  printf 'noproxy = "*"\n'
+  printf 'user = "%s"\n' "$escaped_credentials"
+  printf 'max-time = 60\n'
+  printf 'connect-timeout = 20\n'
+  printf 'upload-file = "%s"\n' "$(escape "$work/message")"
+  printf 'upload-flags = "draft"\n'
 else
   # IMAP: one section per command, so a sequence — search a folder, then fetch
   # what came back — runs on a single connection. curl reuses the connection
@@ -153,6 +162,9 @@ fi
 if [ "$mode" = "smtp" ]; then
   [ $# -ge 3 ] || fail 'mail-transport.sh: smtp needs a sender, a message and a recipient'
   decode "$2" > "$work/message"
+elif [ "$mode" = "imap-append" ]; then
+  [ $# -eq 1 ] || fail 'mail-transport.sh: imap-append needs one message'
+  decode "$1" > "$work/message"
 fi
 
 # curl is the last stage, so `$?` is curl's own exit code rather than the

--- a/tests/qml/imports/Quickshell/FloatingWindow.qml
+++ b/tests/qml/imports/Quickshell/FloatingWindow.qml
@@ -1,0 +1,7 @@
+import QtQuick
+
+Item {
+  property string title: ""
+  property color color: "transparent"
+  property size minimumSize: Qt.size(0, 0)
+}

--- a/tests/qml/imports/Quickshell/qmldir
+++ b/tests/qml/imports/Quickshell/qmldir
@@ -1,2 +1,3 @@
 module Quickshell
 singleton Quickshell 1.0 Quickshell.qml
+FloatingWindow 1.0 FloatingWindow.qml

--- a/tests/qml/imports/qs/Ui/BorderSurface.qml
+++ b/tests/qml/imports/qs/Ui/BorderSurface.qml
@@ -1,0 +1,5 @@
+import QtQuick
+
+Rectangle {
+  property var borderSpec: null
+}

--- a/tests/qml/imports/qs/Ui/Button.qml
+++ b/tests/qml/imports/qs/Ui/Button.qml
@@ -11,6 +11,7 @@ Rectangle {
   property color background: "transparent"
   property bool bordered: false
   property bool selected: false
+  property bool hasCursor: false
   property bool leftAlign: false
   property bool focusable: false
   property string fontFamily: "monospace"
@@ -18,6 +19,7 @@ Rectangle {
   property real horizontalPadding: 8
   property real verticalPadding: 5
   signal clicked()
+  signal hovered(bool isHovered)
   implicitWidth: Math.max(40, label.implicitWidth + horizontalPadding * 2)
   implicitHeight: label.implicitHeight + verticalPadding * 2
   color: background

--- a/tests/qml/imports/qs/Ui/NumberField.qml
+++ b/tests/qml/imports/qs/Ui/NumberField.qml
@@ -1,0 +1,15 @@
+import QtQuick
+
+Item {
+  property string label: ""
+  property int value: 0
+  property int from: 0
+  property int to: 100
+  property int stepSize: 1
+  property color foreground: "transparent"
+  property color accent: "transparent"
+  property string fontFamily: "monospace"
+  property real fontSize: 13
+  property real fieldWidth: 80
+  signal modified(int value)
+}

--- a/tests/qml/imports/qs/Ui/PanelActionButton.qml
+++ b/tests/qml/imports/qs/Ui/PanelActionButton.qml
@@ -1,0 +1,15 @@
+import QtQuick
+
+Item {
+  property string iconText: ""
+  property string tooltipText: ""
+  property color foreground: "transparent"
+  property color hoverColor: foreground
+  property string fontFamily: "monospace"
+  property real fontSize: 13
+  property bool focusable: false
+  property bool hasCursor: false
+  property bool bordered: false
+  signal clicked()
+  signal hovered(bool isHovered)
+}

--- a/tests/qml/imports/qs/Ui/TextField.qml
+++ b/tests/qml/imports/qs/Ui/TextField.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls as QQC
 
 QQC.TextField {
+  property bool password: false
   property color foreground: Qt.rgba(1, 1, 1, 1)
   property color accent: Qt.rgba(1, 0.5, 0, 1)
   property real verticalPadding: 5

--- a/tests/qml/imports/qs/Ui/ToggleSwitch.qml
+++ b/tests/qml/imports/qs/Ui/ToggleSwitch.qml
@@ -1,0 +1,9 @@
+import QtQuick
+
+Item {
+  property bool checked: false
+  property bool busy: false
+  property color foreground: "transparent"
+  property color accent: "transparent"
+  signal toggled()
+}

--- a/tests/qml/imports/qs/Ui/qmldir
+++ b/tests/qml/imports/qs/Ui/qmldir
@@ -1,6 +1,10 @@
 module qs.Ui
 TextField 1.0 TextField.qml
 Button 1.0 Button.qml
+BorderSurface 1.0 BorderSurface.qml
+NumberField 1.0 NumberField.qml
+PanelActionButton 1.0 PanelActionButton.qml
 PanelSeparator 1.0 PanelSeparator.qml
 PanelSectionHeader 1.0 PanelSectionHeader.qml
 PanelToolTip 1.0 PanelToolTip.qml
+ToggleSwitch 1.0 ToggleSwitch.qml

--- a/tests/qml/tst_app_compose_pending.qml
+++ b/tests/qml/tst_app_compose_pending.qml
@@ -1,0 +1,214 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../.." as Omamail
+
+Item {
+  width: 900
+  height: 600
+
+  QtObject {
+    id: mailService
+
+    property bool ready: true
+    property bool anyAccountReady: true
+    property bool sendPending: true
+    property bool sending: false
+    property bool windowOpen: false
+    property bool sidebarCollapsed: false
+    property bool alwaysShowImages: false
+    property bool selectedReaderEmpty: false
+    property bool selectedReaderTooHeavy: false
+    property bool selectedTooHeavy: false
+    property bool detailLoading: false
+    property bool detailPainted: false
+    property bool canOpenOnWeb: false
+    property bool canRespondToInvite: false
+    property bool rsvpSending: false
+    property bool canArchive: true
+    property bool canStar: true
+    property bool canSpam: true
+    property bool canTrash: true
+    property bool canMarkRead: true
+    property bool canMarkUnread: true
+    property bool accountDraftOpen: false
+    property int sendSecondsRemaining: 10
+    property int accountCount: 1
+    property int inboxUnread: 0
+    property real bodyZoom: 1
+    property string bodyMode: "reader"
+    property string providerId: "gmail"
+    property string accountEmail: "me@example.com"
+    property string activeAccountId: "me@example.com"
+    property string mailboxKey: "inbox"
+    property string searchQuery: ""
+    property string rawQuery: ""
+    property string selectedId: "message-1"
+    property string lastError: ""
+    property string actionStatus: ""
+    property string syncedLabel: ""
+    property string recipientContactStatus: ""
+    property var auth: null
+    property var accountSummaries: []
+    property var mailboxes: []
+    property var labels: []
+    property var messages: []
+    property var selectedAttachments: []
+    property var selectedInvite: null
+    property var selectedResponse: ""
+    property var recipientContacts: []
+    property var sendAsAliases: []
+    property var sendIdentities: []
+    property var calendarController: null
+    property var lastSavedDraft: null
+    property bool failDraftSave: false
+    property var selectedBody: ({ text: "Original body" })
+    property var selectedMessage: ({
+      id: "message-1",
+      messageId: "<message-1@example.com>",
+      threadId: "thread-1",
+      subject: "Original subject",
+      from: ({ email: "sender@example.com", display: "Sender" }),
+      replyTo: ({ email: "sender@example.com" }),
+      to: [],
+      cc: [],
+      fullTime: "today"
+    })
+
+    function preferredSendAs(_recipients) { return null }
+    function refreshRecipientContacts() {}
+    function cursorOffset(_id, _delta) { return "" }
+    function clearSelection() {}
+    function send(_fields) {
+      sendPending = true
+      return true
+    }
+    function undoSend() {
+      if (!sendPending) return false
+      sendPending = false
+      return true
+    }
+    function saveDraft(fields, callback) {
+      lastSavedDraft = fields
+      callback(failDraftSave ? null : "draft-1",
+        failDraftSave ? "server refused it" : "")
+    }
+    function fail(text) { lastError = String(text || "") }
+    function note(text) { actionStatus = String(text || "") }
+    signal replySent()
+  }
+
+  Omamail.App {
+    id: app
+    service: mailService
+  }
+
+  TestCase {
+    name: "AppComposePending"
+    when: windowShown
+
+    function named(item, objectName) {
+      if (!item) return null
+      if (item.objectName === objectName) return item
+      var values = item.children || []
+      for (var i = 0; i < values.length; i++) {
+        var found = named(values[i], objectName)
+        if (found) return found
+      }
+      return null
+    }
+
+    function composeView() {
+      var item = named(app, "compose-to-field")
+      while (item && typeof item.resumePendingSend !== "function") item = item.parent
+      return item
+    }
+
+    function init() {
+      mailService.sendPending = false
+      mailService.sending = false
+      mailService.lastSavedDraft = null
+      mailService.failDraftSave = false
+      mailService.lastError = ""
+      mailService.actionStatus = ""
+      var compose = composeView()
+      if (compose) {
+        compose.reset()
+        compose.opened = false
+      }
+    }
+
+    function test_reply_starts_while_another_send_is_pending() {
+      compare(app.composing, false)
+      app.startCompose("reply")
+      compare(app.composing, true,
+        "the undo window must not block a reply")
+      mailService.replySent()
+      compare(app.composing, true,
+        "the queued send must not close the new reply")
+    }
+
+    function test_undo_saves_the_new_compose_before_forgetting_it() {
+      var compose = composeView()
+      verify(compose)
+      app.startCompose("new")
+      named(compose, "compose-to-field").text = "first@example.com"
+      named(compose, "compose-body-editor").text = "First message"
+      compose.submit()
+
+      app.startCompose("new")
+      named(compose, "compose-to-field").text = "second@example.com"
+      named(compose, "compose-subject-field").text = "Second subject"
+      named(compose, "compose-body-editor").text = "Second message"
+
+      verify(app.undoPendingSend())
+      compare(named(compose, "compose-to-field").text, "first@example.com")
+      compare(named(compose, "compose-body-editor").text, "First message")
+      verify(mailService.lastSavedDraft)
+      compare(mailService.lastSavedDraft.to, "second@example.com")
+      compare(mailService.lastSavedDraft.subject, "Second subject")
+      compare(mailService.lastSavedDraft.body, "Second message")
+      compare(compose.interruptedDraft, null,
+        "the server copy replaces the in-memory fallback after saving")
+      compare(app.draftSavedNotice, "Draft saved")
+      verify(compose.restoreRevision > 0,
+        "restoring the queued message must trigger field feedback")
+    }
+
+    function test_failed_save_keeps_the_newer_compose_in_memory() {
+      var compose = composeView()
+      app.startCompose("new")
+      named(compose, "compose-to-field").text = "first@example.com"
+      named(compose, "compose-body-editor").text = "First message"
+      compose.submit()
+
+      app.startCompose("new")
+      named(compose, "compose-to-field").text = "second@example.com"
+      named(compose, "compose-body-editor").text = "Second message"
+      mailService.failDraftSave = true
+
+      verify(app.undoPendingSend())
+      verify(compose.interruptedDraft,
+        "a failed provider save must keep the in-memory fallback")
+      verify(mailService.lastError.indexOf("server refused it") >= 0)
+      compose.finish()
+      compare(named(compose, "compose-to-field").text, "second@example.com")
+      compare(named(compose, "compose-body-editor").text, "Second message")
+    }
+
+    function test_escape_saves_a_nonempty_compose_before_closing_it() {
+      var compose = composeView()
+      app.startCompose("new")
+      named(compose, "compose-subject-field").text = "Quarterly plan"
+      named(compose, "compose-body-editor").text = "First draft"
+
+      app.goBack()
+
+      verify(mailService.lastSavedDraft,
+        "Escape must hand the composition to the provider's Drafts storage")
+      compare(mailService.lastSavedDraft.subject, "Quarterly plan")
+      compare(mailService.lastSavedDraft.body, "First draft")
+      compare(app.composing, false)
+      compare(app.draftSavedNotice, "Draft saved")
+    }
+  }
+}

--- a/tests/qml/tst_app_compose_pending.qml
+++ b/tests/qml/tst_app_compose_pending.qml
@@ -60,6 +60,7 @@ Item {
     property var sendIdentities: []
     property var calendarController: null
     property var lastSavedDraft: null
+    property string lastLoadedAttachmentId: ""
     property bool failDraftSave: false
     property var selectedBody: ({ text: "Original body" })
     property var selectedMessage: ({
@@ -78,6 +79,28 @@ Item {
     function refreshRecipientContacts() {}
     function cursorOffset(_id, _delta) { return "" }
     function clearSelection() {}
+    function select(id) {
+      selectedId = String(id || "")
+      selectedMessage = null
+      selectedBody = ({ text: "", source: "" })
+      selectedAttachments = []
+      detailPainted = false
+      detailLoading = true
+    }
+    function loadAttachments(messageId, attachments, callback) {
+      lastLoadedAttachmentId = String(messageId || "")
+      var listed = Array.isArray(attachments) ? attachments : []
+      var loaded = []
+      for (var i = 0; i < listed.length; i++) {
+        loaded.push({
+          filename: String(listed[i].filename || "attachment"),
+          mimeType: String(listed[i].mimeType || "application/octet-stream"),
+          size: Number(listed[i].size || 0),
+          data: "ZHJhZnQgZmlsZQ"
+        })
+      }
+      callback(loaded, "")
+    }
     function send(_fields) {
       sendPending = true
       return true
@@ -130,6 +153,27 @@ Item {
       mailService.failDraftSave = false
       mailService.lastError = ""
       mailService.actionStatus = ""
+      mailService.lastLoadedAttachmentId = ""
+      mailService.mailboxKey = "inbox"
+      mailService.detailLoading = false
+      mailService.detailPainted = false
+      mailService.selectedId = "message-1"
+      mailService.selectedBody = ({ text: "Original body", source: "plain" })
+      mailService.selectedAttachments = []
+      mailService.selectedMessage = ({
+        id: "message-1",
+        messageId: "<message-1@example.com>",
+        threadId: "thread-1",
+        subject: "Original subject",
+        from: ({ email: "sender@example.com", display: "Sender" }),
+        replyTo: ({ email: "sender@example.com" }),
+        to: [],
+        cc: [],
+        bcc: [],
+        fullTime: "today"
+      })
+      app.currentView = "list"
+      app.cursorId = ""
       var compose = composeView()
       if (compose) {
         compose.reset()
@@ -209,6 +253,57 @@ Item {
       compare(mailService.lastSavedDraft.body, "First draft")
       compare(app.composing, false)
       compare(app.draftSavedNotice, "Draft saved")
+    }
+
+    function test_opening_a_draft_row_waits_for_the_body_then_opens_compose() {
+      var compose = composeView()
+      mailService.mailboxKey = "drafts"
+      app.cursorId = "draft-7"
+
+      app.runShortcut("open", "o")
+
+      compare(mailService.selectedId, "draft-7")
+      compare(app.currentView, "list",
+        "a draft must not open the message reader while its body loads")
+      compare(app.composing, false)
+
+      mailService.selectedMessage = ({
+        id: "draft-7",
+        messageId: "<draft-7@example.com>",
+        threadId: "thread-7",
+        inReplyTo: "<earlier@example.com>",
+        subject: "Saved subject",
+        from: ({ email: "me@example.com", display: "Me" }),
+        replyTo: ({ email: "" }),
+        to: [{ email: "first@example.com" }, { email: "second@example.com" }],
+        cc: [{ email: "copy@example.com" }],
+        bcc: [{ email: "hidden@example.com" }],
+        fullTime: "today",
+        isDraft: true
+      })
+      mailService.selectedBody = ({ text: "Saved body", source: "plain" })
+      mailService.selectedAttachments = [{
+        filename: "plan.txt", mimeType: "text/plain", size: 10,
+        attachmentId: "part:1"
+      }]
+      mailService.detailPainted = true
+      mailService.detailLoading = false
+      wait(30)
+
+      compare(app.composing, true)
+      compare(compose.mode, "draft")
+      compare(compose.fromEmail, "me@example.com")
+      compare(named(compose, "compose-to-field").text,
+        "first@example.com, second@example.com")
+      compare(named(compose, "compose-cc-field").text, "copy@example.com")
+      compare(named(compose, "compose-bcc-field").text, "hidden@example.com")
+      compare(named(compose, "compose-subject-field").text, "Saved subject")
+      compare(named(compose, "compose-body-editor").text, "Saved body")
+      compare(compose.threadId, "thread-7")
+      compare(compose.inReplyTo, "<earlier@example.com>")
+      compare(mailService.lastLoadedAttachmentId, "draft-7")
+      compare(compose.draftAttachments.length, 1)
+      compare(compose.draftAttachments[0].filename, "plan.txt")
     }
   }
 }

--- a/tests/qml/tst_compose_recipients.qml
+++ b/tests/qml/tst_compose_recipients.qml
@@ -205,5 +205,69 @@ Item {
       compare(toField.text, "person@example.com")
       compare(bodyEditor.text, "Keep this draft intact")
     }
+
+    function test_a_pending_send_keeps_a_new_reply_editable() {
+      compose.begin("new", null, "", [])
+      named(compose, "compose-to-field").text = "first@example.com"
+      named(compose, "compose-body-editor").text = "First message"
+      compose.submit()
+
+      compose.begin("reply", ({
+        messageId: "<second@example.com>",
+        threadId: "thread-2",
+        subject: "Second subject",
+        from: ({ email: "second@example.com", display: "Second Person" }),
+        replyTo: ({ email: "second@example.com" }),
+        to: [],
+        cc: [],
+        fullTime: "today"
+      }), "Second body", [])
+
+      compare(compose.opened, true)
+      compare(compose.parkedForSend, true,
+        "the first draft must remain available to undo")
+      compare(named(compose, "compose-to-field").enabled, true)
+      compare(named(compose, "compose-body-editor").enabled, true)
+    }
+
+    function test_undo_does_not_discard_the_new_reply() {
+      compose.begin("new", null, "", [])
+      named(compose, "compose-to-field").text = "first@example.com"
+      named(compose, "compose-body-editor").text = "First message"
+      compose.submit()
+
+      compose.beginDraft({
+        to: "second@example.com", cc: "", bcc: "",
+        subject: "Second subject", body: "Second message"
+      })
+      verify(mailService.undoSend())
+      verify(compose.resumePendingSend())
+      compare(named(compose, "compose-to-field").text, "first@example.com")
+      compare(named(compose, "compose-body-editor").text, "First message")
+
+      compose.finish()
+      compare(compose.opened, true,
+        "closing the restored send must return to the new reply")
+      compare(named(compose, "compose-to-field").text, "second@example.com")
+      compare(named(compose, "compose-subject-field").text, "Second subject")
+      compare(named(compose, "compose-body-editor").text, "Second message")
+    }
+
+    function test_delivery_does_not_close_the_new_reply() {
+      compose.begin("new", null, "", [])
+      named(compose, "compose-to-field").text = "first@example.com"
+      named(compose, "compose-body-editor").text = "First message"
+      compose.submit()
+
+      compose.beginDraft({
+        to: "second@example.com", cc: "", bcc: "",
+        subject: "Second subject", body: "Second message"
+      })
+      mailService.sendPending = false
+      verify(compose.completePendingSend())
+      compare(compose.opened, true)
+      compare(named(compose, "compose-to-field").text, "second@example.com")
+      compare(named(compose, "compose-body-editor").text, "Second message")
+    }
   }
 }

--- a/tests/qml/tst_keyrouter.qml
+++ b/tests/qml/tst_keyrouter.qml
@@ -99,16 +99,20 @@ Item {
         "Ctrl+K opens the shortcut sheet from inside a draft")
     }
 
-    function test_undo_and_mail_navigation_share_the_mail_context() {
+    function test_alt_z_undoes_send_while_composing() {
       host.context = "compose"
       wait(20)
       keyClick(Qt.Key_Z, Qt.ControlModifier)
       compare(host.lastId, "", "Ctrl+Z remains text undo while composing")
+      keyClick(Qt.Key_Z, Qt.AltModifier)
+      compare(host.lastId, "undoSend",
+        "Alt+Z must reach the queued send while composing")
 
+      host.lastId = ""
       host.context = "reader"
       scope.applyContextFocus()
       wait(20)
-      keyClick(Qt.Key_Z, Qt.ControlModifier)
+      keyClick(Qt.Key_Z, Qt.AltModifier)
       compare(host.lastId, "undoSend")
       host.lastId = ""
       keyClick(Qt.Key_Down)

--- a/tests/qml/tst_undo_send_toast.qml
+++ b/tests/qml/tst_undo_send_toast.qml
@@ -56,7 +56,7 @@ Item {
     function test_button_requests_undo() {
       var button = named(toast, "undo-send-button")
       verify(button)
-      compare(button.text, "Undo  Ctrl+Z")
+      compare(button.text, "Undo  Alt+Z")
       mouseClick(button, button.width / 2, button.height / 2)
       compare(undoSpy.count, 1)
     }

--- a/tests/test_gmail_api.js
+++ b/tests/test_gmail_api.js
@@ -38,6 +38,11 @@ assert.strictEqual(api.trashPath("18f3a"), "/users/me/messages/18f3a/trash")
 assert.strictEqual(api.labelPath("INBOX"), "/users/me/labels/INBOX")
 assert.strictEqual(api.sendAsPath(), "/users/me/settings/sendAs")
 assert.strictEqual(api.attachmentPath("m1", "a1"), "/users/me/messages/m1/attachments/a1")
+assert.strictEqual(api.draftsPath(), "/users/me/drafts")
+assert.strictEqual(api.draftPath("draft/a"), "/users/me/drafts/draft%2Fa")
+deepEqual(api.draftBody({ raw: "encoded", threadId: "thread-1" }), {
+  message: { raw: "encoded", threadId: "thread-1" }
+})
 
 deepEqual(api.listQuery("in:inbox", 25, ""), { q: "in:inbox", maxResults: 25, pageToken: "" })
 assert.strictEqual(api.listQuery("", 500).maxResults, 100, "Gmail caps maxResults at 100")

--- a/tests/test_hey.js
+++ b/tests/test_hey.js
@@ -37,6 +37,8 @@ deepEqual(hey.parseQuery("search:dentist"),
   { kind: "search", box: "", label: "", text: "dentist", unseen: false })
 deepEqual(hey.parseQuery("box:trash"),
   { kind: "trash", box: "trash", label: "", text: "", unseen: false })
+deepEqual(hey.parseQuery("drafts:"),
+  { kind: "drafts", box: "", label: "", text: "", unseen: false })
 
 // A search takes the rest of the string verbatim, so typing a mailbox name into
 // the search field searches for those words rather than switching mailbox.
@@ -66,6 +68,28 @@ deepEqual(hey.listCommand(hey.parseQuery("search:dentist"), 25, ""),
   ["search", "dentist", "--json"])
 deepEqual(hey.listCommand(hey.parseQuery("box:trash"), 25, ""),
   ["search", "--in", "trash", "--json"])
+deepEqual(hey.listCommand(hey.parseQuery("drafts:"), 25, ""),
+  ["draft", "list", "--json"])
+deepEqual(hey.listCommand(hey.parseQuery("drafts:"), 25, "0|draft-cursor-2"),
+  ["draft", "list", "--json", "--page", "draft-cursor-2"])
+
+deepEqual(hey.parseDraftListing([
+  { id: 101, summary: "Agenda and decisions", subject: "Quarterly planning",
+    updated_at: "2026-08-20T09:30:00Z" }
+]), [{
+  id: "draft:101", draftId: "101", subject: "Quarterly planning",
+  snippet: "Agenda and decisions", from: { name: "", email: "" }, to: [],
+  date: "2026-08-20T09:30:00Z", seen: true, box: "", appUrl: "", isDraft: true
+}])
+deepEqual(hey.draftShowCommand("draft:101"), ["draft", "show", "101", "--json"])
+deepEqual(hey.parseDraft({ id: 101, subject: "Quarterly planning", body: "Agenda",
+  to: ["maria@example.com"], cc: ["team@example.com"], bcc: [],
+  updated_at: "2026-08-20T09:30:00Z" }), {
+  id: "draft:101", draftId: "101", subject: "Quarterly planning", body: "Agenda",
+  to: [{ name: "", email: "maria@example.com" }],
+  cc: [{ name: "", email: "team@example.com" }], bcc: [],
+  date: "2026-08-20T09:30:00Z", isDraft: true
+})
 
 // The one query that does name a number. Filtering on unseen happens here
 // rather than on the server, so a page of one would find at most one unseen
@@ -142,6 +166,13 @@ deepEqual(hey.composeCommand({
   "compose", "--to", "jane@example.com", "--subject", "Lunch",
   "--attach", "/tmp/menu.pdf"
 ])
+deepEqual(hey.draftCommand({ subject: "Nobody yet" }),
+  ["compose", "--subject", "Nobody yet", "--draft"],
+  "a draft may be saved before it has a recipient")
+deepEqual(hey.draftCommand({
+  threadId: "2106437143",
+  attachments: [{ path: "/tmp/menu.pdf" }]
+}), ["reply", "2106437143", "--draft", "--attach", "/tmp/menu.pdf"])
 assert.strictEqual(hey.isDroppableFlag("--attach"), false)
 assert.strictEqual(hey.isDroppableFlag("--html"), true)
 

--- a/tests/test_keymap.js
+++ b/tests/test_keymap.js
@@ -53,14 +53,11 @@ function byId(id) {
 
 const undoSend = byId("undoSend")
 assert.ok(undoSend, "the delayed-send state offers an undo action")
-assert.strictEqual(keymap.displayFor(undoSend), "Ctrl+Z")
-assert.strictEqual(keymap.isEnabled(undoSend, "list", false), true)
-assert.strictEqual(keymap.isEnabled(undoSend, "reader", false), true)
-assert.strictEqual(keymap.isEnabled(undoSend, "calendar", false), true)
-assert.strictEqual(keymap.isEnabled(undoSend, "compose", false), false,
-  "Ctrl+Z remains text undo while a draft is open")
-assert.strictEqual(keymap.isEnabled(undoSend, "search", false), false,
-  "Ctrl+Z remains text undo while a query is being edited")
+assert.strictEqual(keymap.displayFor(undoSend), "Alt+Z")
+keymap.CONTEXTS.forEach(function (context) {
+  assert.strictEqual(keymap.isEnabled(undoSend, context, false), true,
+    "Alt+Z must undo a delayed send from " + context)
+})
 
 assert.strictEqual(keymap.contextFor({
   sendPending: true,

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -225,7 +225,9 @@ const resource = {
       { name: "From", value: "=?UTF-8?B?" + Buffer.from("李四", "utf8").toString("base64") + "?= <li@example.com>" },
       { name: "To", value: "me@example.com" },
       { name: "Cc", value: "team@example.com, work@example.net" },
+      { name: "Bcc", value: "hidden@example.org" },
       { name: "Subject", value: "  Invoice   for   August  " },
+      { name: "In-Reply-To", value: "<earlier@example.net>" },
       { name: "Date", value: "Wed, 19 Aug 2026 14:50:00 +0000" }
     ]
   }
@@ -239,7 +241,11 @@ assert.strictEqual(summary.from.email, "li@example.com")
 assert.strictEqual(summary.subject, "Invoice for August", "runs of whitespace collapse")
 assert.strictEqual(summary.cc.length, 2, "Cc is carried: a reply picks its alias out of it")
 assert.strictEqual(summary.cc[1].email, "work@example.net")
+deepEqual(summary.bcc || [], [{ name: "hidden", email: "hidden@example.org",
+  display: "hidden" }], "Bcc is carried when a stored draft is reopened")
+assert.strictEqual(summary.inReplyTo, "<earlier@example.net>")
 assert.strictEqual(message.summarize({ payload: { headers: [] } }, now).cc.length, 0)
+assert.strictEqual(message.summarize({ payload: { headers: [] } }, now).bcc.length, 0)
 assert.strictEqual(summary.snippet, "Your receipt is attached & ready")
 assert.strictEqual(summary.time, "10m")
 assert.strictEqual(summary.unread, true)
@@ -274,6 +280,29 @@ const withReplyTo = message.summarize({
 }, now)
 assert.strictEqual(withReplyTo.replyTo.email, "help@example.com")
 assert.strictEqual(withReplyTo.messageId, "<abc@mail.example.com>")
+
+assert.strictEqual(typeof message.draftFields, "function",
+  "stored messages need one provider-neutral path back into compose")
+deepEqual(message.draftFields({
+  from: { email: "me@example.com" },
+  to: [{ email: "first@example.com" }, { email: "second@example.com" }],
+  cc: [{ email: "copy@example.com" }],
+  bcc: [{ email: "hidden@example.com" }],
+  subject: "Saved subject",
+  threadId: "thread-7",
+  inReplyTo: "<earlier@example.com>"
+}, "Saved body"), {
+  mode: "draft",
+  from: "me@example.com",
+  to: "first@example.com, second@example.com",
+  cc: "copy@example.com",
+  bcc: "hidden@example.com",
+  subject: "Saved subject",
+  body: "Saved body",
+  threadId: "thread-7",
+  inReplyTo: "<earlier@example.com>"
+})
+assert.strictEqual(message.draftFields({ subject: "(no subject)" }, "").subject, "")
 
 // ------------------------------------------------------------ composition
 

--- a/tests/test_provider.js
+++ b/tests/test_provider.js
@@ -82,7 +82,7 @@ assert.strictEqual(provider.unavailableReason("hey"), "")
 
 // The glyphs ActionIcon actually draws. A mailbox naming anything else renders
 // as nothing at all.
-const DRAWN = ["inbox", "unread", "star", "send", "archive", "trash", "reply", "pin", "label"]
+const DRAWN = ["inbox", "unread", "star", "send", "archive", "trash", "reply", "pin", "label", "compose"]
 
 // Every provider's first mailbox is its inbox: `mailboxFor` falls back to it,
 // which is what a key belonging to another provider lands on mid-switch.
@@ -110,6 +110,9 @@ assert.strictEqual(provider.mailboxes("gmail").length, boxes.length - 1,
 assert.strictEqual(provider.hasMailbox("gmail", "all"), true)
 assert.strictEqual(provider.hasMailbox("imap", "all"), false, "IMAP has Archive, not All mail")
 assert.strictEqual(provider.hasMailbox("imap", "archive"), true)
+assert.strictEqual(provider.hasMailbox("gmail", "drafts"), true)
+assert.strictEqual(provider.hasMailbox("hey", "drafts"), true)
+assert.strictEqual(provider.hasMailbox("imap", "drafts"), true)
 assert.strictEqual(provider.mailboxFor("gmail", "nonesuch").key, "inbox",
   "an unknown mailbox key falls back to the inbox rather than to undefined")
 assert.strictEqual(provider.mailboxFor("imap", "starred").label, "Flagged",
@@ -121,11 +124,13 @@ assert.strictEqual(provider.mailboxFor("imap", "starred").label, "Flagged",
 assert.strictEqual(provider.query("gmail", "inbox", "", ""), "in:inbox")
 assert.strictEqual(provider.query("gmail", "starred", "", ""), "is:starred")
 assert.strictEqual(provider.query("gmail", "trash", "", ""), "in:trash")
+assert.strictEqual(provider.query("gmail", "drafts", "", ""), "in:drafts")
 
 // IMAP's are the folder DSL.
 assert.strictEqual(provider.query("imap", "inbox", "", ""), "folder:INBOX")
 assert.strictEqual(provider.query("imap", "unread", "", ""), "folder:INBOX UNSEEN")
 assert.strictEqual(provider.query("imap", "sent", "", ""), "folder:\\Sent")
+assert.strictEqual(provider.query("imap", "drafts", "", ""), "folder:\\Drafts")
 
 // A typed search wins over everything, and is shaped by the provider.
 assert.strictEqual(provider.query("gmail", "trash", "from:jane", ""), "from:jane",
@@ -155,6 +160,7 @@ assert.strictEqual(provider.query("hey", "inbox", "", "in:inbox"), "box:imbox")
 assert.strictEqual(provider.query("hey", "inbox", "", ""), "box:imbox")
 assert.strictEqual(provider.query("hey", "feed", "", ""), "box:feedbox")
 assert.strictEqual(provider.query("hey", "trash", "", ""), "box:trash")
+assert.strictEqual(provider.query("hey", "drafts", "", ""), "drafts:")
 assert.strictEqual(provider.query("hey", "inbox", "dentist", ""), "search:dentist")
 
 // The badge counts what the Unread mailbox holds, by lookup rather than by a

--- a/tests/test_transport.sh
+++ b/tests/test_transport.sh
@@ -223,6 +223,17 @@ check_absent "SMTP does not emit --next sections" "$config" 'next'
 check "SMTP keeps its transfer deadline" "$config" 'max-time = 60'
 check "SMTP keeps its connection deadline" "$config" 'connect-timeout = 20'
 
+# --------------------------------------------------------- IMAP draft upload
+
+append="imap-append $(b64 'imaps://imap.example.org:993/Drafts') $(b64 'jane:pw') $(b64 'Subject: saved draft
+
+body')"
+config=$(config_for "$append")
+check "a draft is appended to its resolved mailbox" "$config" 'url = "imaps://imap.example.org:993/Drafts"'
+check "a draft upload uses the RFC 5322 message file" "$config" 'upload-file = "'
+check "an IMAP upload carries the draft flag" "$config" 'upload-flags = "draft"'
+check_absent "an IMAP draft is not sent as a custom request" "$config" 'request = '
+
 # ------------------------------------------------------------- the framing
 
 # The exit code is curl's own, so a transport failure is distinguishable from


### PR DESCRIPTION
## Problem

A queued send blocked every compose action until the undo-send timer expired. Users could not start, reply to, or forward another message during that wait.

Undo Send used `Ctrl+Z`. Inside compose, the editor consumed that shortcut as text undo, so keyboard users could not cancel the queued message.

Back and `Escape` also discarded non-empty compositions. Omamail had no provider-backed save path and no Drafts mailbox for that work.

Draft rows still opened in the reader after storage support landed. A saved draft could be listed, but no click or keyboard action returned it to compose.

## How it was solved

The queued message now parks while delivery waits. New compose, reply, forward, recipient editing, and attachments remain usable. Only another send waits for the pending delivery.

Gmail saves through its Drafts API. HEY uses the CLI draft commands. IMAP uploads to the server's SPECIAL-USE Drafts folder with the `\Draft` flag. Each sidebar now includes Drafts.

If Undo Send runs while another composition is open, Omamail saves the newer draft and restores the queued message. Restored fields flash, and a non-blocking toast reports the saved draft.

If a provider rejects the save, Omamail retains the in-memory draft and reports the failure. Back and `Escape` save non-empty compositions. Discard remains the destructive close action.

Draft rows now wait for the complete message before opening compose. From, To, Cc, Bcc, subject, body, reply threading, and attachments return to editable fields. A click, `Enter`, and `o` use the same activation path.

Undo Send now uses `Alt+Z` from every app context. `Ctrl+Z` remains editor undo in text fields.

## Invariants

- A pending delivery can block another send, but it cannot block editing or navigation.
- A queued delivery completion cannot close a newer composition.
- Drafts use the active provider and its server-resolved Drafts storage.
- Omamail keeps the in-memory fallback until the provider confirms the save.
- A stored draft opens only after its complete body and headers arrive.

## Verification

- `make validate`
- 91 QML tests, including stored draft activation, compose during a queued send, draft save failure, field restoration, and `Alt+Z` routing
- Node, shell transport, source, QML lint, plugin validation, and whitespace checks
- Manual test in the running Omarchy shell, including Undo Send while another composition was open and reopening a stored draft

## Release Notes

- Continue composing, replying, and forwarding while another message waits in the Undo Send window.
- Save non-empty compositions to the provider's Drafts mailbox when leaving with Back or `Escape`.
- Open Drafts from the sidebar for Gmail, HEY, and IMAP accounts.
- Reopen a stored draft in compose by clicking it or pressing `Enter` or `o`.
- Press `Alt+Z` to undo a queued send without losing the composition already open.
