### PR TITLE
Read the tagged completion, not any line the message happens to contain

### DIFF
--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -898,12 +898,25 @@ function redact(text) {
 
 // Whether the tagged completion said OK. curl hides the tag from us for a
 // custom request, so this reads what it does surface.
+//
+// Only the *last* response line can be that completion — mid-response lines
+// are untagged data, and with a FETCH that data is the message itself. A
+// server-side spam scanner header like "X-Spam-Flag: NO" reads exactly like
+// a tagged NO to a regex that isn't told where the literal ends, so this
+// goes through `splitResponse` first: it already folds each literal into the
+// one line it belongs to, which is the only way to reach the true last line
+// without a regex trying to count octets.
+function lastResponseLine(text) {
+  var lines = splitResponse(text)
+  return lines.length ? lines[lines.length - 1] : ""
+}
+
 function isFailure(text) {
-  return /^\S+\s+(NO|BAD)\s/im.test(String(text || ""))
+  return /^\S+\s+(NO|BAD)\b/i.test(lastResponseLine(text))
 }
 
 function failureDetail(text) {
-  var match = String(text || "").match(/^\S+\s+(?:NO|BAD)\s+([\s\S]*)$/im)
+  var match = lastResponseLine(text).match(/^\S+\s+(?:NO|BAD)\s+([\s\S]*)$/i)
   return match ? trimmed(match[1].split(/[\r\n]/)[0]) : ""
 }
 


### PR DESCRIPTION
Fixes #74

## Problem

`isFailure` and `failureDetail` in `ImapProtocol.js` regex-scanned the whole raw FETCH response text — literal payload included, which for a FETCH is the message itself — for a line matching `/^\S+\s+(NO|BAD)\s/im`. A message header that happens to read like a tagged `NO`/`BAD` completion trips it. GMX stamps every delivered message with `X-Spam-Flag: NO`, which matches directly: a successful fetch gets reported as a failed command, the parsed body/html is discarded, and a fragment of the message's own header shows up as the error text. The reader then shows "This message has no text to show" for a message that has text.

Confirmed against a real account: fetched a plain test message over IMAP directly and found `X-Spam-Flag: NO` sitting among its headers, matching the regex `isFailure` runs.

## Fix

`splitResponse` already exists to fold each literal into the one response line it belongs to — the file's own comment above it says why: "where a literal ends is the one thing this cannot be wrong about, and no regular expression can count octets." `isFailure`/`failureDetail` weren't going through it. They now do, and check only the last line `splitResponse` produces — the only line that can be a tagged completion, since an untagged line (including one holding a literal) can never be the final line of a single command's response.

## Verification

- `make test-js` and `make test-shell` both pass, unchanged.
- Added a manual regression against a synthetic FETCH response with `X-Spam-Flag: NO` embedded in the literal: `isFailure` now returns `false` and `failureDetail` returns `""`, where it previously misfired.
- Existing `isFailure`/`failureDetail` unit tests in `tests/test_imap.js` are unaffected — all inputs there are single-line, so the last-line lookup returns the same value the old regex did.

## Release Notes

- Fixed messages sometimes showing as empty ("This message has no text to show") with a garbled error line, caused by a false-positive match on a header inside the message itself (e.g. GMX's `X-Spam-Flag: NO`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbQ5kH613UMeECpu9vchoo