### PR TITLE
Add a setting to always render heavy messages

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -1102,6 +1102,7 @@ Item {
           zoom: root.bodyZoom
           showBack: root.compact
           bodyMode: root.bodyMode
+          alwaysRenderHeavyMessages: !!root.service && root.service.alwaysRenderHeavyMessages
           onBodyModeRequested: function(mode) {
             if (root.service) root.service.setBodyMode(mode)
           }

--- a/Service.qml
+++ b/Service.qml
@@ -47,6 +47,7 @@ Item {
   readonly property var defaultSettingValues: ({
     refreshIntervalSec: 120,
     maxMessages: 25,
+    heavyMessageRendering: Html.HEAVY_MESSAGE_RENDERING_DEFAULT,
     defaultQuery: "in:inbox",
     notifyNewMail: "On",
     oauthPort: 9481,
@@ -55,6 +56,8 @@ Item {
   property var settings: defaultSettingValues
   readonly property int undoSendSeconds: Outbox.normalizeDelay(
     settings ? settings.undoSendSeconds : Outbox.DEFAULT_DELAY_SECONDS)
+  readonly property bool alwaysRenderHeavyMessages: Html.alwaysRenderHeavyMessages(
+    settings ? settings.heavyMessageRendering : null)
 
   // Thunderbird and Betterbird keep both explicit and learned addresses in
   // their local profile. The helper reads those databases without modifying
@@ -98,6 +101,10 @@ Item {
 
   function setUndoSendSeconds(value) {
     persistSetting("undoSendSeconds", Outbox.normalizeDelay(value))
+  }
+
+  function setAlwaysRenderHeavyMessages(value) {
+    persistSetting("heavyMessageRendering", Html.heavyMessageRendering(value))
   }
 
   // ---------------------------------------------------------- the accounts

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -29,6 +29,7 @@ Item {
   // because a message can be too heavy to draw the chosen way.
   property string bodyMode: "reader"
   property real zoom: 1.0
+  property bool alwaysRenderHeavyMessages: false
   // A way back only means something when something is behind it. At desktop
   // width the list is on screen and clicking another row is the navigation;
   // in a single column the reader has replaced the list, so it needs one.
@@ -84,7 +85,7 @@ Item {
     reader: !!root.readerDocument && !!root.service && !root.service.selectedReaderEmpty,
     readerHeavy: !!root.service && root.service.selectedReaderTooHeavy,
     originalHeavy: !!root.service && root.service.selectedTooHeavy,
-    forced: root.forceRichAnyway
+    forced: root.alwaysRenderHeavyMessages || root.forceRichAnyway
   })
   // The mode on screen, which is the chosen one unless this message cannot be
   // drawn that way.

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -105,6 +105,53 @@ Column {
     }
   }
 
+  Rectangle {
+    width: parent.width
+    implicitHeight: Math.max(heavyText.implicitHeight, heavySwitch.implicitHeight)
+      + Style.space(16)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+
+    Column {
+      id: heavyText
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(12)
+      anchors.right: heavySwitch.left
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(2)
+
+      Text {
+        width: parent.width
+        text: "Always render heavy messages"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+      }
+
+      Text {
+        width: parent.width
+        text: "Renders without falling back first; layout can stall the shell while it works"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+      }
+    }
+
+    ToggleSwitch {
+      id: heavySwitch
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      checked: !!root.service && root.service.alwaysRenderHeavyMessages
+      foreground: root.textColor
+      accent: root.accentColor
+      onToggled: if (root.service)
+        root.service.setAlwaysRenderHeavyMessages(!root.service.alwaysRenderHeavyMessages)
+    }
+  }
+
   // --------------------------------------------------------------- writing
 
   Text {

--- a/manifest.json
+++ b/manifest.json
@@ -37,6 +37,7 @@
     "defaults": {
       "refreshIntervalSec": 120,
       "maxMessages": 25,
+      "heavyMessageRendering": "Show plain text first",
       "defaultQuery": "in:inbox",
       "notifyNewMail": "On",
       "oauthPort": 9481,
@@ -62,6 +63,17 @@
         "max": 100,
         "step": 5,
         "defaultValue": 25
+      },
+      {
+        "key": "heavyMessageRendering",
+        "type": "enum",
+        "label": "Heavy message rendering",
+        "options": [
+          "Show plain text first",
+          "Always render"
+        ],
+        "defaultValue": "Show plain text first",
+        "description": "Choose whether potentially expensive rich text falls back to plain text with a Show anyway action."
       },
       {
         "key": "defaultQuery",

--- a/message/Html.js
+++ b/message/Html.js
@@ -2626,6 +2626,16 @@ function readerDocumentFor(source, colors) {
 // can rather than showing an empty panel. The order is reader, then the
 // sender's own formatting, then text.
 var BODY_MODES = { reader: true, original: true, plain: true }
+var HEAVY_MESSAGE_RENDERING_DEFAULT = "Show plain text first"
+var HEAVY_MESSAGE_RENDERING_ALWAYS = "Always render"
+
+function alwaysRenderHeavyMessages(value) {
+  return value === HEAVY_MESSAGE_RENDERING_ALWAYS
+}
+
+function heavyMessageRendering(always) {
+  return always === true ? HEAVY_MESSAGE_RENDERING_ALWAYS : HEAVY_MESSAGE_RENDERING_DEFAULT
+}
 
 // A stored preference, or anything else, read as one of the three. The fallback
 // is what a window written before this existed meant.

--- a/tests/qml/tst_reader_mode.qml
+++ b/tests/qml/tst_reader_mode.qml
@@ -123,6 +123,7 @@ Item {
     function init() {
       reader.bodyMode = "reader"
       reader.forceRichAnyway = false
+      reader.alwaysRenderHeavyMessages = false
       mailService.fetches = 0
       mailService.renders = 0
     }
@@ -268,6 +269,12 @@ Item {
       reader.forceRichAnyway = true
       compare(reader.shownMode, "reader")
       compare(reader.tooHeavy, false)
+      reader.forceRichAnyway = false
+      reader.alwaysRenderHeavyMessages = true
+      compare(reader.shownMode, "reader", "the persistent preference also skips the refusal")
+      compare(reader.tooHeavy, false)
+      reader.bodyMode = "original"
+      compare(reader.shownMode, "original", "the preference applies to the sender's document too")
       mailService.selectedReaderTooHeavy = false
       mailService.selectedTooHeavy = false
     }

--- a/tests/test_html.js
+++ b/tests/test_html.js
@@ -1519,6 +1519,12 @@ function activityMail() {
 // that cannot be drawn the chosen way falls through to one that can rather than
 // leaving an empty panel.
 {
+  assert.strictEqual(html.alwaysRenderHeavyMessages("Always render"), true)
+  assert.strictEqual(html.alwaysRenderHeavyMessages("Show plain text first"), false)
+  assert.strictEqual(html.alwaysRenderHeavyMessages("unknown"), false)
+  assert.strictEqual(html.heavyMessageRendering(true), "Always render")
+  assert.strictEqual(html.heavyMessageRendering(false), "Show plain text first")
+
   const full = { html: true, reader: true }
   assert.strictEqual(html.resolveBodyMode("reader", full), "reader")
   assert.strictEqual(html.resolveBodyMode("original", full), "original")

--- a/tests/test_service_source.sh
+++ b/tests/test_service_source.sh
@@ -13,6 +13,12 @@ grep -q '__sourceDir' Service.qml || fail "pluginDir must come from manifest.__s
 grep -q 'function applySettings' Service.qml || fail "the bar widget pushes settings in via applySettings"
 grep -q 'function setUndoSendSeconds' Service.qml \
   || fail "the in-app settings page must be able to change the undo window"
+grep -q 'function setAlwaysRenderHeavyMessages' Service.qml \
+  || fail "the in-app settings page must be able to change large-message rendering"
+grep -q 'alwaysRenderHeavyMessages' App.qml \
+  || fail "the reader must receive the persistent large-message preference"
+grep -q 'setAlwaysRenderHeavyMessages' components/SettingsPage.qml \
+  || fail "the in-app settings page must expose large-message rendering"
 grep -q 'shell.updateEntryInline(pluginId, entry)' Service.qml \
   || fail "the undo window must persist in shell settings"
 python3 - <<'PY'


### PR DESCRIPTION
Heavy rich text currently falls back to plain text to protect the shell's GUI thread, with a per-message **Show anyway** action. That remains the default behavior.

This adds a **Heavy message rendering** preference with two choices:

- **Show plain text first**
- **Always render**

The preference is available in both the plugin settings and Omamail's Reading settings. **Always render** bypasses the existing weight refusal for Reader and Original modes, while the existing per-message override remains unchanged.

The setting normalization lives in `Html.js` so its default and persisted values are covered by Node tests. The QML tests cover heavy Reader and Original documents with the preference enabled.

**Verification:** `make validate` passes, including Node, shell, offscreen QML, `qmllint`, manifest validation, and `git diff --check`.

## Screenshot

![Heavy message rendering setting](https://raw.githubusercontent.com/Tetraslam/omamail/pr-assets/assets/heavy-message-rendering-setting.png)


## Release Notes

- Choose whether heavy messages open as plain text first or always render
immediately.