### PR TITLE
Mark the current time on the week grid

### DIFF
--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -681,6 +681,35 @@ function eventHeight(event, day, hourHeight) {
   return Math.max(Number(hourHeight) * 0.42, (end - start) / 3600000 * Number(hourHeight))
 }
 
+// Where "now" sits in a day column, or -1 when it does not belong on the grid:
+// another day, or an hour outside the range the week view drew. The caller
+// draws nothing on -1 rather than clamping to an edge, because a line pinned to
+// the top of the grid states a time that is not the time — and the range here
+// is elastic, since weekHourRange widens it to whatever the week's events need.
+function nowOffset(day, firstHour, lastHour, hourHeight, nowMs) {
+  if (!day) return -1
+  var now = Number(nowMs)
+  if (!isFinite(now)) return -1
+  if (now < Number(day.startMs) || now >= Number(day.endMs)) return -1
+  var minutes = (now - Number(day.startMs)) / 60000
+  var first = Number(firstHour) * 60
+  var last = Number(lastHour) * 60
+  if (minutes < first || minutes > last) return -1
+  return (minutes - first) / 60 * Number(hourHeight)
+}
+
+// The same offset for the week as a whole, so the time rail can label the line
+// without the view having to work out which of the seven columns is today.
+// Returns -1 when today is not in view at all, which is every week but this one.
+function weekNowOffset(days, firstHour, lastHour, hourHeight, nowMs) {
+  var values = Array.isArray(days) ? days : []
+  for (var i = 0; i < values.length; i++) {
+    var offset = nowOffset(values[i], firstHour, lastHour, hourHeight, nowMs)
+    if (offset >= 0) return offset
+  }
+  return -1
+}
+
 function eventsOnDay(events, day) {
   var values = Array.isArray(events) ? events : []
   var out = []

--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -667,10 +667,21 @@ function weekTitle(days) {
     + last.day + " " + months[last.month] + " " + last.year
 }
 
+// Minutes on the labeled local-time grid. Subtracting from midnight measures
+// elapsed time instead, which is an hour short or long after a DST transition.
+function dayMinutes(timeMs, day) {
+  var value = Number(timeMs)
+  if (value <= Number(day.startMs)) return 0
+  if (value >= Number(day.endMs)) return 1440
+  var local = new Date(value)
+  return local.getHours() * 60 + local.getMinutes()
+    + local.getSeconds() / 60 + local.getMilliseconds() / 60000
+}
+
 function eventTop(event, day, firstHour, hourHeight) {
   if (!event || !event.start || event.start.allDay) return 0
   var start = Math.max(Number(event.start.ms), Number(day.startMs))
-  var minutes = (start - Number(day.startMs)) / 60000 - Number(firstHour) * 60
+  var minutes = dayMinutes(start, day) - Number(firstHour) * 60
   return Math.max(0, minutes / 60 * Number(hourHeight))
 }
 
@@ -678,7 +689,8 @@ function eventHeight(event, day, hourHeight) {
   if (!event || !event.start || event.start.allDay) return 0
   var start = Math.max(Number(event.start.ms), Number(day.startMs))
   var end = event.end ? Math.min(Number(event.end.ms), Number(day.endMs)) : start + 1800000
-  return Math.max(Number(hourHeight) * 0.42, (end - start) / 3600000 * Number(hourHeight))
+  return Math.max(Number(hourHeight) * 0.42,
+    (dayMinutes(end, day) - dayMinutes(start, day)) / 60 * Number(hourHeight))
 }
 
 // Where "now" sits in a day column, or -1 when it does not belong on the grid:
@@ -691,11 +703,17 @@ function nowOffset(day, firstHour, lastHour, hourHeight, nowMs) {
   var now = Number(nowMs)
   if (!isFinite(now)) return -1
   if (now < Number(day.startMs) || now >= Number(day.endMs)) return -1
-  var minutes = (now - Number(day.startMs)) / 60000
+  var minutes = dayMinutes(now, day)
   var first = Number(firstHour) * 60
   var last = Number(lastHour) * 60
   if (minutes < first || minutes > last) return -1
   return (minutes - first) / 60 * Number(hourHeight)
+}
+
+function timeLabel(timeMs) {
+  var time = new Date(Number(timeMs))
+  if (!isFinite(time.getTime())) return ""
+  return two(time.getHours()) + ":" + two(time.getMinutes())
 }
 
 // The same offset for the week as a whole, so the time rail can label the line
@@ -759,8 +777,8 @@ function weekHourRange(events, days, defaultFirst, defaultLast) {
       var segmentStart = Math.max(startMs, Number(day.startMs))
       var segmentEnd = Math.min(endMs, Number(day.endMs))
       if (segmentEnd <= segmentStart) continue
-      var startMinutes = (segmentStart - Number(day.startMs)) / 60000
-      var endMinutes = (segmentEnd - Number(day.startMs)) / 60000
+      var startMinutes = dayMinutes(segmentStart, day)
+      var endMinutes = dayMinutes(segmentEnd, day)
       first = Math.min(first, Math.floor(startMinutes / 60))
       last = Math.max(last, Math.min(24, Math.ceil(endMinutes / 60)))
     }
@@ -773,5 +791,7 @@ function slotStart(day, y, firstHour, hourHeight, minuteStep) {
   var step = Math.max(1, Math.floor(Number(minuteStep) || 30))
   var minutes = Number(firstHour) * 60 + Math.max(0, Number(y)) / height * 60
   minutes = Math.floor(minutes / step) * step
-  return Number(day.startMs) + minutes * 60000
+  var localDay = new Date(Number(day.startMs))
+  return new Date(localDay.getFullYear(), localDay.getMonth(), localDay.getDate(),
+    Math.floor(minutes / 60), minutes % 60).getTime()
 }

--- a/calendar/CalendarController.qml
+++ b/calendar/CalendarController.qml
@@ -37,6 +37,8 @@ Item {
   property string sourceSecret: ""
   property var sourceBeingSaved: null
   property bool savingSource: false
+  property bool clockRunning: false
+  property double nowMs: Date.now()
   property bool refreshAfterSourceWrite: false
   property bool creatingEvent: false
   property var eventSource: null
@@ -61,6 +63,14 @@ Item {
     contextSources, service ? service.accountSummaries : [])
   // The composer offers only calendars a write can run against.
   readonly property var writableSourceGroups: Sources.writableGroups(sourceGroups)
+
+  Timer {
+    interval: 60000
+    repeat: true
+    running: root.clockRunning
+    triggeredOnStart: true
+    onTriggered: root.nowMs = Date.now()
+  }
 
   onAccountIdChanged: {
     if (!rangeStart || !rangeEnd || !eventCache.loaded) return

--- a/components/CalendarView.qml
+++ b/components/CalendarView.qml
@@ -36,6 +36,13 @@ Item {
   signal editRequested(string sourceId, var event)
   signal deleteRequested(string sourceId, var event)
 
+  Binding {
+    target: root.controller
+    property: "clockRunning"
+    value: root.visible && root.viewMode === "week"
+    when: root.controller !== null
+  }
+
   CalendarPalette {
     id: calendarPalette
     textColor: root.textColor
@@ -475,6 +482,7 @@ Item {
       height: parent.height - y
       visible: root.viewMode === "week"
       controller: root.controller
+      nowMs: root.controller ? root.controller.nowMs : 0
       days: root.weekDays
       textColor: root.textColor
       backgroundColor: root.backgroundColor

--- a/components/WeekCalendarView.qml
+++ b/components/WeekCalendarView.qml
@@ -8,6 +8,7 @@ Item {
 
   required property var controller
   required property var days
+  required property double nowMs
   required property color textColor
   required property color backgroundColor
   required property color accentColor
@@ -33,18 +34,6 @@ Item {
     controller ? controller.events : [], days)
   readonly property real allDayHeight: allDayCount > 0
     ? Style.space(6 + allDayCount * 20) : 0
-
-  // The line has to move on its own, so the view carries a clock. It ticks only
-  // while the week is on screen: a minute timer left running behind the month
-  // view, or behind the whole window, wakes the shell to redraw nothing.
-  property double nowMs: Date.now()
-  Timer {
-    interval: 60000
-    repeat: true
-    running: root.visible
-    triggeredOnStart: true
-    onTriggered: root.nowMs = Date.now()
-  }
 
   CalendarPalette {
     id: calendarPalette
@@ -240,8 +229,7 @@ Item {
         Text {
           id: nowLabel
           anchors.centerIn: parent
-          text: Calendar.two(new Date(root.nowMs).getHours()) + ":"
-            + Calendar.two(new Date(root.nowMs).getMinutes())
+          text: Calendar.timeLabel(root.nowMs)
           color: root.backgroundColor
           font.family: root.panelFontFamily
           font.pixelSize: Style.font.caption

--- a/components/WeekCalendarView.qml
+++ b/components/WeekCalendarView.qml
@@ -34,6 +34,18 @@ Item {
   readonly property real allDayHeight: allDayCount > 0
     ? Style.space(6 + allDayCount * 20) : 0
 
+  // The line has to move on its own, so the view carries a clock. It ticks only
+  // while the week is on screen: a minute timer left running behind the month
+  // view, or behind the whole window, wakes the shell to redraw nothing.
+  property double nowMs: Date.now()
+  Timer {
+    interval: 60000
+    repeat: true
+    running: root.visible
+    triggeredOnStart: true
+    onTriggered: root.nowMs = Date.now()
+  }
+
   CalendarPalette {
     id: calendarPalette
     textColor: root.textColor
@@ -211,6 +223,33 @@ Item {
         }
       }
 
+      // Read off the rail rather than off the line: the hour labels stop at the
+      // hour, so a line between two of them otherwise says only "somewhere in
+      // here". Hidden when today is not the week on screen.
+      Rectangle {
+        readonly property real offset: Calendar.weekNowOffset(
+          root.days, root.firstHour, root.lastHour, timeline.hourHeight, root.nowMs)
+        visible: offset >= 0
+        x: Style.space(4)
+        y: offset - height / 2
+        width: nowLabel.implicitWidth + Style.space(6)
+        height: nowLabel.implicitHeight + Style.space(2)
+        radius: Style.cornerRadius
+        color: root.urgentColor
+        z: 2
+        Text {
+          id: nowLabel
+          anchors.centerIn: parent
+          text: Calendar.two(new Date(root.nowMs).getHours()) + ":"
+            + Calendar.two(new Date(root.nowMs).getMinutes())
+          color: root.backgroundColor
+          font.family: root.panelFontFamily
+          font.pixelSize: Style.font.caption
+          font.bold: true
+          textFormat: Text.PlainText
+        }
+      }
+
       Row {
         anchors.left: parent.left
         anchors.leftMargin: root.timeRailWidth
@@ -297,6 +336,36 @@ Item {
                   cursorShape: Qt.PointingHandCursor
                   onClicked: root.eventActivated(eventBlock.modelData)
                 }
+              }
+            }
+
+            // After the events, so a meeting in progress is crossed by the line
+            // rather than covering it. The dot is what survives a theme whose
+            // urgent colour sits close to an event's border: a bare rule reads
+            // as one more hour separator, a rule with a bead on it does not.
+            Item {
+              readonly property real offset: Calendar.nowOffset(
+                dayColumn.modelData, root.firstHour, root.lastHour,
+                timeline.hourHeight, root.nowMs)
+              visible: offset >= 0
+              y: offset
+              width: parent.width
+              height: 0
+              z: 1
+              Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                height: Math.max(root.calendarBorderWidth, 2)
+                color: root.urgentColor
+              }
+              Rectangle {
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+                width: Style.space(7)
+                height: width
+                radius: width / 2
+                color: root.urgentColor
               }
             }
           }

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -99,6 +99,38 @@ assert.strictEqual(feed.weekNowOffset(splitWeek, 7, 19, 64, halfNine), -1,
   "another week on screen gets no line")
 assert.strictEqual(feed.weekNowOffset([], 7, 19, 64, halfNine), -1)
 
+// The grid names wall-clock hours, not elapsed hours since midnight. On a DST
+// transition those differ by one, so the marker must still sit beside the time
+// its label names.
+const previousTimezone = process.env.TZ
+process.env.TZ = "America/New_York"
+const springDay = feed.weekDays(new Date(2026, 2, 8, 12).getTime(), 0)[0]
+const springHalfThree = new Date(2026, 2, 8, 3, 30).getTime()
+assert.strictEqual(feed.nowOffset(springDay, 0, 24, 60, springHalfThree), 210,
+  "spring-forward now follows the wall-clock hour")
+assert.strictEqual(feed.timeLabel(springHalfThree), "03:30",
+  "the tested marker position and its label use the same local time")
+const springEvent = {
+  start: { ms: springHalfThree, allDay: false },
+  end: { ms: new Date(2026, 2, 8, 4, 30).getTime(), allDay: false }
+}
+assert.strictEqual(feed.eventTop(springEvent, springDay, 0, 60), 210,
+  "an event and now share the wall-clock grid")
+assert.strictEqual(feed.eventHeight(springEvent, springDay, 60), 60,
+  "event height follows the labeled wall-clock interval")
+assert.strictEqual(feed.slotStart(springDay, 210, 0, 60, 30), springHalfThree,
+  "clicking the 03:30 row creates an event at 03:30")
+const springRange = feed.weekHourRange([springEvent], [springDay], 7, 19)
+assert.strictEqual(springRange.first, 3,
+  "a DST-day event widens the labeled hours it occupies")
+assert.strictEqual(springRange.last, 19)
+const autumnDay = feed.weekDays(new Date(2026, 10, 1, 12).getTime(), 0)[0]
+assert.strictEqual(feed.nowOffset(autumnDay, 0, 24, 60,
+  new Date(2026, 10, 1, 3, 30).getTime()), 210,
+  "fall-back now follows the wall-clock hour")
+if (previousTimezone === undefined) delete process.env.TZ
+else process.env.TZ = previousTimezone
+
 const report = feed.caldavReport(
   Date.UTC(2026, 7, 1), Date.UTC(2026, 8, 1))
 assert.ok(report.indexOf('start="20260801T000000Z"') >= 0)

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -71,6 +71,34 @@ assert.strictEqual(feed.maxAllDayEvents(allDayEvents, week), 2)
 assert.strictEqual(feed.slotStart(week[1], 93, 7, 60, 30),
   new Date(2026, 7, 18, 8, 30).getTime(), "empty slots snap to half hours")
 
+// The now line. Same geometry as eventTop, so 9:30 on a 7:00 grid at 64px an
+// hour lands at 160 — but bounded at both ends and to the one day it belongs
+// to, because the alternative is a line claiming a time it is not at.
+const halfNine = new Date(2026, 7, 18, 9, 30).getTime()
+assert.strictEqual(feed.nowOffset(week[1], 7, 19, 64, halfNine), 160)
+assert.strictEqual(feed.nowOffset(week[2], 7, 19, 64, halfNine), -1,
+  "the line belongs to one column, not to the week")
+assert.strictEqual(feed.nowOffset(week[1], 7, 19, 64,
+  new Date(2026, 7, 18, 6, 0).getTime()), -1, "before the first drawn hour")
+assert.strictEqual(feed.nowOffset(week[1], 7, 19, 64,
+  new Date(2026, 7, 18, 21, 0).getTime()), -1, "after the last drawn hour")
+assert.strictEqual(feed.nowOffset(week[1], 7, 19, 64,
+  new Date(2026, 7, 18, 7, 0).getTime()), 0, "the first hour itself is on the grid")
+assert.strictEqual(feed.nowOffset(week[1], 7, 19, 64,
+  new Date(2026, 7, 18, 19, 0).getTime()), 768, "and so is the last")
+assert.strictEqual(feed.nowOffset(week[1], 7, 19, 64, NaN), -1)
+assert.strictEqual(feed.nowOffset(null, 7, 19, 64, halfNine), -1)
+
+// A day whose range weekHourRange widened to the whole day still places it.
+assert.strictEqual(feed.nowOffset(week[1], 0, 24, 64,
+  new Date(2026, 7, 18, 0, 30).getTime()), 32)
+
+assert.strictEqual(feed.weekNowOffset(week, 7, 19, 64, halfNine), 160,
+  "the rail finds today without being told which column it is")
+assert.strictEqual(feed.weekNowOffset(splitWeek, 7, 19, 64, halfNine), -1,
+  "another week on screen gets no line")
+assert.strictEqual(feed.weekNowOffset([], 7, 19, 64, halfNine), -1)
+
 const report = feed.caldavReport(
   Date.UTC(2026, 7, 1), Date.UTC(2026, 8, 1))
 assert.ok(report.indexOf('start="20260801T000000Z"') >= 0)


### PR DESCRIPTION
## Summary

- draw the current time across today in the visible week, with a bead on the day column and a matching label on the time rail
- keep the marker, events, elastic hour range, and click-to-create slots on the same local wall-clock geometry through daylight-saving transitions
- keep the minute clock in the calendar controller and run it only while the week view is visible
- keep placement and time formatting in calendar/Calendar.js so node tests exercise the decisions without a compositor

## Invariants

- no marker is drawn outside today, the visible week, or the drawn hour range
- the marker is declared after events so it crosses a meeting in progress
- inherited urgent and background colors carry the marker and label
- the timer uses triggeredOnStart and stops outside the visible week view

## Verification

- node tests/test_calendar_feed.js, including spring-forward and fall-back cases
- make test-js
- python3 tests/test_qml_names.py
- python3 tests/test_qml_text_format.py
- bash tests/test_source.sh
- git diff --check

The local qmllint installation could not start because its Homebrew Qt build references an unavailable ICU 74 library. The full shell suite also encountered the existing intermittent attachment runtime-directory harness failure.