### PR TITLE
Recover compose state and edit provider drafts in place

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -2,11 +2,13 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Window
 import Quickshell
+import Quickshell.Io
 import qs.Commons
 import qs.Ui
 
 import "account/Model.js" as Model
 import "account/Accounts.js" as Accounts
+import "compose/Recovery.js" as Recovery
 import "keys/Keymap.js" as Keymap
 import "message/Mailto.js" as Mailto
 import "message/Message.js" as Message
@@ -31,6 +33,114 @@ Item {
 
   readonly property string pluginId: manifest && manifest.id
     ? String(manifest.id) : "omamail"
+  readonly property string composeRecoveryPath: {
+    var config = Quickshell.env("XDG_CONFIG_HOME")
+      || (Quickshell.env("HOME") + "/.config")
+    return config + "/omamail/compose.json"
+  }
+  property var composeRecovery: Recovery.empty()
+  property bool composeRecoveryLoaded: false
+  property bool composeRecoveryRestoring: false
+  property bool composeSavePending: false
+  property string lastComposeRecoveryText: ""
+  property string composeWritePayload: ""
+  property bool composeWriteQueued: false
+
+  function loadComposeRecovery(raw) {
+    lastComposeRecoveryText = String(raw || "")
+    composeRecovery = Recovery.parse(raw)
+    composeRecoveryLoaded = true
+    Qt.callLater(root.restoreComposeRecovery)
+  }
+
+  function restoreComposeRecovery() {
+    if (!opened || !composeRecoveryLoaded || composeRecovery.active !== true
+        || compose.opened || !composeRecovery.draft) return false
+    var accountId = String(composeRecovery.draft.accountId || "")
+    if (accountId !== "" && service
+        && String(service.activeAccountId || "") !== accountId
+        && typeof service.switchTo === "function") service.switchTo(accountId)
+    composeReturnView = String(composeRecovery.returnView || "list")
+    composeRecoveryRestoring = true
+    compose.restoreDraft(composeRecovery.draft)
+    composeRecoveryRestoring = false
+    return true
+  }
+
+  function saveComposeRecovery(saved) {
+    composeRecoveryTimer.stop()
+    var draft = saved || (compose.opened ? compose.snapshotDraft()
+      : (compose.parkedForSend ? compose.pendingDraft : null))
+    var raw = Recovery.serialize(composeReturnView, draft)
+    if (raw === "") {
+      clearComposeRecovery()
+      return
+    }
+    composeRecovery = Recovery.parse(raw)
+    if (raw === lastComposeRecoveryText) return
+    lastComposeRecoveryText = raw
+    writeComposeRecovery(raw)
+  }
+
+  function scheduleComposeRecovery() {
+    if (composeRecoveryRestoring) return
+    composeRecoveryTimer.restart()
+  }
+
+  function clearComposeRecovery() {
+    composeRecoveryTimer.stop()
+    composeRecovery = Recovery.empty()
+    if (lastComposeRecoveryText === "") return
+    lastComposeRecoveryText = ""
+    writeComposeRecovery('{"version":1,"active":false}')
+  }
+
+  function writeComposeRecovery(raw) {
+    composeWritePayload = String(raw || "")
+    if (!service || String(service.pluginDir || "") === "") return
+    if (composeRecoveryWriter.running) {
+      composeWriteQueued = true
+      return
+    }
+    composeWriteQueued = false
+    composeRecoveryWriter.command = [String(service.pluginDir)
+      + "/scripts/config-store.sh", "compose.json"]
+    composeRecoveryWriter.running = true
+  }
+
+  FileView {
+    id: composeRecoveryFile
+    path: root.composeRecoveryPath
+    printErrors: false
+    onLoaded: root.loadComposeRecovery(text())
+    onLoadFailed: root.loadComposeRecovery("")
+  }
+
+  Timer {
+    id: composeRecoveryTimer
+    interval: 300
+    repeat: false
+    onTriggered: root.saveComposeRecovery()
+  }
+
+  Process {
+    id: composeRecoveryWriter
+    stdinEnabled: true
+    stdout: StdioCollector { waitForEnd: true }
+    stderr: StdioCollector { waitForEnd: true }
+    onStarted: {
+      write(root.composeWritePayload + "\n")
+      root.composeWritePayload = ""
+    }
+    onExited: {
+      if (root.composeWriteQueued) {
+        root.composeWriteQueued = false
+        Qt.callLater(function() {
+          root.writeComposeRecovery(root.composeWritePayload)
+        })
+      } else root.composeWritePayload = ""
+    }
+  }
 
   readonly property color foreground: Color.foreground
   readonly property color background: Color.background
@@ -178,6 +288,7 @@ Item {
     }
     var draft = Mailto.draftFromPayload(payload)
     if (draft) root.openDraft(draft)
+    Qt.callLater(root.restoreComposeRecovery)
     // The list is usually already loaded by the time the window is summoned —
     // the service keeps running while it is shut — so waiting for the next
     // change to seat the cursor leaves the first j with nowhere to move from.
@@ -187,6 +298,7 @@ Item {
 
   function close() {
     closingFromHost = true
+    if (compose.opened || compose.parkedForSend) saveComposeRecovery()
     opened = false
     if (service) service.windowOpen = false
     closingFromHost = false
@@ -205,15 +317,22 @@ Item {
     pendingDraftId = ""
     reader.forceRichAnyway = false
     cursorId = String(id || "")
-    if (service.mailboxKey === "drafts") {
-      composeReturnView = currentView
-      pendingDraftId = cursorId
-      service.select(cursorId)
-      Qt.callLater(root.resumeHeldDraft)
-      return
-    }
     service.select(cursorId)
     currentView = "reader"
+  }
+
+  function editDraft(id) {
+    if (!service || service.mailboxKey !== "drafts") return false
+    var draftId = String(id || "")
+    if (draftId === "") return false
+    composeReturnView = currentView
+    pendingComposeMode = ""
+    pendingDraftId = draftId
+    if (service.selectedId !== draftId || service.detailLoading
+        || !service.detailPainted || !service.selectedMessage) service.select(draftId)
+    resumeHeldDraft()
+    if (pendingDraftId !== "") Qt.callLater(root.resumeHeldDraft)
+    return true
   }
 
   function backToList() {
@@ -326,16 +445,23 @@ Item {
       compose.finish()
       return
     }
-    var saved = compose.detachForSave()
+    var saved = compose.snapshotDraft()
+    saveComposeRecovery(saved)
+    composeSavePending = true
+    compose.detachForSave()
     var fields = compose.fieldsForDraft(saved)
     service.saveDraft(fields, function(result, error) {
       if (!root) return
+      root.composeSavePending = false
       if (error) {
         compose.recoverDetachedSave(saved)
+        root.saveComposeRecovery(saved)
         service.fail("Could not save draft: " + String(error))
         return
       }
       compose.completeDetachedSave(saved)
+      if (compose.opened) root.scheduleComposeRecovery()
+      else root.clearComposeRecovery()
       root.draftSavedNotice = "Draft saved"
       draftSavedTimer.restart()
       if (service.mailboxKey === "drafts") service.refresh()
@@ -442,6 +568,7 @@ Item {
     if (id === "replyAll") return composeFromCursor("replyAll")
     if (id === "forward") return composeFromCursor("forward")
     if (id === "compose") {
+      if (service && service.mailboxKey === "drafts" && editDraft(cursorId)) return
       composeReturnView = currentView
       return startCompose("new")
     }
@@ -526,7 +653,11 @@ Item {
   Connections {
     target: root.service
     ignoreUnknownSignals: true
-    function onReplySent() { compose.completePendingSend() }
+    function onReplySent() {
+      if (!compose.completePendingSend()) return
+      if (compose.opened) root.scheduleComposeRecovery()
+      else root.clearComposeRecovery()
+    }
     // Every time the list is replaced — first arrival, a mailbox switch, a
     // search, a refresh that dropped things. A cursor whose message survived
     // keeps its place; one whose message is gone would be unfindable, and an
@@ -1211,9 +1342,16 @@ Item {
           popupBackgroundColor: root.popupBackground
           popupBorderColor: root.popupBorder
           panelFontFamily: root.fontFamily
-          onClosed: root.leaveCompose()
+          onClosed: {
+            if (!root.composeSavePending) root.clearComposeRecovery()
+            root.leaveCompose()
+          }
           onCloseRequested: root.saveAndLeaveCompose()
-          onSendQueued: root.backToList()
+          onSendQueued: {
+            root.saveComposeRecovery(compose.pendingDraft)
+            root.backToList()
+          }
+          onDraftChanged: root.scheduleComposeRecovery()
         }
 
         CalendarEventComposer {

--- a/App.qml
+++ b/App.qml
@@ -41,7 +41,8 @@ Item {
   property var composeRecovery: Recovery.empty()
   property bool composeRecoveryLoaded: false
   property bool composeRecoveryRestoring: false
-  property bool composeSavePending: false
+  property int composeRecoveryRevision: 0
+  property bool composeDetachingForSave: false
   property string lastComposeRecoveryText: ""
   property string composeWritePayload: ""
   property bool composeWriteQueued: false
@@ -74,12 +75,14 @@ Item {
     var raw = Recovery.serialize(composeReturnView, draft)
     if (raw === "") {
       clearComposeRecovery()
-      return
+      return composeRecoveryRevision
     }
     composeRecovery = Recovery.parse(raw)
-    if (raw === lastComposeRecoveryText) return
+    if (raw === lastComposeRecoveryText) return composeRecoveryRevision
+    composeRecoveryRevision++
     lastComposeRecoveryText = raw
     writeComposeRecovery(raw)
+    return composeRecoveryRevision
   }
 
   function scheduleComposeRecovery() {
@@ -87,12 +90,16 @@ Item {
     composeRecoveryTimer.restart()
   }
 
-  function clearComposeRecovery() {
+  function clearComposeRecovery(expectedRevision) {
+    if (expectedRevision !== undefined
+        && Number(expectedRevision) !== composeRecoveryRevision) return false
     composeRecoveryTimer.stop()
     composeRecovery = Recovery.empty()
-    if (lastComposeRecoveryText === "") return
+    composeRecoveryRevision++
+    if (lastComposeRecoveryText === "") return true
     lastComposeRecoveryText = ""
     writeComposeRecovery('{"version":1,"active":false}')
+    return true
   }
 
   function writeComposeRecovery(raw) {
@@ -446,23 +453,27 @@ Item {
       return
     }
     var saved = compose.snapshotDraft()
-    saveComposeRecovery(saved)
-    composeSavePending = true
+    var recoveryRevision = saveComposeRecovery(saved)
+    composeDetachingForSave = true
     compose.detachForSave()
+    composeDetachingForSave = false
     var fields = compose.fieldsForDraft(saved)
     service.saveDraft(fields, function(result, error) {
       if (!root) return
-      root.composeSavePending = false
       if (error) {
         compose.recoverDetachedSave(saved)
-        root.saveComposeRecovery(saved)
+        if (root.composeRecoveryRevision === recoveryRevision)
+          root.saveComposeRecovery(saved)
         service.fail("Could not save draft: " + String(error))
         return
       }
       compose.completeDetachedSave(saved)
       if (compose.opened) root.scheduleComposeRecovery()
-      else root.clearComposeRecovery()
-      root.draftSavedNotice = "Draft saved"
+      else root.clearComposeRecovery(recoveryRevision)
+      var warning = String(result && result.warning || "")
+      root.draftSavedNotice = warning === "" ? "Draft saved" : warning
+      if (warning !== "" && service && typeof service.note === "function")
+        service.note(warning)
       draftSavedTimer.restart()
       if (service.mailboxKey === "drafts") service.refresh()
     })
@@ -1343,7 +1354,7 @@ Item {
           popupBorderColor: root.popupBorder
           panelFontFamily: root.fontFamily
           onClosed: {
-            if (!root.composeSavePending) root.clearComposeRecovery()
+            if (!root.composeDetachingForSave) root.clearComposeRecovery()
             root.leaveCompose()
           }
           onCloseRequested: root.saveAndLeaveCompose()

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ test: test-js test-shell test-qml
 # The parsing, formatting, and decision rules live in plain JS precisely so
 # they can be tested without a compositor. These run anywhere node does.
 test-js:
+	node tests/test_compose_recovery.js
 	node tests/test_outbox.js
 	node tests/test_recipients.js
 	node tests/test_senders.js

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1724,6 +1724,7 @@ Item {
       inReplyTo: values.inReplyTo,
       references: values.references
     })
+    payload.draftId = String(values.draftId || "")
     return api.saveDraft(payload, function(saved, error) {
       if (typeof callback === "function") callback(saved, error)
     })

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -43,6 +43,8 @@ DropArea {
   // A failed provider save stays reachable after Back or Escape.
   property var recoveryDrafts: []
   property string accountId: ""
+  // The provider message that this form replaces when it is saved.
+  property string sourceDraftId: ""
   property int restoreRevision: 0
   property real restoreFlashOpacity: 0
   property string mode: "new"
@@ -65,6 +67,20 @@ DropArea {
   property var attachJobs: []
   property bool attaching: false
   property bool pasteInFlight: false
+
+  function noteDraftChanged() {
+    if (opened) draftChanged()
+  }
+
+  onAccountIdChanged: noteDraftChanged()
+  onModeChanged: noteDraftChanged()
+  onThreadIdChanged: noteDraftChanged()
+  onInReplyToChanged: noteDraftChanged()
+  onCcVisibleChanged: noteDraftChanged()
+  onBccVisibleChanged: noteDraftChanged()
+  onFromEmailChanged: noteDraftChanged()
+  onDraftAttachmentsChanged: noteDraftChanged()
+  onForwardedAttachmentsChanged: noteDraftChanged()
 
   readonly property string attachScript: service && service.pluginDir
     ? service.pluginDir + "/scripts/attachment.sh" : ""
@@ -116,6 +132,7 @@ DropArea {
     subjectField.text = ""
     bodyEdit.text = ""
     accountId = ""
+    sourceDraftId = ""
     mode = "new"
     threadId = ""
     inReplyTo = ""
@@ -147,6 +164,7 @@ DropArea {
       subject: subjectField.text,
       body: bodyEdit.text,
       accountId: accountId,
+      sourceDraftId: sourceDraftId,
       mode: mode,
       threadId: threadId,
       inReplyTo: inReplyTo,
@@ -165,6 +183,7 @@ DropArea {
     var saved = draft || ({})
     mode = String(saved.mode || "new")
     accountId = String(saved.accountId || "")
+    sourceDraftId = String(saved.sourceDraftId || "")
     threadId = String(saved.threadId || "")
     inReplyTo = String(saved.inReplyTo || "")
     ccVisible = saved.ccVisible === true
@@ -185,6 +204,24 @@ DropArea {
     subjectField.text = String(saved.subject || "")
     bodyEdit.text = String(saved.body || "")
     opened = true
+    rehydrateDraftAttachments()
+  }
+
+  function rehydrateDraftAttachments() {
+    var listed = draftAttachments.slice()
+    var kept = []
+    var recover = []
+    for (var i = 0; i < listed.length; i++) {
+      var file = listed[i] || ({})
+      if (String(file.path || "") !== "" && String(file.data || "") === "")
+        recover.push(file)
+      else kept.push(file)
+    }
+    if (recover.length === 0) return
+    draftAttachments = kept
+    for (var r = 0; r < recover.length; r++)
+      enqueueAttach(recover[r].owned === true ? "recover-owned" : "recover",
+        String(recover[r].path || ""))
   }
 
   function reset() {
@@ -366,6 +403,7 @@ DropArea {
     begin("new", null, "", [])
     var values = draft || ({})
     mode = String(values.mode || "new") === "draft" ? "draft" : "new"
+    sourceDraftId = String(messageId || values.sourceDraftId || "")
     threadId = String(values.threadId || "")
     inReplyTo = String(values.inReplyTo || "")
     toField.text = String(values.to || "")
@@ -403,6 +441,7 @@ DropArea {
   signal closed()
   signal closeRequested()
   signal sendQueued()
+  signal draftChanged()
 
   function finish() {
     clearCurrentDraft(true)
@@ -445,6 +484,7 @@ DropArea {
     for (i = 0; i < owned.length; i++) attachments.push(owned[i])
     return ({
       accountId: String(draft.accountId || ""),
+      draftId: String(draft.sourceDraftId || ""),
       from: String(draft.fromEmail || ""),
       to: String(draft.to || ""),
       cc: String(draft.cc || ""),
@@ -674,7 +714,7 @@ DropArea {
       size: Math.max(0, Math.floor(Number(result.size) || 0)),
       data: String(result.data || ""),
       path: String(result.path || ""),
-      owned: mode === "clipboard"
+      owned: mode === "clipboard" || mode === "recover-owned"
     })
     var next = root.draftAttachments.slice()
     next.push(entry)
@@ -924,7 +964,10 @@ DropArea {
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.bodySmall
         placeholderText: "recipient@example.com"
-        onTextChanged: root.updateRecipientSuggestions()
+        onTextChanged: {
+          root.updateRecipientSuggestions()
+          root.noteDraftChanged()
+        }
         onActiveFocusChanged: root.updateRecipientSuggestions()
         Keys.priority: Keys.BeforeItem
         Keys.onPressed: function(event) {
@@ -1004,7 +1047,10 @@ DropArea {
         accent: root.accentColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.bodySmall
-        onTextChanged: root.updateRecipientSuggestions()
+        onTextChanged: {
+          root.updateRecipientSuggestions()
+          root.noteDraftChanged()
+        }
         onActiveFocusChanged: root.updateRecipientSuggestions()
         Keys.priority: Keys.BeforeItem
         Keys.onPressed: function(event) {
@@ -1079,7 +1125,10 @@ DropArea {
         accent: root.accentColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.bodySmall
-        onTextChanged: root.updateRecipientSuggestions()
+        onTextChanged: {
+          root.updateRecipientSuggestions()
+          root.noteDraftChanged()
+        }
         onActiveFocusChanged: root.updateRecipientSuggestions()
         Keys.priority: Keys.BeforeItem
         Keys.onPressed: function(event) {
@@ -1159,6 +1208,7 @@ DropArea {
         font.pixelSize: Style.font.bodySmall
         placeholderText: "Subject"
         KeyNavigation.tab: bodyEdit
+        onTextChanged: root.noteDraftChanged()
         onAccepted: bodyEdit.forceActiveFocus()
         Keys.priority: Keys.BeforeItem
         Keys.onPressed: root.pasteKey(event)
@@ -1376,6 +1426,7 @@ DropArea {
       selectedTextColor: root.textColor
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.bodySmall
+      onTextChanged: root.noteDraftChanged()
       Keys.priority: Keys.BeforeItem
       Keys.onPressed: root.pasteKey(event)
     }

--- a/compose/Recovery.js
+++ b/compose/Recovery.js
@@ -1,0 +1,107 @@
+.pragma library
+
+var VERSION = 1
+
+function empty() {
+  return { active: false, returnView: "", draft: null }
+}
+
+function text(value) {
+  return String(value || "")
+}
+
+function person(value) {
+  var row = value && typeof value === "object" ? value : ({})
+  return { email: text(row.email), display: text(row.display) }
+}
+
+function people(value) {
+  var rows = Array.isArray(value) ? value : []
+  var out = []
+  for (var i = 0; i < rows.length; i++) out.push(person(rows[i]))
+  return out
+}
+
+function attachment(value) {
+  var row = value && typeof value === "object" ? value : ({})
+  var path = text(row.path)
+  return {
+    filename: text(row.filename),
+    mimeType: text(row.mimeType),
+    size: Math.max(0, Math.floor(Number(row.size) || 0)),
+    data: path === "" ? text(row.data) : "",
+    path: path,
+    owned: row.owned === true,
+    attachmentId: text(row.attachmentId),
+    partId: text(row.partId)
+  }
+}
+
+function attachments(value) {
+  var rows = Array.isArray(value) ? value : []
+  var out = []
+  for (var i = 0; i < rows.length; i++) out.push(attachment(rows[i]))
+  return out
+}
+
+function draft(value) {
+  var row = value && typeof value === "object" ? value : ({})
+  return {
+    to: text(row.to),
+    cc: text(row.cc),
+    bcc: text(row.bcc),
+    subject: text(row.subject),
+    body: text(row.body),
+    accountId: text(row.accountId),
+    sourceDraftId: text(row.sourceDraftId),
+    mode: text(row.mode) || "new",
+    threadId: text(row.threadId),
+    inReplyTo: text(row.inReplyTo),
+    ccVisible: row.ccVisible === true,
+    bccVisible: row.bccVisible === true,
+    fromEmail: text(row.fromEmail),
+    replyRecipients: people(row.replyRecipients),
+    fromWasChosen: row.fromWasChosen === true,
+    originalAttachments: attachments(row.originalAttachments),
+    forwardedAttachments: attachments(row.forwardedAttachments),
+    draftAttachments: attachments(row.draftAttachments)
+  }
+}
+
+function hasMeaningfulDraft(value) {
+  var row = value && typeof value === "object" ? value : ({})
+  if (text(row.to).trim() !== "") return true
+  if (text(row.cc).trim() !== "") return true
+  if (text(row.bcc).trim() !== "") return true
+  if (text(row.subject).trim() !== "") return true
+  if (text(row.body).trim() !== "") return true
+  if (Array.isArray(row.forwardedAttachments) && row.forwardedAttachments.length > 0)
+    return true
+  return Array.isArray(row.draftAttachments) && row.draftAttachments.length > 0
+}
+
+function returnView(value) {
+  var view = text(value)
+  return view === "reader" || view === "calendar" ? view : "list"
+}
+
+function parse(raw) {
+  var value
+  try { value = JSON.parse(text(raw)) } catch (error) { return empty() }
+  if (!value || typeof value !== "object" || value.version !== VERSION
+      || value.active !== true) return empty()
+  var saved = draft(value.draft)
+  if (!hasMeaningfulDraft(saved)) return empty()
+  return { active: true, returnView: returnView(value.returnView), draft: saved }
+}
+
+function serialize(view, value) {
+  var saved = draft(value)
+  if (!hasMeaningfulDraft(saved)) return ""
+  return JSON.stringify({
+    version: VERSION,
+    active: true,
+    returnView: returnView(view),
+    draft: saved
+  }) + "\n"
+}

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -97,7 +97,7 @@ used to exist, and they had.
 | `reply` | `r` | mail | Reply |
 | `replyAll` | `a` | mail | Reply to all |
 | `forward` | `f` | mail | Forward |
-| `compose` | `c` | mail | Compose |
+| `compose` | `c` | mail | Compose or edit a draft |
 | `createEvent` | `c` | calendar | Create an event |
 | `calendarNext` | `j`, `Down` | calendar | Select the next event |
 | `calendarPrevious` | `k`, `Up` | calendar | Select the previous event |
@@ -128,6 +128,8 @@ used to exist, and they had.
 
 The bare `/` stays in the mailbox because fields need it as text. `Ctrl+K`
 opens the complete key sheet from every context.
+
+In Drafts, `Enter` and `o` preview the selected draft. Press `c` to edit it. In every other mailbox, `c` starts a new message.
 
 The delayed-send toast does not create a keyboard context. The current screen keeps its normal keys while the toast is visible. A new draft, reply, or forward can open during the delay. The send button waits for the queued message, but every draft field remains editable. The toast button restores the queued message. `Alt+Z` does the same from every context. `Ctrl+Z` remains text undo while composing or searching. If another compose is open, Omamail saves it to the provider's Drafts storage before dropping its in-memory fallback. A failed save keeps that fallback. Back and `Escape` save a non-empty composition before leaving it. The explicit Discard button remains the destructive exit.
 

--- a/keys/Keymap.js
+++ b/keys/Keymap.js
@@ -66,7 +66,7 @@ var BINDINGS = [
   { id: "forward", keys: ["f"], contexts: MAIL,
     group: "Writing", label: "Forward" },
   { id: "compose", keys: ["c"], contexts: MAIL,
-    group: "Writing", label: "Compose", hint: { list: "compose" } },
+    group: "Writing", label: "Compose or edit a draft", hint: { list: "compose" } },
   { id: "createEvent", keys: ["c"], contexts: ["calendar"],
     group: "Writing", label: "Create an event", hint: { calendar: "create" } },
   { id: "calendarNext", keys: ["j", "Down"], contexts: ["calendar"],

--- a/providers/GmailApi.js
+++ b/providers/GmailApi.js
@@ -121,6 +121,21 @@ function sendPath() { return "/users/me/messages/send" }
 function draftsPath() { return "/users/me/drafts" }
 function draftPath(id) { return "/users/me/drafts/" + encode(id) }
 
+function draftListQuery(pageToken) {
+  return { maxResults: 500, pageToken: String(pageToken || "") }
+}
+
+function draftIdForMessage(payload, messageId) {
+  var wanted = String(messageId || "")
+  var rows = arrayValues(payload && payload.drafts)
+  for (var i = 0; i < rows.length; i++) {
+    var row = rows[i] || {}
+    if (row.message && String(row.message.id || "") === wanted)
+      return String(row.id || "")
+  }
+  return ""
+}
+
 function sendBody(payload) {
   var source = payload || {}
   var body = { raw: String(source.raw || "") }

--- a/providers/GmailApiClient.qml
+++ b/providers/GmailApiClient.qml
@@ -354,9 +354,46 @@ Item {
   }
 
   function saveDraft(payload, callback) {
+    var messageId = payload ? String(payload.draftId || "") : ""
+    if (messageId !== "") return updateDraft(messageId, payload, callback)
     return request("POST", Api.draftsPath(), null, Api.draftBody(payload),
       function(status, body, error) {
         if (typeof callback === "function") callback(body, error)
       })
+  }
+
+  // The message list names Gmail's message id. The update endpoint names its
+  // enclosing draft resource, so resolve that immutable id before replacing it.
+  function updateDraft(messageId, payload, callback) {
+    var handle = newHandle()
+
+    function find(pageToken) {
+      root.request("GET", Api.draftsPath(), Api.draftListQuery(pageToken), null,
+        function(status, body, error) {
+          if (handle.aborted) return
+          if (error) {
+            if (typeof callback === "function") callback(null, error)
+            return
+          }
+          var draftId = Api.draftIdForMessage(body, messageId)
+          if (draftId !== "") {
+            root.request("PUT", Api.draftPath(draftId), null, Api.draftBody(payload),
+              function(updateStatus, saved, updateError) {
+                if (typeof callback === "function") callback(saved, updateError)
+              }, false, handle)
+            return
+          }
+          var next = String(body && body.nextPageToken || "")
+          if (next !== "") {
+            find(next)
+            return
+          }
+          if (typeof callback === "function")
+            callback(null, "That draft is no longer in the mailbox")
+        }, false, handle)
+    }
+
+    find("")
+    return handle
   }
 }

--- a/providers/HeyCli.js
+++ b/providers/HeyCli.js
@@ -366,7 +366,7 @@ function draftEditCommand(id, fields) {
     "--bcc", String(values.bcc || ""),
     "--subject", String(values.subject || ""),
     "--message", String(values.body || "")
-  ]
+  ].concat(attachArgs(values.attachments))
 }
 
 function attachArgs(files) {

--- a/providers/HeyCli.js
+++ b/providers/HeyCli.js
@@ -355,6 +355,20 @@ function draftCommand(fields) {
   return command.concat(attachArgs(values.attachments))
 }
 
+function draftEditCommand(id, fields) {
+  var draft = draftIdOf(id)
+  if (draft === "") return []
+  var values = fields || {}
+  return [
+    "draft", "edit", draft,
+    "--to", String(values.to || ""),
+    "--cc", String(values.cc || ""),
+    "--bcc", String(values.bcc || ""),
+    "--subject", String(values.subject || ""),
+    "--message", String(values.body || "")
+  ]
+}
+
 function attachArgs(files) {
   var list = Array.isArray(files) ? files : []
   var out = []

--- a/providers/HeyClient.qml
+++ b/providers/HeyClient.qml
@@ -623,15 +623,19 @@ Item {
     if (threadId === "" && payload && payload.threadId)
       threadId = String(payload.threadId)
 
-    var command = Cli.draftCommand({
+    var fields = {
       threadId: threadId,
       to: Mail.headerFrom(parsed.headers, "To"),
       cc: Mail.headerFrom(parsed.headers, "Cc"),
       bcc: Mail.headerFrom(parsed.headers, "Bcc"),
       subject: Mail.decodeHeaderValue(Mail.headerFrom(parsed.headers, "Subject")),
+      body: body,
       attachments: files
-    })
-    run(command, body, function(text, error) {
+    }
+    var draftId = payload ? String(payload.draftId || "") : ""
+    var command = draftId === ""
+      ? Cli.draftCommand(fields) : Cli.draftEditCommand(draftId, fields)
+    run(command, draftId === "" ? body : "", function(text, error) {
       if (handle.aborted) return
       var answer = error ? null : Cli.payload(text)
       if (typeof callback === "function") callback(error ? null : (answer ? answer.data : {}), error)

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -748,7 +748,20 @@ Item {
             callback(null, Imap.responseError(status, detail, "The draft could not be saved"))
             return
           }
-          callback({}, "")
+          var sourceId = payload ? String(payload.draftId || "") : ""
+          if (sourceId === "") {
+            callback({}, "")
+            return
+          }
+          var commands = Imap.draftReplacementCommands(sourceId, folder)
+          if (commands.length === 0) {
+            callback(null, "That draft is no longer in the mailbox")
+            return
+          }
+          root.run(folder, commands, function(text, replaceError) {
+            if (handle.aborted || typeof callback !== "function") return
+            callback(replaceError ? null : {}, replaceError)
+          }, handle)
         })
         process.running = true
       })

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -753,14 +753,14 @@ Item {
             callback({}, "")
             return
           }
-          var commands = Imap.draftReplacementCommands(sourceId, folder)
-          if (commands.length === 0) {
-            callback(null, "That draft is no longer in the mailbox")
+          var replacement = Imap.draftReplacementPlan(sourceId, folder)
+          if (replacement.commands.length === 0) {
+            callback({ saved: true, warning: replacement.warning }, "")
             return
           }
-          root.run(folder, commands, function(text, replaceError) {
+          root.run(folder, replacement.commands, function(text, replaceError) {
             if (handle.aborted || typeof callback !== "function") return
-            callback(replaceError ? null : {}, replaceError)
+            callback(Imap.draftSaveResult(replaceError), "")
           }, handle)
         })
         process.running = true

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -548,6 +548,15 @@ function expungeCommand(uids) {
   return set === "" ? "" : "UID EXPUNGE " + set
 }
 
+function draftReplacementCommands(id, draftsFolder) {
+  var parsed = parseMessageId(id)
+  if (parsed.uid < 1 || parsed.folder !== String(draftsFolder || "")) return []
+  return [
+    "UID STORE " + parsed.uid + " +FLAGS.SILENT (\\Deleted)",
+    expungeCommand([parsed.uid])
+  ]
+}
+
 function statusCommand(folder) {
   return "STATUS " + quote(folder) + " (MESSAGES UNSEEN)"
 }

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -557,6 +557,24 @@ function draftReplacementCommands(id, draftsFolder) {
   ]
 }
 
+function draftReplacementPlan(id, draftsFolder) {
+  var commands = draftReplacementCommands(id, draftsFolder)
+  return {
+    commands: commands,
+    warning: commands.length > 0 ? ""
+      : "The updated draft was saved, but the old copy could not be identified"
+  }
+}
+
+function draftSaveResult(replaceError) {
+  var detail = trimmed(replaceError)
+  return {
+    saved: true,
+    warning: detail === "" ? ""
+      : "The updated draft was saved, but the old copy could not be removed: " + detail
+  }
+}
+
 function statusCommand(folder) {
   return "STATUS " + quote(folder) + " (MESSAGES UNSEEN)"
 }

--- a/scripts/config-store.sh
+++ b/scripts/config-store.sh
@@ -2,10 +2,11 @@
 # Writes one line from stdin to $XDG_CONFIG_HOME/omamail/<name> with
 # owner-only permissions.
 #
-# Neither file it writes is world-readable: a desktop client's secret is only
+# No file it writes is world-readable: a desktop client's secret is only
 # "not treated as confidential" by Google, which is not the same as public, and
-# the account list names every mailbox on this machine. Plugin settings would
-# have been the obvious home for both, but shell.json is world-readable.
+# the account list names every mailbox on this machine. Compose recovery also
+# contains message text. Plugin settings would have been the obvious home for
+# these files, but shell.json is world-readable.
 #
 # One line, read with `read` rather than `cat`: Quickshell's Process.write()
 # never closes stdin, so anything waiting for EOF hangs forever.
@@ -13,9 +14,9 @@ set -eu
 
 name=${1:-}
 case "$name" in
-  credentials.json|accounts.json|window.json|calendars.json) ;;
+  credentials.json|accounts.json|window.json|calendars.json|compose.json) ;;
   *)
-    printf '%s\n' 'usage: config-store.sh credentials.json|accounts.json|window.json|calendars.json' >&2
+    printf '%s\n' 'usage: config-store.sh credentials.json|accounts.json|window.json|calendars.json|compose.json' >&2
     exit 2
     ;;
 esac

--- a/tests/qml/imports/Quickshell/Io/Process.qml
+++ b/tests/qml/imports/Quickshell/Io/Process.qml
@@ -5,7 +5,11 @@ Item {
   property bool running: false
   property bool stdinEnabled: false
   property string jobMode: ""
+  property string written: ""
   property var stdout: StdioCollector {}
   property var stderr: StdioCollector {}
+  signal started()
   signal exited(int exitCode)
+
+  function write(value) { written += String(value || "") }
 }

--- a/tests/qml/tst_app_compose_pending.qml
+++ b/tests/qml/tst_app_compose_pending.qml
@@ -63,6 +63,8 @@ Item {
     property var lastSavedDraft: null
     property string lastLoadedAttachmentId: ""
     property bool failDraftSave: false
+    property bool deferDraftSave: false
+    property var draftSaveCallbacks: []
     property var selectedBody: ({ text: "Original body" })
     property var selectedMessage: ({
       id: "message-1",
@@ -113,8 +115,21 @@ Item {
     }
     function saveDraft(fields, callback) {
       lastSavedDraft = fields
+      if (deferDraftSave) {
+        var queued = draftSaveCallbacks.slice()
+        queued.push(callback)
+        draftSaveCallbacks = queued
+        return
+      }
       callback(failDraftSave ? null : "draft-1",
         failDraftSave ? "server refused it" : "")
+    }
+    function finishDraftSave(index, error) {
+      var queued = draftSaveCallbacks.slice()
+      var callback = queued[index]
+      queued.splice(index, 1)
+      draftSaveCallbacks = queued
+      callback(error ? null : "draft-1", String(error || ""))
     }
     function refresh() {}
     function fail(text) { lastError = String(text || "") }
@@ -150,13 +165,14 @@ Item {
 
     function init() {
       app.opened = false
-      app.composeSavePending = false
       app.loadComposeRecovery("")
       app.clearComposeRecovery()
       mailService.sendPending = false
       mailService.sending = false
       mailService.lastSavedDraft = null
       mailService.failDraftSave = false
+      mailService.deferDraftSave = false
+      mailService.draftSaveCallbacks = []
       mailService.lastError = ""
       mailService.actionStatus = ""
       mailService.lastLoadedAttachmentId = ""
@@ -282,6 +298,50 @@ Item {
       compare(mailService.lastSavedDraft.body, "First draft")
       compare(app.composing, false)
       compare(app.draftSavedNotice, "Draft saved")
+    }
+
+    function test_an_older_save_cannot_clear_a_newer_drafts_recovery() {
+      var compose = composeView()
+      mailService.deferDraftSave = true
+
+      app.startCompose("new")
+      named(compose, "compose-body-editor").text = "First draft"
+      app.goBack()
+
+      app.startCompose("new")
+      named(compose, "compose-body-editor").text = "Second draft"
+      app.goBack()
+      compare(mailService.draftSaveCallbacks.length, 2)
+      compare(app.composeRecovery.draft.body, "Second draft")
+
+      mailService.finishDraftSave(0, "")
+
+      compare(app.composeRecovery.active, true)
+      compare(app.composeRecovery.draft.body, "Second draft",
+        "the first request must not clear the newer recovery snapshot")
+    }
+
+    function test_failed_older_save_waits_behind_newer_recovery() {
+      var compose = composeView()
+      mailService.deferDraftSave = true
+
+      app.startCompose("new")
+      named(compose, "compose-body-editor").text = "First draft"
+      app.goBack()
+      app.startCompose("new")
+      named(compose, "compose-body-editor").text = "Second draft"
+      app.goBack()
+
+      mailService.finishDraftSave(0, "server refused it")
+      compare(app.composeRecovery.draft.body, "Second draft",
+        "the newer in-flight draft keeps the durable recovery slot")
+      compare(named(compose, "compose-body-editor").text, "First draft",
+        "the older failed draft remains available in memory")
+
+      mailService.finishDraftSave(0, "")
+      wait(350)
+      compare(app.composeRecovery.draft.body, "First draft",
+        "once the newer draft is durable, recovery follows the older failed draft")
     }
 
     function test_open_previews_a_draft_and_compose_edits_it() {

--- a/tests/qml/tst_app_compose_pending.qml
+++ b/tests/qml/tst_app_compose_pending.qml
@@ -37,6 +37,7 @@ Item {
     property real bodyZoom: 1
     property string bodyMode: "reader"
     property string providerId: "gmail"
+    property string pluginDir: ""
     property string accountEmail: "me@example.com"
     property string activeAccountId: "me@example.com"
     property string mailboxKey: "inbox"
@@ -115,6 +116,7 @@ Item {
       callback(failDraftSave ? null : "draft-1",
         failDraftSave ? "server refused it" : "")
     }
+    function refresh() {}
     function fail(text) { lastError = String(text || "") }
     function note(text) { actionStatus = String(text || "") }
     signal replySent()
@@ -147,6 +149,10 @@ Item {
     }
 
     function init() {
+      app.opened = false
+      app.composeSavePending = false
+      app.loadComposeRecovery("")
+      app.clearComposeRecovery()
       mailService.sendPending = false
       mailService.sending = false
       mailService.lastSavedDraft = null
@@ -179,6 +185,29 @@ Item {
         compose.reset()
         compose.opened = false
       }
+    }
+
+    function test_shell_close_flushes_and_restores_the_current_draft() {
+      var compose = composeView()
+      app.open("{}")
+      app.startCompose("new")
+      named(compose, "compose-subject-field").text = "Quarterly plan"
+      named(compose, "compose-body-editor").text = "Keep every word"
+
+      app.close()
+
+      compare(app.composeRecovery.active, true)
+      compare(app.composeRecovery.draft.subject, "Quarterly plan")
+      compare(app.composeRecovery.draft.body, "Keep every word")
+
+      compose.reset()
+      compose.opened = false
+      app.open("{}")
+      wait(20)
+
+      compare(compose.opened, true)
+      compare(named(compose, "compose-subject-field").text, "Quarterly plan")
+      compare(named(compose, "compose-body-editor").text, "Keep every word")
     }
 
     function test_reply_starts_while_another_send_is_pending() {
@@ -255,7 +284,7 @@ Item {
       compare(app.draftSavedNotice, "Draft saved")
     }
 
-    function test_opening_a_draft_row_waits_for_the_body_then_opens_compose() {
+    function test_open_previews_a_draft_and_compose_edits_it() {
       var compose = composeView()
       mailService.mailboxKey = "drafts"
       app.cursorId = "draft-7"
@@ -263,8 +292,8 @@ Item {
       app.runShortcut("open", "o")
 
       compare(mailService.selectedId, "draft-7")
-      compare(app.currentView, "list",
-        "a draft must not open the message reader while its body loads")
+      compare(app.currentView, "reader",
+        "a draft opens in the same reader as every other message")
       compare(app.composing, false)
 
       mailService.selectedMessage = ({
@@ -290,6 +319,12 @@ Item {
       mailService.detailLoading = false
       wait(30)
 
+      compare(app.composing, false,
+        "loading the draft body must not turn the preview into an editor")
+
+      app.runShortcut("compose", "c")
+      wait(30)
+
       compare(app.composing, true)
       compare(compose.mode, "draft")
       compare(compose.fromEmail, "me@example.com")
@@ -304,6 +339,14 @@ Item {
       compare(mailService.lastLoadedAttachmentId, "draft-7")
       compare(compose.draftAttachments.length, 1)
       compare(compose.draftAttachments[0].filename, "plan.txt")
+
+      named(compose, "compose-subject-field").text = "Updated subject"
+      app.goBack()
+
+      verify(mailService.lastSavedDraft)
+      compare(mailService.lastSavedDraft.draftId, "draft-7",
+        "closing an edited draft must update the source draft")
+      compare(mailService.lastSavedDraft.subject, "Updated subject")
     }
   }
 }

--- a/tests/test_compose_recovery.js
+++ b/tests/test_compose_recovery.js
@@ -1,0 +1,56 @@
+const assert = require("assert")
+const { load, deepEqual } = require("./load")
+
+const recovery = load("compose/Recovery.js")
+
+const draft = {
+  accountId: "me@example.com",
+  sourceDraftId: "draft-7",
+  mode: "reply",
+  threadId: "thread-7",
+  inReplyTo: "<message-7@example.com>",
+  fromEmail: "alias@example.com",
+  to: "jane@example.com",
+  cc: "copy@example.com",
+  bcc: "",
+  subject: "Quarterly plan",
+  body: "First draft",
+  ccVisible: true,
+  bccVisible: false,
+  fromWasChosen: true,
+  replyRecipients: [{ email: "jane@example.com" }],
+  originalAttachments: [],
+  forwardedAttachments: [],
+  draftAttachments: [{
+    filename: "plan.txt", mimeType: "text/plain", size: 10,
+    path: "/tmp/plan.txt", owned: true
+  }]
+}
+
+deepEqual(recovery.parse(""), recovery.empty())
+deepEqual(recovery.parse("not json"), recovery.empty())
+deepEqual(recovery.parse('{"version":2,"active":true}'), recovery.empty())
+deepEqual(recovery.parse('{"version":1,"active":false}'), recovery.empty())
+
+const encoded = recovery.serialize("reader", draft)
+const parsed = recovery.parse(encoded)
+assert.strictEqual(parsed.active, true)
+assert.strictEqual(parsed.returnView, "reader")
+assert.strictEqual(parsed.draft.sourceDraftId, "draft-7")
+deepEqual(parsed.draft, recovery.draft(draft))
+assert.strictEqual(parsed.draft.draftAttachments[0].data, "",
+  "a file path is durable, so autosave does not rewrite its base64 on every key")
+
+assert.strictEqual(recovery.hasMeaningfulDraft({ subject: " Plan " }), true)
+assert.strictEqual(recovery.hasMeaningfulDraft({ body: "\n\n" }), false)
+assert.strictEqual(recovery.hasMeaningfulDraft({
+  draftAttachments: [{ filename: "plan.txt" }]
+}), true)
+assert.strictEqual(recovery.serialize("list", { body: "  " }), "")
+
+const unsafe = JSON.parse(encoded)
+unsafe.draft.extra = "drop me"
+unsafe.draft.draftAttachments[0].extra = "drop me"
+const cleaned = recovery.parse(JSON.stringify(unsafe))
+assert.strictEqual(cleaned.draft.extra, undefined)
+assert.strictEqual(cleaned.draft.draftAttachments[0].extra, undefined)

--- a/tests/test_gmail_api.js
+++ b/tests/test_gmail_api.js
@@ -40,6 +40,15 @@ assert.strictEqual(api.sendAsPath(), "/users/me/settings/sendAs")
 assert.strictEqual(api.attachmentPath("m1", "a1"), "/users/me/messages/m1/attachments/a1")
 assert.strictEqual(api.draftsPath(), "/users/me/drafts")
 assert.strictEqual(api.draftPath("draft/a"), "/users/me/drafts/draft%2Fa")
+deepEqual(api.draftListQuery("next page"), {
+  maxResults: 500,
+  pageToken: "next page"
+})
+assert.strictEqual(api.draftIdForMessage({ drafts: [
+  { id: "resource-1", message: { id: "message-1" } },
+  { id: "resource-2", message: { id: "message-2" } }
+] }, "message-2"), "resource-2")
+assert.strictEqual(api.draftIdForMessage({ drafts: [] }, "message-2"), "")
 deepEqual(api.draftBody({ raw: "encoded", threadId: "thread-1" }), {
   message: { raw: "encoded", threadId: "thread-1" }
 })

--- a/tests/test_hey.js
+++ b/tests/test_hey.js
@@ -178,14 +178,16 @@ deepEqual(hey.draftEditCommand("draft:42", {
   cc: "",
   bcc: "hidden@example.com",
   subject: "Revised",
-  body: "New body"
+  body: "New body",
+  attachments: [{ path: "/tmp/revised.pdf" }]
 }), [
   "draft", "edit", "42",
   "--to", "jane@example.com",
   "--cc", "",
   "--bcc", "hidden@example.com",
   "--subject", "Revised",
-  "--message", "New body"
+  "--message", "New body",
+  "--attach", "/tmp/revised.pdf"
 ])
 assert.strictEqual(hey.isDroppableFlag("--attach"), false)
 assert.strictEqual(hey.isDroppableFlag("--html"), true)

--- a/tests/test_hey.js
+++ b/tests/test_hey.js
@@ -173,6 +173,20 @@ deepEqual(hey.draftCommand({
   threadId: "2106437143",
   attachments: [{ path: "/tmp/menu.pdf" }]
 }), ["reply", "2106437143", "--draft", "--attach", "/tmp/menu.pdf"])
+deepEqual(hey.draftEditCommand("draft:42", {
+  to: "jane@example.com",
+  cc: "",
+  bcc: "hidden@example.com",
+  subject: "Revised",
+  body: "New body"
+}), [
+  "draft", "edit", "42",
+  "--to", "jane@example.com",
+  "--cc", "",
+  "--bcc", "hidden@example.com",
+  "--subject", "Revised",
+  "--message", "New body"
+])
 assert.strictEqual(hey.isDroppableFlag("--attach"), false)
 assert.strictEqual(hey.isDroppableFlag("--html"), true)
 

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -269,6 +269,11 @@ assert.strictEqual(imap.fullFetchCommand([]), "")
 // Two STOREs, because IMAP has no combined add-and-remove.
 deepEqual(imap.storeCommand([4], ["\\Seen"], []), ["UID STORE 4 +FLAGS.SILENT (\\Seen)"])
 deepEqual(imap.storeCommand([4], [], ["\\Seen"]), ["UID STORE 4 -FLAGS.SILENT (\\Seen)"])
+deepEqual(imap.draftReplacementCommands("42:Drafts", "Drafts"), [
+  "UID STORE 42 +FLAGS.SILENT (\\Deleted)",
+  "UID EXPUNGE 42"
+])
+deepEqual(imap.draftReplacementCommands("42:Archive", "Drafts"), [])
 deepEqual(imap.storeCommand([4, 5], ["\\Seen"], ["\\Flagged"]), [
   "UID STORE 4,5 +FLAGS.SILENT (\\Seen)",
   "UID STORE 4,5 -FLAGS.SILENT (\\Flagged)"

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -274,6 +274,22 @@ deepEqual(imap.draftReplacementCommands("42:Drafts", "Drafts"), [
   "UID EXPUNGE 42"
 ])
 deepEqual(imap.draftReplacementCommands("42:Archive", "Drafts"), [])
+deepEqual(imap.draftReplacementPlan("42:Drafts", "Drafts"), {
+  commands: [
+    "UID STORE 42 +FLAGS.SILENT (\\Deleted)",
+    "UID EXPUNGE 42"
+  ],
+  warning: ""
+})
+deepEqual(imap.draftReplacementPlan("42:Archive", "Drafts"), {
+  commands: [],
+  warning: "The updated draft was saved, but the old copy could not be identified"
+}, "a stale source id must not turn a completed APPEND into a failed save")
+deepEqual(imap.draftSaveResult("server refused UID EXPUNGE"), {
+  saved: true,
+  warning: "The updated draft was saved, but the old copy could not be removed: server refused UID EXPUNGE"
+}, "a cleanup failure must not invite another APPEND of the saved draft")
+deepEqual(imap.draftSaveResult(""), { saved: true, warning: "" })
 deepEqual(imap.storeCommand([4, 5], ["\\Seen"], ["\\Flagged"]), [
   "UID STORE 4,5 +FLAGS.SILENT (\\Seen)",
   "UID STORE 4,5 -FLAGS.SILENT (\\Flagged)"

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -58,6 +58,11 @@ actual_accounts=$(cat "$test_root/config/omamail/accounts.json")
 [ "$actual_accounts" = "$updated_accounts" ] \
   || fail "config-store.sh refused a replacement that still contains a saved account"
 
+printf '%s\n' '{"version":1,"active":true}' \
+  | XDG_CONFIG_HOME="$test_root/config" sh scripts/config-store.sh compose.json >/dev/null
+[ "$(stat -c '%a' "$test_root/config/omamail/compose.json")" = 600 ] \
+  || fail "compose recovery must be owner-readable only"
+
 # The keyring helper takes attribute pairs now, because keying a refresh token
 # on the OAuth client alone lets two accounts sharing one client overwrite each
 # other. An empty value is a secret-tool wildcard, so it is refused outright.

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -452,7 +452,7 @@ grep -q 'placeholderText: "Password or app password"' components/CalendarSetting
   || fail "calendar setup needs its own password field"
 grep -q 'text: "Set password"' components/CalendarSettings.qml \
   || fail "existing CalDAV calendars need a password action"
-grep -q 'credentials.json|accounts.json|window.json|calendars.json' scripts/config-store.sh \
+grep -q 'credentials.json|accounts.json|window.json|calendars.json|compose.json' scripts/config-store.sh \
   || fail "the config writer must accept calendar source records"
 if grep -q 'Five Nextcloud calendars\|imported from Thunderbird\|Nextcloud password' components/CalendarSettings.qml; then
   fail "calendar settings must not describe one user's imported setup"


### PR DESCRIPTION
## Summary

- Autosave active compose state after 300 ms and restore it after shell or plugin reloads.
- Store recovery text in an owner-only file.
- Preview drafts with Enter or o, then edit the selected draft with c.
- Replace the source draft across Gmail, HEY, and IMAP instead of creating duplicates.

## Design

ComposeView snapshots provider-neutral draft state, including attachments and the source message ID.

Gmail resolves the draft resource before updating it. HEY uses draft edit. IMAP appends the replacement before deleting the old UID.

Recovery uses the existing atomic config writer. The file and its parent directory remain owner-only.

## Verification

- make validate
- 92 QML tests passed
- JavaScript and shell tests passed
- qmllint exited successfully
- omarchy plugin validate passed
- git diff --check passed

## Release notes

- Recover active drafts after shell reloads
- Preview drafts before editing them
- Update saved drafts without duplicate copies