### PR TITLE
Show all accessible Google calendars, not just primary

### DIFF
--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -347,7 +347,7 @@ function googleMoment(value, dateOnly) {
   return { ms: ms, allDay: dateOnly, tzid: "", resolved: true }
 }
 
-function eventsFromGoogle(payload, sourceId) {
+function eventsFromGoogle(payload, sourceId, calendarId) {
   var items = payload && Array.isArray(payload.items) ? payload.items : []
   var out = []
   for (var i = 0; i < items.length; i++) {
@@ -372,15 +372,26 @@ function eventsFromGoogle(payload, sourceId) {
       attendees: Array.isArray(item.attendees) ? item.attendees : [],
       start: start, end: end, recurrence: Array.isArray(item.recurrence)
         ? item.recurrence.join("; ") : "", meetLink: String(item.hangoutLink || ""),
-      sourceId: String(sourceId || ""), href: String(item.htmlLink || ""), source: null
+       sourceId: String(sourceId || ""), calendarId: String(calendarId || "primary"),
+       href: String(item.htmlLink || ""), source: null
     })
   }
   out.sort(compareEvents)
   return out
 }
 
-function googleEventsUrl(startMs, endMs) {
-  return "https://www.googleapis.com/calendar/v3/calendars/primary/events?"
+function googleCalendarsUrl(pageToken) {
+  var url = "https://www.googleapis.com/calendar/v3/users/me/calendarList?maxResults=250"
+  return pageToken ? url + "&pageToken=" + encodeURIComponent(String(pageToken)) : url
+}
+
+function googleCalendarEventsUrl(calendarId) {
+  return "https://www.googleapis.com/calendar/v3/calendars/"
+    + encodeURIComponent(String(calendarId || "primary")) + "/events"
+}
+
+function googleEventsUrl(startMs, endMs, calendarId) {
+  return googleCalendarEventsUrl(calendarId) + "?"
     + "singleEvents=true&orderBy=startTime&maxResults=2500"
     + "&timeMin=" + encodeURIComponent(new Date(Number(startMs) || 0).toISOString())
     + "&timeMax=" + encodeURIComponent(new Date(Number(endMs) || 0).toISOString())
@@ -554,8 +565,9 @@ function updateEvent(fields, existing, nowMs) {
   }
 }
 
-function googleEventUrl(eventId) {
-  return "https://www.googleapis.com/calendar/v3/calendars/primary/events/"
+function googleEventUrl(eventId, calendarId) {
+  return "https://www.googleapis.com/calendar/v3/calendars/"
+    + encodeURIComponent(String(calendarId || "primary")) + "/events/"
     + encodeURIComponent(String(eventId || ""))
 }
 

--- a/calendar/CalendarController.qml
+++ b/calendar/CalendarController.qml
@@ -42,6 +42,9 @@ Item {
   property bool lookupHandled: false
   property var googleRequest: null
   property bool googleRequestTimedOut: false
+  property var googleCalendarQueue: []
+  property string googleCalendarPageToken: ""
+  property bool googleEventsStarted: false
   property var passwordSaveQueue: []
   property string passwordToSave: ""
   property bool savingPassword: false
@@ -278,9 +281,11 @@ Item {
       root.eventRequest = request
       root.eventRequestTimedOut = false
       if (root.writeOp === "delete") {
-        request.open("DELETE", Calendar.googleEventUrl(eventId))
+         request.open("DELETE", Calendar.googleEventUrl(eventId,
+           writeEvent && writeEvent.calendarId))
       } else {
-        request.open("PATCH", Calendar.googleEventUrl(eventId))
+         request.open("PATCH", Calendar.googleEventUrl(eventId,
+           writeEvent && writeEvent.calendarId))
         request.setRequestHeader("Content-Type", "application/json")
       }
       request.setRequestHeader("Authorization", "Bearer " + token)
@@ -326,7 +331,8 @@ Item {
       var request = new XMLHttpRequest()
       root.eventRequest = request
       root.eventRequestTimedOut = false
-      request.open("POST", "https://www.googleapis.com/calendar/v3/calendars/primary/events")
+      request.open("POST", Calendar.googleCalendarEventsUrl(
+        eventSource && eventSource.calendarId))
       request.setRequestHeader("Authorization", "Bearer " + token)
       request.setRequestHeader("Content-Type", "application/json")
       request.onreadystatechange = function() {
@@ -479,16 +485,16 @@ Item {
     passwordStore.running = true
   }
 
-  function replaceActiveSourceEvents(values) {
+  function replaceActiveSourceEvents(values, clear) {
     if (refreshScope !== calendarScope) return
     var sourceId = activeSource ? String(activeSource.id || "") : ""
-    var next = events.filter(function(event) {
+    var next = clear !== false ? events.filter(function(event) {
       return String(event && event.sourceId || "") !== sourceId
-    })
+    }) : events.slice()
     var additions = Array.isArray(values) ? values : []
     for (var i = 0; i < additions.length; i++) {
-      additions[i].sourceName = activeSource
-        ? String(activeSource.name || activeSource.id || "Calendar") : "Calendar"
+      additions[i].sourceName = String(additions[i].sourceName || (activeSource
+        ? activeSource.name || activeSource.id || "Calendar" : "Calendar"))
       next.push(additions[i])
     }
     next.sort(Calendar.compareEvents)
@@ -562,12 +568,19 @@ Item {
       failSource("Google calendar access is unavailable")
       return
     }
+    googleCalendarQueue = []
+    googleCalendarPageToken = ""
+    googleEventsStarted = false
+    startGoogleCalendarList()
+  }
+
+  function startGoogleCalendarList() {
     service.withGoogleAccessToken(activeSource.accountId, function(token, error) {
       if (!token) { root.failSource(error); return }
       var request = new XMLHttpRequest()
       root.googleRequest = request
       root.googleRequestTimedOut = false
-      request.open("GET", Calendar.googleEventsUrl(root.rangeStart, root.rangeEnd))
+      request.open("GET", Calendar.googleCalendarsUrl(root.googleCalendarPageToken))
       request.setRequestHeader("Authorization", "Bearer " + token)
       request.onreadystatechange = function() {
         if (request.readyState !== XMLHttpRequest.DONE) return
@@ -587,8 +600,58 @@ Item {
         var payload = null
         try { payload = JSON.parse(request.responseText) } catch (e) {}
         if (!payload) { root.failSource("Google Calendar returned an unreadable response"); return }
-        root.replaceActiveSourceEvents(Calendar.eventsFromGoogle(payload, root.activeSource.id))
-        root.processNext()
+        var calendars = Array.isArray(payload.items) ? payload.items : []
+        for (var i = 0; i < calendars.length; i++) {
+          if (calendars[i] && calendars[i].id) root.googleCalendarQueue.push(calendars[i])
+        }
+        root.googleCalendarPageToken = String(payload.nextPageToken || "")
+        if (root.googleCalendarPageToken !== "") root.startGoogleCalendarList()
+        else {
+          root.replaceActiveSourceEvents([], true)
+          root.googleEventsStarted = true
+          root.startGoogleCalendar()
+        }
+      }
+      googleDeadline.restart()
+      request.send()
+      token = ""
+    })
+  }
+
+  function startGoogleCalendar() {
+    if (googleCalendarQueue.length === 0) { processNext(); return }
+    var pending = googleCalendarQueue.slice()
+    var calendar = pending.shift()
+    googleCalendarQueue = pending
+    service.withGoogleAccessToken(activeSource.accountId, function(token, error) {
+      if (!token) { root.failSource(error); return }
+      var request = new XMLHttpRequest()
+      root.googleRequest = request
+      root.googleRequestTimedOut = false
+      request.open("GET", Calendar.googleEventsUrl(root.rangeStart, root.rangeEnd, calendar.id))
+      request.setRequestHeader("Authorization", "Bearer " + token)
+      request.onreadystatechange = function() {
+        if (request.readyState !== XMLHttpRequest.DONE) return
+        googleDeadline.stop()
+        root.googleRequest = null
+        var timedOut = root.googleRequestTimedOut
+        root.googleRequestTimedOut = false
+        if (request.status < 200 || request.status >= 300) {
+          var reason = timedOut
+            ? "The Google Calendar request timed out"
+            : Calendar.googleResponseError(request.status, request.responseText)
+          root.failSource(reason, !timedOut
+            && Calendar.isGoogleCalendarApiDisabledError(reason) ? "googleApiDisabled" : "")
+          return
+        }
+        var payload = null
+        try { payload = JSON.parse(request.responseText) } catch (e) {}
+        if (!payload) { root.failSource("Google Calendar returned an unreadable response"); return }
+        var additions = Calendar.eventsFromGoogle(payload, root.activeSource.id, calendar.id)
+        for (var i = 0; i < additions.length; i++)
+          additions[i].sourceName = String(calendar.summary || calendar.id)
+        root.replaceActiveSourceEvents(additions, false)
+        root.startGoogleCalendar()
       }
       googleDeadline.restart()
       request.send()

--- a/providers/Credentials.js
+++ b/providers/Credentials.js
@@ -331,7 +331,7 @@ var KEYRING_KIND = "refresh-token"
 // A token stored before Calendar support cannot prove it carries the new
 // permission. A versioned lookup leaves that token untouched and presents the
 // sign-in flow again, where Google extends the existing grant.
-var KEYRING_GRANT = "calendar-events-v1"
+var KEYRING_GRANT = "calendar-readonly-v1"
 
 // secret-tool reads an empty attribute value as "match anything", which would
 // hand back some other account's token, so an account with no name yet gets a

--- a/providers/OAuth.js
+++ b/providers/OAuth.js
@@ -25,7 +25,8 @@ var CALLBACK_PATH = "/oauth2callback"
 var SCOPES = [
   "https://www.googleapis.com/auth/gmail.modify",
   "https://www.googleapis.com/auth/gmail.send",
-  "https://www.googleapis.com/auth/calendar.events"
+  "https://www.googleapis.com/auth/calendar.events",
+  "https://www.googleapis.com/auth/calendar.readonly"
 ]
 
 function normalizedPort(value) {

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -230,17 +230,23 @@ const google = feed.eventsFromGoogle({ items: [{
   start: { dateTime: "2026-08-24T10:00:00+02:00" },
   end: { dateTime: "2026-08-24T11:00:00+02:00" },
   status: "confirmed"
-}] }, "google:me")
+}] }, "google:me", "work/team")
 assert.strictEqual(google.length, 1)
 assert.strictEqual(google[0].uid, "g1")
 assert.strictEqual(google[0].googleId, "g1",
   "the write URL needs the item id, separate from the iCalUID")
 assert.strictEqual(google[0].sourceId, "google:me")
+assert.strictEqual(google[0].calendarId, "work/team")
 assert.strictEqual(google[0].start.ms, Date.parse("2026-08-24T10:00:00+02:00"))
-const googleUrl = feed.googleEventsUrl(Date.UTC(2026, 7, 1), Date.UTC(2026, 8, 1))
-assert.ok(googleUrl.indexOf("https://www.googleapis.com/calendar/v3/calendars/primary/events?") === 0)
+const googleUrl = feed.googleEventsUrl(Date.UTC(2026, 7, 1), Date.UTC(2026, 8, 1), "work/team")
+assert.ok(googleUrl.indexOf("https://www.googleapis.com/calendar/v3/calendars/work%2Fteam/events?") === 0)
+assert.ok(feed.googleCalendarsUrl().indexOf("/users/me/calendarList?") > 0)
+assert.strictEqual(feed.googleCalendarEventsUrl("work/team"),
+  "https://www.googleapis.com/calendar/v3/calendars/work%2Fteam/events")
 assert.strictEqual(feed.googleEventUrl("g1_20260824T080000Z"),
   "https://www.googleapis.com/calendar/v3/calendars/primary/events/g1_20260824T080000Z")
+assert.strictEqual(feed.googleEventUrl("g1", "work/team"),
+  "https://www.googleapis.com/calendar/v3/calendars/work%2Fteam/events/g1")
 
 const created = feed.createEvent({
   title: "Planning", startMs: Date.UTC(2026, 7, 24, 8, 0),

--- a/tests/test_credentials.js
+++ b/tests/test_credentials.js
@@ -137,7 +137,7 @@ deepEqual(first, [
   "kind", "refresh-token",
   "client-id", sharedClient,
   "account", "one@gmail.com",
-  "grant", "calendar-events-v1"
+  "grant", "calendar-readonly-v1"
 ])
 assert.notStrictEqual(JSON.stringify(first), JSON.stringify(second),
   "two accounts on one client must not share a keyring entry")

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -83,11 +83,11 @@ chmod +x "$test_root/bin/secret-tool"
 KEYRING_CALLS="$test_root/keyring-calls" PATH="$test_root/bin:$PATH" \
   sh scripts/keyring-store.sh \
     service omamail kind refresh-token client-id client account me@example.com \
-    grant calendar-events-v1 <<EOF
+    grant calendar-readonly-v1 <<EOF
 token
 EOF
 expected_calls='clear service omamail kind refresh-token client-id client account me@example.com
-store --label=Omamail refresh token service omamail kind refresh-token client-id client account me@example.com grant calendar-events-v1'
+  store --label=Omamail refresh token service omamail kind refresh-token client-id client account me@example.com grant calendar-readonly-v1'
 actual_calls=$(cat "$test_root/keyring-calls")
 [ "$actual_calls" = "$expected_calls" ] \
   || fail "keyring-store.sh did not replace the unversioned grant before storing the versioned one"

--- a/tests/test_oauth.js
+++ b/tests/test_oauth.js
@@ -37,6 +37,7 @@ assert.ok(url.indexOf("prompt=consent") > 0)
 assert.ok(url.indexOf("redirect_uri=http%3A%2F%2F127.0.0.1%3A9481%2Foauth2callback") > 0)
 assert.ok(url.indexOf("scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.modify%20") > 0)
 assert.ok(url.indexOf("https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.events") > 0)
+assert.ok(url.indexOf("https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.readonly") > 0)
 assert.ok(url.indexOf("login_hint") < 0, "an absent hint is omitted, not sent empty")
 
 const hinted = oauth.authorizationUrl({
@@ -125,11 +126,11 @@ assert.strictEqual(oauth.refreshRetryDelay(100), 300000)
 // --------------------------------------------------------------- scopes
 
 deepEqual(
-  oauth.missingScopes("https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/calendar.events"),
+  oauth.missingScopes("https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.readonly"),
   [])
 deepEqual(
   oauth.missingScopes("https://www.googleapis.com/auth/gmail.modify"),
-  ["https://www.googleapis.com/auth/gmail.send", "https://www.googleapis.com/auth/calendar.events"])
+  ["https://www.googleapis.com/auth/gmail.send", "https://www.googleapis.com/auth/calendar.events", "https://www.googleapis.com/auth/calendar.readonly"])
 assert.strictEqual(
   oauth.missingScopeMessage(["https://www.googleapis.com/auth/gmail.send"]),
   "Google sign-in finished without the gmail.send permission. Sign in again and leave every checkbox ticked")


### PR DESCRIPTION
Fixes #53

## Problem

Omamail only queries `/calendars/primary/events`, so secondary, shared, or subscribed Google calendars never appear. The Calendar API and OAuth scope were already enabled, but the code never asked for the calendar list.

## Solution

1. **Discover calendars**: call `calendarList.list` to get every calendar the account can access.
2. **Fetch events from each**: iterate the list and query `/calendars/{calendarId}/events` for each enabled calendar.
3. **New OAuth scope**: add `calendar.readonly` alongside the existing `calendar.events` scope.
4. **Keyring grant version bump**: force re-authentication so the new scope is actually granted.
5. **Safe URL encoding**: all `calendarId` values are percent-encoded in API URLs.

## Changes

- `providers/OAuth.js` — add `calendar.readonly` scope
- `calendar/Calendar.js` — add `googleCalendarsUrl()`, parameterize `googleEventsUrl()` and `googleEventUrl()` with `calendarId`
- `calendar/CalendarController.qml` — discover calendars, iterate and fetch events per calendar, preserve `sourceName`
- `providers/Credentials.js` — bump keyring grant to force re-auth
- Tests updated to match

## Verified

- `make test-js` passes
- `make validate` passes (qmllint warnings are pre-existing)
- Tested locally: secondary Google calendars now appear in the calendar view

## Notes

- Event creation still defaults to the primary calendar; edits/deletes use the event's discovered `calendarId`.
- Existing Google sessions will need to sign in again to grant the new scope.