### PR TITLE
Keep reloads from replacing saved accounts

### DIFF
--- a/Service.qml
+++ b/Service.qml
@@ -156,7 +156,18 @@ Item {
   // each account keeps its own cache on disk. A queued send belongs to its
   // account host and remains reachable after the visible account changes.
   function switchTo(id) {
-    if (String(id) === activeAccountId && activeIndex < 0) return true
+    // A notification can outlive the account it names. Refuse it before it can
+    // disturb either the visible account or what is persisted on disk.
+    if (!Accounts.find(accountList, id)) return false
+    // The saved account can already be active while Add account has put its
+    // draft on screen. Switching back still has work to do, just no file write.
+    if (String(id) === activeAccountId) {
+      if (activeIndex >= 0) {
+        activeIndex = -1
+        refreshCurrent()
+      }
+      return true
+    }
     activeIndex = -1
     accountList = Accounts.setActive(accountList, id)
     saveAccounts()
@@ -307,6 +318,11 @@ Item {
 
   function saveAccounts() {
     if (!accountsLoaded) return
+    // A nameless row is setup state, never a mailbox. There is no legitimate
+    // path that persists only one — Add waits for configureAccount, and the UI
+    // does not remove the final saved account — so refusing this write is the
+    // last line of defence against replacing every account with first-run.
+    if (!Accounts.hasSavedAccounts(accountList)) return
     if (accountsWriter.running) {
       accountsSaveQueued = true
       return
@@ -318,6 +334,11 @@ Item {
   }
 
   function applyAccounts(raw) {
+    // FileView can report a failed read while an atomically replaced watched
+    // file is settling. First run still gets its placeholder below, but once a
+    // real list is in memory an unreadable instant must not erase the UI and
+    // become the next value written back to disk.
+    if (accountsLoaded && !Accounts.isSerializedList(raw)) return
     var loaded = Accounts.load(raw)
     // First run, or an install that predates several accounts: one nameless
     // row so the existing credentials file still has somewhere to live.

--- a/account/Accounts.js
+++ b/account/Accounts.js
@@ -37,6 +37,16 @@ function parseJson(text, fallback) {
   }
 }
 
+// Whether text is an accounts file rather than a failed or half-finished read.
+// `load` deliberately turns either into an empty list for first run; a service
+// that already has accounts needs the distinction so a transient FileView
+// failure cannot replace them with the first-run placeholder.
+function isSerializedList(text) {
+  var raw = parseJson(text, null)
+  return isObject(raw) && Number(raw.version) === VERSION
+    && Array.isArray(raw.accounts)
+}
+
 function isValidEmail(value) {
   return EMAIL_PATTERN.test(trimmed(value))
 }
@@ -285,8 +295,7 @@ function setActive(list, id) {
 // failure leaves them with nothing to do it from.
 function load(text) {
   var raw = parseJson(text, null)
-  if (!isObject(raw)) return emptyList()
-  if (Number(raw.version) !== VERSION) return emptyList()
+  if (!isSerializedList(text)) return emptyList()
 
   var next = emptyList()
   var entries = Array.isArray(raw.accounts) ? raw.accounts : []

--- a/scripts/config-store.sh
+++ b/scripts/config-store.sh
@@ -31,6 +31,20 @@ if [ -z "$payload" ]; then
   exit 3
 fi
 
+# A plugin reload can briefly leave the retiring service with only its setup
+# row in memory. If that stale instance reaches this writer after a real list
+# has already been stored, accepting the write would replace every mailbox
+# with first-run state. A saved account always has a validated email address;
+# a draft has an empty one. Keep this invariant at the final write boundary so
+# it also protects an old service instance during an upgrade.
+if [ "$name" = accounts.json ] && [ -s "$target" ] \
+  && grep -Eq '"email"[[:space:]]*:[[:space:]]*"[^"]+"' "$target" \
+  && ! printf '%s\n' "$payload" \
+    | grep -Eq '"email"[[:space:]]*:[[:space:]]*"[^"]+"'; then
+  printf '%s\n' 'refusing to replace saved accounts with setup state' >&2
+  exit 4
+fi
+
 mkdir -p "$target_dir"
 chmod 700 "$target_dir" 2>/dev/null || true
 

--- a/tests/test_accounts.js
+++ b/tests/test_accounts.js
@@ -196,6 +196,14 @@ deepEqual(accounts.load("{not json"), accounts.emptyList())
 deepEqual(accounts.load("[]"), accounts.emptyList(), "an array is not a list of accounts")
 deepEqual(accounts.load("null"), accounts.emptyList())
 deepEqual(accounts.load(null), accounts.emptyList())
+assert.strictEqual(accounts.isSerializedList(""), false)
+assert.strictEqual(accounts.isSerializedList("{not json"), false)
+assert.strictEqual(accounts.isSerializedList(JSON.stringify({
+  version: accounts.VERSION, accounts: []
+})), true, "a real empty first-run file is distinguishable from a failed read")
+assert.strictEqual(accounts.isSerializedList(JSON.stringify({
+  version: accounts.VERSION + 1, accounts: []
+})), false, "a newer format must not be mistaken for this build's list")
 deepEqual(accounts.load(JSON.stringify({ accounts: [] })), accounts.emptyList(), "no version at all")
 deepEqual(accounts.load(JSON.stringify({
   version: accounts.VERSION + 99,

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -37,6 +37,27 @@ XDG_CONFIG_HOME="$test_root/config" XDG_CACHE_HOME="$test_root/cache" \
 [ ! -e "$test_root/config/omarchy-gmail" ] || fail "legacy config directory remains"
 [ ! -e "$test_root/cache/omarchy-gmail" ] || fail "legacy cache directory remains"
 
+# A stale service instance from before a plugin reload must not be able to
+# replace a real account list with the first-run setup row. The writer is the
+# one boundary both old and new service code still cross.
+saved_accounts='{"version":1,"accounts":[{"id":"imap:me@example.com","email":"me@example.com"}],"activeId":"imap:me@example.com"}'
+setup_accounts='{"version":1,"accounts":[{"id":"","email":""}],"activeId":""}'
+printf '%s\n' "$saved_accounts" \
+  | XDG_CONFIG_HOME="$test_root/config" sh scripts/config-store.sh accounts.json >/dev/null
+if printf '%s\n' "$setup_accounts" \
+  | XDG_CONFIG_HOME="$test_root/config" sh scripts/config-store.sh accounts.json >/dev/null 2>&1; then
+  fail "config-store.sh replaced saved accounts with setup state"
+fi
+actual_accounts=$(cat "$test_root/config/omamail/accounts.json")
+[ "$actual_accounts" = "$saved_accounts" ] \
+  || fail "config-store.sh changed the account list after refusing setup state"
+updated_accounts='{"version":1,"accounts":[{"id":"imap:you@example.com","email":"you@example.com"}],"activeId":"imap:you@example.com"}'
+printf '%s\n' "$updated_accounts" \
+  | XDG_CONFIG_HOME="$test_root/config" sh scripts/config-store.sh accounts.json >/dev/null
+actual_accounts=$(cat "$test_root/config/omamail/accounts.json")
+[ "$actual_accounts" = "$updated_accounts" ] \
+  || fail "config-store.sh refused a replacement that still contains a saved account"
+
 # The keyring helper takes attribute pairs now, because keying a refresh token
 # on the OAuth client alone lets two accounts sharing one client overwrite each
 # other. An empty value is a secret-tool wildcard, so it is refused outright.

--- a/tests/test_service_source.sh
+++ b/tests/test_service_source.sh
@@ -26,9 +26,36 @@ if "sendPending" in block:
     raise SystemExit(
         "test_service_source.sh: a pending send must not block account switching"
     )
+if "Accounts.find(accountList, id)" not in block:
+    raise SystemExit(
+        "test_service_source.sh: a stale account switch must be refused before changing state"
+    )
+same_start = block.index("if (String(id) === activeAccountId)")
+same_end = block.index("accountList = Accounts.setActive", same_start)
+same_block = block[same_start:same_end]
+if "activeIndex = -1" not in same_block or "refreshCurrent()" not in same_block:
+    raise SystemExit(
+        "test_service_source.sh: switching from a draft to the saved active account must refresh"
+    )
 if "pendingSendHost" not in text:
     raise SystemExit(
         "test_service_source.sh: undo must remain reachable after account switching"
+    )
+
+save_start = text.index("function saveAccounts()")
+save_end = text.index("function applyAccounts(raw)", save_start)
+save_block = text[save_start:save_end]
+if "Accounts.hasSavedAccounts(accountList)" not in save_block:
+    raise SystemExit(
+        "test_service_source.sh: first-run state must never overwrite saved accounts"
+    )
+
+apply_start = save_end
+apply_end = text.index("signal accountAdded()", apply_start)
+apply_block = text[apply_start:apply_end]
+if "accountsLoaded && !Accounts.isSerializedList(raw)" not in apply_block:
+    raise SystemExit(
+        "test_service_source.sh: a transient account read must not erase the loaded list"
     )
 PY
 


### PR DESCRIPTION
## Summary

- distinguish a valid accounts file from a transient or malformed `FileView` read
- refuse stale account switches and placeholder-only saves while preserving the path back from an Add-account draft
- enforce the same invariant at the atomic config writer, so a retiring pre-update service instance cannot replace saved accounts during a plugin reload

During a live plugin reload, the watched accounts file can briefly be reported as unreadable. `Accounts.load` intentionally maps unreadable input to an empty first-run list, and the service then supplies its setup placeholder. A delayed account switch could persist that placeholder over the real file. Guards only in the newly loaded service are not sufficient because an instance created from the previous plugin version can still finish a queued write.

The writer therefore refuses only one destructive transition: replacing an existing `accounts.json` containing a saved email address with a payload containing no saved email address. First run and ordinary account updates continue to work.

## Testing

- `make test` (all JavaScript and shell tests; 81 QML tests passed)
- integration coverage verifies that the writer refuses setup-only replacement, leaves the original file unchanged, and still accepts a valid account replacement

## Release Notes

- Keep saved mail accounts intact during plugin reloads.
