### PR TITLE
Select local IMAP transport from the server address

### DIFF
--- a/components/ImapSetupPage.qml
+++ b/components/ImapSetupPage.qml
@@ -40,14 +40,14 @@ Column {
   spacing: Style.space(16)
 
   function currentSettings() {
-    return {
+    return Imap.setupSettings({
+      address: addressField.text,
       imapHost: imapHostField.text.trim(),
-      imapPort: imapPortField.text.trim() === "" ? 993 : Number(imapPortField.text.trim()),
+      imapPort: imapPortField.text,
       smtpHost: smtpHostField.text.trim(),
-      smtpPort: smtpPortField.text.trim() === "" ? 465 : Number(smtpPortField.text.trim()),
-      username: (usernameField.text.trim() || addressField.text.trim()),
-      insecure: false
-    }
+      smtpPort: smtpPortField.text,
+      username: usernameField.text
+    })
   }
 
   // The address drives the servers until the user takes them over. Once a field

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -246,7 +246,9 @@ function imapUrl(settings, folder) {
 function smtpUrl(settings) {
   var values = normalizeSettings(settings)
   if (!isValidHost(values.smtpHost)) return ""
-  var scheme = values.insecure ? "smtp" : "smtps"
+  // IMAP and SMTP may name different hosts. The shared local-transport flag
+  // cannot let a loopback IMAP server downgrade a remote SMTP connection.
+  var scheme = values.insecure && isLoopback(values.smtpHost) ? "smtp" : "smtps"
   return scheme + "://" + values.smtpHost + ":" + values.smtpPort
 }
 

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -199,6 +199,22 @@ function isLoopback(host) {
   return name === "127.0.0.1" || name === "::1" || name === "localhost"
 }
 
+// Turn the setup form's visible fields into the same validated shape every
+// client call consumes. The server, not the mailbox's email domain, decides
+// whether this is a local bridge: Proton can serve addresses on custom domains
+// that never select its address preset.
+function setupSettings(raw) {
+  var values = raw || {}
+  return normalizeSettings({
+    imapHost: values.imapHost,
+    imapPort: values.imapPort,
+    smtpHost: values.smtpHost,
+    smtpPort: values.smtpPort,
+    username: trimmed(values.username) || trimmed(values.address),
+    insecure: isLoopback(values.imapHost)
+  })
+}
+
 // Reported one at a time and in the order the form reads, so the message names
 // the first field the user has to go back to rather than all of them at once.
 function validateSettings(raw) {

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -37,6 +37,19 @@ const proton = imap.suggestedSettings("jane@proton.me")
 assert.strictEqual(proton.imapHost, "127.0.0.1")
 assert.strictEqual(proton.insecure, true)
 
+// A Proton mailbox may use a custom domain, so its address cannot select the
+// Proton preset. The server fields still identify a local Bridge and must
+// produce plain local IMAP rather than implicit TLS on Bridge's STARTTLS port.
+const customDomainBridge = imap.setupSettings({
+  address: "jane@example.com",
+  username: "jane@example.com",
+  imapHost: "127.0.0.1", imapPort: "1143",
+  smtpHost: "127.0.0.1", smtpPort: "1025"
+})
+assert.strictEqual(customDomainBridge.insecure, true)
+assert.strictEqual(imap.imapUrl(customDomainBridge, "INBOX"),
+  "imap://127.0.0.1:1143/INBOX")
+
 // ------------------------------------------------------------- host safety
 //
 // Every one of these ends up inside a URL handed to an authenticated client.

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -49,6 +49,9 @@ const customDomainBridge = imap.setupSettings({
 assert.strictEqual(customDomainBridge.insecure, true)
 assert.strictEqual(imap.imapUrl(customDomainBridge, "INBOX"),
   "imap://127.0.0.1:1143/INBOX")
+assert.strictEqual(imap.smtpUrl(customDomainBridge),
+  "smtp://127.0.0.1:1025",
+  "the local SMTP half of the bridge keeps its local transport")
 
 // ------------------------------------------------------------- host safety
 //
@@ -106,6 +109,14 @@ assert.strictEqual(imap.imapUrl({ imapHost: "a b" }, "INBOX"), "",
 assert.strictEqual(
   imap.smtpUrl({ smtpHost: "smtp.fastmail.com", smtpPort: 465 }),
   "smtps://smtp.fastmail.com:465")
+assert.strictEqual(
+  imap.smtpUrl(imap.setupSettings({
+    address: "jane@example.com",
+    imapHost: "127.0.0.1", imapPort: 1143,
+    smtpHost: "smtp.example.com", smtpPort: 465
+  })),
+  "smtps://smtp.example.com:465",
+  "a local IMAP bridge must not permit plaintext SMTP to a remote host")
 
 // -------------------------------------------------------------- the query DSL
 

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -508,6 +508,11 @@ if grep -qE 'signal (signIn|signOut|remove)Requested' components/SettingsPage.qm
 fi
 grep -q 'signal removeRequested()' components/ImapSetupPage.qml \
   || fail "the IMAP edit page needs to own account removal"
+
+# The tested protocol helper owns the setup decision; the form must not grow a
+# second, untested copy that can drop Proton Bridge's local transport again.
+grep -q 'return Imap\.setupSettings({' components/ImapSetupPage.qml \
+  || fail "the IMAP setup form must use the tested settings builder"
 grep -q 'service\.discardCurrentDraft()' App.qml \
   || fail "leaving Add account must discard its unnamed draft"
 if awk '


### PR DESCRIPTION
## What changed

The IMAP setup form now builds its settings through tested protocol logic that selects local transport when the IMAP server is a loopback address. This lets Proton Mail Bridge work for custom-domain Proton addresses as well as addresses whose domain selects the built-in Proton preset.

Previously, `currentSettings()` always wrote `insecure: false`. That discarded Bridge's local transport and made curl attempt implicit TLS against IMAP port 1143, failing with curl error 35 before authentication. The server address now owns the decision through `Imap.setupSettings()`, while normalization preserves the invariant that plaintext is permitted only on this machine.

## Regression proof

The behavioral test constructs setup fields for a custom-domain mailbox using `127.0.0.1:1143`. Before the implementation existed, the test failed; after the fix, it proves the resulting URL is `imap://127.0.0.1:1143/INBOX`, not `imaps://`.

A source check also ensures the QML form continues delegating to the tested settings builder instead of growing a second copy of the transport decision.

## Verification

- `make test` — passed, including 81 QML tests
- `make validate` — passed
- `git diff --check` — passed
- Confirmed Proton Mail Bridge listening on `127.0.0.1:1143` and reproduced the implicit-TLS failure before the fix
- Confirmed a live custom-domain Proton mailbox connects successfully through Bridge with the patched plugin

## Release Notes

- Connect Proton Mail Bridge accounts that use a custom email domain.
