### PR TITLE
Say what the mailbox does in the manifest, and where its site is

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,7 @@
   "version": "0.7.0",
   "author": "huacnlee",
   "license": "MIT",
+  "homepage": "https://huacnlee.github.io/omamail/",
   "description": "Email client for Omarchy: read, triage, and reply to Gmail, HEY and any IMAP mailbox in a native window. Fastmail, iCloud, Outlook, Zoho, Proton Bridge, or your own server — several accounts at once, each with its own inbox and unread count. Keyboard-first, three columns when there is room and one when there is not, and it follows your theme. Meeting invitations are drawn as meetings you can answer, newsletters unsubscribe in one click, and remote images stay blocked until you ask.",
   "kinds": [
     "service",

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "version": "0.7.0",
   "author": "huacnlee",
   "license": "MIT",
-  "description": "Email client for Omarchy: read, triage, and reply to Gmail, HEY and any IMAP mailbox in a native window. Fastmail, iCloud, Outlook, Zoho, or your own server.",
+  "description": "Email client for Omarchy: read, triage, and reply to Gmail, HEY and any IMAP mailbox in a native window. Fastmail, iCloud, Outlook, Zoho, Proton Bridge, or your own server — several accounts at once, each with its own inbox and unread count. Keyboard-first, three columns when there is room and one when there is not, and it follows your theme. Meeting invitations are drawn as meetings you can answer, newsletters unsubscribe in one click, and remote images stay blocked until you ask.",
   "kinds": [
     "service",
     "bar-widget",


### PR DESCRIPTION
## What changed

Two fields in `manifest.json`:

- `description` now spends 486 of the 500 characters the marketplace allows, instead of stopping at 157. It covers several accounts at once, keyboard-first navigation, the theme it follows, meeting invitations it answers, one-click unsubscribe, and blocked remote images.
- `homepage` records `https://huacnlee.github.io/omamail/`.

## Why

The marketplace renders the description verbatim on `plugin.html` and renders nothing else of ours: `site/assets/js/plugin.js` builds the detail page from `name`, `id`, `version`, `author`, `description`, one preview image and the listing's tags. There is no README render, no image gallery and no homepage link — the only outbound link on the page is **View source ↗** to this repository. So the description is the whole of the prose a reader gets before deciding whether to click through.

`homepage` is read by nobody today. The shell's `PluginRegistry.qml` checks `schemaVersion`, five required fields and `barWidget.defaultSection`, then keeps the object as-is; the marketplace's `validateManifest` does the same and projects seven fields into the catalog. Neither rejects an unknown key and neither displays this one. It is written down because it is a fact about the plugin that belongs beside the license and the author, and `homepage` is the name every package manifest already uses for it.

## Invariants

- The description's first clause is unchanged on purpose. `.plugin-card-body .plugin-description` clamps the string to one `white-space: nowrap` line with a fade mask, so on the browse grid only that opening clause is ever read.
- Single line, no control characters, 486 ≤ 500 — `scripts/build-catalog.mjs` rejects a community manifest on any of those three.
- Nothing the shell loads changed: `kinds`, `entryPoints`, and the `barWidget` block are untouched.

## Verification

- `tests/test_install.sh` — the manifest parses, `kinds` still names all three, and every declared entry point exists. (The run stops later at a `stat -c` call that only exists on Linux; unrelated to this change.)
- Character count checked against `manifestFieldLimits.description` (500) in the marketplace's `build-catalog.mjs`.
- Unknown-key tolerance read off `PluginRegistry.qml`, `bin/omarchy-plugin-validate` and `scripts/build-catalog.mjs` rather than assumed.

## Follow-up

The catalog still shows `0.6.0` because it tracks `upstreamValidatedCommit` (`f69df2d`, Aug 29), and the preview it holds is an older 1472×1049 copy. Both refresh once this lands and the marketplace's **Verify and publish a newer upstream commit** issue runs against the new HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCADd1kREtBpqndUcpwji6
