### PR TITLE
Write from an alias, reach a STARTTLS server, and pick a recipient from the address book

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ node_modules/
 # repository; see AGENTS.md for what is kept and why.
 docs/design/
 docs/superpowers/
+
+# Python leaves these beside the harvester scripts.
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ test-js:
 	node tests/test_senders.js
 	node tests/test_oauth.js
 	node tests/test_credentials.js
+	node tests/test_secrets.js
 	node tests/test_gmail_api.js
 	node tests/test_message.js
 	node tests/test_calendar.js
@@ -82,6 +83,7 @@ test-js:
 	node tests/test_model.js
 	node tests/test_keymap.js
 	node tests/test_accounts.js
+	node tests/test_aliases.js
 	node tests/test_menu.js
 	node tests/test_provider.js
 	node tests/test_imap.js

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/ReaderSkeleton.qml \
 	components/ComposeView.qml \
 	components/RecipientSuggestions.qml \
+	components/ContactsPicker.qml \
 	components/UndoSendToast.qml \
 	components/DraftSavedToast.qml \
 	components/SearchBar.qml \

--- a/Service.qml
+++ b/Service.qml
@@ -58,6 +58,7 @@ Item {
     settings ? settings.undoSendSeconds : Outbox.DEFAULT_DELAY_SECONDS)
   readonly property bool alwaysRenderHeavyMessages: Html.alwaysRenderHeavyMessages(
     settings ? settings.heavyMessageRendering : null)
+  readonly property bool notifyNewMail: String(settings ? settings.notifyNewMail : "On") !== "Off"
 
   // Thunderbird and Betterbird keep both explicit and learned addresses in
   // their local profile. The helper reads those databases without modifying
@@ -105,6 +106,10 @@ Item {
 
   function setAlwaysRenderHeavyMessages(value) {
     persistSetting("heavyMessageRendering", Html.heavyMessageRendering(value))
+  }
+
+  function setNotifyNewMail(value) {
+    persistSetting("notifyNewMail", value ? "On" : "Off")
   }
 
   // ---------------------------------------------------------- the accounts

--- a/account/Accounts.js
+++ b/account/Accounts.js
@@ -102,6 +102,39 @@ function portOr(value, fallback) {
   return port
 }
 
+function normalizeAliases(value) {
+  if (!value) return []
+  var rawList = []
+  if (Array.isArray(value)) {
+    rawList = value
+  } else if (typeof value === "string") {
+    rawList = value.split(/[\r\n,]+/)
+  }
+  var out = []
+  var seen = {}
+  for (var i = 0; i < rawList.length; i++) {
+    var item = rawList[i]
+    var email = ""
+    var displayName = ""
+    if (typeof item === "string") {
+      email = trimmed(item).toLowerCase()
+    } else if (item && typeof item === "object") {
+      email = trimmed(item.email || item.sendAsEmail).toLowerCase()
+      displayName = trimmed(item.displayName || item.name)
+    }
+    if (!email || !isValidEmail(email)) continue
+    if (seen[email]) continue
+    seen[email] = true
+    out.push({
+      email: email,
+      displayName: displayName,
+      isPrimary: false,
+      isDefault: false
+    })
+  }
+  return out
+}
+
 function makeImapSettings(raw) {
   var values = raw || {}
   return {
@@ -110,6 +143,7 @@ function makeImapSettings(raw) {
     smtpHost: trimmed(values.smtpHost),
     smtpPort: portOr(values.smtpPort, 465),
     username: trimmed(values.username),
+    aliases: normalizeAliases(values.aliases),
     insecure: values.insecure === true
   }
 }

--- a/account/Accounts.js
+++ b/account/Accounts.js
@@ -116,11 +116,30 @@ function normalizeAliases(value) {
     var item = rawList[i]
     var email = ""
     var displayName = ""
+    var isDef = false
     if (typeof item === "string") {
-      email = trimmed(item).toLowerCase()
+      var str = trimmed(item)
+      if (/\(default\)|\[default\]/i.test(str)) {
+        isDef = true
+        str = str.replace(/\(default\)|\[default\]/gi, "").trim()
+      } else if (str.endsWith("*")) {
+        isDef = true
+        str = str.replace(/\*+$/, "").trim()
+      } else if (str.startsWith("*")) {
+        isDef = true
+        str = str.replace(/^\*+/, "").trim()
+      }
+      var matchAngle = str.match(/^(.*?)\s*<([^\s@]+@[^>]+)>\s*$/)
+      if (matchAngle) {
+        displayName = trimmed(matchAngle[1])
+        email = trimmed(matchAngle[2]).toLowerCase()
+      } else {
+        email = trimmed(str).toLowerCase()
+      }
     } else if (item && typeof item === "object") {
       email = trimmed(item.email || item.sendAsEmail).toLowerCase()
       displayName = trimmed(item.displayName || item.name)
+      isDef = item.isDefault === true || item.default === true || item.defaultFrom === true
     }
     if (!email || !isValidEmail(email)) continue
     if (seen[email]) continue
@@ -129,8 +148,18 @@ function normalizeAliases(value) {
       email: email,
       displayName: displayName,
       isPrimary: false,
-      isDefault: false
+      isDefault: isDef
     })
+  }
+  var foundDefault = false
+  for (var j = 0; j < out.length; j++) {
+    if (out[j].isDefault) {
+      if (foundDefault) {
+        out[j].isDefault = false
+      } else {
+        foundDefault = true
+      }
+    }
   }
   return out
 }

--- a/account/Accounts.js
+++ b/account/Accounts.js
@@ -1,5 +1,7 @@
 .pragma library
 
+.import "Aliases.js" as Aliases
+
 // The list of Gmail accounts and which one the window is showing. One account
 // was the original design; several is a list plus a selection, and every rule
 // about what that selection may point at lives here so the QML only has to
@@ -102,68 +104,6 @@ function portOr(value, fallback) {
   return port
 }
 
-function normalizeAliases(value) {
-  if (!value) return []
-  var rawList = []
-  if (Array.isArray(value)) {
-    rawList = value
-  } else if (typeof value === "string") {
-    rawList = value.split(/[\r\n,]+/)
-  }
-  var out = []
-  var seen = {}
-  for (var i = 0; i < rawList.length; i++) {
-    var item = rawList[i]
-    var email = ""
-    var displayName = ""
-    var isDef = false
-    if (typeof item === "string") {
-      var str = trimmed(item)
-      if (/\(default\)|\[default\]/i.test(str)) {
-        isDef = true
-        str = str.replace(/\(default\)|\[default\]/gi, "").trim()
-      } else if (str.endsWith("*")) {
-        isDef = true
-        str = str.replace(/\*+$/, "").trim()
-      } else if (str.startsWith("*")) {
-        isDef = true
-        str = str.replace(/^\*+/, "").trim()
-      }
-      var matchAngle = str.match(/^(.*?)\s*<([^\s@]+@[^>]+)>\s*$/)
-      if (matchAngle) {
-        displayName = trimmed(matchAngle[1])
-        email = trimmed(matchAngle[2]).toLowerCase()
-      } else {
-        email = trimmed(str).toLowerCase()
-      }
-    } else if (item && typeof item === "object") {
-      email = trimmed(item.email || item.sendAsEmail).toLowerCase()
-      displayName = trimmed(item.displayName || item.name)
-      isDef = item.isDefault === true || item.default === true || item.defaultFrom === true
-    }
-    if (!email || !isValidEmail(email)) continue
-    if (seen[email]) continue
-    seen[email] = true
-    out.push({
-      email: email,
-      displayName: displayName,
-      isPrimary: false,
-      isDefault: isDef
-    })
-  }
-  var foundDefault = false
-  for (var j = 0; j < out.length; j++) {
-    if (out[j].isDefault) {
-      if (foundDefault) {
-        out[j].isDefault = false
-      } else {
-        foundDefault = true
-      }
-    }
-  }
-  return out
-}
-
 function makeImapSettings(raw) {
   var values = raw || {}
   return {
@@ -172,7 +112,7 @@ function makeImapSettings(raw) {
     smtpHost: trimmed(values.smtpHost),
     smtpPort: portOr(values.smtpPort, 465),
     username: trimmed(values.username),
-    aliases: normalizeAliases(values.aliases),
+    aliases: Aliases.parse(values.aliases),
     insecure: values.insecure === true
   }
 }

--- a/account/Aliases.js
+++ b/account/Aliases.js
@@ -1,0 +1,226 @@
+.pragma library
+
+// The send-as addresses a mailbox may write from, as the settings page shows
+// them and as the account file stores them.
+//
+// This is one module rather than a copy in `Accounts.js` and another in
+// `ImapProtocol.js` because the two ends have to agree exactly: the setup page
+// parses what the user typed, the account file stores what came back, and an
+// alias the first accepts and the second drops disappears between a save and
+// the next start with nothing said. There is one parser, so there is one
+// answer.
+//
+// It is also neither of those files' subject. An alias is not a string sent to
+// a server, and it is not the shape of the account list — it is a small format
+// the user types, which is why it has a file.
+
+// ------------------------------------------------------------------ parsing
+
+// Deliberately not the address grammar: this is the gate on what may become an
+// envelope sender, so it wants a name, a dot and a plausible TLD rather than
+// everything RFC 5321 permits.
+var EMAIL_PATTERN = /^[^\s@]+@[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}$/
+
+function trimmed(value) {
+  return String(value === undefined || value === null ? "" : value).trim()
+}
+
+// Entries are comma- or newline-separated, but a display name may hold a comma
+// of its own — `"Lee, Jason" <j@example.com>` is one alias, not two. So the
+// split is a scan rather than a `split()`: a separator inside quotes or inside
+// angle brackets is part of the value.
+//
+// Splitting on the comma regardless is what used to happen, and because the
+// setup page re-formats the list every time it opens, the halves were written
+// back apart — the name lost everything before its comma, permanently, without
+// the user having touched the field.
+function splitEntries(text) {
+  var out = []
+  var current = ""
+  var quoted = false
+  var angled = false
+  for (var i = 0; i < text.length; i++) {
+    var character = text.charAt(i)
+    if (quoted) {
+      // A backslash escapes the next character, including the closing quote.
+      if (character === "\\" && i + 1 < text.length) {
+        current += character + text.charAt(i + 1)
+        i++
+        continue
+      }
+      if (character === "\"") quoted = false
+      current += character
+      continue
+    }
+    if (character === "\"") {
+      quoted = true
+      current += character
+      continue
+    }
+    if (character === "<") angled = true
+    else if (character === ">") angled = false
+    if (!angled && (character === "," || character === "\n" || character === "\r")) {
+      out.push(current)
+      current = ""
+      continue
+    }
+    current += character
+  }
+  out.push(current)
+  return out
+}
+
+// `"Lee, Jason"` is the quoted form; anything else is taken as written. The
+// escapes are the two a quoted string can carry.
+function unquoted(value) {
+  var text = trimmed(value)
+  if (text.length < 2 || text.charAt(0) !== "\"" || text.charAt(text.length - 1) !== "\"")
+    return text
+  return text.substring(1, text.length - 1).replace(/\\([\\"])/g, "$1")
+}
+
+// The default marker, in the spellings the settings field offers and the one
+// `format` writes back. Only at an end, so a name that says "(default)" in the
+// middle of itself is a name.
+function withoutDefaultMarker(text) {
+  var value = trimmed(text)
+  var match = value.match(/^(.*?)\s*(?:\(default\)|\[default\])$/i)
+  if (match) return { text: trimmed(match[1]), isDefault: true }
+  if (/\*+$/.test(value)) return { text: value.replace(/\*+$/, "").trim(), isDefault: true }
+  if (/^\*+/.test(value)) return { text: value.replace(/^\*+/, "").trim(), isDefault: true }
+  return { text: value, isDefault: false }
+}
+
+function fromText(entry) {
+  var marked = withoutDefaultMarker(entry)
+  var text = marked.text
+  var angle = text.match(/^(.*?)\s*<([^\s@<>]+@[^<>]+)>$/)
+  if (angle) {
+    return {
+      email: trimmed(angle[2]).toLowerCase(),
+      displayName: unquoted(angle[1]),
+      isDefault: marked.isDefault
+    }
+  }
+  return { email: text.toLowerCase(), displayName: "", isDefault: marked.isDefault }
+}
+
+function fromObject(item) {
+  return {
+    email: trimmed(item.email || item.sendAsEmail).toLowerCase(),
+    displayName: trimmed(item.displayName || item.name),
+    isDefault: item.isDefault === true || item.default === true || item.defaultFrom === true
+  }
+}
+
+// One list, whether it arrives as the settings field's text or as the array
+// the account file holds. Invalid addresses and repeats are dropped rather
+// than reported: this runs on every load, and a mailbox that refused to open
+// because one of its aliases has a typo in it would be worse than the alias
+// being missing from the menu.
+function parse(value) {
+  if (!value) return []
+  var raw = []
+  if (Array.isArray(value)) raw = value
+  else if (typeof value === "string") raw = splitEntries(value)
+  else return []
+
+  var out = []
+  var seen = {}
+  var haveDefault = false
+  for (var i = 0; i < raw.length; i++) {
+    var item = raw[i]
+    var parsed = typeof item === "string" ? fromText(item)
+      : (item && typeof item === "object" ? fromObject(item) : null)
+    if (!parsed) continue
+    if (!parsed.email || !EMAIL_PATTERN.test(parsed.email)) continue
+    if (seen[parsed.email]) continue
+    seen[parsed.email] = true
+    // The first marked one wins. Two defaults is not a state the composer can
+    // act on, and silently keeping the earlier is what the settings field
+    // shows back to the user.
+    var isDefault = parsed.isDefault && !haveDefault
+    if (isDefault) haveDefault = true
+    out.push({
+      email: parsed.email,
+      displayName: parsed.displayName,
+      isPrimary: false,
+      isDefault: isDefault
+    })
+  }
+  return out
+}
+
+// ---------------------------------------------------------------- formatting
+
+// A name carrying either of the two characters the split reads is quoted, so
+// what `format` writes is what `parse` reads back. Everything else is left as
+// the user typed it, because a field full of quotation marks nobody asked for
+// reads as the client having mangled the value.
+function quotedName(name) {
+  var text = trimmed(name)
+  if (text === "") return ""
+  if (!/[",]/.test(text)) return text
+  return "\"" + text.replace(/([\\"])/g, "\\$1") + "\""
+}
+
+function format(aliases) {
+  var list = parse(aliases)
+  var entries = []
+  for (var i = 0; i < list.length; i++) {
+    var item = list[i]
+    var text = item.displayName !== ""
+      ? quotedName(item.displayName) + " <" + item.email + ">"
+      : item.email
+    if (item.isDefault) text += " (default)"
+    entries.push(text)
+  }
+  return entries.join(", ")
+}
+
+// ------------------------------------------------------------- send-as list
+
+// The identities a mailbox may write from, in the shape the composer reads —
+// the same one Gmail's send-as settings arrive in, so nothing above the
+// provider boundary has to know which kind of account it is looking at.
+//
+// The mailbox's own address is always first and is the primary one. It is also
+// the default unless an alias claimed that, which is what makes "default" mean
+// the address the composer opens on rather than merely a marked row.
+//
+// Here rather than in `ImapClient.qml` because it is a decision, and a
+// decision in QML is one the node tests cannot reach.
+function sendAsList(address, aliases) {
+  var primary = trimmed(address)
+  var list = []
+  var seen = {}
+  var rows = parse(aliases)
+  var claimed = false
+  for (var i = 0; i < rows.length; i++) {
+    if (rows[i].isDefault) {
+      claimed = true
+      break
+    }
+  }
+  if (primary !== "") {
+    seen[primary.toLowerCase()] = true
+    list.push({
+      email: primary,
+      displayName: "",
+      isPrimary: true,
+      isDefault: !claimed
+    })
+  }
+  for (var j = 0; j < rows.length; j++) {
+    var row = rows[j]
+    if (seen[row.email]) continue
+    seen[row.email] = true
+    list.push({
+      email: row.email,
+      displayName: row.displayName,
+      isPrimary: false,
+      isDefault: row.isDefault
+    })
+  }
+  return list
+}

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -319,6 +319,7 @@ Item {
   // what was already there.
   property var seenIds: ({})
   property bool notificationsPrimed: false
+  readonly property double sessionStartedAt: Date.now()
   // The unread count needs a baseline of its own, separate from the message
   // cache: a mailbox that has never been opened has no cached page to prime
   // from, and would otherwise never be allowed to announce anything.
@@ -885,7 +886,7 @@ Item {
     // never held. That is a result, not newly arrived mail, so it must not turn
     // into a desktop notification.
     var arrivals = append || suppressArrivals === true ? []
-      : Model.newArrivals(summaries, seenIds, notificationsPrimed)
+      : Model.newArrivals(summaries, seenIds, notificationsPrimed, sessionStartedAt)
 
     var seen = {}
     for (var i = 0; i < merged.length; i++) seen[merged[i].id] = true

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -319,7 +319,10 @@ Item {
   // what was already there.
   property var seenIds: ({})
   property bool notificationsPrimed: false
-  readonly property double sessionStartedAt: Date.now()
+  // The mailbox's own newest timestamp at the moment notifications were
+  // primed. Set once, from the server's clock rather than this machine's, and
+  // never raised — see `Model.newArrivals`.
+  property double arrivalFloor: 0
   // The unread count needs a baseline of its own, separate from the message
   // cache: a mailbox that has never been opened has no cached page to prime
   // from, and would otherwise never be allowed to announce anything.
@@ -580,6 +583,7 @@ Item {
     seenIds = seen
     // The cache is also a record of what was on screen last time, so a live
     // load on top of it can tell genuinely new mail from a first look.
+    if (arrivalFloor === 0) arrivalFloor = Model.newestDate(restored)
     notificationsPrimed = true
     listRefreshed()
     return true
@@ -886,7 +890,7 @@ Item {
     // never held. That is a result, not newly arrived mail, so it must not turn
     // into a desktop notification.
     var arrivals = append || suppressArrivals === true ? []
-      : Model.newArrivals(summaries, seenIds, notificationsPrimed, sessionStartedAt)
+      : Model.newArrivals(summaries, seenIds, notificationsPrimed, arrivalFloor)
 
     var seen = {}
     for (var i = 0; i < merged.length; i++) seen[merged[i].id] = true
@@ -894,6 +898,7 @@ Item {
     // does not get announced again when it comes back.
     for (var key in seenIds) seen[key] = true
     seenIds = seen
+    if (arrivalFloor === 0) arrivalFloor = Model.newestDate(merged)
     notificationsPrimed = true
 
     messages = merged
@@ -2185,6 +2190,7 @@ Item {
     inboxUnread = 0
     listLoaded = false
     seenIds = ({})
+    arrivalFloor = 0
     notificationsPrimed = false
     countPrimed = false
     cacheStore.clear()

--- a/account/Model.js
+++ b/account/Model.js
@@ -586,23 +586,54 @@ function barTooltip(state, email, unread, provider, authKind) {
 
 // ------------------------------------------------------------ new mail
 
+// The newest timestamp in a page of rows, in milliseconds, or zero if none of
+// them carry one. This is the mailbox's own clock rather than this machine's,
+// which is the whole point of it below.
+function newestDate(summaries) {
+  var list = Array.isArray(summaries) ? summaries : []
+  var newest = 0
+  for (var i = 0; i < list.length; i++) {
+    var summary = list[i]
+    if (!summary || !summary.date || typeof summary.date.getTime !== "function") continue
+    var time = summary.date.getTime()
+    if (isFinite(time) && time > newest) newest = time
+  }
+  return newest
+}
+
 // Only messages the panel has not seen before, and only ones that are actually
 // new rather than merely newly fetched: the first load after start must not
 // fire a notification for every message already sitting in the inbox.
-function newArrivals(summaries, seenIds, primed, sessionStartMs) {
+//
+// `seenIds` answers that for everything the first page held, and `floorMs`
+// answers it for the rest — an unread message from last year that was never on
+// the cached page is not an arrival just because this is the fetch that first
+// returned it. The floor is the newest timestamp the mailbox itself reported
+// when notifications were primed, so the comparison is the server's clock
+// against the server's clock. Taking it from `Date.now()` instead is what made
+// a machine whose clock ran fast stop notifying altogether, silently and for
+// the whole session: every arrival was older than a "now" that had not
+// happened yet on the server.
+//
+// It is set once and never raised, so a message that arrives out of order —
+// which a mailing list does routinely — is still announced.
+//
+// A row with no usable date is announced rather than dropped. `seenIds` is the
+// guard that matters, and a provider that does not date a summary would
+// otherwise never notify at all.
+function newArrivals(summaries, seenIds, primed, floorMs) {
   if (!primed) return []
   var list = Array.isArray(summaries) ? summaries : []
   var seen = seenIds || {}
   var arrivals = []
-  var minTime = typeof sessionStartMs === "number" && sessionStartMs > 0 ? sessionStartMs : 0
+  var floor = typeof floorMs === "number" && isFinite(floorMs) && floorMs > 0 ? floorMs : 0
   for (var i = 0; i < list.length; i++) {
     var summary = list[i]
     if (!summary || !summary.unread || !summary.inInbox) continue
     if (seen[summary.id]) continue
-    if (minTime > 0) {
-      if (!summary.date || typeof summary.date.getTime !== "function") continue
+    if (floor > 0 && summary.date && typeof summary.date.getTime === "function") {
       var time = summary.date.getTime()
-      if (isNaN(time) || time < minTime) continue
+      if (isFinite(time) && time < floor) continue
     }
     arrivals.push(summary)
   }

--- a/account/Model.js
+++ b/account/Model.js
@@ -599,8 +599,11 @@ function newArrivals(summaries, seenIds, primed, sessionStartMs) {
     var summary = list[i]
     if (!summary || !summary.unread || !summary.inInbox) continue
     if (seen[summary.id]) continue
-    if (minTime > 0 && summary.date && typeof summary.date.getTime === "function"
-        && summary.date.getTime() < minTime) continue
+    if (minTime > 0) {
+      if (!summary.date || typeof summary.date.getTime !== "function") continue
+      var time = summary.date.getTime()
+      if (isNaN(time) || time < minTime) continue
+    }
     arrivals.push(summary)
   }
   return arrivals

--- a/account/Model.js
+++ b/account/Model.js
@@ -589,15 +589,18 @@ function barTooltip(state, email, unread, provider, authKind) {
 // Only messages the panel has not seen before, and only ones that are actually
 // new rather than merely newly fetched: the first load after start must not
 // fire a notification for every message already sitting in the inbox.
-function newArrivals(summaries, seenIds, primed) {
+function newArrivals(summaries, seenIds, primed, sessionStartMs) {
   if (!primed) return []
   var list = Array.isArray(summaries) ? summaries : []
   var seen = seenIds || {}
   var arrivals = []
+  var minTime = typeof sessionStartMs === "number" && sessionStartMs > 0 ? sessionStartMs : 0
   for (var i = 0; i < list.length; i++) {
     var summary = list[i]
     if (!summary || !summary.unread || !summary.inInbox) continue
     if (seen[summary.id]) continue
+    if (minTime > 0 && summary.date && typeof summary.date.getTime === "function"
+        && summary.date.getTime() < minTime) continue
     arrivals.push(summary)
   }
   return arrivals

--- a/calendar/CalendarController.qml
+++ b/calendar/CalendarController.qml
@@ -5,6 +5,7 @@ import qs.Commons
 import "Calendar.js" as Calendar
 import "Sources.js" as Sources
 import "../message/Message.js" as Mail
+import "../providers/Secrets.js" as Secrets
 
 Item {
   id: root
@@ -575,12 +576,19 @@ Item {
 
   Process {
     id: passwordLookup
-    stdout: SplitParser {
-      splitMarker: "\n"
-      onRead: function(line) { root.handlePassword(line) }
-    }
+    // `secret-tool lookup` writes the secret with no trailing newline, so a
+    // SplitParser splitting on one never fires its read at all: the password
+    // was found, the callback was not, and the source reported itself as
+    // having no password saved. The whole output, read when the process is
+    // done with, is the same answer without depending on how it ends —
+    // which is what `eventPasswordLookup` below already does.
+    stdout: StdioCollector { id: passwordLookupOutput; waitForEnd: true }
     stderr: StdioCollector { waitForEnd: true }
-    onExited: function(_exitCode) { if (!root.lookupHandled) root.handlePassword("") }
+    onExited: function(exitCode) {
+      // No entry is not an error: it is what a source that has never been
+      // given a password looks like.
+      root.handlePassword(exitCode === 0 ? Secrets.fromKeyring(passwordLookupOutput.text) : "")
+    }
   }
 
   Process {

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -891,6 +891,19 @@ DropArea {
         spacing: Style.space(4)
 
         Button {
+          id: contactsButton
+          objectName: "compose-contacts-button"
+          text: "Contacts"
+          foreground: contactsPicker.opened ? root.textColor : root.dimColor
+          bordered: false
+          fontSize: Style.font.caption
+          onClicked: {
+            var global = contactsButton.mapToGlobal(0, contactsButton.height)
+            contactsPicker.opened ? contactsPicker.close() : contactsPicker.openAt(global.x, global.y)
+          }
+        }
+
+        Button {
           id: ccToggle
           objectName: "compose-cc-toggle"
           text: "Cc"
@@ -1334,6 +1347,32 @@ DropArea {
 
         HoverHandler { id: fromHover }
         TapHandler { onTapped: root.chooseFrom(fromRow.modelData) }
+      }
+    }
+  }
+
+  ContactsPicker {
+    id: contactsPicker
+    objectName: "compose-contacts-picker"
+    contacts: root.contactBook
+    textColor: root.textColor
+    dimColor: root.dimColor
+    accentColor: root.accentColor
+    popupBackgroundColor: root.popupBackgroundColor
+    popupBorderColor: root.popupBorderColor
+    panelFontFamily: root.panelFontFamily
+    onContactChosen: function(contact, target) {
+      if (target === "cc") {
+        root.ccVisible = true
+        ccField.text = Recipients.append(ccField.text, contact)
+        ccField.forceActiveFocus()
+      } else if (target === "bcc") {
+        root.bccVisible = true
+        bccField.text = Recipients.append(bccField.text, contact)
+        bccField.forceActiveFocus()
+      } else {
+        toField.text = Recipients.append(toField.text, contact)
+        toField.forceActiveFocus()
       }
     }
   }

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -43,6 +43,11 @@ DropArea {
   // A failed provider save stays reachable after Back or Escape.
   property var recoveryDrafts: []
   property string accountId: ""
+  // Both popups reparent themselves into the window overlay, so their state is
+  // not reachable by walking this view's children. Named here so the tests can
+  // ask whether a control put its own popup away.
+  readonly property bool fromMenuOpened: fromMenu.opened
+  readonly property bool contactsPickerOpened: contactsPicker.opened
   property int restoreRevision: 0
   property real restoreFlashOpacity: 0
   property string mode: "new"
@@ -110,6 +115,10 @@ DropArea {
   function clearCurrentDraft(forgetAttachments) {
     forwardLoadSerial++
     fromMenu.close()
+    // Both of these live in the window overlay, and this view is hidden rather
+    // than destroyed — so a popup left open outlives the draft it belonged to
+    // and sits over the message list.
+    contactsPicker.close()
     toField.text = ""
     ccField.text = ""
     bccField.text = ""
@@ -216,6 +225,27 @@ DropArea {
     root.accountId = accountId
     if (String(root.service.activeAccountId || "") === accountId) return
     if (typeof root.service.switchTo === "function") root.service.switchTo(accountId)
+  }
+
+  // When a control opens a popup that closes on a press outside itself, the
+  // press that reaches the control has already closed it — so by the time the
+  // release becomes a click, `opened` reads false and the toggle opens it
+  // straight back up. The control could never be used to put its own popup
+  // away, and it flickers instead. The moment it closed is what tells "the
+  // user wants this open" apart from "this just closed under the same press".
+  property double fromMenuClosedAt: 0
+
+  function reopeningAfterOutsidePress(closedAt) {
+    return Date.now() - closedAt < 250
+  }
+
+  function toggleFromMenu() {
+    if (fromMenu.opened) {
+      fromMenu.close()
+      return
+    }
+    if (reopeningAfterOutsidePress(fromMenuClosedAt)) return
+    fromMenu.open()
   }
 
   function placeFromMenu() {
@@ -837,7 +867,7 @@ DropArea {
         leftAlign: true
         selected: fromMenu.opened
         enabled: root.canChooseFrom
-        onClicked: fromMenu.opened ? fromMenu.close() : fromMenu.open()
+        onClicked: root.toggleFromMenu()
 
         // The kit's own chevron is a font glyph, which at this size renders
         // thinner than every other mark in the window. This is the app's drawn
@@ -899,7 +929,7 @@ DropArea {
           fontSize: Style.font.caption
           onClicked: {
             var global = contactsButton.mapToGlobal(0, contactsButton.height)
-            contactsPicker.opened ? contactsPicker.close() : contactsPicker.openAt(global.x, global.y)
+            contactsPicker.toggleAt(global.x, global.y)
           }
         }
 
@@ -1287,6 +1317,7 @@ DropArea {
     closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
     onHeightChanged: root.placeFromMenu()
     onOpened: root.placeFromMenu()
+    onClosed: root.fromMenuClosedAt = Date.now()
     background: Rectangle {
       radius: Style.cornerRadius
       color: Qt.rgba(root.popupBackgroundColor.r, root.popupBackgroundColor.g,

--- a/components/ContactsPicker.qml
+++ b/components/ContactsPicker.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Controls as QQC
 import qs.Commons
 import qs.Ui
@@ -57,6 +56,21 @@ Item {
     menu.close()
   }
 
+  // The popup closes on a press outside itself, and the control that opens it
+  // is outside it — so the press that looks like "close this" has already done
+  // so, and a plain `opened ? close() : openAt()` would reopen it on the
+  // release every time. The moment it closed is what separates the two.
+  property double closedAt: 0
+
+  function toggleAt(sceneX, sceneY) {
+    if (menu.opened) {
+      close()
+      return
+    }
+    if (Date.now() - closedAt < 250) return
+    openAt(sceneX, sceneY)
+  }
+
   function place() {
     if (!menu.visible) return
     var x = Math.max(Style.space(8), Math.min(anchorX, root.width - menu.width - Style.space(8)))
@@ -75,6 +89,7 @@ Item {
     closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
     onHeightChanged: root.place()
     onOpened: root.place()
+    onClosed: root.closedAt = Date.now()
 
     background: Rectangle {
       radius: Style.cornerRadius
@@ -127,7 +142,7 @@ Item {
         implicitHeight: Math.min(contentHeight, Style.space(280))
         clip: true
         model: root.filteredContacts
-        ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+        QQC.ScrollBar.vertical: QQC.ScrollBar { policy: QQC.ScrollBar.AsNeeded }
 
         delegate: Rectangle {
           id: contactRow

--- a/components/ContactsPicker.qml
+++ b/components/ContactsPicker.qml
@@ -1,0 +1,262 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Controls as QQC
+import qs.Commons
+import qs.Ui
+import "../compose/Recipients.js" as Recipients
+
+Item {
+  id: root
+
+  required property var contacts
+  required property color textColor
+  required property color dimColor
+  required property color accentColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
+  required property string panelFontFamily
+
+  readonly property bool opened: menu.opened
+  property string searchQuery: ""
+
+  readonly property var filteredContacts: Recipients.filter(
+    root.contacts || [],
+    root.searchQuery,
+    100)
+
+  signal contactChosen(var contact, string target)
+
+  anchors.fill: parent
+  z: 60
+
+  property real anchorX: 0
+  property real anchorY: 0
+
+  function openAt(sceneX, sceneY) {
+    var local = root.mapFromGlobal(sceneX, sceneY)
+    anchorX = local.x
+    anchorY = local.y
+    searchField.text = ""
+    root.searchQuery = ""
+    menu.open()
+    place()
+    searchField.forceActiveFocus()
+  }
+
+  function open() {
+    anchorX = Math.max(0, root.width - menu.width - Style.space(16))
+    anchorY = Style.space(70)
+    searchField.text = ""
+    root.searchQuery = ""
+    menu.open()
+    place()
+    searchField.forceActiveFocus()
+  }
+
+  function close() {
+    menu.close()
+  }
+
+  function place() {
+    if (!menu.visible) return
+    var x = Math.max(Style.space(8), Math.min(anchorX, root.width - menu.width - Style.space(8)))
+    var y = Math.max(Style.space(8), Math.min(anchorY, root.height - menu.implicitHeight - Style.space(8)))
+    menu.x = x
+    menu.y = y
+  }
+
+  QQC.Popup {
+    id: menu
+    width: Math.min(Style.space(340), root.width - Style.space(24))
+    implicitHeight: Math.min(contentColumn.implicitHeight + Style.space(16), Style.space(420))
+    padding: Style.space(8)
+    modal: false
+    focus: true
+    closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
+    onHeightChanged: root.place()
+    onOpened: root.place()
+
+    background: Rectangle {
+      radius: Style.cornerRadius
+      color: Qt.rgba(root.popupBackgroundColor.r, root.popupBackgroundColor.g,
+        root.popupBackgroundColor.b, 1)
+      border.width: 1
+      border.color: root.popupBorderColor
+    }
+
+    contentItem: Column {
+      id: contentColumn
+      spacing: Style.space(8)
+
+      Row {
+        width: parent.width
+        spacing: Style.space(8)
+
+        Text {
+          text: "Contacts"
+          color: root.textColor
+          font.family: root.panelFontFamily
+          font.pixelSize: Style.font.bodySmall
+          font.bold: true
+          anchors.verticalCenter: parent.verticalCenter
+        }
+
+        Text {
+          text: "(" + (root.contacts ? root.contacts.length : 0) + ")"
+          color: root.dimColor
+          font.family: root.panelFontFamily
+          font.pixelSize: Style.font.caption
+          anchors.verticalCenter: parent.verticalCenter
+        }
+      }
+
+      TextField {
+        id: searchField
+        width: parent.width
+        foreground: root.textColor
+        accent: root.accentColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        placeholderText: "Search contacts..."
+        onTextChanged: root.searchQuery = text
+      }
+
+      ListView {
+        id: contactsList
+        width: parent.width
+        implicitHeight: Math.min(contentHeight, Style.space(280))
+        clip: true
+        model: root.filteredContacts
+        ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+
+        delegate: Rectangle {
+          id: contactRow
+          required property var modelData
+          required property int index
+
+          width: contactsList.width
+          implicitHeight: Style.space(44)
+          radius: Style.cornerRadius
+          color: contactHover.hovered
+            ? Style.hoverFillFor(root.textColor, root.accentColor) : "transparent"
+
+          Rectangle {
+            id: avatar
+            anchors.left: parent.left
+            anchors.leftMargin: Style.space(6)
+            anchors.verticalCenter: parent.verticalCenter
+            width: Style.space(26)
+            height: width
+            radius: width / 2
+            color: Style.selectedFillFor(root.textColor, root.accentColor)
+
+            Text {
+              anchors.centerIn: parent
+              textFormat: Text.PlainText
+              text: {
+                var name = String(contactRow.modelData.name || contactRow.modelData.email || "")
+                return name.length > 0 ? name.charAt(0).toUpperCase() : "?"
+              }
+              color: root.textColor
+              font.family: root.panelFontFamily
+              font.pixelSize: Style.font.caption
+              font.bold: true
+            }
+          }
+
+          Column {
+            anchors.left: avatar.right
+            anchors.leftMargin: Style.space(8)
+            anchors.right: actionPills.left
+            anchors.rightMargin: Style.space(4)
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: Style.space(1)
+
+            Text {
+              width: parent.width
+              textFormat: Text.PlainText
+              text: String(contactRow.modelData.name || contactRow.modelData.email || "")
+              color: root.textColor
+              font.family: root.panelFontFamily
+              font.pixelSize: Style.font.bodySmall
+              font.bold: true
+              elide: Text.ElideRight
+            }
+
+            Text {
+              visible: String(contactRow.modelData.name || "") !== ""
+              width: parent.width
+              textFormat: Text.PlainText
+              text: String(contactRow.modelData.email || "")
+              color: root.dimColor
+              font.family: root.panelFontFamily
+              font.pixelSize: Style.font.caption
+              elide: Text.ElideMiddle
+            }
+          }
+
+          Row {
+            id: actionPills
+            anchors.right: parent.right
+            anchors.rightMargin: Style.space(6)
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: Style.space(3)
+
+            Button {
+              text: "+ To"
+              bordered: false
+              fontSize: Style.font.caption
+              foreground: root.accentColor
+              onClicked: {
+                root.contactChosen(contactRow.modelData, "to")
+                menu.close()
+              }
+            }
+
+            Button {
+              text: "+ Cc"
+              bordered: false
+              fontSize: Style.font.caption
+              foreground: root.dimColor
+              onClicked: {
+                root.contactChosen(contactRow.modelData, "cc")
+                menu.close()
+              }
+            }
+
+            Button {
+              text: "+ Bcc"
+              bordered: false
+              fontSize: Style.font.caption
+              foreground: root.dimColor
+              onClicked: {
+                root.contactChosen(contactRow.modelData, "bcc")
+                menu.close()
+              }
+            }
+          }
+
+          HoverHandler { id: contactHover }
+          TapHandler {
+            onTapped: {
+              root.contactChosen(contactRow.modelData, "to")
+              menu.close()
+            }
+          }
+        }
+      }
+
+      Text {
+        visible: root.filteredContacts.length === 0
+        width: parent.width
+        horizontalAlignment: Text.AlignHCenter
+        text: "No contacts found"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        topPadding: Style.space(12)
+        bottomPadding: Style.space(12)
+      }
+    }
+  }
+}

--- a/components/ImapSetupPage.qml
+++ b/components/ImapSetupPage.qml
@@ -2,6 +2,7 @@ import QtQuick
 import qs.Commons
 import qs.Ui
 import "../providers/ImapProtocol.js" as Imap
+import "../account/Aliases.js" as Aliases
 
 // Connecting an ordinary mailbox: an address, a password, and — only if the
 // guess was wrong — the servers.
@@ -76,7 +77,7 @@ Column {
       usernameField.text = settings.username
     }
     if (settings.aliases) {
-      aliasesField.text = Imap.formatAliases(settings.aliases)
+      aliasesField.text = Aliases.format(settings.aliases)
     }
     if (settings.imapHost !== "") {
       imapHostField.text = settings.imapHost

--- a/components/ImapSetupPage.qml
+++ b/components/ImapSetupPage.qml
@@ -356,6 +356,7 @@ Column {
 
       TextField {
         id: aliasesField
+        objectName: "imap-aliases-field"
         width: parent.width
         foreground: root.textColor
         font.family: root.panelFontFamily
@@ -367,7 +368,7 @@ Column {
     Text {
       width: parent.width
       visible: root.serversVisible
-      text: "Connections are TLS on the port given. Plain text is refused unless the server is on this machine."
+      text: "TLS on connect, or a required STARTTLS upgrade on ports 143, 25 and 587. Plain text is refused unless the server is on this machine."
       color: root.dimColor
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.caption

--- a/components/ImapSetupPage.qml
+++ b/components/ImapSetupPage.qml
@@ -359,7 +359,7 @@ Column {
         foreground: root.textColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.bodySmall
-        placeholderText: "Send-as aliases — comma-separated (e.g. alias@icloud.com)"
+        placeholderText: "Send-as aliases — comma-separated (e.g. alias@icloud.com (default))"
       }
     }
 

--- a/components/ImapSetupPage.qml
+++ b/components/ImapSetupPage.qml
@@ -46,7 +46,8 @@ Column {
       imapPort: imapPortField.text,
       smtpHost: smtpHostField.text.trim(),
       smtpPort: smtpPortField.text,
-      username: usernameField.text
+      username: usernameField.text,
+      aliases: aliasesField.text
     })
   }
 
@@ -73,6 +74,9 @@ Column {
     addressField.text = service ? service.accountAddress : ""
     if (settings.username !== "") {
       usernameField.text = settings.username
+    }
+    if (settings.aliases) {
+      aliasesField.text = Imap.formatAliases(settings.aliases)
     }
     if (settings.imapHost !== "") {
       imapHostField.text = settings.imapHost
@@ -347,6 +351,15 @@ Column {
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.bodySmall
         placeholderText: "Username — only if it is not the address"
+      }
+
+      TextField {
+        id: aliasesField
+        width: parent.width
+        foreground: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        placeholderText: "Send-as aliases — comma-separated (e.g. alias@icloud.com)"
       }
     }
 

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -152,6 +152,63 @@ Column {
     }
   }
 
+  // -------------------------------------------------------- notifications
+
+  Text {
+    text: "NOTIFICATIONS"
+    color: root.dimColor
+    font.family: root.panelFontFamily
+    font.pixelSize: Style.font.caption
+    font.letterSpacing: 1
+  }
+
+  Rectangle {
+    width: parent.width
+    implicitHeight: Math.max(notifyText.implicitHeight, notifySwitch.implicitHeight)
+      + Style.space(16)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+
+    Column {
+      id: notifyText
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(12)
+      anchors.right: notifySwitch.left
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(2)
+
+      Text {
+        width: parent.width
+        text: "New mail notifications"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+      }
+
+      Text {
+        width: parent.width
+        text: "Send a desktop notification when new mail arrives in your inbox"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+      }
+    }
+
+    ToggleSwitch {
+      id: notifySwitch
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      checked: !!root.service && root.service.notifyNewMail
+      foreground: root.textColor
+      accent: root.accentColor
+      onToggled: if (root.service)
+        root.service.setNotifyNewMail(!root.service.notifyNewMail)
+    }
+  }
+
   // --------------------------------------------------------------- writing
 
   Text {

--- a/compose/Recipients.js
+++ b/compose/Recipients.js
@@ -89,3 +89,37 @@ function accept(text, contact) {
   var prefix = split >= 0 ? value.substring(0, split + 1).trim() + " " : ""
   return prefix + address(contact)
 }
+
+function append(text, contact) {
+  var addr = address(contact)
+  if (!addr) return String(text || "")
+  var current = String(text || "").trim()
+  if (current === "") return addr
+  current = current.replace(/[,;]+$/, "").trim()
+  var used = usedAddresses(current + ",")
+  var clean = cleanContact(contact)
+  if (clean && used[clean.email.toLowerCase()]) return current
+  return current + ", " + addr
+}
+
+function filter(values, query, limit) {
+  var contacts = normalize(values)
+  var q = String(query || "").trim().toLowerCase()
+  var out = []
+  for (var i = 0; i < contacts.length; i++) {
+    var c = contacts[i]
+    if (q === "" || c.email.toLowerCase().indexOf(q) >= 0 || c.name.toLowerCase().indexOf(q) >= 0) {
+      out.push(c)
+    }
+  }
+  out.sort(function(left, right) {
+    var leftName = (left.name || left.email).toLowerCase()
+    var rightName = (right.name || right.email).toLowerCase()
+    return leftName < rightName ? -1 : (leftName > rightName ? 1 : 0)
+  })
+  if (typeof limit === "number" && limit > 0) {
+    return out.slice(0, limit)
+  }
+  return out
+}
+

--- a/providers/AuthManager.qml
+++ b/providers/AuthManager.qml
@@ -5,6 +5,7 @@ import qs.Commons
 
 import "OAuth.js" as OAuth
 import "Credentials.js" as Credentials
+import "Secrets.js" as Secrets
 
 // Google sign-in and token storage. Nothing else in the plugin needs to know
 // what a refresh token looks like: callers ask for `withAccessToken` and get a
@@ -779,7 +780,8 @@ Item {
     stdout: StdioCollector { id: secretLookupOutput; waitForEnd: true }
     stderr: StdioCollector { waitForEnd: true }
     onExited: function(exitCode) {
-      var value = (exitCode === 0 && secretLookupOutput.text) ? String(secretLookupOutput.text).trim() : ""
+      // One trailing newline is the pipe's; everything else is the secret.
+      var value = exitCode === 0 ? Secrets.fromKeyring(secretLookupOutput.text) : ""
       root.handleSecretLookup(value)
     }
   }

--- a/providers/AuthManager.qml
+++ b/providers/AuthManager.qml
@@ -776,13 +776,11 @@ Item {
 
   Process {
     id: secretLookup
-    stdout: SplitParser {
-      splitMarker: "\n"
-      onRead: function(line) { root.handleSecretLookup(line) }
-    }
+    stdout: StdioCollector { id: secretLookupOutput; waitForEnd: true }
     stderr: StdioCollector { waitForEnd: true }
     onExited: function(exitCode) {
-      if (!root.lookupHandled) root.handleSecretLookup("")
+      var value = (exitCode === 0 && secretLookupOutput.text) ? String(secretLookupOutput.text).trim() : ""
+      root.handleSecretLookup(value)
     }
   }
 

--- a/providers/ImapAuth.qml
+++ b/providers/ImapAuth.qml
@@ -4,6 +4,7 @@ import Quickshell.Io
 
 import "ImapProtocol.js" as Imap
 import "Credentials.js" as Credentials
+import "Secrets.js" as Secrets
 
 // An IMAP account's sign-in, which is a server address and a password.
 //
@@ -256,7 +257,8 @@ Item {
     stdout: StdioCollector { id: secretOutput; waitForEnd: true }
     stderr: StdioCollector { waitForEnd: true }
     onExited: function(exitCode) {
-      var value = (exitCode === 0 && secretOutput.text) ? String(secretOutput.text).trim() : ""
+      // One trailing newline is the pipe's; everything else is the secret.
+      var value = exitCode === 0 ? Secrets.fromKeyring(secretOutput.text) : ""
       root.handleSecretLookup(value)
     }
   }

--- a/providers/ImapAuth.qml
+++ b/providers/ImapAuth.qml
@@ -253,15 +253,11 @@ Item {
 
   Process {
     id: secretLookup
-    stdout: SplitParser {
-      splitMarker: "\n"
-      onRead: function(line) { root.handleSecretLookup(line) }
-    }
+    stdout: StdioCollector { id: secretOutput; waitForEnd: true }
     stderr: StdioCollector { waitForEnd: true }
     onExited: function(exitCode) {
-      // No entry is not an error: it is what a mailbox that has never been
-      // signed in to looks like.
-      if (!root.lookupHandled) root.handleSecretLookup("")
+      var value = (exitCode === 0 && secretOutput.text) ? String(secretOutput.text).trim() : ""
+      root.handleSecretLookup(value)
     }
   }
 

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -4,6 +4,7 @@ import Quickshell.Io
 
 import "ImapProtocol.js" as Imap
 import "../message/Message.js" as Mail
+import "../account/Aliases.js" as Aliases
 
 // An IMAP mailbox, wearing the same interface `GmailApiClient` wears.
 //
@@ -561,49 +562,18 @@ Item {
     return newHandle()
   }
 
-  // IMAP has no send-as settings endpoint. Its senders are the mailbox
-  // address and any aliases configured by the user, returned in the same shape
-  // as Gmail aliases so everything above the provider boundary stays provider-neutral.
+  // IMAP has no send-as settings endpoint. Its senders are the mailbox address
+  // and whatever aliases the user configured, returned in the same shape as
+  // Gmail's so everything above the provider boundary stays provider-neutral.
+  // Which of them is the default is `Aliases.sendAsList`'s decision, where the
+  // node tests can reach it.
   function getSendAs(callback) {
     if (typeof callback !== "function") return newHandle()
     var address = String(root.email || "")
-    var settings = auth ? auth.settings : null
-    var customAliases = settings && Array.isArray(settings.aliases) ? settings.aliases : []
+    var configured = auth && auth.settings ? auth.settings.aliases : null
     Qt.callLater(function() {
       if (!root) return
-      var list = []
-      var seen = ({})
-      var hasDefaultAlias = false
-      for (var k = 0; k < customAliases.length; k++) {
-        if (customAliases[k] && customAliases[k].isDefault === true) {
-          hasDefaultAlias = true
-          break
-        }
-      }
-      if (address !== "") {
-        list.push({
-          email: address,
-          displayName: "",
-          isPrimary: true,
-          isDefault: !hasDefaultAlias
-        })
-        seen[address.toLowerCase()] = true
-      }
-      for (var i = 0; i < customAliases.length; i++) {
-        var item = customAliases[i]
-        var email = (typeof item === "string" ? item : (item ? item.email : "")).trim()
-        var isDef = item && typeof item === "object" ? (item.isDefault === true) : false
-        if (email !== "" && !seen[email.toLowerCase()]) {
-          seen[email.toLowerCase()] = true
-          list.push({
-            email: email,
-            displayName: (item && item.displayName) ? String(item.displayName).trim() : "",
-            isPrimary: false,
-            isDefault: isDef
-          })
-        }
-      }
-      callback(list, "")
+      callback(Aliases.sendAsList(address, configured), "")
     })
     return newHandle()
   }

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -561,20 +561,41 @@ Item {
     return newHandle()
   }
 
-  // IMAP has no send-as settings endpoint. Its one sender is the mailbox
-  // address the user configured, returned in the same shape as Gmail aliases
-  // so everything above the provider boundary can stay provider-neutral.
+  // IMAP has no send-as settings endpoint. Its senders are the mailbox
+  // address and any aliases configured by the user, returned in the same shape
+  // as Gmail aliases so everything above the provider boundary stays provider-neutral.
   function getSendAs(callback) {
     if (typeof callback !== "function") return newHandle()
     var address = String(root.email || "")
+    var settings = auth ? auth.settings : null
+    var customAliases = settings && Array.isArray(settings.aliases) ? settings.aliases : []
     Qt.callLater(function() {
       if (!root) return
-      callback(address === "" ? [] : [{
-        email: address,
-        displayName: "",
-        isPrimary: true,
-        isDefault: true
-      }], "")
+      var list = []
+      var seen = ({})
+      if (address !== "") {
+        list.push({
+          email: address,
+          displayName: "",
+          isPrimary: true,
+          isDefault: true
+        })
+        seen[address.toLowerCase()] = true
+      }
+      for (var i = 0; i < customAliases.length; i++) {
+        var item = customAliases[i]
+        var email = (typeof item === "string" ? item : (item ? item.email : "")).trim()
+        if (email !== "" && !seen[email.toLowerCase()]) {
+          seen[email.toLowerCase()] = true
+          list.push({
+            email: email,
+            displayName: (item && item.displayName) ? String(item.displayName).trim() : "",
+            isPrimary: false,
+            isDefault: false
+          })
+        }
+      }
+      callback(list, "")
     })
     return newHandle()
   }
@@ -802,7 +823,10 @@ Item {
         if (typeof callback === "function") callback(null, credentialError || "Not signed in")
         return
       }
-      var sender = settings ? String(settings.username || "") : ""
+      var fromAddresses = Mail.parseAddressList(Mail.headerFrom(parsed.headers, "From"))
+      var sender = (fromAddresses.length > 0 && fromAddresses[0].email)
+        ? fromAddresses[0].email
+        : (settings ? String(settings.username || "") : "") || root.email
       var fields = [Mail.encodeBase64(smtp), Mail.encodeBase64(credentials),
         Mail.encodeBase64(sender), Mail.encodeBase64(message)]
       for (var k = 0; k < recipients.length; k++) fields.push(Mail.encodeBase64(recipients[k]))

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -573,25 +573,33 @@ Item {
       if (!root) return
       var list = []
       var seen = ({})
+      var hasDefaultAlias = false
+      for (var k = 0; k < customAliases.length; k++) {
+        if (customAliases[k] && customAliases[k].isDefault === true) {
+          hasDefaultAlias = true
+          break
+        }
+      }
       if (address !== "") {
         list.push({
           email: address,
           displayName: "",
           isPrimary: true,
-          isDefault: true
+          isDefault: !hasDefaultAlias
         })
         seen[address.toLowerCase()] = true
       }
       for (var i = 0; i < customAliases.length; i++) {
         var item = customAliases[i]
         var email = (typeof item === "string" ? item : (item ? item.email : "")).trim()
+        var isDef = item && typeof item === "object" ? (item.isDefault === true) : false
         if (email !== "" && !seen[email.toLowerCase()]) {
           seen[email.toLowerCase()] = true
           list.push({
             email: email,
             displayName: (item && item.displayName) ? String(item.displayName).trim() : "",
             isPrimary: false,
-            isDefault: false
+            isDefault: isDef
           })
         }
       }

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -279,7 +279,8 @@ function validateSettings(raw) {
 function imapUrl(settings, folder) {
   var values = normalizeSettings(settings)
   if (!isValidHost(values.imapHost)) return ""
-  var scheme = values.insecure ? "imap" : "imaps"
+  var isTls = Number(values.imapPort) === 993 && !values.insecure
+  var scheme = isTls ? "imaps" : "imap"
   var url = scheme + "://" + values.imapHost + ":" + values.imapPort
   var box = trimmed(folder)
   // The mailbox is a path segment, so anything that could end the segment or
@@ -292,9 +293,9 @@ function imapUrl(settings, folder) {
 function smtpUrl(settings) {
   var values = normalizeSettings(settings)
   if (!isValidHost(values.smtpHost)) return ""
-  // IMAP and SMTP may name different hosts. The shared local-transport flag
-  // cannot let a loopback IMAP server downgrade a remote SMTP connection.
-  var scheme = values.insecure && isLoopback(values.smtpHost) ? "smtp" : "smtps"
+  // Port 465 is implicit TLS (smtps). Port 587 and others use STARTTLS over smtp.
+  var isTls = Number(values.smtpPort) === 465 && !(values.insecure && isLoopback(values.smtpHost))
+  var scheme = isTls ? "smtps" : "smtp"
   return scheme + "://" + values.smtpHost + ":" + values.smtpPort
 }
 

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -1,5 +1,7 @@
 .pragma library
 
+.import "../account/Aliases.js" as Aliases
+
 // The IMAP protocol, and nothing else. No transport lives here — `ImapClient.qml`
 // owns the process that speaks to the server — and no message format lives here
 // either: an RFC 822 message is `Message.js`'s subject, and this file hands one
@@ -172,89 +174,6 @@ function isValidHost(value) {
   return /^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*$/.test(host)
 }
 
-var EMAIL_PATTERN = /^[^\s@]+@[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}$/
-
-function parseAliases(value) {
-  if (!value) return []
-  var rawList = []
-  if (Array.isArray(value)) {
-    rawList = value
-  } else if (typeof value === "string") {
-    rawList = value.split(/[\r\n,]+/)
-  }
-  var out = []
-  var seen = {}
-  for (var i = 0; i < rawList.length; i++) {
-    var item = rawList[i]
-    var email = ""
-    var displayName = ""
-    var isDef = false
-    if (typeof item === "string") {
-      var str = trimmed(item)
-      if (/\(default\)|\[default\]/i.test(str)) {
-        isDef = true
-        str = str.replace(/\(default\)|\[default\]/gi, "").trim()
-      } else if (str.endsWith("*")) {
-        isDef = true
-        str = str.replace(/\*+$/, "").trim()
-      } else if (str.startsWith("*")) {
-        isDef = true
-        str = str.replace(/^\*+/, "").trim()
-      }
-      var matchAngle = str.match(/^(.*?)\s*<([^\s@]+@[^>]+)>\s*$/)
-      if (matchAngle) {
-        displayName = trimmed(matchAngle[1])
-        email = trimmed(matchAngle[2]).toLowerCase()
-      } else {
-        email = trimmed(str).toLowerCase()
-      }
-    } else if (item && typeof item === "object") {
-      email = trimmed(item.email || item.sendAsEmail).toLowerCase()
-      displayName = trimmed(item.displayName || item.name)
-      isDef = item.isDefault === true || item.default === true || item.defaultFrom === true
-    }
-    if (!email || !EMAIL_PATTERN.test(email)) continue
-    if (seen[email]) continue
-    seen[email] = true
-    out.push({
-      email: email,
-      displayName: displayName,
-      isPrimary: false,
-      isDefault: isDef
-    })
-  }
-  var foundDefault = false
-  for (var j = 0; j < out.length; j++) {
-    if (out[j].isDefault) {
-      if (foundDefault) {
-        out[j].isDefault = false
-      } else {
-        foundDefault = true
-      }
-    }
-  }
-  return out
-}
-
-function formatAliases(aliases) {
-  var list = parseAliases(aliases)
-  var entries = []
-  for (var i = 0; i < list.length; i++) {
-    var item = list[i]
-    var str = ""
-    if (item.displayName) {
-      str = item.displayName + " <" + item.email + ">"
-    } else {
-      str = item.email
-    }
-    if (item.isDefault) {
-      str += " (default)"
-    }
-    entries.push(str)
-  }
-  return entries.join(", ")
-}
-
 function normalizedPort(value, fallback) {
   var port = Math.floor(Number(value))
   var backup = Math.floor(Number(fallback)) || DEFAULT_IMAP_PORT
@@ -262,15 +181,21 @@ function normalizedPort(value, fallback) {
   return port
 }
 
+// A host name is case-insensitive, and lowercasing it here is what keeps every
+// later reading of it the same one. `isLoopback` already compares lowercased,
+// so a user who typed "LocalHost" was judged local up here and then failed to
+// match the transport's own loopback patterns further down — which meant the
+// local bridge, the one server that legitimately speaks plaintext, was the one
+// refused for not offering TLS.
 function normalizeSettings(raw) {
   var values = raw || {}
   return {
-    imapHost: trimmed(values.imapHost),
+    imapHost: trimmed(values.imapHost).toLowerCase(),
     imapPort: normalizedPort(values.imapPort, DEFAULT_IMAP_PORT),
-    smtpHost: trimmed(values.smtpHost),
+    smtpHost: trimmed(values.smtpHost).toLowerCase(),
     smtpPort: normalizedPort(values.smtpPort, DEFAULT_SMTP_PORT),
     username: trimmed(values.username),
-    aliases: parseAliases(values.aliases),
+    aliases: Aliases.parse(values.aliases),
     // Loopback only. A plaintext session to anywhere else is a password on the
     // wire, and the one legitimate case — a local bridge — never leaves the
     // machine.
@@ -315,11 +240,34 @@ function validateSettings(raw) {
 // The URL the transport connects with. Built here rather than in the shell
 // script so the host has been through `isValidHost` on the way, and so the
 // tests can see what a given account would dial.
+// Which ports mean "connect in the clear, then upgrade". Naming the STARTTLS
+// ports rather than the TLS ones is the whole of the difference between this
+// and asking whether the port is 993: a server on 9993, or on whatever a
+// hosting panel picked, speaks TLS from the first byte and has no STARTTLS to
+// offer, so a client that inferred STARTTLS from "not 993" would simply stop
+// connecting to it. These three are the ports the RFCs assign to the upgrade,
+// and a server on any other one is dialled the way it was before this list
+// existed.
+//
+// The upgrade is not optional once it is chosen: `mail-transport.sh` adds
+// `ssl-reqd` to every non-loopback plaintext scheme, so a server that turns
+// out not to offer STARTTLS is refused rather than spoken to in the clear.
+var STARTTLS_IMAP_PORTS = [143]
+var STARTTLS_SMTP_PORTS = [25, 587]
+
+function usesStartTls(port, ports) {
+  var value = Number(port)
+  for (var i = 0; i < ports.length; i++) {
+    if (ports[i] === value) return true
+  }
+  return false
+}
+
 function imapUrl(settings, folder) {
   var values = normalizeSettings(settings)
   if (!isValidHost(values.imapHost)) return ""
-  var isTls = Number(values.imapPort) === 993 && !values.insecure
-  var scheme = isTls ? "imaps" : "imap"
+  var plain = values.insecure || usesStartTls(values.imapPort, STARTTLS_IMAP_PORTS)
+  var scheme = plain ? "imap" : "imaps"
   var url = scheme + "://" + values.imapHost + ":" + values.imapPort
   var box = trimmed(folder)
   // The mailbox is a path segment, so anything that could end the segment or
@@ -332,9 +280,11 @@ function imapUrl(settings, folder) {
 function smtpUrl(settings) {
   var values = normalizeSettings(settings)
   if (!isValidHost(values.smtpHost)) return ""
-  // Port 465 is implicit TLS (smtps). Port 587 and others use STARTTLS over smtp.
-  var isTls = Number(values.smtpPort) === 465 && !(values.insecure && isLoopback(values.smtpHost))
-  var scheme = isTls ? "smtps" : "smtp"
+  // IMAP and SMTP may name different hosts. The shared local-transport flag
+  // cannot let a loopback IMAP server downgrade a remote SMTP connection.
+  var local = values.insecure && isLoopback(values.smtpHost)
+  var plain = local || usesStartTls(values.smtpPort, STARTTLS_SMTP_PORTS)
+  var scheme = plain ? "smtp" : "smtps"
   return scheme + "://" + values.smtpHost + ":" + values.smtpPort
 }
 

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -172,6 +172,50 @@ function isValidHost(value) {
   return /^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*$/.test(host)
 }
 
+var EMAIL_PATTERN = /^[^\s@]+@[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}$/
+
+function parseAliases(value) {
+  if (!value) return []
+  var rawList = []
+  if (Array.isArray(value)) {
+    rawList = value
+  } else if (typeof value === "string") {
+    rawList = value.split(/[\r\n,]+/)
+  }
+  var out = []
+  var seen = {}
+  for (var i = 0; i < rawList.length; i++) {
+    var item = rawList[i]
+    var email = ""
+    var displayName = ""
+    if (typeof item === "string") {
+      email = trimmed(item).toLowerCase()
+    } else if (item && typeof item === "object") {
+      email = trimmed(item.email || item.sendAsEmail).toLowerCase()
+      displayName = trimmed(item.displayName || item.name)
+    }
+    if (!email || !EMAIL_PATTERN.test(email)) continue
+    if (seen[email]) continue
+    seen[email] = true
+    out.push({
+      email: email,
+      displayName: displayName,
+      isPrimary: false,
+      isDefault: false
+    })
+  }
+  return out
+}
+
+function formatAliases(aliases) {
+  var list = parseAliases(aliases)
+  var emails = []
+  for (var i = 0; i < list.length; i++) {
+    emails.push(list[i].email)
+  }
+  return emails.join(", ")
+}
+
 function normalizedPort(value, fallback) {
   var port = Math.floor(Number(value))
   var backup = Math.floor(Number(fallback)) || DEFAULT_IMAP_PORT
@@ -187,6 +231,7 @@ function normalizeSettings(raw) {
     smtpHost: trimmed(values.smtpHost),
     smtpPort: normalizedPort(values.smtpPort, DEFAULT_SMTP_PORT),
     username: trimmed(values.username),
+    aliases: parseAliases(values.aliases),
     // Loopback only. A plaintext session to anywhere else is a password on the
     // wire, and the one legitimate case — a local bridge — never leaves the
     // machine.
@@ -211,6 +256,7 @@ function setupSettings(raw) {
     smtpHost: values.smtpHost,
     smtpPort: values.smtpPort,
     username: trimmed(values.username) || trimmed(values.address),
+    aliases: values.aliases,
     insecure: isLoopback(values.imapHost)
   })
 }

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -188,11 +188,30 @@ function parseAliases(value) {
     var item = rawList[i]
     var email = ""
     var displayName = ""
+    var isDef = false
     if (typeof item === "string") {
-      email = trimmed(item).toLowerCase()
+      var str = trimmed(item)
+      if (/\(default\)|\[default\]/i.test(str)) {
+        isDef = true
+        str = str.replace(/\(default\)|\[default\]/gi, "").trim()
+      } else if (str.endsWith("*")) {
+        isDef = true
+        str = str.replace(/\*+$/, "").trim()
+      } else if (str.startsWith("*")) {
+        isDef = true
+        str = str.replace(/^\*+/, "").trim()
+      }
+      var matchAngle = str.match(/^(.*?)\s*<([^\s@]+@[^>]+)>\s*$/)
+      if (matchAngle) {
+        displayName = trimmed(matchAngle[1])
+        email = trimmed(matchAngle[2]).toLowerCase()
+      } else {
+        email = trimmed(str).toLowerCase()
+      }
     } else if (item && typeof item === "object") {
       email = trimmed(item.email || item.sendAsEmail).toLowerCase()
       displayName = trimmed(item.displayName || item.name)
+      isDef = item.isDefault === true || item.default === true || item.defaultFrom === true
     }
     if (!email || !EMAIL_PATTERN.test(email)) continue
     if (seen[email]) continue
@@ -201,19 +220,39 @@ function parseAliases(value) {
       email: email,
       displayName: displayName,
       isPrimary: false,
-      isDefault: false
+      isDefault: isDef
     })
+  }
+  var foundDefault = false
+  for (var j = 0; j < out.length; j++) {
+    if (out[j].isDefault) {
+      if (foundDefault) {
+        out[j].isDefault = false
+      } else {
+        foundDefault = true
+      }
+    }
   }
   return out
 }
 
 function formatAliases(aliases) {
   var list = parseAliases(aliases)
-  var emails = []
+  var entries = []
   for (var i = 0; i < list.length; i++) {
-    emails.push(list[i].email)
+    var item = list[i]
+    var str = ""
+    if (item.displayName) {
+      str = item.displayName + " <" + item.email + ">"
+    } else {
+      str = item.email
+    }
+    if (item.isDefault) {
+      str += " (default)"
+    }
+    entries.push(str)
   }
-  return emails.join(", ")
+  return entries.join(", ")
 }
 
 function normalizedPort(value, fallback) {

--- a/providers/Secrets.js
+++ b/providers/Secrets.js
@@ -1,0 +1,20 @@
+.pragma library
+
+// What comes back from `secret-tool`, and what it is safe to change about it.
+//
+// A secret is bytes the user chose and the keyring stored, so the only thing
+// this may remove is punctuation the pipe added. `secret-tool lookup` writes
+// the value with no trailing newline of its own — which is the bug this exists
+// for, because a `SplitParser` splitting on "\n" then never fires at all and a
+// stored password reads back as no password at all — but the shells and stores
+// around it are not all so careful, and one trailing newline is the shape a
+// line-oriented pipe can add.
+//
+// Exactly one, and only at the end. `trim()` looks like the same thing and is
+// not: a password may legitimately begin or end with a space, and a client that
+// quietly removed it would authenticate as a different string and report the
+// password as wrong, with nothing the user could do about it from the interface.
+function fromKeyring(value) {
+  var text = String(value === undefined || value === null ? "" : value)
+  return text.charAt(text.length - 1) === "\n" ? text.substring(0, text.length - 1) : text
+}

--- a/scripts/contact-suggestions.py
+++ b/scripts/contact-suggestions.py
@@ -69,15 +69,118 @@ def records(database: Path) -> list[dict[str, str]]:
     return contacts
 
 
+def parse_vcf(path: Path) -> list[dict[str, str]]:
+    if not path.is_file():
+        return []
+    contacts: list[dict[str, str]] = []
+    current_name = ""
+    current_emails: list[str] = []
+    try:
+        for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            line = line.strip()
+            if line.startswith("BEGIN:VCARD"):
+                current_name = ""
+                current_emails = []
+            elif line.startswith("FN:") or line.startswith("FN;"):
+                current_name = line.split(":", 1)[1].strip()
+            elif line.startswith("EMAIL:") or line.startswith("EMAIL;"):
+                current_emails.append(line.split(":", 1)[1].strip())
+            elif line.startswith("END:VCARD"):
+                for em in current_emails:
+                    if "@" in em:
+                        contacts.append({"name": current_name, "email": em})
+    except Exception:
+        pass
+    return contacts
+
+
+def omamail_cache_records(cache_dir: Path) -> list[dict[str, str]]:
+    if not cache_dir.is_dir():
+        return []
+    contacts: list[dict[str, str]] = []
+    for acc_file in sorted(cache_dir.glob("account-*.json")):
+        try:
+            data = json.loads(acc_file.read_text(encoding="utf-8", errors="ignore"))
+            queries = data.get("queries", {})
+            if isinstance(queries, dict):
+                for qdata in queries.values():
+                    if not isinstance(qdata, dict):
+                        continue
+                    entries = qdata.get("summaries", []) or qdata.get("messages", [])
+                    if isinstance(entries, list):
+                        for msg in entries:
+                            if not isinstance(msg, dict):
+                                continue
+                            for f in ("from", "replyTo"):
+                                val = msg.get(f)
+                                if isinstance(val, dict):
+                                    name = val.get("name") or val.get("display") or ""
+                                    email = val.get("email") or ""
+                                    if "@" in email:
+                                        contacts.append({"name": str(name).strip(), "email": str(email).strip()})
+                            for f in ("to", "cc", "bcc"):
+                                val = msg.get(f)
+                                if isinstance(val, list):
+                                    for item in val:
+                                        if isinstance(item, dict):
+                                            name = item.get("name") or item.get("display") or ""
+                                            email = item.get("email") or ""
+                                            if "@" in email:
+                                                contacts.append({"name": str(name).strip(), "email": str(email).strip()})
+        except Exception:
+            pass
+    return contacts
+
+
+def json_contacts(path: Path) -> list[dict[str, str]]:
+    if not path.is_file():
+        return []
+    contacts: list[dict[str, str]] = []
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8", errors="ignore"))
+        if isinstance(raw, list):
+            for item in raw:
+                if isinstance(item, dict) and "email" in item:
+                    contacts.append({"name": str(item.get("name") or "").strip(), "email": str(item["email"]).strip()})
+        elif isinstance(raw, dict):
+            for k, v in raw.items():
+                if "@" in k:
+                    contacts.append({"name": str(v or "").strip(), "email": k.strip()})
+                elif "@" in str(v):
+                    contacts.append({"name": k.strip(), "email": str(v).strip()})
+    except Exception:
+        pass
+    return contacts
+
+
 def main() -> None:
     home = Path(os.environ.get("HOME", "")).expanduser()
+    cache_env = os.environ.get("XDG_CACHE_HOME")
+    cache_dir = (Path(cache_env) if cache_env else (home / ".cache")) / "omamail"
+    config_env = os.environ.get("XDG_CONFIG_HOME")
+    config_dir = (Path(config_env) if config_env else (home / ".config")) / "omamail"
     roots = [home / ".thunderbird", home / ".betterbird"]
     contacts: dict[str, dict[str, str]] = {}
+
+    def collect(entries: list[dict[str, str]]) -> None:
+        for contact in entries:
+            email = str(contact.get("email") or "").strip()
+            name = str(contact.get("name") or "").strip()
+            if "@" not in email or email.startswith("@") or email.endswith("@"):
+                continue
+            key = email.lower()
+            if key not in contacts or (not contacts[key]["name"] and name):
+                contacts[key] = {"name": name, "email": email}
+
     for root in roots:
         for profile in profiles(root):
             for database in databases(profile):
-                for contact in records(database):
-                    contacts.setdefault(contact["email"].lower(), contact)
+                collect(records(database))
+
+    collect(omamail_cache_records(cache_dir))
+    collect(json_contacts(config_dir / "contacts.json"))
+    collect(parse_vcf(config_dir / "contacts.vcf"))
+
     result = sorted(
         contacts.values(),
         key=lambda contact: (contact["name"] or contact["email"]).casefold(),

--- a/scripts/contact-suggestions.py
+++ b/scripts/contact-suggestions.py
@@ -3,9 +3,43 @@
 import configparser
 import json
 import os
+import re
 import sqlite3
 from pathlib import Path
 from urllib.parse import quote
+
+# The one gate every harvested address passes, because the harvesters below
+# read files this program did not write and shapes it did not choose. "@ is
+# somewhere in the string" is not that gate: a JSON value stringified by
+# accident contains one, and what reached the picker was a whole serialised
+# object offered as an address to send mail to.
+ADDRESS = re.compile(r"^[^\s@<>,;\"\\]+@[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}$")
+
+# A recipient list longer than this is a bulk send rather than a conversation.
+# Harvesting one puts fifty strangers who happened to share a mailing with the
+# user into the address completion, ahead of the addresses they curated.
+MAX_HARVESTED_RECIPIENTS = 5
+
+# The cache holds every query the panel has ever run. This is the ceiling on
+# what any one of them may contribute, so a single large mailbox cannot fill
+# the picker on its own.
+MAX_CACHE_CONTACTS = 2000
+
+
+def is_address(value: str) -> bool:
+    return bool(ADDRESS.match(value))
+
+
+# `Message.parseAddress` fills a missing display name from the local part
+# verbatim, so a sender with no name of its own arrives here calling itself
+# "noreply". That is not a name anybody wrote, and offering it as one puts
+# `noreply <noreply@example.com>` into a To: field.
+#
+# Compared exactly rather than case-insensitively, because the fabricated value
+# is the local part character for character. "Jane" against jane@example.com is
+# a name the sender typed and is kept; "jane" against it is the fallback.
+def real_name(name: str, email: str) -> str:
+    return "" if name == email.split("@", 1)[0] else name
 
 
 def profiles(root: Path) -> list[Path]:
@@ -72,12 +106,25 @@ def records(database: Path) -> list[dict[str, str]]:
 def parse_vcf(path: Path) -> list[dict[str, str]]:
     if not path.is_file():
         return []
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return []
+
+    # vCard folds a value past ~75 characters onto a continuation line marked
+    # by a leading space or tab. Stripping every line first turns those into
+    # unrecognised properties, which truncates long names and long addresses at
+    # the fold — and exports from Google Contacts and iOS fold routinely.
+    unfolded = re.sub(r"\r?\n[ \t]", "", text)
+
     contacts: list[dict[str, str]] = []
     current_name = ""
     current_emails: list[str] = []
-    try:
-        for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
-            line = line.strip()
+    for line in unfolded.splitlines():
+        line = line.strip()
+        # Per line, not per file. One property without a colon used to raise
+        # out of the whole loop and silently discard every remaining card.
+        try:
             if line.startswith("BEGIN:VCARD"):
                 current_name = ""
                 current_emails = []
@@ -86,70 +133,99 @@ def parse_vcf(path: Path) -> list[dict[str, str]]:
             elif line.startswith("EMAIL:") or line.startswith("EMAIL;"):
                 current_emails.append(line.split(":", 1)[1].strip())
             elif line.startswith("END:VCARD"):
-                for em in current_emails:
-                    if "@" in em:
-                        contacts.append({"name": current_name, "email": em})
-    except Exception:
-        pass
+                for address in current_emails:
+                    contacts.append({"name": current_name, "email": address})
+                current_name = ""
+                current_emails = []
+        except IndexError:
+            continue
     return contacts
 
 
+# Everybody the panel has already shown the user, out of the pages it cached.
+#
+# Bounded on both sides. A recipient list longer than MAX_HARVESTED_RECIPIENTS
+# is a bulk send, and every stranger who shared that mailing is not a contact —
+# harvesting them buries the addresses the user actually corresponds with under
+# a list they never chose. Bcc is left out entirely: in a received message it
+# is either empty or the reader's own address.
 def omamail_cache_records(cache_dir: Path) -> list[dict[str, str]]:
     if not cache_dir.is_dir():
         return []
     contacts: list[dict[str, str]] = []
-    for acc_file in sorted(cache_dir.glob("account-*.json")):
+
+    def take(value: object) -> None:
+        if not isinstance(value, dict):
+            return
+        email = str(value.get("email") or "").strip()
+        if not is_address(email):
+            return
+        name = str(value.get("name") or value.get("display") or "").strip()
+        contacts.append({"name": real_name(name, email), "email": email})
+
+    for account in sorted(cache_dir.glob("account-*.json")):
         try:
-            data = json.loads(acc_file.read_text(encoding="utf-8", errors="ignore"))
-            queries = data.get("queries", {})
-            if isinstance(queries, dict):
-                for qdata in queries.values():
-                    if not isinstance(qdata, dict):
+            data = json.loads(account.read_text(encoding="utf-8", errors="ignore"))
+        except (OSError, ValueError):
+            continue
+        queries = data.get("queries", {})
+        if not isinstance(queries, dict):
+            continue
+        for entry in queries.values():
+            if not isinstance(entry, dict):
+                continue
+            rows = entry.get("summaries", []) or entry.get("messages", [])
+            if not isinstance(rows, list):
+                continue
+            for message in rows:
+                if not isinstance(message, dict):
+                    continue
+                if len(contacts) >= MAX_CACHE_CONTACTS:
+                    return contacts
+                for field in ("from", "replyTo"):
+                    take(message.get(field))
+                for field in ("to", "cc"):
+                    people = message.get(field)
+                    if not isinstance(people, list):
                         continue
-                    entries = qdata.get("summaries", []) or qdata.get("messages", [])
-                    if isinstance(entries, list):
-                        for msg in entries:
-                            if not isinstance(msg, dict):
-                                continue
-                            for f in ("from", "replyTo"):
-                                val = msg.get(f)
-                                if isinstance(val, dict):
-                                    name = val.get("name") or val.get("display") or ""
-                                    email = val.get("email") or ""
-                                    if "@" in email:
-                                        contacts.append({"name": str(name).strip(), "email": str(email).strip()})
-                            for f in ("to", "cc", "bcc"):
-                                val = msg.get(f)
-                                if isinstance(val, list):
-                                    for item in val:
-                                        if isinstance(item, dict):
-                                            name = item.get("name") or item.get("display") or ""
-                                            email = item.get("email") or ""
-                                            if "@" in email:
-                                                contacts.append({"name": str(name).strip(), "email": str(email).strip()})
-        except Exception:
-            pass
+                    if len(people) > MAX_HARVESTED_RECIPIENTS:
+                        continue
+                    for person in people:
+                        take(person)
     return contacts
 
 
+# A hand-written address book, in either of the two shapes somebody would
+# reasonably write one in: a list of objects, or a mapping.
+#
+# The mapping branch used to ask whether `str(value)` contained an "@", which
+# is true of a stringified list — so the natural wrapper `{"contacts": [...]}`
+# produced a contact named "contacts" whose address was the whole serialised
+# array, offered in the picker as something to send mail to. Both sides are
+# checked as addresses now, and a value that is not a string is not one.
 def json_contacts(path: Path) -> list[dict[str, str]]:
     if not path.is_file():
         return []
-    contacts: list[dict[str, str]] = []
     try:
         raw = json.loads(path.read_text(encoding="utf-8", errors="ignore"))
-        if isinstance(raw, list):
-            for item in raw:
-                if isinstance(item, dict) and "email" in item:
-                    contacts.append({"name": str(item.get("name") or "").strip(), "email": str(item["email"]).strip()})
-        elif isinstance(raw, dict):
-            for k, v in raw.items():
-                if "@" in k:
-                    contacts.append({"name": str(v or "").strip(), "email": k.strip()})
-                elif "@" in str(v):
-                    contacts.append({"name": k.strip(), "email": str(v).strip()})
-    except Exception:
-        pass
+    except (OSError, ValueError):
+        return []
+
+    contacts: list[dict[str, str]] = []
+    if isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            email = str(item.get("email") or "").strip()
+            if is_address(email):
+                contacts.append({"name": str(item.get("name") or "").strip(), "email": email})
+    elif isinstance(raw, dict):
+        for key, value in raw.items():
+            name = value if isinstance(value, str) else ""
+            if is_address(str(key).strip()):
+                contacts.append({"name": name.strip(), "email": str(key).strip()})
+            elif isinstance(value, str) and is_address(value.strip()):
+                contacts.append({"name": str(key).strip(), "email": value.strip()})
     return contacts
 
 
@@ -166,7 +242,7 @@ def main() -> None:
         for contact in entries:
             email = str(contact.get("email") or "").strip()
             name = str(contact.get("name") or "").strip()
-            if "@" not in email or email.startswith("@") or email.endswith("@"):
+            if not is_address(email):
                 continue
             key = email.lower()
             if key not in contacts or (not contacts[key]["name"] and name):

--- a/scripts/mail-transport.sh
+++ b/scripts/mail-transport.sh
@@ -184,6 +184,9 @@ fi
 set +e
 build_config "$@" | curl \
   --fail-early \
+  --retry 2 \
+  --retry-all-errors \
+  --retry-delay 1 \
   --config - \
   --silent \
   --show-error \

--- a/scripts/mail-transport.sh
+++ b/scripts/mail-transport.sh
@@ -114,7 +114,7 @@ if [ "$mode" = "smtp" ]; then
   printf 'max-time = 60\n'
   printf 'connect-timeout = 20\n'
   case "$url" in
-    smtp://127.0.0.1:*|smtp://localhost:*|smtp://::1:*) ;;
+    smtp://127.0.0.1:*|smtp://localhost:*) ;;
     smtp://*) printf 'ssl-reqd\n' ;;
   esac
   printf 'mail-from = "%s"\n' "$(escape "$sender")"
@@ -132,7 +132,7 @@ elif [ "$mode" = "imap-append" ]; then
   printf 'max-time = 60\n'
   printf 'connect-timeout = 20\n'
   case "$url" in
-    imap://127.0.0.1:*|imap://localhost:*|imap://::1:*) ;;
+    imap://127.0.0.1:*|imap://localhost:*) ;;
     imap://*) printf 'ssl-reqd\n' ;;
   esac
   printf 'upload-file = "%s"\n' "$(escape "$work/message")"
@@ -161,7 +161,7 @@ else
     printf 'max-time = 60\n'
     printf 'connect-timeout = 20\n'
     case "$url" in
-      imap://127.0.0.1:*|imap://localhost:*|imap://::1:*) ;;
+      imap://127.0.0.1:*|imap://localhost:*) ;;
       imap://*) printf 'ssl-reqd\n' ;;
     esac
     printf 'request = "%s"\n' "$(escape "$(decode "$argument")")"
@@ -181,19 +181,45 @@ fi
 
 # curl is the last stage, so `$?` is curl's own exit code rather than the
 # config builder's.
-set +e
-build_config "$@" | curl \
-  --fail-early \
-  --retry 2 \
-  --retry-all-errors \
-  --retry-delay 1 \
-  --config - \
-  --silent \
-  --show-error \
-  --dump-header "$work/headers" \
-  > "$work/out" 2> "$work/err"
-status=$?
-set -e
+attempt_curl() {
+  build_config "$@" | curl \
+    --fail-early \
+    --config - \
+    --silent \
+    --show-error \
+    --dump-header "$work/headers" \
+    > "$work/out" 2> "$work/err"
+}
+
+# A dropped TLS handshake is worth a second go; a delivered message is not.
+#
+# curl's own `--retry` covers neither on its own: its idea of a transient error
+# is a timeout or an HTTP status, so a handshake that died mid-negotiation is
+# not retried without `--retry-all-errors`. That flag then retries everything —
+# including a transfer that failed *after* the server took it, which for SMTP
+# is the message delivered twice and for APPEND a second copy in the folder.
+# curl cannot tell those apart because by then it has already sent them.
+#
+# So the retry is here, on the three exit codes that mean the command never
+# reached the server at all: the name did not resolve (6), the socket never
+# connected (7), and TLS failed before the session existed (35). Every one of
+# those is safe to repeat whatever the mode is. A rejected password (67) is
+# not retried, because three LOGIN attempts per operation is what iCloud and
+# Gmail lock an app password for.
+attempt=0
+while :; do
+  set +e
+  attempt_curl "$@"
+  status=$?
+  set -e
+  case "$status" in
+    6|7|35) ;;
+    *) break ;;
+  esac
+  attempt=$((attempt + 1))
+  [ "$attempt" -le 2 ] || break
+  sleep 1
+done
 
 printf '%s\n' "$status"
 if [ "$mode" = "imap" ] && [ ! -s "$work/out" ] && [ -s "$work/headers" ]; then

--- a/scripts/mail-transport.sh
+++ b/scripts/mail-transport.sh
@@ -113,6 +113,10 @@ if [ "$mode" = "smtp" ]; then
   printf 'user = "%s"\n' "$escaped_credentials"
   printf 'max-time = 60\n'
   printf 'connect-timeout = 20\n'
+  case "$url" in
+    smtp://127.0.0.1:*|smtp://localhost:*|smtp://::1:*) ;;
+    smtp://*) printf 'ssl-reqd\n' ;;
+  esac
   printf 'mail-from = "%s"\n' "$(escape "$sender")"
   for recipient in "$@"; do
     printf 'mail-rcpt = "%s"\n' "$(escape "$(decode "$recipient")")"
@@ -127,6 +131,10 @@ elif [ "$mode" = "imap-append" ]; then
   printf 'user = "%s"\n' "$escaped_credentials"
   printf 'max-time = 60\n'
   printf 'connect-timeout = 20\n'
+  case "$url" in
+    imap://127.0.0.1:*|imap://localhost:*|imap://::1:*) ;;
+    imap://*) printf 'ssl-reqd\n' ;;
+  esac
   printf 'upload-file = "%s"\n' "$(escape "$work/message")"
   printf 'upload-flags = "draft"\n'
 else
@@ -152,6 +160,10 @@ else
     # every command give up eventually, rather than only the final one.
     printf 'max-time = 60\n'
     printf 'connect-timeout = 20\n'
+    case "$url" in
+      imap://127.0.0.1:*|imap://localhost:*|imap://::1:*) ;;
+      imap://*) printf 'ssl-reqd\n' ;;
+    esac
     printf 'request = "%s"\n' "$(escape "$(decode "$argument")")"
   done
 fi

--- a/tests/qml/tst_compose_recipients.qml
+++ b/tests/qml/tst_compose_recipients.qml
@@ -269,5 +269,21 @@ Item {
       compare(named(compose, "compose-to-field").text, "second@example.com")
       compare(named(compose, "compose-body-editor").text, "Second message")
     }
+
+    function test_contacts_button_and_picker() {
+      compose.begin("new", null, "", [])
+      var contactsBtn = named(compose, "compose-contacts-button")
+      var picker = named(compose, "compose-contacts-picker")
+      verify(contactsBtn)
+      verify(picker)
+
+      picker.contactChosen({ name: "Alice", email: "alice@example.com" }, "to")
+      compare(named(compose, "compose-to-field").text, "Alice <alice@example.com>")
+
+      picker.contactChosen({ name: "Bob", email: "bob@example.com" }, "cc")
+      compare(compose.ccVisible, true)
+      compare(named(compose, "compose-cc-field").text, "Bob <bob@example.com>")
+    }
   }
 }
+

--- a/tests/qml/tst_popup_toggles.qml
+++ b/tests/qml/tst_popup_toggles.qml
@@ -1,0 +1,86 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../../components" as Omamail
+
+Item {
+  width: 900
+  height: 600
+
+  QtObject {
+    id: mailService
+    property bool sendPending: false
+    property bool sending: false
+    property int sendSecondsRemaining: 10
+    property var lastSent: null
+    property var recipientContacts: [({ name: "First Person", email: "first@example.com" })]
+    property var sendAsAliases: []
+    property var sendIdentities: [
+      ({ email: "me@example.com", accountId: "me@example.com", label: "me" }),
+      ({ email: "alt@example.com", accountId: "me@example.com", label: "alt" })
+    ]
+    property string accountEmail: "me@example.com"
+    property string activeAccountId: "me@example.com"
+    function preferredSendAs(_r) { return null }
+    function switchTo(_id) { return true }
+    function refreshRecipientContacts() {}
+    function send(_f) { return true }
+  }
+
+  Omamail.ComposeView {
+    id: compose
+    anchors.fill: parent
+    service: mailService
+    textColor: Qt.rgba(1, 1, 1, 1)
+    backgroundColor: Qt.rgba(0.06, 0.06, 0.06, 1)
+    accentColor: Qt.rgba(1, 0.5, 0, 1)
+    dimColor: Qt.rgba(0.67, 0.67, 0.67, 1)
+    dimmerColor: Qt.rgba(0.47, 0.47, 0.47, 1)
+    popupBackgroundColor: Qt.rgba(0.13, 0.13, 0.13, 1)
+    popupBorderColor: Qt.rgba(0.3, 0.3, 0.3, 1)
+    panelFontFamily: "sans"
+  }
+
+  TestCase {
+    name: "PopupToggles"
+    when: windowShown
+
+    function named(item, objectName) {
+      if (!item) return null
+      if (item.objectName === objectName) return item
+      var values = item.children || []
+      for (var i = 0; i < values.length; i++) {
+        var found = named(values[i], objectName)
+        if (found) return found
+      }
+      return null
+    }
+
+    // A popup that closes on a press outside itself is already closed by the
+    // press that reaches the control which opened it, so a plain
+    // `opened ? close() : open()` reopens it on the release and the control can
+    // never put its own popup away. Both of these read as a flicker.
+    function test_the_from_menu_toggles_shut() {
+      compose.begin("new", null, "", [])
+      var button = named(compose, "compose-from-button")
+      verify(button)
+      mouseClick(button)
+      wait(50)
+      var openedOnce = compose.fromMenuOpened
+      mouseClick(button)
+      wait(50)
+      compare([openedOnce, compose.fromMenuOpened], [true, false])
+    }
+
+    function test_the_contacts_button_toggles_shut() {
+      compose.begin("new", null, "", [])
+      var button = named(compose, "compose-contacts-button")
+      verify(button)
+      mouseClick(button)
+      wait(50)
+      var openedOnce = compose.contactsPickerOpened
+      mouseClick(button)
+      wait(50)
+      compare([openedOnce, compose.contactsPickerOpened], [true, false])
+    }
+  }
+}

--- a/tests/test_accounts.js
+++ b/tests/test_accounts.js
@@ -354,7 +354,8 @@ assert.strictEqual(accounts.count(accounts.discardDraftAt(pendingList, 0)), 3)
     imap: {
       imapHost: "imap.fastmail.com", imapPort: 993,
       smtpHost: "smtp.fastmail.com", smtpPort: 465,
-      username: "jane@fastmail.com"
+      username: "jane@fastmail.com",
+      aliases: "alias@fastmail.com, work@domain.com"
     }
   }))
   const reloaded = accounts.find(accounts.load(saved), "imap:jane@fastmail.com")
@@ -362,6 +363,8 @@ assert.strictEqual(accounts.count(accounts.discardDraftAt(pendingList, 0)), 3)
   assert.strictEqual(reloaded.imap.imapHost, "imap.fastmail.com")
   assert.strictEqual(reloaded.imap.smtpPort, 465)
   assert.strictEqual(reloaded.imap.username, "jane@fastmail.com")
+  assert.strictEqual(reloaded.imap.aliases.length, 2)
+  assert.strictEqual(reloaded.imap.aliases[0].email, "alias@fastmail.com")
   assert.strictEqual(reloaded.imap.insecure, false)
 
   // Ports out of range fall back rather than reaching a URL.

--- a/tests/test_accounts.js
+++ b/tests/test_accounts.js
@@ -355,7 +355,7 @@ assert.strictEqual(accounts.count(accounts.discardDraftAt(pendingList, 0)), 3)
       imapHost: "imap.fastmail.com", imapPort: 993,
       smtpHost: "smtp.fastmail.com", smtpPort: 465,
       username: "jane@fastmail.com",
-      aliases: "alias@fastmail.com, work@domain.com"
+      aliases: "alias@fastmail.com (default), work@domain.com"
     }
   }))
   const reloaded = accounts.find(accounts.load(saved), "imap:jane@fastmail.com")
@@ -365,6 +365,8 @@ assert.strictEqual(accounts.count(accounts.discardDraftAt(pendingList, 0)), 3)
   assert.strictEqual(reloaded.imap.username, "jane@fastmail.com")
   assert.strictEqual(reloaded.imap.aliases.length, 2)
   assert.strictEqual(reloaded.imap.aliases[0].email, "alias@fastmail.com")
+  assert.strictEqual(reloaded.imap.aliases[0].isDefault, true)
+  assert.strictEqual(reloaded.imap.aliases[1].isDefault, false)
   assert.strictEqual(reloaded.imap.insecure, false)
 
   // Ports out of range fall back rather than reaching a URL.

--- a/tests/test_aliases.js
+++ b/tests/test_aliases.js
@@ -1,0 +1,107 @@
+const assert = require("assert")
+const { load, deepEqual } = require("./load.js")
+
+const aliases = load("account/Aliases.js")
+
+deepEqual(aliases.parse("alias1@icloud.com, alias2@example.org"), [
+  { email: "alias1@icloud.com", displayName: "", isPrimary: false, isDefault: false },
+  { email: "alias2@example.org", displayName: "", isPrimary: false, isDefault: false }
+])
+deepEqual(aliases.parse("alias1@icloud.com (default), alias2@example.org"), [
+  { email: "alias1@icloud.com", displayName: "", isPrimary: false, isDefault: true },
+  { email: "alias2@example.org", displayName: "", isPrimary: false, isDefault: false }
+])
+deepEqual(aliases.parse("Work <alias1@icloud.com> (default), alias2@example.org"), [
+  { email: "alias1@icloud.com", displayName: "Work", isPrimary: false, isDefault: true },
+  { email: "alias2@example.org", displayName: "", isPrimary: false, isDefault: false }
+])
+deepEqual(aliases.parse(["alias@me.com", "not an email", "duplicate@me.com", "duplicate@me.com"]), [
+  { email: "alias@me.com", displayName: "", isPrimary: false, isDefault: false },
+  { email: "duplicate@me.com", displayName: "", isPrimary: false, isDefault: false }
+])
+
+// One default. A list naming two is not a state the composer can act on, so
+// the first is kept and the rest read as ordinary aliases.
+deepEqual(
+  aliases.parse("a@me.com (default), b@me.com (default)").map(row => row.isDefault),
+  [true, false])
+
+assert.strictEqual(aliases.format([
+  { email: "a@icloud.com" },
+  { email: "b@icloud.com" }
+]), "a@icloud.com, b@icloud.com")
+assert.strictEqual(aliases.format([
+  { email: "a@icloud.com", isDefault: true },
+  { email: "b@icloud.com", displayName: "Work" }
+]), "a@icloud.com (default), Work <b@icloud.com>")
+
+// ----------------------------------------------------------- the round trip
+
+// The settings page re-formats this list every time it opens and writes back
+// what it shows, so anything `format` produces that `parse` reads differently
+// is a value the user loses without touching the field.
+function roundTrip(text) {
+  return aliases.format(aliases.parse(text))
+}
+
+const commaName = "\"Lee, Jason\" <j@icloud.com>, second@icloud.com (default)"
+deepEqual(aliases.parse(commaName), [
+  { email: "j@icloud.com", displayName: "Lee, Jason", isPrimary: false, isDefault: false },
+  { email: "second@icloud.com", displayName: "", isPrimary: false, isDefault: true }
+])
+assert.strictEqual(roundTrip(commaName), commaName,
+  "a display name holding a comma survives being written back")
+assert.strictEqual(roundTrip(roundTrip(commaName)), commaName,
+  "and survives it a second time")
+
+// A quotation mark in a name is escaped rather than ending the name early.
+const quotedName = "\"Jay \\\"JJ\\\" Lee\" <jj@icloud.com>"
+deepEqual(aliases.parse(quotedName), [
+  { email: "jj@icloud.com", displayName: "Jay \"JJ\" Lee", isPrimary: false, isDefault: false }
+])
+assert.strictEqual(roundTrip(quotedName), quotedName)
+
+// A name with nothing to escape is left as the user typed it.
+assert.strictEqual(roundTrip("Work <b@icloud.com>"), "Work <b@icloud.com>")
+
+// Newlines separate too, so a field that was pasted into keeps its entries.
+deepEqual(aliases.parse("a@me.com\nb@me.com").map(row => row.email),
+  ["a@me.com", "b@me.com"])
+
+// A name that says "(default)" in the middle of itself is a name.
+deepEqual(aliases.parse("\"Not (default) really\" <c@me.com>"), [
+  { email: "c@me.com", displayName: "Not (default) really", isPrimary: false, isDefault: false }
+])
+
+assert.strictEqual(aliases.format(""), "")
+deepEqual(aliases.parse(null), [])
+deepEqual(aliases.parse(42), [])
+
+// ------------------------------------------------------------- send-as list
+
+// The mailbox's own address leads and is primary. Nothing else may claim that.
+deepEqual(aliases.sendAsList("me@icloud.com", "work@icloud.com"), [
+  { email: "me@icloud.com", displayName: "", isPrimary: true, isDefault: true },
+  { email: "work@icloud.com", displayName: "", isPrimary: false, isDefault: false }
+])
+
+// An alias marked default takes it from the mailbox address, which is what
+// makes the marker mean "the address the composer opens on".
+deepEqual(aliases.sendAsList("me@icloud.com", "work@icloud.com (default)"), [
+  { email: "me@icloud.com", displayName: "", isPrimary: true, isDefault: false },
+  { email: "work@icloud.com", displayName: "", isPrimary: false, isDefault: true }
+])
+
+// An alias that repeats the mailbox address is the mailbox address.
+deepEqual(aliases.sendAsList("me@icloud.com", "ME@icloud.com, other@icloud.com")
+  .map(row => row.email), ["me@icloud.com", "other@icloud.com"])
+
+// No address at all is an account still being set up, not a list with a blank
+// row in it.
+deepEqual(aliases.sendAsList("", ""), [])
+deepEqual(aliases.sendAsList("", "work@icloud.com").map(row => row.email), ["work@icloud.com"])
+deepEqual(aliases.sendAsList("me@icloud.com", null), [
+  { email: "me@icloud.com", displayName: "", isPrimary: true, isDefault: true }
+])
+
+console.log("Aliases.js ok")

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -93,4 +93,92 @@ with tempfile.TemporaryDirectory() as temporary:
         {"name": "", "email": "morgan@example.com"},
     ]
 
+
+# --------------------------------------------------------------- the readers
+#
+# These read files this program did not write, so each one is checked against
+# the shape somebody would plausibly produce rather than only the shape the
+# happy path above builds.
+
+import importlib.util
+
+spec = importlib.util.spec_from_file_location("contact_suggestions", SCRIPT)
+harvester = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(harvester)
+
+with tempfile.TemporaryDirectory() as temporary:
+    scratch = Path(temporary)
+
+    # A wrapped address book. Asking whether str(value) contains an "@" is true
+    # of a stringified list, and what came out was a contact named "contacts"
+    # whose address was the whole serialised array.
+    wrapped = scratch / "wrapped.json"
+    wrapped.write_text(
+        json.dumps({"contacts": [{"name": "A", "email": "a@example.com"}]}),
+        encoding="utf-8",
+    )
+    assert harvester.json_contacts(wrapped) == [], harvester.json_contacts(wrapped)
+
+    # The two shapes that are an address book.
+    listed = scratch / "listed.json"
+    listed.write_text(
+        json.dumps([{"name": "Ada", "email": "ada@example.com"},
+                    {"name": "Bad", "email": "not an address"}]),
+        encoding="utf-8",
+    )
+    assert harvester.json_contacts(listed) == [{"name": "Ada", "email": "ada@example.com"}]
+
+    mapped = scratch / "mapped.json"
+    mapped.write_text(
+        json.dumps({"grace@example.com": "Grace", "Alan": "alan@example.com"}),
+        encoding="utf-8",
+    )
+    assert sorted(harvester.json_contacts(mapped), key=lambda row: row["email"]) == [
+        {"name": "Alan", "email": "alan@example.com"},
+        {"name": "Grace", "email": "grace@example.com"},
+    ]
+
+    # A folded vCard, and a malformed property after it. The fold has to be
+    # rejoined before the value is read, and the bad line must not take the
+    # cards that follow it with it.
+    folded = scratch / "book.vcf"
+    folded.write_text(
+        "BEGIN:VCARD\r\n"
+        "FN:Wilhelmina Fitzgerald-Montmorency the Th\r\n ird\r\n"
+        "EMAIL:wilhelmina@example.com\r\n"
+        "END:VCARD\r\n"
+        "BEGIN:VCARD\r\n"
+        "MALFORMED-LINE-WITHOUT-A-COLON\r\n"
+        "FN:Second Card\r\n"
+        "EMAIL:second@example.com\r\n"
+        "END:VCARD\r\n",
+        encoding="utf-8",
+    )
+    assert harvester.parse_vcf(folded) == [
+        {"name": "Wilhelmina Fitzgerald-Montmorency the Third",
+         "email": "wilhelmina@example.com"},
+        {"name": "Second Card", "email": "second@example.com"},
+    ], harvester.parse_vcf(folded)
+
+    # A bulk send is not a room full of the user's contacts, and a display name
+    # the parser filled in from the local part is not a name anybody wrote.
+    cache = scratch / "cache"
+    cache.mkdir()
+    bulk = [{"name": "P%d" % i, "email": "p%d@example.com" % i} for i in range(20)]
+    (cache / "account-x.json").write_text(
+        json.dumps({"queries": {"q": {"summaries": [
+            {"from": {"name": "noreply", "email": "noreply@example.com"},
+             "to": bulk, "cc": [], "bcc": [{"name": "B", "email": "b@example.com"}]},
+            {"from": {"name": "Jane Doe", "email": "jane@example.com"},
+             "to": [{"name": "Me", "email": "me@example.com"}]},
+        ]}}}),
+        encoding="utf-8",
+    )
+    harvested = harvester.omamail_cache_records(cache)
+    addresses = sorted(row["email"] for row in harvested)
+    assert addresses == ["jane@example.com", "me@example.com", "noreply@example.com"], addresses
+    by_email = {row["email"]: row["name"] for row in harvested}
+    assert by_email["noreply@example.com"] == ""
+    assert by_email["jane@example.com"] == "Jane Doe"
+
 print("contact discovery tests passed")

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -45,8 +45,37 @@ with tempfile.TemporaryDirectory() as temporary:
         ],
     )
 
+    # Also create omamail cache and contacts.json
+    cache_dir = home / ".cache" / "omamail"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "account-test.json").write_text(
+        json.dumps({
+            "queries": {
+                "folder:INBOX|25": {
+                    "summaries": [
+                        {
+                            "from": {"name": "Cached Sender", "email": "sender@cached.org"},
+                            "to": [{"name": "Cached Recipient", "email": "to@cached.org"}],
+                            "cc": []
+                        }
+                    ]
+                }
+            }
+        }),
+        encoding="utf-8"
+    )
+
+    config_dir = home / ".config" / "omamail"
+    config_dir.mkdir(parents=True)
+    (config_dir / "contacts.json").write_text(
+        json.dumps([{"name": "Local Friend", "email": "friend@local.net"}]),
+        encoding="utf-8"
+    )
+
     environment = dict(os.environ)
     environment["HOME"] = str(home)
+    environment.pop("XDG_CACHE_HOME", None)
+    environment.pop("XDG_CONFIG_HOME", None)
     result = subprocess.run(
         [str(SCRIPT)],
         check=True,
@@ -57,7 +86,10 @@ with tempfile.TemporaryDirectory() as temporary:
     contacts = json.loads(result.stdout)
     assert contacts == [
         {"name": "Ada Lovelace", "email": "ada@example.com"},
+        {"name": "Cached Recipient", "email": "to@cached.org"},
+        {"name": "Cached Sender", "email": "sender@cached.org"},
         {"name": "Jane Doe", "email": "jane@example.com"},
+        {"name": "Local Friend", "email": "friend@local.net"},
         {"name": "", "email": "morgan@example.com"},
     ]
 

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -98,6 +98,14 @@ deepEqual(imap.parseAliases("alias1@icloud.com, alias2@example.org"), [
   { email: "alias1@icloud.com", displayName: "", isPrimary: false, isDefault: false },
   { email: "alias2@example.org", displayName: "", isPrimary: false, isDefault: false }
 ])
+deepEqual(imap.parseAliases("alias1@icloud.com (default), alias2@example.org"), [
+  { email: "alias1@icloud.com", displayName: "", isPrimary: false, isDefault: true },
+  { email: "alias2@example.org", displayName: "", isPrimary: false, isDefault: false }
+])
+deepEqual(imap.parseAliases("Work <alias1@icloud.com> (default), alias2@example.org"), [
+  { email: "alias1@icloud.com", displayName: "Work", isPrimary: false, isDefault: true },
+  { email: "alias2@example.org", displayName: "", isPrimary: false, isDefault: false }
+])
 deepEqual(imap.parseAliases(["alias@me.com", "not an email", "duplicate@me.com", "duplicate@me.com"]), [
   { email: "alias@me.com", displayName: "", isPrimary: false, isDefault: false },
   { email: "duplicate@me.com", displayName: "", isPrimary: false, isDefault: false }
@@ -106,15 +114,21 @@ assert.strictEqual(imap.formatAliases([
   { email: "a@icloud.com" },
   { email: "b@icloud.com" }
 ]), "a@icloud.com, b@icloud.com")
+assert.strictEqual(imap.formatAliases([
+  { email: "a@icloud.com", isDefault: true },
+  { email: "b@icloud.com", displayName: "Work" }
+]), "a@icloud.com (default), Work <b@icloud.com>")
 
 const withAliases = imap.setupSettings({
   address: "primary@icloud.com",
   username: "primary",
   imapHost: "imap.mail.me.com",
-  aliases: "alias1@icloud.com, alias2@icloud.com"
+  aliases: "alias1@icloud.com (default), alias2@icloud.com"
 })
 assert.strictEqual(withAliases.aliases.length, 2)
 assert.strictEqual(withAliases.aliases[0].email, "alias1@icloud.com")
+assert.strictEqual(withAliases.aliases[0].isDefault, true)
+assert.strictEqual(withAliases.aliases[1].isDefault, false)
 
 // ------------------------------------------------------------------- URLs
 

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -92,6 +92,30 @@ assert.strictEqual(imap.validateSettings({ username: "jane", imapHost: "" }).ok,
 assert.ok(/valid IMAP server/i.test(
   imap.validateSettings({ username: "jane", imapHost: "a b c" }).error))
 
+// ------------------------------------------------------------------ aliases
+
+deepEqual(imap.parseAliases("alias1@icloud.com, alias2@example.org"), [
+  { email: "alias1@icloud.com", displayName: "", isPrimary: false, isDefault: false },
+  { email: "alias2@example.org", displayName: "", isPrimary: false, isDefault: false }
+])
+deepEqual(imap.parseAliases(["alias@me.com", "not an email", "duplicate@me.com", "duplicate@me.com"]), [
+  { email: "alias@me.com", displayName: "", isPrimary: false, isDefault: false },
+  { email: "duplicate@me.com", displayName: "", isPrimary: false, isDefault: false }
+])
+assert.strictEqual(imap.formatAliases([
+  { email: "a@icloud.com" },
+  { email: "b@icloud.com" }
+]), "a@icloud.com, b@icloud.com")
+
+const withAliases = imap.setupSettings({
+  address: "primary@icloud.com",
+  username: "primary",
+  imapHost: "imap.mail.me.com",
+  aliases: "alias1@icloud.com, alias2@icloud.com"
+})
+assert.strictEqual(withAliases.aliases.length, 2)
+assert.strictEqual(withAliases.aliases[0].email, "alias1@icloud.com")
+
 // ------------------------------------------------------------------- URLs
 
 assert.strictEqual(

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -93,31 +93,10 @@ assert.ok(/valid IMAP server/i.test(
   imap.validateSettings({ username: "jane", imapHost: "a b c" }).error))
 
 // ------------------------------------------------------------------ aliases
-
-deepEqual(imap.parseAliases("alias1@icloud.com, alias2@example.org"), [
-  { email: "alias1@icloud.com", displayName: "", isPrimary: false, isDefault: false },
-  { email: "alias2@example.org", displayName: "", isPrimary: false, isDefault: false }
-])
-deepEqual(imap.parseAliases("alias1@icloud.com (default), alias2@example.org"), [
-  { email: "alias1@icloud.com", displayName: "", isPrimary: false, isDefault: true },
-  { email: "alias2@example.org", displayName: "", isPrimary: false, isDefault: false }
-])
-deepEqual(imap.parseAliases("Work <alias1@icloud.com> (default), alias2@example.org"), [
-  { email: "alias1@icloud.com", displayName: "Work", isPrimary: false, isDefault: true },
-  { email: "alias2@example.org", displayName: "", isPrimary: false, isDefault: false }
-])
-deepEqual(imap.parseAliases(["alias@me.com", "not an email", "duplicate@me.com", "duplicate@me.com"]), [
-  { email: "alias@me.com", displayName: "", isPrimary: false, isDefault: false },
-  { email: "duplicate@me.com", displayName: "", isPrimary: false, isDefault: false }
-])
-assert.strictEqual(imap.formatAliases([
-  { email: "a@icloud.com" },
-  { email: "b@icloud.com" }
-]), "a@icloud.com, b@icloud.com")
-assert.strictEqual(imap.formatAliases([
-  { email: "a@icloud.com", isDefault: true },
-  { email: "b@icloud.com", displayName: "Work" }
-]), "a@icloud.com (default), Work <b@icloud.com>")
+//
+// The alias format itself is `account/Aliases.js` and is tested there. What
+// belongs here is that the setup page's text reaches the settings shape as a
+// parsed list.
 
 const withAliases = imap.setupSettings({
   address: "primary@icloud.com",
@@ -155,6 +134,32 @@ assert.strictEqual(
   })),
   "smtps://smtp.example.com:465",
   "a local IMAP bridge must not permit plaintext SMTP to a remote host")
+
+// The upgrade ports connect in the clear and are required to upgrade; every
+// other port is TLS from the first byte, which is what a server on a
+// non-standard port actually speaks.
+assert.strictEqual(
+  imap.imapUrl({ imapHost: "imap.example.com", imapPort: 143 }, "INBOX"),
+  "imap://imap.example.com:143/INBOX",
+  "143 is the STARTTLS port")
+assert.strictEqual(
+  imap.imapUrl({ imapHost: "imap.example.com", imapPort: 9993 }, "INBOX"),
+  "imaps://imap.example.com:9993/INBOX",
+  "an unfamiliar port is implicit TLS, not a guess at STARTTLS")
+assert.strictEqual(
+  imap.smtpUrl({ smtpHost: "smtp.mail.me.com", smtpPort: 587 }),
+  "smtp://smtp.mail.me.com:587",
+  "587 is the submission port and upgrades")
+assert.strictEqual(
+  imap.smtpUrl({ smtpHost: "smtp.example.com", smtpPort: 2465 }),
+  "smtps://smtp.example.com:2465",
+  "an unfamiliar SMTP port is implicit TLS")
+
+// A host is case-insensitive, and the transport recognises its loopback
+// exemption by literal text — so the two have to agree on one spelling.
+assert.strictEqual(
+  imap.imapUrl({ imapHost: "LocalHost", imapPort: 1143, insecure: true }, "INBOX"),
+  "imap://localhost:1143/INBOX")
 
 // -------------------------------------------------------------- the query DSL
 

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -182,14 +182,36 @@ deepEqual(model.newArrivals(inbox, { a: true }, true).map(entry => entry.id), ["
 deepEqual(model.newArrivals(inbox, { a: true, c: true }, true), [])
 deepEqual(model.newArrivals([], {}, true), [])
 
-const now = Date.now()
+// The floor keeps an old unread message that was never on the cached page from
+// being announced as an arrival the first time a fetch returns it.
+const floor = Date.parse("2026-08-01T00:00:00Z")
 const timeInbox = [
-  { id: "old", unread: true, inInbox: true, date: new Date(now - 1000000) },
-  { id: "new", unread: true, inInbox: true, date: new Date(now + 1000) },
+  { id: "old", unread: true, inInbox: true, date: new Date(floor - 1000000) },
+  { id: "new", unread: true, inInbox: true, date: new Date(floor + 1000) },
   { id: "nodate", unread: true, inInbox: true, date: null }
 ]
-deepEqual(model.newArrivals(timeInbox, {}, true, now).map(entry => entry.id), ["new"],
-  "messages older than session start or without a date are ignored for notifications")
+deepEqual(model.newArrivals(timeInbox, {}, true, floor).map(entry => entry.id),
+  ["new", "nodate"],
+  "an older message is not an arrival, and one with no date is still announced")
+
+// The floor is the mailbox's own newest timestamp, not this machine's clock.
+// Taken from `Date.now()` on a machine running fast, every arrival is older
+// than a "now" the server has not reached and notifications stop for the whole
+// session — so what seeds it is the page, and it has to come out of the page.
+assert.strictEqual(model.newestDate(timeInbox), floor + 1000)
+assert.strictEqual(model.newestDate([{ id: "x", date: null }]), 0)
+assert.strictEqual(model.newestDate([]), 0)
+assert.strictEqual(model.newestDate(null), 0)
+
+// A clock an hour ahead of the server used to silence the mailbox entirely.
+const skewed = model.newestDate(timeInbox)
+deepEqual(model.newArrivals(timeInbox, {}, true, skewed).map(entry => entry.id),
+  ["new", "nodate"],
+  "the newest row is itself never below the floor it set")
+
+// No floor at all is the shape every caller had before one existed.
+deepEqual(model.newArrivals(timeInbox, {}, true, 0).map(entry => entry.id),
+  ["old", "new", "nodate"])
 
 assert.strictEqual(model.notificationBody({ subject: "Invoice", snippet: "Due Friday" }), "Invoice\nDue Friday")
 assert.strictEqual(model.notificationBody({ subject: "Invoice", snippet: "" }), "Invoice")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -185,10 +185,11 @@ deepEqual(model.newArrivals([], {}, true), [])
 const now = Date.now()
 const timeInbox = [
   { id: "old", unread: true, inInbox: true, date: new Date(now - 1000000) },
-  { id: "new", unread: true, inInbox: true, date: new Date(now + 1000) }
+  { id: "new", unread: true, inInbox: true, date: new Date(now + 1000) },
+  { id: "nodate", unread: true, inInbox: true, date: null }
 ]
 deepEqual(model.newArrivals(timeInbox, {}, true, now).map(entry => entry.id), ["new"],
-  "messages older than session start are ignored for notifications")
+  "messages older than session start or without a date are ignored for notifications")
 
 assert.strictEqual(model.notificationBody({ subject: "Invoice", snippet: "Due Friday" }), "Invoice\nDue Friday")
 assert.strictEqual(model.notificationBody({ subject: "Invoice", snippet: "" }), "Invoice")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -182,6 +182,14 @@ deepEqual(model.newArrivals(inbox, { a: true }, true).map(entry => entry.id), ["
 deepEqual(model.newArrivals(inbox, { a: true, c: true }, true), [])
 deepEqual(model.newArrivals([], {}, true), [])
 
+const now = Date.now()
+const timeInbox = [
+  { id: "old", unread: true, inInbox: true, date: new Date(now - 1000000) },
+  { id: "new", unread: true, inInbox: true, date: new Date(now + 1000) }
+]
+deepEqual(model.newArrivals(timeInbox, {}, true, now).map(entry => entry.id), ["new"],
+  "messages older than session start are ignored for notifications")
+
 assert.strictEqual(model.notificationBody({ subject: "Invoice", snippet: "Due Friday" }), "Invoice\nDue Friday")
 assert.strictEqual(model.notificationBody({ subject: "Invoice", snippet: "" }), "Invoice")
 assert.strictEqual(model.notificationBody(null), "")

--- a/tests/test_recipients.js
+++ b/tests/test_recipients.js
@@ -29,8 +29,21 @@ assert.strictEqual(
   "other@example.com, Jane Doe <jane@example.com>"
 )
 assert.strictEqual(
-  recipients.accept("ja", { name: "", email: "jane@example.com" }),
-  "jane@example.com"
+  recipients.append("first@example.com", contacts[0]),
+  "first@example.com, Jane Doe <jane@example.com>"
 )
+assert.strictEqual(
+  recipients.append("", contacts[0]),
+  "Jane Doe <jane@example.com>"
+)
+assert.strictEqual(
+  recipients.append("Jane Doe <jane@example.com>", contacts[0]),
+  "Jane Doe <jane@example.com>"
+)
+
+deepEqual(recipients.filter(contacts, "morgan"), [
+  { name: "Morgan Reed", email: "morgan@example.com" }
+])
+deepEqual(recipients.filter(contacts, "").length, 2)
 
 console.log("recipient tests passed")

--- a/tests/test_recipients.js
+++ b/tests/test_recipients.js
@@ -28,6 +28,12 @@ assert.strictEqual(
   recipients.accept("other@example.com, ja", contacts[0]),
   "other@example.com, Jane Doe <jane@example.com>"
 )
+// A contact with no name is its address, which is the branch `address()` takes
+// when there is no phrase to put in front of one.
+assert.strictEqual(
+  recipients.accept("ja", { name: "", email: "jane@example.com" }),
+  "jane@example.com"
+)
 assert.strictEqual(
   recipients.append("first@example.com", contacts[0]),
   "first@example.com, Jane Doe <jane@example.com>"

--- a/tests/test_secrets.js
+++ b/tests/test_secrets.js
@@ -1,0 +1,22 @@
+const assert = require("assert")
+const { load } = require("./load.js")
+
+const secrets = load("providers/Secrets.js")
+
+// The bug this exists for: `secret-tool lookup` writes no trailing newline, so
+// a reader that split on one never saw the value at all.
+assert.strictEqual(secrets.fromKeyring("hunter2"), "hunter2")
+assert.strictEqual(secrets.fromKeyring("hunter2\n"), "hunter2")
+
+// One, and only at the end. A password may legitimately end in a space, and
+// trimming it authenticates as a different string with no way to tell.
+assert.strictEqual(secrets.fromKeyring("hunter2 \n"), "hunter2 ")
+assert.strictEqual(secrets.fromKeyring(" hunter2"), " hunter2")
+assert.strictEqual(secrets.fromKeyring("hunter2\n\n"), "hunter2\n")
+assert.strictEqual(secrets.fromKeyring("two\nlines"), "two\nlines")
+
+assert.strictEqual(secrets.fromKeyring(""), "")
+assert.strictEqual(secrets.fromKeyring(null), "")
+assert.strictEqual(secrets.fromKeyring(undefined), "")
+
+console.log("Secrets.js ok")

--- a/tests/test_transport.sh
+++ b/tests/test_transport.sh
@@ -15,6 +15,7 @@ trap 'rm -rf "$work"' EXIT INT TERM HUP
 mkdir -p "$work/bin"
 cat > "$work/bin/curl" <<'STUB'
 #!/bin/sh
+[ -z "${CURL_STUB_COUNT:-}" ] || printf 'x\n' >> "$CURL_STUB_COUNT"
 header_file=
 saw_fail_early=0
 while [ "$#" -gt 0 ]; do
@@ -256,6 +257,45 @@ else
   printf '  FAIL expected 3 lines of output, got %s\n' "$lines"
   failures=$(( failures + 1 ))
 fi
+
+# ------------------------------------------------------------- retrying
+
+# Retrying is safe only before anything has been sent. curl's own --retry-all-
+# errors cannot tell a handshake that never opened a session from a transfer
+# the server already took, so an SMTP send it retried would deliver the message
+# twice. The retry is the script's own, on the pre-transfer exit codes.
+attempts_for() {
+  count="$work/attempts"
+  rm -f "$count"
+  printf '%s\n' "$1" \
+    | CURL_STUB_COUNT="$count" CURL_STUB_EXIT="$2" PATH="$work/bin:$PATH" sh "$script" \
+      >/dev/null 2>&1
+  if [ -f "$count" ]; then wc -l < "$count" | tr -d ' '; else printf '0'; fi
+}
+
+send_request="smtp $(b64 'smtp://smtp.example.org:587') $(b64 'j:p') $(b64 'j@example.org') $(b64 'Subject: x
+
+body') $(b64 'her@example.org')"
+read_request="imap $(b64 'imaps://a.example.org/INBOX') $(b64 'j:p') $(b64 'NOOP')"
+
+expect_attempts() {
+  got=$(attempts_for "$2" "$3")
+  if [ "$got" = "$4" ]; then
+    printf '  ok   %s\n' "$1"
+  else
+    printf '  FAIL %s: expected %s attempt(s), got %s\n' "$1" "$4" "$got"
+    failures=$(( failures + 1 ))
+  fi
+}
+
+expect_attempts "a dropped TLS handshake is tried again" "$read_request" 35 3
+expect_attempts "a name that does not resolve is tried again" "$read_request" 6 3
+expect_attempts "a rejected password is not tried again" "$read_request" 67 1
+# The one that matters: 56 is a receive error, which happens after the message
+# has been handed over. Sending it a second time is a second copy delivered.
+expect_attempts "a send that failed mid-transfer is not repeated" "$send_request" 56 1
+expect_attempts "a send that timed out is not repeated" "$send_request" 28 1
+expect_attempts "a send is still retried before it has left" "$send_request" 7 3
 
 # A malformed request must fail rather than run curl with something guessed.
 if printf 'not-base64-at-all\n' | PATH="$work/bin:$PATH" sh "$script" >/dev/null 2>&1; then


### PR DESCRIPTION
An IMAP mailbox can now write from more than one address, reach a server that speaks STARTTLS, keep its password across a restart, choose whether new mail is announced, and fill a recipient from an address book rather than from memory.

## Send-as aliases

An IMAP account has no settings endpoint to ask, so the addresses it may write from are typed on the setup page and stored with the account. They arrive in the composer's From menu in the same shape Gmail's send-as settings do, so nothing above the provider boundary has to know which kind of mailbox it is looking at, and the envelope sender is resolved from the From header that was actually chosen rather than from the account's username.

One alias may be marked the default, which is the address a new message opens on. `account/Aliases.js` is the one place that reads the field and the one place that writes it back — the setup page re-formats the list every time it opens, so a parser that disagreed with the formatter would rewrite the user's own text under them. It reads quoted display names, which is what keeps `"Lee, Jason" <j@example.com>` one alias rather than two halves of one.

## STARTTLS

Ports 143 and 587 are the upgrade ports, and dialling them as implicit TLS is why iCloud's submission host failed its handshake. They are named as a list rather than inferred from "not 993", because a server offering implicit TLS on a port a hosting panel picked has no STARTTLS to negotiate and would simply stop connecting. The plaintext scheme is never a plaintext session: `mail-transport.sh` adds `ssl-reqd` to every non-loopback `imap://` and `smtp://`, so a server that turns out not to offer the upgrade is refused rather than spoken to in the clear. The loopback exemption is recognised by literal text down there, so a host is lowercased once on the way in.

## Notifications

New mail can be announced or not, from the settings page. What counts as new is answered by the ids already seen, and — for an unread message that was never on the cached page — by a floor: the mailbox's own newest timestamp at the moment notifications were primed. Server clock against server clock, set once and never raised, so a machine whose clock runs ahead does not go silent for the session and a message that arrives out of order is still announced.

## Contacts

A picker beside the recipient fields, filled from Thunderbird's collected addresses, a `contacts.json` or `contacts.vcf` under the config directory, and the addresses already in the message cache. Everything it reads is a file this program did not write, so every address passes one gate before it can be offered as somebody to send mail to; a bulk send is not a room full of contacts, and a display name the parser filled in from a local part is not a name anybody wrote.

## Secrets

`secret-tool lookup` writes its value with no trailing newline, so a reader splitting on one never fired and a stored password read back as no password at all — the mailbox asked to be signed in to again on every restart, and a CalDAV source reported itself as having none. All three lookups now read the whole output when the process is done with it, and strip the pipe's newline and nothing else: a password may legitimately end in a space, and trimming it would authenticate as a different string.

## Sending is not retried

A dropped TLS handshake is worth a second attempt; a message the server already took is not. curl's `--retry-all-errors` cannot tell them apart, because by the time the transfer failed it had already been sent — so the retry is the transport's own, on the three exit codes that mean the command never left this machine (6, 7, 35). A rejected password is not retried at all, which is what iCloud and Gmail lock an app password for.

## Verification

`make validate` — node tests, source regressions, the QML tests, `qmllint` and `omarchy plugin validate` — passes on a clean checkout of this branch, on Omarchy with Qt 6.

New coverage: `tests/test_aliases.js` holds the alias format and its round trip, including that a display name carrying a comma survives being written back twice; `tests/test_secrets.js` holds what may be stripped from a keyring value; `tests/test_transport.sh` holds that a send failing mid-transfer or on a timeout is attempted exactly once while a handshake failure is attempted three times; `tests/qml/tst_popup_toggles.qml` holds that a control can put its own popup away; `tests/test_contacts.py` holds the shapes the harvesters are handed. `tests/test_model.js` and `tests/test_imap.js` cover the notification floor and the scheme chosen per port.

Tested live against iCloud IMAP and SMTP with several send-as aliases.

## Release Notes

- An IMAP mailbox can be given send-as aliases, set on its setup page and offered in the composer's From menu. One may be marked the default, which is the address a new message opens on.
- IMAP and SMTP servers that use STARTTLS — iCloud's submission host on port 587, and any server on 143 — now connect. The upgrade is required, never optional.
- A saved IMAP password survives a restart, and a CalDAV calendar no longer asks for a password it already has.
- New-mail notifications can be turned off, on the settings page under Notifications.
- A Contacts button beside the recipient fields fills To, Cc or Bcc from Thunderbird's address book, from a `contacts.json` or `contacts.vcf` in the config directory, or from addresses already seen in the mailbox.
