### PR TITLE
Refuse CR/LF in remote-image URLs to close a curl config injection

### DIFF
--- a/scripts/image-fetch.sh
+++ b/scripts/image-fetch.sh
@@ -15,6 +15,22 @@ IFS= read -r encoded || fail 'image-fetch.sh: no request on stdin'
 [ -n "$encoded" ] || fail 'image-fetch.sh: empty request'
 url=$(printf '%s' "$encoded" | base64 -d 2>/dev/null) || fail 'image-fetch.sh: bad base64 field'
 
+# The URL crosses into curl's config format, where escape() below neutralises
+# the quote and the backslash but a line break is a field of its own: a CR or
+# LF in the value ends the `url = "..."` line and turns whatever follows into
+# another curl option. The src of a mail <img> is written by a stranger, and
+# `Html.imageSourceKind` classifies it through a normaliser that strips these
+# characters — so a URL that reads as a public host to the gate can still carry
+# a newline down here. Refuse it, the way calendar-write.sh refuses one, before
+# any config is built. (The newline is a literal: command substitution would
+# strip a trailing one.)
+nl='
+'
+cr=$(printf '\r')
+case $url in
+  *"$nl"* | *"$cr"*) fail 'image-fetch.sh: URL may not span lines' ;;
+esac
+
 case "$url" in
   http://*|https://*) ;;
   *) fail 'image-fetch.sh: refusing a URL that is not HTTP(S)' ;;

--- a/tests/test_image_fetch.sh
+++ b/tests/test_image_fetch.sh
@@ -46,4 +46,24 @@ code=$?
 set -e
 if [ "$code" -ne 0 ]; then ok "a non-network URL is refused"; else bad "a non-network URL is refused"; fi
 
+# A CR or LF in the URL would end the `url = "..."` config line and inject a
+# curl option — `output = <path>` writes the fetched (attacker-served) bytes to
+# a path of the sender's choosing. The value that reaches here is classified up
+# in Html.js through a normaliser that strips these characters, so the URL can
+# read as a public host to the gate and still carry a newline down here. The
+# scheme check does not catch it (the value still starts with https://), so the
+# line-break refusal has to be its own gate.
+nl='
+'
+target="$work/injected"
+rm -f "$target"
+set +e
+printf '%s\n' "$(b64 "https://cdn.example.com/a.png${nl}output = $target")" |
+  CURL_STUB_DUMP="$work/config-inject" PATH="$work/bin:$PATH" sh "$script" >/dev/null 2>&1
+code=$?
+set -e
+if [ "$code" -ne 0 ]; then ok "a URL carrying a line break is refused"; else bad "a URL carrying a line break is refused"; fi
+if [ ! -e "$target" ]; then ok "an injected output option never writes a file"; else bad "an injected output option never writes a file"; fi
+if [ ! -e "$work/config-inject" ]; then ok "no curl config is built for an injected URL"; else bad "no curl config is built for an injected URL"; fi
+
 [ "$failures" -eq 0 ]


### PR DESCRIPTION
image-fetch.sh builds a curl config with `url = "<url>"`, where the escape helper neutralises the quote and the backslash but not a line break. A CR or LF in the URL therefore ends the url line and turns whatever follows into another curl option — `output = <path>` writes the fetched (attacker-served) bytes to a path of the sender's choosing.

The value is a mail <img> src, written by a stranger. It is classified up in Html.js through `imageSourceKind`, whose normaliser strips CR/LF/HT before reading the host — so a URL that reads as a public host to that gate can still carry a raw newline by the time it reaches this script, and the scheme check here does not catch it because the value still begins with https://.

Refuse a URL that spans lines before any config is built, the same guard calendar-write.sh and calendar-delete.sh already apply to their fields. Adds a regression test that a line-broken URL is refused and builds no config.