### PR TITLE
Stop losing a mailbox, and fix the IMAP faults behind an unreadable one

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -929,13 +929,29 @@ Item {
     pushEntry("setup", { provider: provider, draft: false })
   }
 
+  // The row this page is editing, not the mailbox the id happens to name: with
+  // a freshly added draft on screen those are different rows, and asking for
+  // the second one is how Remove came to delete a working account while the
+  // page in front of the user showed an empty form.
   function removeCurrentAccountFromEditor() {
     if (!service || service.accountCount <= 1) return
-    var index = service.indexOfActiveAccount()
+    var index = service.editingIndex()
     if (index < 0) return
     var values = service.accountSummaries || []
     var request = Accounts.removalRequest({ accounts: values }, index)
-    if (request) accountRemovalDialog.openFor(request)
+    if (request) {
+      accountRemovalDialog.openFor(request)
+      return
+    }
+    // No request means this row is the form's own draft: it has no id, so there
+    // is no mailbox for a confirmation to name — which is exactly why
+    // `removalRequest` refuses it. A draft is canceled rather than removed, so
+    // discard it and leave the page it was being edited on, the way Back does.
+    // Without this the button would simply do nothing on the page of a mailbox
+    // that has just been added.
+    service.discardCurrentDraft()
+    navUntouched = false
+    nav = Nav.push(Nav.resetTo(nav, rootKind()), Nav.entry("settings"))
   }
 
   function confirmAccountRemoval(request) {

--- a/App.qml
+++ b/App.qml
@@ -943,13 +943,12 @@ Item {
       accountRemovalDialog.openFor(request)
       return
     }
-    // No request means this row is the form's own draft: it has no id, so there
-    // is no mailbox for a confirmation to name — which is exactly why
-    // `removalRequest` refuses it. A draft is canceled rather than removed, so
-    // discard it and leave the page it was being edited on, the way Back does.
-    // Without this the button would simply do nothing on the page of a mailbox
-    // that has just been added.
-    service.discardCurrentDraft()
+    // No request means there is no mailbox id a confirmation can name. For the
+    // form's pending row that is expected: cancel it and leave the page, the
+    // way Back does. An idless persisted mailbox is different — if its damaged
+    // address could not be repaired it stays here for correction rather than
+    // being silently removed and mistaken for canceled setup state.
+    if (service.discardCurrentDraft() !== true) return
     navUntouched = false
     nav = Nav.push(Nav.resetTo(nav, rootKind()), Nav.entry("settings"))
   }

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ test-shell:
 	python3 tests/test_qml_text_format.py
 	bash tests/test_source.sh
 	bash tests/test_service_source.sh
+	bash tests/test_config_store.sh
 	bash tests/test_link_plugin.sh
 	bash tests/test_mailto.sh
 	bash tests/test_transport.sh

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ test-shell:
 	bash tests/test_link_plugin.sh
 	bash tests/test_mailto.sh
 	bash tests/test_transport.sh
+	bash tests/test_imap_ordering.sh
 	bash tests/test_unsubscribe_transport.sh
 	bash tests/test_image_fetch.sh
 	bash tests/test_attachment_open.sh

--- a/Service.qml
+++ b/Service.qml
@@ -244,7 +244,12 @@ Item {
   function addAccount(provider) {
     accountList = Accounts.add(accountList, ({
       email: "", clientId: "", clientSecret: "",
-      provider: provider || Provider.DEFAULT_ID
+      provider: provider || Provider.DEFAULT_ID,
+      // Working state for the form, and it says so rather than leaving the
+      // write boundary to guess from a missing id — which is what it used to
+      // do, and what made it delete a mailbox whose address had been corrupted.
+      // `makeAccount` clears this the moment a real address arrives.
+      pending: true
     }))
     // This row is working state for the form, not an account yet. Persisting
     // it here leaves a "New account" behind when Back cancels Add; the first
@@ -398,6 +403,13 @@ Item {
     // trusting the two to agree.
     var writable = Accounts.savedOnly(accountList)
     if (!Accounts.hasSavedAccounts(writable)) return
+    // And no mailbox the list could name may go missing on the way to the
+    // payload. The guard above is about the list as a whole — one real mailbox
+    // in it is enough to satisfy it, which is exactly why it let a write
+    // through that had dropped a different, working account. This one is per
+    // row. Removal never arrives here as an omission: it goes through
+    // `remove` or `removeAt`, so the row is gone from `accountList` too.
+    if (Accounts.dropsNamedMailbox(accountList, writable)) return
     if (accountsWriter.running) {
       accountsSaveQueued = true
       return
@@ -418,7 +430,7 @@ Item {
     // First run, or an install that predates several accounts: one nameless
     // row so the existing credentials file still has somewhere to live.
     if (Accounts.count(loaded) === 0)
-      loaded = Accounts.add(loaded, ({ email: "", clientId: "", clientSecret: "" }))
+      loaded = Accounts.add(loaded, ({ email: "", clientId: "", clientSecret: "", pending: true }))
     // Reading back our own write must change nothing. The list is watched so
     // that an edit from outside is picked up, but every save triggers that
     // watch — and reassigning the list re-derives every account's id, which

--- a/Service.qml
+++ b/Service.qml
@@ -217,7 +217,19 @@ Item {
   function switchToIndex(index) {
     var accounts = accountList ? accountList.accounts : []
     if (index < 0 || index >= accounts.length) return false
-    if (index === indexOfActiveAccount()) return true
+    // Already the row the id names — but `activeIndex` can still be holding a
+    // draft opened before this call, and it outranks the id everywhere the
+    // editing row is worked out. Clearing it is the same correction `switchTo`
+    // makes above. Without it, Edit on a mailbox chosen while Add had a draft
+    // on screen opened that draft's empty form instead, and Remove then
+    // targeted the draft rather than the mailbox that was clicked.
+    if (index === indexOfActiveAccount()) {
+      if (activeIndex >= 0) {
+        activeIndex = -1
+        refreshCurrent()
+      }
+      return true
+    }
     if (accounts[index].id !== "") {
       return switchTo(accounts[index].id)
     }
@@ -247,7 +259,7 @@ Item {
   }
 
   function discardCurrentDraft() {
-    var index = activeIndex >= 0 ? activeIndex : indexOfActiveAccount()
+    var index = editingIndex()
     var next = Accounts.discardDraftAt(accountList, index)
     if (Accounts.count(next) === accountCount) return
     activeIndex = -1
@@ -279,6 +291,13 @@ Item {
     // provider decides what it is about to be called.
     var named = Accounts.accountId(email, accounts[index].provider)
     if (accounts[index].id === named) return
+    // The other place an address reaches the list, and the other place one that
+    // is not an address can destroy a mailbox: an empty id means `accountId`
+    // could make nothing of what the provider reported, and writing it would
+    // replace a working row's address with a name that addresses nothing. A
+    // rename that cannot produce an id has nothing to offer, so it is refused
+    // rather than stored — the row keeps the address it already answers to.
+    if (named === "") return
 
     // Two rows cannot hold one address. Rebuilding the list would fold them
     // together and take the row being added with it, which read as the add
@@ -370,13 +389,21 @@ Item {
     // path that persists only one — Add waits for configureAccount, and the UI
     // does not remove the final saved account — so refusing this write is the
     // last line of defence against replacing every account with first-run.
-    if (!Accounts.hasSavedAccounts(accountList)) return
+    //
+    // Only the mailboxes, never the form's own working row: a save triggered by
+    // one account used to carry whatever draft happened to be open along with
+    // it, stranding a row on disk that nothing could select or remove. The
+    // guard is applied to that stripped list rather than to what is in memory,
+    // so it is testing the bytes that are about to be written instead of
+    // trusting the two to agree.
+    var writable = Accounts.savedOnly(accountList)
+    if (!Accounts.hasSavedAccounts(writable)) return
     if (accountsWriter.running) {
       accountsSaveQueued = true
       return
     }
     accountsSaveQueued = false
-    accountsWritePayload = Accounts.serialize(accountList)
+    accountsWritePayload = Accounts.serialize(writable)
     accountsWriter.command = [pluginDir + "/scripts/config-store.sh", "accounts.json"]
     accountsWriter.running = true
   }
@@ -398,7 +425,13 @@ Item {
     // resets its cache and its session. That is what made adding a mailbox
     // flicker through several states: the window was rebuilding every account
     // each time the file it had just written landed back.
-    if (accountsLoaded && Accounts.serialize(loaded) === Accounts.serialize(accountList))
+    //
+    // Compared on the saved rows alone, because that is all the write contains.
+    // Against the whole in-memory list an open draft would make every read-back
+    // look like an outside edit, and adopting it would destroy the row the user
+    // is typing into.
+    if (accountsLoaded && Accounts.serialize(Accounts.savedOnly(loaded))
+        === Accounts.serialize(Accounts.savedOnly(accountList)))
       return
     // What is on disk is behind what is in memory until the pending write
     // lands, so a reload now would be a straight revert.
@@ -672,7 +705,7 @@ Item {
   }
   readonly property string accountAddress: {
     var accounts = accountList ? accountList.accounts : []
-    var index = activeIndex >= 0 ? activeIndex : indexOfActiveAccount()
+    var index = editingIndex()
     return index >= 0 && index < accounts.length ? String(accounts[index].email || "") : ""
   }
   readonly property int inboxUnread: current ? current.inboxUnread : 0
@@ -815,7 +848,7 @@ Item {
   // one on screen. Addressed by index because that is the only handle on a row
   // that has no address yet — which is exactly the row being filled in.
   function configureCurrentAccount(values) {
-    configureAccount(activeIndex >= 0 ? activeIndex : indexOfActiveAccount(), values)
+    configureAccount(editingIndex(), values)
   }
 
   // Saving a new address rebuilds the account host. Wait for that replacement
@@ -840,6 +873,18 @@ Item {
     }
     return -1
   }
+
+  // Which row the setup page is editing. `activeIndex` is the override a row
+  // with no id needs — it cannot be named — and the active account's own
+  // position answers for every other row. One function because three callers
+  // used to spell this out for themselves and a fourth, the Remove button,
+  // spelled it differently: it asked `indexOfActiveAccount()` alone, so on the
+  // page of a freshly added mailbox it named the mailbox that was on screen
+  // before the add, and removing it deleted a working account.
+  function editingIndex() {
+    return activeIndex >= 0 ? activeIndex : indexOfActiveAccount()
+  }
+
   function openInBrowser(id) { if (current) current.openInBrowser(id) }
   function openWebInbox() { if (current) current.openWebInbox() }
 

--- a/Service.qml
+++ b/Service.qml
@@ -266,10 +266,11 @@ Item {
   function discardCurrentDraft() {
     var index = editingIndex()
     var next = Accounts.discardDraftAt(accountList, index)
-    if (Accounts.count(next) === accountCount) return
+    if (Accounts.count(next) === accountCount) return false
     activeIndex = -1
     accountList = next
     refreshCurrent()
+    return true
   }
 
   function removeAccount(id) {

--- a/account/Accounts.js
+++ b/account/Accounts.js
@@ -134,8 +134,45 @@ function makeAccount(account) {
     clientSecret: trimmed(raw.clientSecret),
     imap: makeImapSettings(raw.imap),
     label: trimmed(raw.label),
-    signature: trimmed(raw.signature)
+    signature: trimmed(raw.signature),
+    // Whether this row is the setup form's working state rather than a
+    // mailbox. It used to be inferred from the id being empty, and that read
+    // a mailbox whose address had been corrupted as a draft and dropped it at
+    // the write boundary — which is how a working account was deleted by the
+    // act of adding an unrelated one.
+    //
+    // Self-maintaining, so no caller has to remember to clear it: a row that
+    // has a real address is not something being typed into, whatever the flag
+    // says. `configureAccount` copies every key of the row it edits, so a flag
+    // that had to be cleared by hand would have survived setup forever.
+    pending: raw.pending === true && !isValidEmail(email)
   }
+}
+
+// A mailbox whose address was overwritten by something that is not one — a
+// username typed into the address field, which the setup form used to save
+// without checking. Everything else about the row survived: its server
+// settings, its keyring entry, its cache directory. And the address itself
+// survived too, in `imap.username`, because `setupSettings` folds the address
+// into the username when no separate one was given.
+//
+// So the row is repairable, and repairing it is the difference between a
+// mailbox that comes back and one that is silently dropped the next time the
+// list is written.
+//
+// Done here rather than in `makeAccount`, which also builds the row the setup
+// form is being typed into: adopting a username there would drop an address
+// into the field before anyone had typed one.
+function repairedAddress(entry) {
+  var raw = entry || {}
+  if (isValidEmail(raw.email)) return raw
+  if (normalizeProvider(raw.provider) !== "imap") return raw
+  var username = trimmed((raw.imap || {}).username)
+  if (!isValidEmail(username)) return raw
+  var next = {}
+  for (var key in raw) next[key] = raw[key]
+  next.email = username
+  return next
 }
 
 function copyList(list) {
@@ -334,7 +371,7 @@ function load(text) {
   var entries = Array.isArray(raw.accounts) ? raw.accounts : []
   for (var i = 0; i < entries.length; i++) {
     if (!isObject(entries[i])) continue
-    var entry = makeAccount(entries[i])
+    var entry = makeAccount(repairedAddress(entries[i]))
     // The id is recomputed rather than trusted, so a hand-edited file cannot
     // introduce two entries the rest of the code believes are different
     // accounts while Gmail treats them as one.
@@ -352,14 +389,61 @@ function load(text) {
 // a mailbox — the comment on `Service.addAccount` says as much, but nothing
 // enforced it at the write boundary, so any later save carried the draft along
 // and left a "New mailbox" behind that nothing could select and nothing could
-// remove. A row with no id is exactly that draft, and only rows that are
-// mailboxes are written; the drafts live in memory for as long as the form is
-// open, which is all the life they were meant to have.
+// remove. The drafts live in memory for as long as the form is open, which is
+// all the life they were meant to have.
+//
+// A draft says so — `pending` — rather than being inferred from having no id.
+// The two are not the same thing: a mailbox whose address was corrupted also
+// has no id, and reading it as a draft is what deleted a working account here.
+// Whether a row holds anything its owner would miss. An addressable mailbox
+// obviously does. So does one whose address is unusable but whose server
+// settings were typed in and whose password is in the keyring — that is a
+// mailbox with a broken name, not an empty row.
+//
+// A row with none of it is the leftover of an Add that was never filled in.
+// Those did reach the file before drafts were marked as such, and there is
+// nothing in one to preserve.
+function carriesData(entry) {
+  var raw = entry || {}
+  if (trimmed(raw.id) !== "") return true
+  var imap = raw.imap || {}
+  return trimmed(imap.username) !== "" || trimmed(imap.imapHost) !== ""
+    || trimmed(raw.clientId) !== "" || trimmed(raw.clientSecret) !== ""
+}
+
+// Whether a payload would drop a mailbox the list could name. Nothing in the
+// UI removes an account by writing a list that quietly omits it — removal goes
+// through `remove` or `removeAt` first — so a missing id at the write boundary
+// is a bug upstream, and refusing the write is what keeps it off the disk.
+function dropsNamedMailbox(list, payload) {
+  var source = Array.isArray((list || {}).accounts) ? list.accounts : []
+  var kept = Array.isArray((payload || {}).accounts) ? payload.accounts : []
+  for (var i = 0; i < source.length; i++) {
+    var id = trimmed((source[i] || {}).id)
+    if (id !== "" && indexOfId(kept, id) < 0) return true
+  }
+  return false
+}
+
+function draftCount(list) {
+  var values = Array.isArray((list || {}).accounts) ? list.accounts : []
+  var drafts = 0
+  for (var i = 0; i < values.length; i++) {
+    if (values[i] && values[i].pending === true) drafts++
+  }
+  return drafts
+}
+
 function savedOnly(list) {
   var next = copyList(list)
   var kept = []
   for (var i = 0; i < next.accounts.length; i++) {
-    if (next.accounts[i] && next.accounts[i].id !== "") kept.push(next.accounts[i])
+    // Drafts, and nothing else. A row with no id that is not a draft is a
+    // mailbox whose address `repairedAddress` could not recover — unusable
+    // until someone corrects it, but its settings and its keyring entry are
+    // still there, and deleting it is not this function's decision to make.
+    var entry = next.accounts[i]
+    if (entry && entry.pending !== true && carriesData(entry)) kept.push(entry)
   }
   next.accounts = kept
   if (indexOfId(kept, next.activeId) < 0) next.activeId = nextActiveId(kept, 0)

--- a/account/Accounts.js
+++ b/account/Accounts.js
@@ -178,12 +178,20 @@ function count(list) {
 // must not be inferred from whether a host is signed in: sessions are restored
 // asynchronously, and signed-out accounts still exist and must never be
 // overwritten by Add account.
+//
+// An address that is merely non-empty is not enough to call a row saved. A row
+// carrying something that is not an address — a username typed into the address
+// field — gets the empty id from `accountId`, so it is a draft to every lookup
+// here while still reading as a real account to this guard. That combination
+// disarmed the write guard in `Service.saveAccounts` and let a working mailbox
+// be replaced on disk by a row nothing could select or remove. The same
+// predicate that derives the id decides this.
 function hasSavedAccounts(list) {
   var source = list || {}
   var values = Array.isArray(source.accounts) ? source.accounts : []
   for (var i = 0; i < values.length; i++) {
     var entry = values[i] || {}
-    if (trimmed(entry.id) !== "" || trimmed(entry.email) !== "") return true
+    if (trimmed(entry.id) !== "" || isValidEmail(entry.email)) return true
   }
   return false
 }
@@ -336,6 +344,25 @@ function load(text) {
 
   var wanted = trimmed(raw.activeId).toLowerCase()
   next.activeId = indexOfId(next.accounts, wanted) >= 0 ? wanted : nextActiveId(next.accounts, 0)
+  return next
+}
+
+// What belongs in the file. `add` creates a row before the user has typed
+// anything into it, and that row is the setup form's working state rather than
+// a mailbox — the comment on `Service.addAccount` says as much, but nothing
+// enforced it at the write boundary, so any later save carried the draft along
+// and left a "New mailbox" behind that nothing could select and nothing could
+// remove. A row with no id is exactly that draft, and only rows that are
+// mailboxes are written; the drafts live in memory for as long as the form is
+// open, which is all the life they were meant to have.
+function savedOnly(list) {
+  var next = copyList(list)
+  var kept = []
+  for (var i = 0; i < next.accounts.length; i++) {
+    if (next.accounts[i] && next.accounts[i].id !== "") kept.push(next.accounts[i])
+  }
+  next.accounts = kept
+  if (indexOfId(kept, next.activeId) < 0) next.activeId = nextActiveId(kept, 0)
   return next
 }
 

--- a/account/Accounts.js
+++ b/account/Accounts.js
@@ -285,9 +285,9 @@ function remove(list, id) {
 // An id that is not in the list means the caller is acting on a list that has
 // moved on. Leaving the previous account on screen is better than blanking the
 // window, so an unknown id — "" included — changes nothing.
-// An account that never finished signing in has no id, so nothing can name it
-// — and a failed sign-in leaves exactly that. Removing by position is the only
-// handle the window has on one.
+// A row that has no id cannot be removed by name. Removing by position is the
+// only handle the window has on one, so callers must decide separately whether
+// it is pending setup or a persisted mailbox with a damaged address.
 function removeAt(list, index) {
   var source = copyList(list)
   var at = Math.floor(Number(index))
@@ -326,7 +326,10 @@ function discardDraftAt(list, index) {
   var source = copyList(list)
   var at = Math.floor(Number(index))
   if (!isFinite(at) || at < 0 || at >= source.accounts.length) return source
-  if (source.accounts[at].id !== "") return source
+  // A missing id does not make a draft: a persisted mailbox whose damaged
+  // address cannot be repaired has no id either. Only the setup row explicitly
+  // marked as working state may be discarded without confirmation.
+  if (source.accounts[at].pending !== true) return source
   return removeAt(source, at)
 }
 

--- a/components/ImapSetupPage.qml
+++ b/components/ImapSetupPage.qml
@@ -2,6 +2,7 @@ import QtQuick
 import qs.Commons
 import qs.Ui
 import "../providers/ImapProtocol.js" as Imap
+import "../account/Accounts.js" as Accounts
 import "../account/Aliases.js" as Aliases
 
 // Connecting an ordinary mailbox: an address, a password, and — only if the
@@ -88,10 +89,33 @@ Column {
     }
   }
 
+  // The address is this mailbox's identity, not just a label on it:
+  // `Accounts.accountId` derives the account id from it, and anything that is
+  // not an address derives the empty id a pending row carries. That row then
+  // looks saved and behaves like a draft — it cannot be selected, switched to,
+  // signed, or removed, and there is no way back to it from inside the window.
+  // `validateSettings` cannot catch this: `setupSettings` folds the address
+  // into `username` and hands on no address at all. So it is checked here,
+  // against the same predicate that derives the id, while it is still a typo
+  // the user can see.
+  //
+  // Checked before the server settings because the form reads address first,
+  // and an error should name the first field to go back to.
+  function validatedAddress() {
+    var address = addressField.text.trim()
+    if (Accounts.isValidEmail(address)) return address
+    errorText.text = address === ""
+      ? "Add the email address for this mailbox"
+      : "That is not a full email address"
+    return ""
+  }
+
   // Saved before the password is tried, so a mailbox that the server rejects
   // still has its settings to correct rather than an empty form to fill again.
   function save() {
     if (!service) return
+    var address = validatedAddress()
+    if (address === "") return
     var check = Imap.validateSettings(currentSettings())
     if (!check.ok) {
       errorText.text = check.error
@@ -100,13 +124,15 @@ Column {
     errorText.text = ""
     service.configureCurrentAccount({
       provider: "imap",
-      email: addressField.text.trim(),
+      email: address,
       imap: check.settings
     })
   }
 
   function signIn() {
     if (!service) return
+    var address = validatedAddress()
+    if (address === "") return
     var check = Imap.validateSettings(currentSettings())
     if (!check.ok) {
       errorText.text = check.error
@@ -115,7 +141,7 @@ Column {
     errorText.text = ""
     service.configureCurrentAccountAndSignIn({
       provider: "imap",
-      email: addressField.text.trim(),
+      email: address,
       imap: check.settings
     }, passwordField.text)
   }
@@ -284,6 +310,7 @@ Column {
 
     Text {
       id: errorText
+      objectName: "imap-error"
       width: parent.width
       visible: text !== ""
       text: ""

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -105,15 +105,32 @@ Item {
         return
       }
 
+      // Some servers refuse every SELECT until the client has identified itself
+      // — see `Imap.idCommand` — and curl derives its SELECT from the URL's
+      // path before the first command it was handed. `imap-id` is the way past
+      // that: the opening command runs against the server itself, the rest
+      // against the mailbox, all on the one connection.
+      //
+      // Only where a mailbox is actually opened, and only to a server that
+      // advertised ID — one that has not heard of it answers BAD, and
+      // --fail-early would discard the whole invocation with it. Every folder
+      // request runs behind `ensureFolders`, so the capabilities are known by
+      // the time this asks.
+      var opening = folder !== "" && Imap.hasCapability(root.serverCapabilities, "ID")
+        ? Imap.idCommand() : ""
+
       // Every field crosses base64-encoded, so a password containing a quote,
       // a space or a backslash needs no escaping anywhere along the way — and
       // none of it reaches the process table.
-      var fields = [Mail.encodeBase64(url), Mail.encodeBase64(credentials)]
+      var fields = opening === ""
+        ? [Mail.encodeBase64(url), Mail.encodeBase64(credentials)]
+        : [Mail.encodeBase64(Imap.imapUrl(auth.settings, "")), Mail.encodeBase64(url),
+           Mail.encodeBase64(credentials), Mail.encodeBase64(opening)]
       for (var j = 0; j < wanted.length; j++) fields.push(Mail.encodeBase64(wanted[j]))
 
       var process = transportComponent.createObject(root, {
         command: [root.transport],
-        requestLine: "imap " + fields.join(" ")
+        requestLine: (opening === "" ? "imap " : "imap-id ") + fields.join(" ")
       })
       if (!process) {
         root.inFlight = Math.max(0, root.inFlight - 1)

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -135,7 +135,7 @@ Item {
         var text = Imap.decodeResponse(out, Mail.base64ToBytes, Mail.bytesToLatin1)
         var detail = Imap.decodeResponse(err, Mail.base64ToBytes, Mail.bytesToLatin1)
         if (status !== 0) {
-          callback("", Imap.responseError(status, detail, ""))
+          callback("", Imap.transportError(status, text, detail, ""))
           return
         }
         // curl exits 0 for a command the server refused, so the tagged
@@ -877,7 +877,7 @@ Item {
       var text = Imap.decodeResponse(out, Mail.base64ToBytes, Mail.bytesToLatin1)
       var detail = Imap.decodeResponse(err, Mail.base64ToBytes, Mail.bytesToLatin1)
       if (status !== 0) {
-        callback(false, Imap.responseError(status, detail, ""))
+        callback(false, Imap.transportError(status, text, detail, ""))
         return
       }
       if (Imap.isFailure(text)) {

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -522,8 +522,12 @@ Item {
         var folder = root.folders[i]
         if (!folder.selectable) continue
         out.push({
+          // The id and the wire name stay exactly as the server said them:
+          // one is a cache key, the other is what goes back in a SELECT. Only
+          // the name the sidebar prints is decoded, which is why nothing here
+          // has to be encoded again on the way out.
           id: folder.name,
-          name: folder.name,
+          name: Imap.decodeMailbox(folder.name),
           rawName: folder.name,
           // "system" means the mailbox row already offers it, so the sidebar
           // lists only the rest below. Judged on SPECIAL-USE rather than on the

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -109,6 +109,31 @@ var PRESETS = [
     imapHost: "imap.gmx.com", imapPort: 993,
     smtpHost: "mail.gmx.com", smtpPort: 465
   },
+  // Here for the note rather than the servers: imap.163.com and smtp.163.com
+  // on the standard ports are exactly what `imap.<domain>` would have guessed.
+  // What no address can imply is that the mailbox refuses the account
+  // password, and a user who does not know that is told only that they were
+  // rejected — which is the one sentence that stops the next hour.
+  //
+  // 163.com alone, deliberately. NetEase's other consumer domains are the same
+  // service on their own hostnames, so 126.com and yeah.net cannot be added to
+  // this row's `domains` — they would be handed the 163 servers. They need a
+  // row each, and until someone wants one the guess already reaches them.
+  {
+    id: "netease-163",
+    name: "163 Mail",
+    domains: ["163.com"],
+    imapHost: "imap.163.com", imapPort: 993,
+    smtpHost: "smtp.163.com", smtpPort: 465,
+    note: "163 does not accept your account password here. Switch IMAP on in the "
+      + "mailbox's own settings, then paste the authorisation code it hands you — it "
+      + "is a separate string from the password you sign in to the website with.",
+    guide: {
+      url: "https://help.mail.163.com/faqDetail.do?code="
+        + "d7a5dc8471cd0c0e8b4b8f4f8e49998b374173cfe9171305fa1ce630d7f67ac2a5feb28b66796d3b",
+      label: "How to get a 163 authorisation code"
+    }
+  },
   {
     id: "proton",
     name: "Proton Mail",

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -1036,6 +1036,14 @@ function responseError(status, detail, fallback) {
   if (code === 35) return "A secure connection to the mail server could not be established"
   if (code === 60 || code === 51)
     return "The mail server's security certificate could not be verified"
+  // curl gives a refused SELECT the same exit code as a denied login — 67, with
+  // only "Select failed" against "Access denied" to tell them apart — and 21 to
+  // a command the server answered BAD. Reading either as an authentication
+  // failure sends someone off to change a password that was never the problem:
+  // a server that will not open a folder still took the password, and saying
+  // otherwise is the one error message a user cannot act on.
+  if (code === 21 || (code === 67 && /select failed/i.test(text)))
+    return "The mail server refused that command"
   if (code === 67 || /AUTHENTICATIONFAILED|invalid credentials|login failed/i.test(text))
     return "The server rejected that username or password"
   if (/\[ALERT\]/i.test(text)) {
@@ -1049,6 +1057,21 @@ function responseError(status, detail, fallback) {
     return "That folder is no longer on the server"
   if (text !== "") return redact(text)
   return fallback || "The mail server could not complete this request"
+}
+
+// The error for a finished transport call, whichever half of it failed.
+//
+// curl's exit code says that something went wrong; the server's own tagged NO
+// or BAD says what, and it is in the response even when curl exits non-zero.
+// Preferring it is what keeps a refused command reported in the words the
+// server chose rather than as whichever of curl's exit codes it happened to
+// share with an unrelated failure.
+function transportError(status, response, detail, fallback) {
+  if (isFailure(response)) {
+    var served = failureDetail(response)
+    if (trimmed(served) !== "") return responseError(0, served, fallback)
+  }
+  return responseError(status, detail, fallback)
 }
 
 // A password can end up in a curl error line, in a server's echo of a failed

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -896,6 +896,89 @@ function parseList(text) {
   return out
 }
 
+// ------------------------------------------------- mailbox names on the wire
+//
+// A mailbox name is not text. RFC 3501 section 5.1.3 carries it in "modified
+// UTF-7": everything outside printable US-ASCII is shifted into a base64 run
+// introduced by "&" and closed by "-", with "," standing in for base64's "/"
+// because "/" is a hierarchy delimiter, and "&-" spelling a literal "&".
+//
+// So a Chinese mailbox arrives as "&g0l6P3ux-" and a sidebar that prints what
+// the server said prints that. This is the only place it is turned back into
+// the name its owner gave it — and the decoded form is for display and nothing
+// else. Every name that goes back to the server travels as `rawName`, exactly
+// as it arrived, so nothing here has to be re-encoded and no round trip can
+// lose a byte in the process.
+//
+// Anything that does not decode is passed through unchanged rather than
+// rejected: a server that sends a bare "&" is not a reason to hide a folder.
+
+var MODIFIED_BASE64 =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+,"
+
+// The base64 run holds UTF-16BE, so it decodes to whole code units — which is
+// what a JavaScript string is made of, surrogate pairs included.
+function decodeShift(chunk) {
+  var bits = 0
+  var width = 0
+  var units = []
+  var pending = -1
+  for (var i = 0; i < chunk.length; i++) {
+    var value = MODIFIED_BASE64.indexOf(chunk.charAt(i))
+    if (value < 0) return null
+    bits = (bits << 6) | value
+    width += 6
+    if (width < 8) continue
+    width -= 8
+    var byte = (bits >> width) & 0xff
+    if (pending < 0) pending = byte
+    else {
+      units.push((pending << 8) | byte)
+      pending = -1
+    }
+  }
+  // A trailing half of a code unit means the run was truncated, and the bits
+  // left over past the last whole byte are the run's padding, which must be
+  // zero. A run that yields no code unit at all is malformed too: the one
+  // legitimately empty run is "&-", and that is an ampersand, handled above.
+  if (pending >= 0) return null
+  if (width > 0 && (bits & ((1 << width) - 1)) !== 0) return null
+  if (units.length === 0) return null
+  var out = ""
+  for (var j = 0; j < units.length; j++) out += String.fromCharCode(units[j])
+  return out
+}
+
+function decodeMailbox(name) {
+  var text = String(name === undefined || name === null ? "" : name)
+  if (text.indexOf("&") < 0) return text
+  var out = ""
+  var at = 0
+  while (at < text.length) {
+    if (text.charAt(at) !== "&") {
+      out += text.charAt(at)
+      at++
+      continue
+    }
+    var close = text.indexOf("-", at + 1)
+    if (close < 0) {
+      // An unterminated run is not a name this can improve on.
+      out += text.substring(at)
+      break
+    }
+    var chunk = text.substring(at + 1, close)
+    if (chunk === "") {
+      // "&-" is how the protocol spells an ampersand.
+      out += "&"
+    } else {
+      var decoded = decodeShift(chunk)
+      out += decoded === null ? text.substring(at, close + 1) : decoded
+    }
+    at = close + 1
+  }
+  return out
+}
+
 // The SPECIAL-USE attributes this plugin cares about, mapped to the folder the
 // server named. A server that advertises none leaves the map empty and
 // `resolveFolder` falls back to the plain word.

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -643,6 +643,26 @@ function capabilityCommand() {
   return "CAPABILITY"
 }
 
+// RFC 2971's client identification, sent to any server that advertises ID.
+// Most servers tolerate its absence, which is why it went missing for so long.
+// Coremail does not: it answers every SELECT with "Unsafe Login" until this has
+// arrived, and that is how the omission was found rather than what it is for.
+//
+// Delivered by the transport's `imap-id` mode, which is the only way to get a
+// command in front of the SELECT curl derives from a URL's path.
+//
+// Sent only to a server that advertised ID: one that has never heard of it
+// answers BAD, and the transport runs curl with --fail-early, so that single
+// BAD would take every command after it.
+//
+// A name and nothing else. This string goes into someone else's server log,
+// and the operating system, the hostname and the user are none of its
+// business — RFC 2971 section 3.3 says as much.
+function idCommand() {
+  return "ID (\"name\" \"omamail\")"
+}
+
+
 // ------------------------------------------------------- search translation
 
 // The criteria a mailbox query carries are already IMAP's own words (UNSEEN,

--- a/scripts/config-store.sh
+++ b/scripts/config-store.sh
@@ -38,10 +38,19 @@ fi
 # with first-run state. A saved account always has a validated email address;
 # a draft has an empty one. Keep this invariant at the final write boundary so
 # it also protects an old service instance during an upgrade.
+#
+# A merely non-empty address is not the test. A row holding something that is
+# not an address — a username typed into the address field — derives no account
+# id, so it is setup state too, and treating it as a saved account is what let
+# a working mailbox be overwritten by a row nothing could select or remove.
+# This is a coarse stand-in for Accounts.js's EMAIL_PATTERN rather than a mirror
+# of it: it only has to tell an address from setup state, and the QML guard has
+# already refused anything looser by the time a payload reaches here.
+saved_account='"email"[[:space:]]*:[[:space:]]*"[^"@]+@[^"@.]+(\.[^"@.]+)+"'
+
 if [ "$name" = accounts.json ] && [ -s "$target" ] \
-  && grep -Eq '"email"[[:space:]]*:[[:space:]]*"[^"]+"' "$target" \
-  && ! printf '%s\n' "$payload" \
-    | grep -Eq '"email"[[:space:]]*:[[:space:]]*"[^"]+"'; then
+  && grep -Eq "$saved_account" "$target" \
+  && ! printf '%s\n' "$payload" | grep -Eq "$saved_account"; then
   printf '%s\n' 'refusing to replace saved accounts with setup state' >&2
   exit 4
 fi

--- a/scripts/mail-transport.sh
+++ b/scripts/mail-transport.sh
@@ -12,6 +12,7 @@
 # One line, fields separated by spaces:
 #
 #   imap <b64 url> <b64 user:password> <b64 command> [<b64 command> ...]
+#   imap-id <b64 root url> <b64 url> <b64 user:password> <b64 preamble> <b64 command> ...
 #   imap-append <b64 url> <b64 user:password> <b64 message>
 #   smtp <b64 url> <b64 user:password> <b64 from> <b64 message> <b64 rcpt> ...
 #
@@ -72,13 +73,32 @@ set -- $line
 [ $# -ge 4 ] || fail 'mail-transport.sh: usage: <mode> <url> <credentials> <arg>...'
 
 mode=$1
-url=$(decode "$2")
-credentials=$(decode "$3")
-shift 3
+# `imap-id` carries two URLs. The first section has to reach the server without
+# naming a mailbox: curl opens a URL's path before the first command it was
+# given, so a path there is a SELECT that nothing can be placed in front of,
+# and some servers refuse SELECT until the client has sent RFC 2971's ID. The
+# connection is reused across the sections, so a command sent by the first one
+# still applies to the mailbox the next one opens.
+if [ "$mode" = imap-id ]; then
+  [ $# -ge 6 ] || fail 'mail-transport.sh: imap-id needs a root url, a url, credentials, a preamble and a command'
+  root_url=$(decode "$2")
+  url=$(decode "$3")
+  credentials=$(decode "$4")
+  shift 4
+  case "$root_url" in
+    imaps://*|imap://*) ;;
+    *) fail 'mail-transport.sh: refusing a root URL that is not imap(s)' ;;
+  esac
+  escaped_root_url=$(escape "$root_url")
+else
+  url=$(decode "$2")
+  credentials=$(decode "$3")
+  shift 3
+fi
 
 case "$mode" in
-  imap|imap-append|smtp) ;;
-  *) fail 'mail-transport.sh: mode must be imap, imap-append or smtp' ;;
+  imap|imap-id|imap-append|smtp) ;;
+  *) fail 'mail-transport.sh: mode must be imap, imap-id, imap-append or smtp' ;;
 esac
 
 # The URL is built and validated by Imap.js, which has already refused anything
@@ -147,8 +167,22 @@ else
   first=1
   for argument in "$@"; do
     [ "$first" = "1" ] || printf 'next\n'
+    # In imap-id the opening command runs against the server rather than a
+    # mailbox, so that it lands in front of the SELECT curl derives from the
+    # path. Every later section names the mailbox as usual.
+    if [ "$mode" = imap-id ] && [ "$first" = "1" ]; then
+      printf 'url = "%s"\n' "$escaped_root_url"
+      # The opening command's own reply is of no interest, and leaving it on
+      # stdout would be worse than useless: the test below reads a non-empty
+      # stdout as "the answer is here", and a single-UID BODY FETCH is the one
+      # request whose answer really does arrive there. One stray line from this
+      # section is enough to make a message body look like an empty one.
+      # `output` is per-section, so only this reply is discarded.
+      printf 'output = "%s"\n' "/dev/null"
+    else
+      printf 'url = "%s"\n' "$escaped_url"
+    fi
     first=0
-    printf 'url = "%s"\n' "$escaped_url"
     # Desktop HTTP/SOCKS proxy settings are for web traffic. In particular,
     # Omarchy's local SOCKS proxy accepts the IMAPS socket and then drops its
     # TLS handshake, which curl reports as error 35. Direct mail transport also
@@ -222,7 +256,8 @@ while :; do
 done
 
 printf '%s\n' "$status"
-if [ "$mode" = "imap" ] && [ ! -s "$work/out" ] && [ -s "$work/headers" ]; then
+if { [ "$mode" = "imap" ] || [ "$mode" = "imap-id" ]; } \
+  && [ ! -s "$work/out" ] && [ -s "$work/headers" ]; then
   # libcurl recognises only a single numeric UID as a BODY FETCH. A legal IMAP
   # sequence-set is treated as a generic custom request, whose response is
   # delivered through curl's protocol-header callback instead of stdout.

--- a/tests/qml/tst_account_removal.qml
+++ b/tests/qml/tst_account_removal.qml
@@ -1,0 +1,231 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../.." as Omamail
+import "../../account/Accounts.js" as Accounts
+
+// Which mailbox the setup page is actually working on.
+//
+// `activeId` names the mailbox on screen; `activeIndex` overrides it for a row
+// that has no id yet, because a draft cannot be named. Add account leaves both
+// set — the draft at `activeIndex`, the previous mailbox still at `activeId` —
+// and every reader has to agree on which one wins. Remove account did not: it
+// asked `indexOfActiveAccount()` alone, so on the page of a freshly added
+// mailbox it named the mailbox that was there before, and confirming deleted a
+// working account while the page in front of the user showed an empty form.
+//
+// The list is assigned rather than fed through `applyAccounts`, so no test
+// depends on the file watcher or on the state a previous test left the writer
+// in.
+Item {
+  width: 900
+  height: 600
+
+  QtObject {
+    id: shellStore
+    function updateEntryInline(id, entry) {}
+    function hide(id) {}
+  }
+
+  Omamail.Service {
+    id: mailService
+    shell: shellStore
+    manifest: ({ id: "omamail", __sourceDir: "/tmp/omamail-test" })
+  }
+
+  Omamail.App { id: app; service: mailService }
+
+  TestCase {
+    name: "AccountRemoval"
+    when: windowShown
+
+    readonly property string ada: "ada@example.com"
+    readonly property string bob: "bob@example.com"
+    readonly property string adaId: "imap:ada@example.com"
+    readonly property string bobId: "imap:bob@example.com"
+
+    function entry(email) {
+      return { email: email, provider: "imap", clientId: "", clientSecret: "",
+        imap: { imapHost: "imap.example.com", imapPort: 993, smtpHost: "smtp.example.com",
+                smtpPort: 465, username: email, aliases: [], insecure: false },
+        label: "", signature: "" }
+    }
+
+    function seed(emails, activeId) {
+      var list = Accounts.emptyList()
+      for (var i = 0; i < emails.length; i++) list = Accounts.add(list, entry(emails[i]))
+      list = Accounts.setActive(list, activeId)
+      mailService.activeIndex = -1
+      mailService.accountList = list
+      mailService.accountsLoaded = true
+      mailService.refreshCurrent()
+    }
+
+    function named(item, objectName) {
+      if (!item) return null
+      if (item.objectName === objectName) return item
+      var values = item.children || []
+      for (var i = 0; i < values.length; i++) {
+        var found = named(values[i], objectName)
+        if (found) return found
+      }
+      return null
+    }
+
+    function dialog() {
+      var found = named(app, "")
+      // The dialog carries the request it was opened for; find it by shape,
+      // since it has no object name of its own.
+      function walk(item) {
+        if (!item) return null
+        if (item.hasOwnProperty("request") && item.hasOwnProperty("opened")
+            && String(item).indexOf("AccountRemovalDialog") === 0) return item
+        var kids = item.children || []
+        for (var i = 0; i < kids.length; i++) {
+          var f = walk(kids[i])
+          if (f) return f
+        }
+        return null
+      }
+      return walk(app)
+    }
+
+    function emails() {
+      var out = []
+      var values = mailService.accountSummaries || []
+      for (var i = 0; i < values.length; i++) out.push(values[i].email)
+      return out
+    }
+
+    // The bug this file exists for.
+    function test_remove_on_a_new_mailbox_page_spares_the_mailbox_behind_it() {
+      seed([ada], adaId)
+      app.chooseProvider("imap")           // Add a mailbox... -> IMAP
+      compare(mailService.accountCount, 2)
+      compare(mailService.editingIndex(), 1, "the page is editing the new row")
+
+      app.removeCurrentAccountFromEditor()
+
+      compare(dialog().request, null,
+        "a draft has no mailbox to name, so nothing is offered for confirmation")
+      compare(emails(), [ada], "the mailbox that was there before is untouched")
+      compare(mailService.accountCount, 1, "the draft is discarded instead")
+    }
+
+    // The same divergence, reached the other way: `switchToIndex` used to
+    // return early without clearing `activeIndex`, so Edit opened whatever
+    // draft happened to be open rather than the mailbox that was clicked.
+    function test_edit_opens_the_mailbox_that_was_clicked_not_an_open_draft() {
+      seed([ada, bob], adaId)
+      app.chooseProvider("imap")           // draft is row 2
+      compare(mailService.editingIndex(), 2)
+
+      app.editAccount(0)
+      compare(mailService.editingIndex(), 0)
+      compare(mailService.accountAddress, ada, "the editor opens on ada")
+
+      app.editAccount(1)
+      compare(mailService.editingIndex(), 1)
+      compare(mailService.accountAddress, bob, "and on bob")
+    }
+
+    function test_remove_on_a_real_mailbox_names_that_mailbox() {
+      seed([ada, bob], adaId)
+      app.editAccount(1)
+      app.removeCurrentAccountFromEditor()
+
+      var request = dialog().request
+      verify(request !== null, "a mailbox can be removed")
+      compare(request.email, bob, "and the confirmation names the one on screen")
+      compare(request.index, 1)
+
+      app.confirmAccountRemoval(request)
+      compare(emails(), [ada])
+    }
+
+    // An address that is not an address derives no account id, which leaves a
+    // row that reads as saved and behaves like a draft: unselectable,
+    // uneditable and unremovable. `validateSettings` cannot catch it —
+    // `setupSettings` folds the address into `username` and passes no address
+    // on — so the form refuses it.
+    function test_the_imap_form_refuses_an_address_that_is_not_one() {
+      seed([ada], adaId)
+      app.chooseProvider("imap")
+      var page = named(app, "setup-page")
+      verify(page !== null && page.item !== null, "the IMAP setup page is up")
+
+      var field = named(page.item, "imap-address-field")
+      var error = named(page.item, "imap-error")
+      verify(field !== null && error !== null)
+
+      // The message has to be the address's own. Without the check the server
+      // fields — which a junk address cannot fill in either — reject the form
+      // one field later, so "something was refused" would pass either way and
+      // test nothing.
+      field.text = "ada"
+      page.item.save()
+      compare(mailService.accountSummaries[1].email, "", "nothing was saved")
+      compare(error.text, "That is not a full email address")
+
+      field.text = ""
+      page.item.save()
+      compare(mailService.accountSummaries[1].email, "")
+      compare(error.text, "Add the email address for this mailbox")
+
+      field.text = "carol@example.com"
+      page.item.save()
+      compare(mailService.accountSummaries[1].email, "carol@example.com",
+        "a real address goes through")
+      compare(mailService.accountSummaries[1].id, "imap:carol@example.com")
+    }
+
+    // The form is not the only way an address reaches the list: an account
+    // reports its own on its first profile read. A provider that answers with
+    // something that is not an address — an IMAP username, say — must not be
+    // able to rename a working mailbox into one that addresses nothing.
+    function test_a_profile_cannot_rename_a_mailbox_to_a_non_address() {
+      seed([ada], adaId)
+      mailService.nameAccount(0, "ada")
+      compare(mailService.accountSummaries[0].email, ada, "the address is kept")
+      compare(mailService.accountSummaries[0].id, adaId, "and so is the id")
+
+      // A real address still renames.
+      mailService.nameAccount(0, "carol@example.com")
+      compare(mailService.accountSummaries[0].id, "imap:carol@example.com")
+    }
+
+    // `accountAddress` is a binding that now reaches `activeIndex` through a
+    // function call. QML captures property reads made inside the callee, so it
+    // still re-evaluates — but silently going stale here would put the wrong
+    // mailbox in the editor, so it is pinned down rather than assumed.
+    function test_the_address_binding_still_tracks_activeIndex_alone() {
+      seed([ada, bob], adaId)
+      compare(mailService.accountAddress, ada)
+      mailService.activeIndex = 1
+      compare(mailService.accountAddress, bob, "the binding re-evaluates")
+      mailService.activeIndex = 0
+      compare(mailService.accountAddress, ada)
+      mailService.activeIndex = -1
+      compare(mailService.accountAddress, ada)
+    }
+
+    // A draft is the form's working state. It used to ride along on whatever
+    // save happened next, leaving a "New mailbox" on disk that nothing could
+    // select and nothing could remove.
+    function test_a_draft_is_never_part_of_what_is_written() {
+      seed([ada], adaId)
+      app.chooseProvider("imap")
+      compare(mailService.accountCount, 2)
+
+      // Something unrelated to the draft saves the list.
+      mailService.accountsWritePayload = ""
+      mailService.setAccountSignature(adaId, "signed")
+      verify(mailService.accountsWritePayload !== "", "the list was written")
+
+      var written = Accounts.load(mailService.accountsWritePayload)
+      compare(Accounts.count(written), 1, "only the mailbox is written")
+      compare(written.accounts[0].email, ada)
+      compare(written.activeId, adaId, "and it is still the selected one")
+      compare(mailService.accountCount, 2, "the draft stays in memory for the form")
+    }
+  }
+}

--- a/tests/qml/tst_account_removal.qml
+++ b/tests/qml/tst_account_removal.qml
@@ -142,6 +142,22 @@ Item {
       compare(emails(), [ada])
     }
 
+    // A persisted mailbox whose address cannot be repaired has no id too, but
+    // it is not the form's pending draft. Remove must not silently discard it
+    // and leave its editor merely because no confirmation request can name it.
+    function test_remove_does_not_discard_an_unrepairable_mailbox_as_a_draft() {
+      seed([ada, "broken"], adaId)
+      app.editAccount(1)
+      compare(mailService.editingIndex(), 1)
+      verify(app.showSetup, "the damaged mailbox is open for correction")
+
+      app.removeCurrentAccountFromEditor()
+
+      compare(mailService.accountCount, 2, "the persisted mailbox is retained")
+      compare(mailService.accountSummaries[1].email, "broken")
+      verify(app.showSetup, "the editor stays open so its address can be corrected")
+    }
+
     // An address that is not an address derives no account id, which leaves a
     // row that reads as saved and behaves like a draft: unselectable,
     // uneditable and unremovable. `validateSettings` cannot catch it —

--- a/tests/qml/tst_app_first_run_setup.qml
+++ b/tests/qml/tst_app_first_run_setup.qml
@@ -111,7 +111,7 @@ Item {
       next.push(text)
       log = next
     }
-    function indexOfActiveAccount() { return 0 }
+    function editingIndex() { return 0 }
     function addAccount(provider) {
       lastAddedProvider = String(provider || "")
       record("add:" + lastAddedProvider)

--- a/tests/qml/tst_app_navigation.qml
+++ b/tests/qml/tst_app_navigation.qml
@@ -122,7 +122,7 @@ Item {
       for (var i = 0; i < log.length; i++) if (log[i] === text) n++
       return n
     }
-    function indexOfActiveAccount() { return 0 }
+    function editingIndex() { return 0 }
     function addAccount(provider) {
       record("add:" + String(provider || ""))
       accountCount += 1

--- a/tests/qml/tst_settings_sidebar.qml
+++ b/tests/qml/tst_settings_sidebar.qml
@@ -122,7 +122,7 @@ Item {
       for (var i = 0; i < log.length; i++) if (log[i] === text) n++
       return n
     }
-    function indexOfActiveAccount() { return 0 }
+    function editingIndex() { return 0 }
     function addAccount(provider) {
       record("add:" + String(provider || ""))
       accountCount += 1

--- a/tests/test_accounts.js
+++ b/tests/test_accounts.js
@@ -257,7 +257,7 @@ assert.strictEqual(messy.activeId, "bob@example.com")
 let saved = accounts.emptyList()
 saved = accounts.add(saved, account("ada@example.com", { label: "工作邮箱" }))
 saved = accounts.add(saved, account("bob@example.com", { label: "Personal" }))
-saved = accounts.add(saved, account("", { clientId: "cid5" }))
+saved = accounts.add(saved, account("", { clientId: "cid5", pending: true }))
 saved = accounts.setActive(saved, "bob@example.com")
 
 const text = accounts.serialize(saved)
@@ -277,23 +277,106 @@ const multiline = accounts.serialize(accounts.add(accounts.emptyList(), account(
 assert.strictEqual(multiline.indexOf("\n"), -1)
 assert.strictEqual(accounts.load(multiline).accounts[0].label, "a\nb")
 
+// ------------------------------------------------------ repairing an address
+//
+// The IMAP form used to save whatever the address field held, unchecked. A
+// username typed there became the row's address, and since the id is derived
+// from the address the row stopped being addressable: it could not be
+// selected, signed, switched to or removed, and the next write dropped it.
+//
+// The address was never actually lost. `setupSettings` folds the address into
+// the username when no separate one was given, so `imap.username` still holds
+// it — and a row that can be repaired is repaired on the way in.
+const damaged = JSON.stringify({ version: accounts.VERSION, accounts: [{
+  email: "ada", provider: "imap", imap: {
+    imapHost: "imap.example.org", smtpHost: "smtp.example.org",
+    username: "ada@example.org" } }], activeId: "" })
+const mended = accounts.load(damaged)
+assert.strictEqual(mended.accounts[0].email, "ada@example.org",
+  "the address comes back from the username it was folded into")
+assert.strictEqual(mended.accounts[0].id, "imap:ada@example.org")
+assert.strictEqual(mended.activeId, "imap:ada@example.org", "and the row is selectable again")
+assert.strictEqual(mended.accounts[0].imap.imapHost, "imap.example.org",
+  "everything else about the row is untouched")
+
+// Only where there is an address to adopt. A username that is not one leaves
+// the row exactly as unusable as it was — better than inventing something.
+const unfixable = accounts.load(JSON.stringify({ version: accounts.VERSION, accounts: [{
+  email: "ada", provider: "imap", imap: { imapHost: "imap.example.org", username: "ada" } }],
+  activeId: "" }))
+assert.strictEqual(unfixable.accounts[0].email, "ada")
+assert.strictEqual(unfixable.accounts[0].id, "")
+
+// A Gmail row has no username to adopt, and one that turned up there would not
+// be an address this may act on.
+const gmailRow = accounts.load(JSON.stringify({ version: accounts.VERSION, accounts: [{
+  email: "ada", provider: "gmail", imap: { username: "ada@example.org" } }], activeId: "" }))
+assert.strictEqual(gmailRow.accounts[0].email, "ada")
+
+// And not while the form is open: `add` must never adopt a username, or typing
+// one into the servers section would fill in an address nobody asked for.
+const typing = accounts.add(accounts.emptyList(),
+  { email: "", provider: "imap", imap: { username: "ada@example.org" }, pending: true })
+assert.strictEqual(typing.accounts[0].email, "", "a row being typed into invents nothing")
+
+// A real address makes a row a mailbox whatever the flag says, because
+// `configureAccount` copies every key of the row it edits and a flag that had
+// to be cleared by hand would have outlived setup.
+const configured = accounts.add(accounts.emptyList(),
+  { email: "ada@example.org", provider: "imap", pending: true })
+assert.strictEqual(configured.accounts[0].pending, false)
+
+// The whole sequence, as it happened: a corrupted mailbox on disk, then an
+// unrelated account added. It was that second step that satisfied the old
+// list-wide guard and let the write through with the first row missing.
+let recovered = accounts.load(damaged)
+recovered = accounts.add(recovered, account("bob@example.com"))
+const payload = accounts.savedOnly(recovered)
+assert.strictEqual(accounts.count(payload), 2, "adding one mailbox must not delete another")
+deepEqual(payload.accounts.map(a => a.email), ["ada@example.org", "bob@example.com"])
+assert.strictEqual(accounts.dropsNamedMailbox(recovered, payload), false)
+
 // -------------------------------------------------------------- what is written
 //
 // The row `add` creates before anything has been typed into it is the setup
-// form's working state, not a mailbox. Any save used to carry whichever draft
-// happened to be open along with it, leaving a "New mailbox" on disk that
-// nothing could select and nothing could remove.
+// form's working state, not a mailbox, and it says so — `pending`. Any save
+// used to carry whichever draft happened to be open along with it, leaving a
+// "New mailbox" on disk that nothing could select and nothing could remove.
 const withDraft = accounts.savedOnly(saved)
 assert.strictEqual(accounts.count(saved), 3, "savedOnly leaves its input alone")
 assert.strictEqual(accounts.count(withDraft), 2, "the draft row is not written")
 deepEqual(withDraft.accounts.map(a => a.id), ["ada@example.com", "bob@example.com"])
 assert.strictEqual(withDraft.activeId, "bob@example.com", "the selection is kept")
+assert.strictEqual(accounts.draftCount(saved), 1)
 
-// A row that is a draft only because its address is unusable goes the same way.
-let junk = accounts.emptyList()
-junk = accounts.add(junk, account("ada@example.com"))
-junk = accounts.add(junk, account("ada", { provider: "imap" }))
-assert.strictEqual(accounts.count(accounts.savedOnly(junk)), 1)
+// A draft is a row that says it is one. Inferring it from a missing id read a
+// mailbox whose address had been corrupted as working state and dropped it
+// here — which is how adding one mailbox deleted a different, working one.
+// This row has no id either, and it is not a draft: its servers were typed in
+// and its password is in the keyring.
+let broken = accounts.emptyList()
+broken = accounts.add(broken, account("ada@example.com"))
+broken = accounts.add(broken, account("ada", { provider: "imap",
+  imap: { imapHost: "imap.example.org", username: "ada" } }))
+assert.strictEqual(accounts.count(accounts.savedOnly(broken)), 2,
+  "a mailbox with an unusable address is kept, not quietly deleted")
+assert.strictEqual(accounts.draftCount(broken), 0)
+
+// A row holding nothing at all is a different thing: the leftover of an Add
+// nobody filled in, and there is nothing in one to preserve.
+let hollow = accounts.emptyList()
+hollow = accounts.add(hollow, account("ada@example.com"))
+hollow = accounts.add(hollow, { email: "" })
+assert.strictEqual(accounts.count(accounts.savedOnly(hollow)), 1)
+assert.strictEqual(accounts.carriesData({ email: "", imap: {} }), false)
+assert.ok(accounts.carriesData({ id: "", imap: { username: "ada@example.org" } }))
+
+// Nothing may drop a mailbox the list can name. The guard this replaces asked
+// only whether the payload still held *some* mailbox, which one freshly added
+// account was enough to satisfy.
+assert.ok(accounts.dropsNamedMailbox(broken, accounts.emptyList()))
+assert.strictEqual(accounts.dropsNamedMailbox(saved, accounts.savedOnly(saved)), false)
+assert.strictEqual(accounts.dropsNamedMailbox(broken, accounts.savedOnly(broken)), false)
 
 // The selection follows when the row it named is the one dropped.
 let activeDraft = accounts.add(accounts.emptyList(), account("ada@example.com"))
@@ -305,7 +388,7 @@ assert.strictEqual(accounts.savedOnly(activeDraft).activeId, "ada@example.com",
 // Nothing to keep is left empty rather than invented; the write guard in
 // Service.saveAccounts is what stops that reaching disk.
 assert.strictEqual(accounts.count(accounts.savedOnly(
-  accounts.add(accounts.emptyList(), account("")))), 0)
+  accounts.add(accounts.emptyList(), { email: "", pending: true }))), 0)
 assert.strictEqual(accounts.serialize(accounts.savedOnly(saved)).indexOf("\n"), -1)
 
 // ------------------------------------------------------- removing by index

--- a/tests/test_accounts.js
+++ b/tests/test_accounts.js
@@ -28,6 +28,18 @@ assert.strictEqual(accounts.hasSavedAccounts({ accounts: [
 assert.strictEqual(accounts.hasSavedAccounts({ accounts: [
   { id: "", email: "" }
 ] }), false)
+// A non-empty address is not the test. A row holding something that is not an
+// address derives no id, so every lookup here treats it as a draft; counting it
+// as a saved account is what let `Service.saveAccounts` write a list whose only
+// entry was unusable, replacing a working mailbox on disk with a row that could
+// not be selected, edited or removed.
+assert.strictEqual(accounts.hasSavedAccounts({ accounts: [
+  { id: "", email: "ada" }
+] }), false, "a username in the address field is setup state, not an account")
+assert.strictEqual(accounts.hasSavedAccounts({ accounts: [
+  { id: "", email: "ada" },
+  { id: "ada@example.com", email: "ada@example.com" }
+] }), true, "one real mailbox alongside it is still a saved list")
 assert.strictEqual(accounts.active(accounts.emptyList()), null)
 assert.strictEqual(accounts.find(accounts.emptyList(), "a@example.com"), null)
 
@@ -264,6 +276,37 @@ assert.strictEqual(accounts.count(reloaded), 3)
 const multiline = accounts.serialize(accounts.add(accounts.emptyList(), account("ada@example.com", { label: "a\nb" })))
 assert.strictEqual(multiline.indexOf("\n"), -1)
 assert.strictEqual(accounts.load(multiline).accounts[0].label, "a\nb")
+
+// -------------------------------------------------------------- what is written
+//
+// The row `add` creates before anything has been typed into it is the setup
+// form's working state, not a mailbox. Any save used to carry whichever draft
+// happened to be open along with it, leaving a "New mailbox" on disk that
+// nothing could select and nothing could remove.
+const withDraft = accounts.savedOnly(saved)
+assert.strictEqual(accounts.count(saved), 3, "savedOnly leaves its input alone")
+assert.strictEqual(accounts.count(withDraft), 2, "the draft row is not written")
+deepEqual(withDraft.accounts.map(a => a.id), ["ada@example.com", "bob@example.com"])
+assert.strictEqual(withDraft.activeId, "bob@example.com", "the selection is kept")
+
+// A row that is a draft only because its address is unusable goes the same way.
+let junk = accounts.emptyList()
+junk = accounts.add(junk, account("ada@example.com"))
+junk = accounts.add(junk, account("ada", { provider: "imap" }))
+assert.strictEqual(accounts.count(accounts.savedOnly(junk)), 1)
+
+// The selection follows when the row it named is the one dropped.
+let activeDraft = accounts.add(accounts.emptyList(), account("ada@example.com"))
+activeDraft = accounts.add(activeDraft, account(""))
+activeDraft.activeId = ""
+assert.strictEqual(accounts.savedOnly(activeDraft).activeId, "ada@example.com",
+  "a list written with no selection still names a mailbox")
+
+// Nothing to keep is left empty rather than invented; the write guard in
+// Service.saveAccounts is what stops that reaching disk.
+assert.strictEqual(accounts.count(accounts.savedOnly(
+  accounts.add(accounts.emptyList(), account("")))), 0)
+assert.strictEqual(accounts.serialize(accounts.savedOnly(saved)).indexOf("\n"), -1)
 
 // ------------------------------------------------------- removing by index
 //

--- a/tests/test_accounts.js
+++ b/tests/test_accounts.js
@@ -391,6 +391,16 @@ assert.strictEqual(accounts.count(accounts.savedOnly(
   accounts.add(accounts.emptyList(), { email: "", pending: true }))), 0)
 assert.strictEqual(accounts.serialize(accounts.savedOnly(saved)).indexOf("\n"), -1)
 
+// An idless row is not necessarily the setup form's draft. A legacy mailbox
+// whose address cannot be repaired is deliberately kept by `savedOnly`, and
+// cancelling a draft must not become a second path that silently deletes it.
+const damagedDraftLookalike = accounts.add(accounts.emptyList(), {
+  email: "ada", provider: "imap",
+  imap: { imapHost: "imap.example.org", username: "ada" }
+})
+assert.strictEqual(accounts.count(accounts.discardDraftAt(damagedDraftLookalike, 0)), 1,
+  "only a row marked pending may be discarded as a draft")
+
 // ------------------------------------------------------- removing by index
 //
 // A pending account has no id, so nothing can name it — and a sign-in that
@@ -399,7 +409,7 @@ assert.strictEqual(accounts.serialize(accounts.savedOnly(saved)).indexOf("\n"), 
 
 let pendingList = accounts.emptyList()
 pendingList = accounts.add(pendingList, { email: "one@example.com", clientId: "c1" })
-pendingList = accounts.add(pendingList, { email: "", clientId: "c2" })
+pendingList = accounts.add(pendingList, { email: "", clientId: "c2", pending: true })
 pendingList = accounts.add(pendingList, { email: "two@example.com", clientId: "c3" })
 assert.strictEqual(accounts.count(pendingList), 3)
 

--- a/tests/test_config_store.sh
+++ b/tests/test_config_store.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+project_dir=$(cd "$(dirname "$0")/.." && pwd)
+work=$(mktemp -d /tmp/omamail-config-store-test.XXXXXX)
+trap 'rm -rf "$work"' EXIT
+export XDG_CONFIG_HOME="$work/config"
+store="$project_dir/scripts/config-store.sh"
+target="$XDG_CONFIG_HOME/omamail/accounts.json"
+
+saved='{"version":1,"accounts":[{"id":"ada@example.com","email":"ada@example.com"}],"activeId":"ada@example.com"}'
+write() { printf '%s\n' "$1" | "$store" accounts.json >/dev/null; }
+refused() {
+  if printf '%s\n' "$1" | "$store" accounts.json >/dev/null 2>&1; then
+    echo "config-store.sh: $2" >&2
+    exit 1
+  fi
+}
+
+# First run has nothing to protect, so the placeholder list is written.
+write '{"version":1,"accounts":[{"id":"","email":""}],"activeId":""}'
+grep -q '"email":""' "$target"
+
+# A real account replaces it, and one real account replaces another.
+write "$saved"
+grep -q 'ada@example.com' "$target"
+write '{"version":1,"accounts":[{"id":"bob@example.com","email":"bob@example.com"}],"activeId":"bob@example.com"}'
+grep -q 'bob@example.com' "$target"
+
+write "$saved"
+
+# Setup state must never replace a saved account.
+refused '{"version":1,"accounts":[{"id":"","email":""}],"activeId":""}' \
+  'a first-run payload must not replace saved accounts'
+grep -q 'ada@example.com' "$target"
+
+# The address field can hold something that is not an address — a username
+# typed into it, most likely. Accounts.js derives no id from such a row, so it
+# is setup state too, and a merely non-empty address must not read as a saved
+# account here. This is what let a working mailbox be overwritten by a row
+# nothing could select or remove.
+for junk in 'ada' 'ada@' '@example.com' 'no-at-sign' 'trailing@dot.'; do
+  refused "{\"version\":1,\"accounts\":[{\"id\":\"\",\"email\":\"$junk\"}],\"activeId\":\"\"}" \
+    "\"$junk\" is not an address and must not replace saved accounts"
+done
+grep -q 'ada@example.com' "$target"
+
+# A real address still gets through, including the shapes the coarse pattern
+# has to keep accepting.
+for good in 'ada@example.com' 'a.b+c@mail.example.co.uk' 'x@a.io'; do
+  write "{\"version\":1,\"accounts\":[{\"id\":\"$good\",\"email\":\"$good\"}],\"activeId\":\"$good\"}"
+  grep -qF "$good" "$target"
+done
+
+# The guard is for the account list alone; the other files it writes are
+# unconditional.
+printf '%s\n' '{"zoom":1}' | "$store" window.json >/dev/null
+grep -q '"zoom":1' "$XDG_CONFIG_HOME/omamail/window.json"
+
+# An unknown name, an empty payload, and the permissions the files are kept at.
+if printf '%s\n' 'x' | "$store" secrets.json >/dev/null 2>&1; then
+  echo 'config-store.sh: an unknown file name must be refused' >&2
+  exit 1
+fi
+if printf '\n' | "$store" accounts.json >/dev/null 2>&1; then
+  echo 'config-store.sh: an empty payload must be refused' >&2
+  exit 1
+fi
+[ "$(stat -c '%a' "$target")" = 600 ] \
+  || { echo 'config-store.sh: the account list must stay owner-only' >&2; exit 1; }
+
+echo 'config-store.sh ok'

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -611,6 +611,31 @@ assert.strictEqual(imap.responseError(0, "", "fallback text"), "fallback text")
 assert.ok(/over its storage quota/i.test(imap.responseError(0, "A1 NO [OVERQUOTA] mailbox full", "")))
 assert.ok(/no longer on the server/i.test(imap.responseError(0, "A1 NO [NONEXISTENT] no such folder", "")))
 
+// curl spends exit 67 on both a denied login and a refused SELECT, and the only
+// thing separating them is the sentence beside it. Reading the second as the
+// first is what told a NetEase user their password had been rejected: those
+// servers refuse SELECT until the client has sent ID, and the password was
+// right the whole time.
+assert.strictEqual(imap.responseError(67, "curl: (67) Access denied. ", ""),
+  "The server rejected that username or password")
+assert.strictEqual(imap.responseError(67, "curl: (67) Select failed", ""),
+  "The mail server refused that command",
+  "a folder that would not open is not a password that was refused")
+assert.strictEqual(imap.responseError(21, "curl: (21) Quote command returned error", ""),
+  "The mail server refused that command")
+
+// The server said why. curl only said that something failed, and picked an exit
+// code it shares with an unrelated failure — so the server's own words win.
+assert.strictEqual(
+  imap.transportError(67, "A3 NO SELECT Unsafe Login. Please contact kefu@188.com for help",
+    "curl: (67) Select failed", ""),
+  "SELECT Unsafe Login. Please contact kefu@188.com for help")
+assert.strictEqual(
+  imap.transportError(67, "A2 OK LOGIN completed", "curl: (67) Access denied. ", ""),
+  "The server rejected that username or password",
+  "with no tagged failure to read, the exit code is all there is")
+assert.strictEqual(imap.transportError(0, "A1 OK done", "", "fallback text"), "fallback text")
+
 // A server's [ALERT] is written for the user by definition — the RFC says a
 // client must show it — so it is passed through rather than translated.
 assert.strictEqual(

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -598,6 +598,58 @@ deepEqual(imap.flagPlanForLabels(["STARRED"], ["UNREAD"], {}),
 
 deepEqual(imap.flagPlanForLabels(null, null, null), { add: [], remove: [], move: "" })
 
+// ------------------------------------------------------- mailbox names
+
+// RFC 3501 section 5.1.3. These seven are the folders a real 163.com mailbox
+// lists, verbatim, and what the sidebar printed before this existed.
+assert.strictEqual(imap.decodeMailbox("&g0l6P3ux-"), "\u8349\u7a3f\u7bb1")
+assert.strictEqual(imap.decodeMailbox("&XfJT0ZAB-"), "\u5df2\u53d1\u9001")
+assert.strictEqual(imap.decodeMailbox("&XfJSIJZk-"), "\u5df2\u5220\u9664")
+assert.strictEqual(imap.decodeMailbox("&V4NXPpCuTvY-"), "\u5783\u573e\u90ae\u4ef6")
+assert.strictEqual(imap.decodeMailbox("&dcVr0mWHTvZZOQ-"), "\u75c5\u6bd2\u6587\u4ef6\u5939")
+assert.strictEqual(imap.decodeMailbox("&Xn9USpCuTvY-"), "\u5e7f\u544a\u90ae\u4ef6")
+assert.strictEqual(imap.decodeMailbox("&i6KWBZCuTvY-"), "\u8ba2\u9605\u90ae\u4ef6")
+
+// Plain US-ASCII is already the name, and must come back untouched — it is
+// also what every lookup and every cache key is keyed on.
+assert.strictEqual(imap.decodeMailbox("INBOX"), "INBOX")
+assert.strictEqual(imap.decodeMailbox("[Gmail]/All Mail"), "[Gmail]/All Mail")
+assert.strictEqual(imap.decodeMailbox(""), "")
+assert.strictEqual(imap.decodeMailbox(null), "")
+
+// "&-" is how the protocol spells an ampersand, and a shift run can sit
+// anywhere in a hierarchy or beside another one.
+assert.strictEqual(imap.decodeMailbox("&-"), "&")
+assert.strictEqual(imap.decodeMailbox("Bed &- Breakfast"), "Bed & Breakfast")
+assert.strictEqual(imap.decodeMailbox("Parent/&g0l6P3ux-"), "Parent/\u8349\u7a3f\u7bb1")
+assert.strictEqual(imap.decodeMailbox("&g0l6P3ux-x&XfJT0ZAB-"),
+  "\u8349\u7a3f\u7bb1x\u5df2\u53d1\u9001")
+
+// The run carries UTF-16BE, so a character outside the BMP arrives as a
+// surrogate pair — which is what a JavaScript string is made of anyway.
+assert.strictEqual(imap.decodeMailbox("&2DzfiQ-"), "\ud83c\udf89")
+
+// A name that does not decode is passed through rather than dropped: a server
+// sending something malformed is not a reason to hide a folder, and the
+// undecoded name is still the one that selects it.
+assert.strictEqual(imap.decodeMailbox("&abc"), "&abc", "an unterminated run")
+assert.strictEqual(imap.decodeMailbox("&!!!-"), "&!!!-", "not modified base64")
+assert.strictEqual(imap.decodeMailbox("&A-"), "&A-", "half of a code unit")
+assert.strictEqual(imap.decodeMailbox("&AAEB-"), "&AAEB-", "a run cut mid-unit")
+
+// The decoded name is for reading. The id and the wire name are what a cache
+// key and a SELECT are built from, and decoding either would make every
+// non-ASCII folder unselectable.
+const clientSource = require("fs").readFileSync(
+  require("path").join(__dirname, "..", "providers", "ImapClient.qml"), "utf8")
+const labelShape = clientSource.slice(clientSource.indexOf("function getLabels"))
+  .slice(0, clientSource.slice(clientSource.indexOf("function getLabels")).indexOf("callback(out"))
+assert.ok(/name:\s*Imap\.decodeMailbox\(folder\.name\)/.test(labelShape),
+  "the name the sidebar prints must be decoded")
+assert.ok(/id:\s*folder\.name\b/.test(labelShape), "the id must stay as the server said it")
+assert.ok(/rawName:\s*folder\.name\b/.test(labelShape),
+  "the name that goes back in a SELECT must stay as the server said it")
+
 // ------------------------------------------------------------------ errors
 
 assert.strictEqual(imap.responseError(7, "", ""),

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -355,6 +355,10 @@ assert.strictEqual(imap.moveCommand([4], "Archive"), "UID MOVE 4 \"Archive\"")
 assert.strictEqual(imap.copyCommand([4], "Sent Items"), "UID COPY 4 \"Sent Items\"")
 assert.strictEqual(imap.statusCommand("INBOX"), "STATUS \"INBOX\" (MESSAGES UNSEEN)")
 
+// A name and nothing else: this goes into someone else's server log, and the
+// host and the user are none of its business (RFC 2971 section 3.3).
+assert.strictEqual(imap.idCommand(), 'ID ("name" "omamail")')
+
 // UID EXPUNGE, never plain EXPUNGE: the latter removes every \Deleted message
 // in the folder, including ones another client marked.
 assert.strictEqual(imap.expungeCommand([4, 5]), "UID EXPUNGE 4,5")

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -17,6 +17,26 @@ assert.strictEqual(imap.presetFor("jane@hotmail.com").id, "outlook", "aliases re
 assert.strictEqual(imap.presetFor("jane@me.com").id, "icloud")
 assert.strictEqual(imap.presetFor("jane@example.org"), null)
 
+// 163 has an entry for its note, not its servers — those are what
+// `imap.<domain>` would have guessed anyway. The note is the part no address
+// can imply: this mailbox refuses the account password.
+assert.strictEqual(imap.presetFor("jane@163.com").id, "netease-163")
+assert.strictEqual(imap.suggestedSettings("jane@163.com").imapHost, "imap.163.com")
+assert.strictEqual(imap.suggestedSettings("jane@163.com").smtpHost, "smtp.163.com")
+assert.ok(/authorisation code/i.test(imap.suggestedSettings("jane@163.com").note),
+  "a mailbox that refuses the account password has to say so")
+assert.ok(/^https:\/\//.test(imap.suggestedSettings("jane@163.com").guideUrl))
+assert.ok(imap.suggestedSettings("jane@163.com").guideLabel !== "")
+
+// And 163 alone: its sibling domains are the same service on their own
+// hostnames, so adding them to that row would hand them the 163 servers. The
+// guess reaches them correctly until someone gives them a row of their own.
+assert.strictEqual(imap.presetFor("jane@126.com"), null)
+assert.strictEqual(imap.presetFor("jane@yeah.net"), null)
+assert.strictEqual(imap.suggestedSettings("jane@126.com").imapHost, "imap.126.com")
+assert.strictEqual(imap.suggestedSettings("jane@yeah.net").smtpHost, "smtp.yeah.net")
+assert.strictEqual(imap.suggestedSettings("jane@126.com").note, "")
+
 // An unknown domain still gets a guess: imap.<domain> is right far more often
 // than an empty field is useful, and a wrong guess is visible and editable.
 const guess = imap.suggestedSettings("jane@example.org")

--- a/tests/test_imap_ordering.sh
+++ b/tests/test_imap_ordering.sh
@@ -1,0 +1,220 @@
+# The order an IMAP conversation reaches the server in, checked against a real
+# curl and a real server.
+#
+# A Coremail server — 163.com and the mailboxes around it — answers every
+# SELECT with "Unsafe Login" until the client has sent the RFC 2971 ID command.
+# curl gives that refusal the same exit code as a denied login, so the mailbox
+# reported a perfectly good password as wrong and loaded nothing.
+#
+# Getting ID in front of the SELECT is harder than it sounds, and the three
+# facts below are why the transport has an `imap-id` mode rather than one more
+# command in the ordinary one:
+#
+#   1. curl opens the URL's path itself, before the first command it was given,
+#      so nothing can be placed in front of that SELECT.
+#   2. Dropping the path wins the order and loses the answer: curl then hands
+#      the reply to a different channel than the one the transport reads, which
+#      is silent — exit 0, no error, an empty mailbox.
+#   3. A server that has never heard of ID answers BAD, and curl runs with
+#      --fail-early, so one BAD takes every command after it. Hence the
+#      capability gate rather than sending it to everyone.
+#
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+command -v curl >/dev/null 2>&1 || { echo "test_imap_ordering.sh: no curl, skipped"; exit 0; }
+command -v python3 >/dev/null 2>&1 || { echo "test_imap_ordering.sh: no python3, skipped"; exit 0; }
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/omamail-imap-ordering.XXXXXX")
+trap 'rm -rf "$work"; [ -z "${srv_pid:-}" ] || kill "$srv_pid" 2>/dev/null || true' EXIT INT TERM HUP
+
+fail() { printf 'test_imap_ordering.sh: %s\n' "$1" >&2; exit 1; }
+
+cat > "$work/server.py" <<'PY'
+import re, socket, sys, threading
+
+log_path, id_reply = sys.argv[1], sys.argv[2]
+
+def handle(conn):
+    f = conn.makefile("rwb", buffering=0)
+    f.write(b"* OK [CAPABILITY IMAP4rev1 ID] fake ready\r\n")
+    while True:
+        line = f.readline()
+        if not line:
+            break
+        text = line.decode("latin1").rstrip("\r\n")
+        with open(log_path, "a") as fh:
+            # The password is never interesting here and must not be written down.
+            fh.write(re.sub(r"(?i)^(\S+\s+LOGIN)\s+.*$", r"\1", text) + "\n")
+        parts = text.split(" ", 2)
+        if len(parts) < 2:
+            continue
+        tag, cmd = parts[0], parts[1].upper()
+        rest = parts[2].upper() if len(parts) > 2 else ""
+        if cmd == "ID" and id_reply == "bad":
+            f.write(("%s BAD Unknown command\r\n" % tag).encode())
+        elif cmd == "ID":
+            # Untagged, as a real server answers. curl treats this section as a
+            # generic custom request and puts the line on stdout, where it is
+            # indistinguishable from a message body unless the transport keeps
+            # it out — so a server that stayed silent here would let a broken
+            # transport pass this file.
+            f.write(b'* ID ("name" "fake" "version" "1")\r\n')
+            f.write(("%s OK done\r\n" % tag).encode())
+        elif cmd == "CAPABILITY":
+            f.write(b"* CAPABILITY IMAP4rev1 ID\r\n")
+            f.write(("%s OK done\r\n" % tag).encode())
+        elif cmd == "SELECT":
+            f.write(b"* 2 EXISTS\r\n")
+            f.write(("%s OK [READ-WRITE] done\r\n" % tag).encode())
+        elif cmd == "UID" and "BODY" in rest:
+            # A single numeric UID with a BODY item is the one request libcurl
+            # recognises as a message fetch, and it puts the answer on stdout
+            # rather than through the header callback.
+            body = b"Subject: hello\r\n\r\nthe body\r\n"
+            f.write(b"* 1 FETCH (UID 101 BODY[] {%d}\r\n" % len(body))
+            f.write(body)
+            f.write(b")\r\n")
+            f.write(("%s OK done\r\n" % tag).encode())
+        elif cmd == "UID" and "FETCH" in rest:
+            f.write(b"* 1 FETCH (UID 101)\r\n* 2 FETCH (UID 102)\r\n")
+            f.write(("%s OK done\r\n" % tag).encode())
+        elif cmd in ("UID", "SEARCH"):
+            f.write(b"* SEARCH 1\r\n")
+            f.write(("%s OK done\r\n" % tag).encode())
+        elif cmd == "LOGOUT":
+            f.write(b"* BYE bye\r\n")
+            f.write(("%s OK done\r\n" % tag).encode())
+            break
+        else:
+            f.write(("%s OK done\r\n" % tag).encode())
+    conn.close()
+
+srv = socket.socket()
+srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+srv.bind(("127.0.0.1", 0))
+srv.listen(5)
+print(srv.getsockname()[1], flush=True)
+while True:
+    c, _ = srv.accept()
+    threading.Thread(target=handle, args=(c,), daemon=True).start()
+PY
+
+b64() { printf '%s' "$1" | base64 | tr -d '\n'; }
+
+start_server() {
+  : > "$work/log"
+  : > "$work/port"
+  python3 "$work/server.py" "$work/log" "$1" > "$work/port" 2>/dev/null &
+  srv_pid=$!
+  port=""
+  for _ in $(seq 1 50); do
+    port=$(cat "$work/port" 2>/dev/null || true)
+    [ -n "$port" ] && break
+    sleep 0.1
+  done
+  [ -n "$port" ] || fail "the fake server never reported a port"
+}
+
+stop_server() {
+  kill "$srv_pid" 2>/dev/null || true
+  wait "$srv_pid" 2>/dev/null || true
+  srv_pid=""
+}
+
+# One transport invocation. Prints curl's exit code; leaves the commands the
+# server saw in "$work/log" and what the caller was handed in "$work/reply".
+transport() {
+  local id_reply=$1 path=$2; shift 2
+  start_server "$id_reply"
+  local fields=""
+  for c in "$@"; do fields="$fields $(b64 "$c")"; done
+  printf 'imap %s %s%s\n' "$(b64 "imap://127.0.0.1:$port$path")" "$(b64 'jane:pw')" "$fields" \
+    | ./scripts/mail-transport.sh > "$work/out" 2>/dev/null || true
+  stop_server
+  sed -n 2p "$work/out" | base64 -d > "$work/reply" 2>/dev/null || : > "$work/reply"
+  head -1 "$work/out"
+}
+
+commands() { sed -E 's/^[A-Za-z0-9]+ //' "$work/log" | tr '\n' '|'; }
+fetch_rows() { grep -c '^\* [0-9]* FETCH' "$work/reply" || true; }
+
+# The mode that carries the fix: the opening command runs against the server,
+# the mailbox is opened after it, and the answer still reaches the caller.
+start_server ok
+printf 'imap-id %s %s %s %s %s\n' \
+  "$(b64 "imap://127.0.0.1:$port")" "$(b64 "imap://127.0.0.1:$port/INBOX")" \
+  "$(b64 'jane:pw')" "$(b64 'ID ("name" "omamail")')" "$(b64 'UID FETCH 1:* (UID)')" \
+  | ./scripts/mail-transport.sh > "$work/out" 2>/dev/null || true
+stop_server
+sed -n 2p "$work/out" | base64 -d > "$work/reply" 2>/dev/null || : > "$work/reply"
+[ "$(head -1 "$work/out")" = "0" ] || fail "imap-id should have succeeded, curl exited $(head -1 "$work/out")"
+[ "$(commands)" = 'CAPABILITY|LOGIN|ID ("name" "omamail")|SELECT INBOX|UID FETCH 1:* (UID)|LOGOUT|' ] \
+  || fail "ID must reach the server before SELECT, saw: $(commands)"
+[ "$(fetch_rows)" = "2" ] || fail "imap-id must still deliver its FETCH rows, saw $(fetch_rows)"
+[ "$(grep -c '^[A-Za-z0-9]* LOGIN$' "$work/log")" = "1" ] \
+  || fail "the two sections must share one connection, and so one LOGIN"
+
+# And a message body, which arrives by the other channel entirely: libcurl
+# recognises a single numeric UID with a BODY item as a message fetch and puts
+# it on stdout, where a sequence set's answer goes through the header callback.
+# The opening command's own reply has to be kept off stdout for that to still
+# be readable — one stray line there and every uncached message reads as having
+# no text at all, which is what shipping this without the case did.
+start_server ok
+printf 'imap-id %s %s %s %s %s\n' \
+  "$(b64 "imap://127.0.0.1:$port")" "$(b64 "imap://127.0.0.1:$port/INBOX")" \
+  "$(b64 'jane:pw')" "$(b64 'ID ("name" "omamail")')" \
+  "$(b64 'UID FETCH 101 (UID FLAGS BODY.PEEK[])')" \
+  | ./scripts/mail-transport.sh > "$work/out" 2>/dev/null || true
+stop_server
+sed -n 2p "$work/out" | base64 -d > "$work/reply" 2>/dev/null || : > "$work/reply"
+[ "$(head -1 "$work/out")" = "0" ] || fail "a body fetch should have succeeded, curl exited $(head -1 "$work/out")"
+grep -q "the body" "$work/reply" \
+  || fail "imap-id must deliver a message body, got: $(head -c 200 "$work/reply")"
+case "$(commands)" in
+  *'ID ("name" "omamail")|SELECT INBOX|UID FETCH 101'*) ;;
+  *) fail "the body fetch must still run behind ID and SELECT, saw: $(commands)" ;;
+esac
+
+# Fact 1: why the ID cannot simply be the first command of an ordinary request.
+code=$(transport ok "/INBOX" 'ID ("name" "omamail")' 'UID FETCH 1:* (UID)')
+[ "$code" = "0" ] || fail "a pathed URL should have succeeded, curl exited $code"
+case "$(commands)" in
+  *'SELECT INBOX|ID '*) ;;
+  *) fail "expected curl's own SELECT to precede the first command, saw: $(commands)" ;;
+esac
+
+# Fact 2: and why dropping the path instead is not the answer — the order comes
+# out right and the FETCH rows never reach the caller.
+code=$(transport ok "" 'ID ("name" "omamail")' 'SELECT "INBOX"' 'UID FETCH 1:* (UID)')
+[ "$code" = "0" ] || fail "a pathless URL should have succeeded, curl exited $code"
+[ "$(fetch_rows)" = "0" ] \
+  || fail "a pathless URL now delivers FETCH rows; imap-id may be simplifiable"
+
+# Fact 3: and why ID is gated on the capability rather than sent to everyone.
+code=$(transport bad "" 'ID ("name" "omamail")' 'SELECT "INBOX"' 'UID FETCH 1:* (UID)')
+[ "$code" = "0" ] && fail "a server that refuses ID must not be reported as success"
+case "$(commands)" in
+  *'UID FETCH'*) fail "--fail-early must stop the run at the BAD, saw: $(commands)" ;;
+esac
+
+# The gate itself lives in QML, where none of the above can reach it.
+python3 - <<'SRC' || exit 1
+import re, sys
+
+text = open("providers/ImapClient.qml", encoding="utf-8").read()
+start = text.index("function run(folder, commands, callback, existingHandle)")
+end = text.index("function ensureFolders", start)
+block = text[start:end]
+
+gate = re.search(r'hasCapability\(root\.serverCapabilities,\s*"ID"\)', block)
+if not gate:
+    sys.exit("test_imap_ordering.sh: ID must be sent only to a server that advertised it")
+if block.index("Imap.idCommand()") < gate.start():
+    sys.exit("test_imap_ordering.sh: the ID command must sit behind the capability check")
+if "imap-id " not in block:
+    sys.exit("test_imap_ordering.sh: the ID command must travel in the transport's imap-id mode")
+SRC
+
+echo "imap ordering ok"

--- a/tests/test_service_source.sh
+++ b/tests/test_service_source.sh
@@ -22,6 +22,7 @@ grep -q 'setAlwaysRenderHeavyMessages' components/SettingsPage.qml \
 grep -q 'shell.updateEntryInline(pluginId, entry)' Service.qml \
   || fail "the undo window must persist in shell settings"
 python3 - <<'PY'
+import re
 from pathlib import Path
 
 text = Path("Service.qml").read_text()
@@ -51,9 +52,22 @@ if "pendingSendHost" not in text:
 save_start = text.index("function saveAccounts()")
 save_end = text.index("function applyAccounts(raw)", save_start)
 save_block = text[save_start:save_end]
-if "Accounts.hasSavedAccounts(accountList)" not in save_block:
+# The guard and the payload must be the same value. Writing the stripped list
+# while testing the one in memory would let the two disagree — and the whole
+# point of the guard is that what reaches disk still names a mailbox.
+written = re.search(r"var (\w+) = Accounts\.savedOnly\(accountList\)", save_block)
+if not written:
+    raise SystemExit(
+        "test_service_source.sh: the form's own draft row must never be written to disk"
+    )
+name = written.group(1)
+if "Accounts.hasSavedAccounts(%s)" % name not in save_block:
     raise SystemExit(
         "test_service_source.sh: first-run state must never overwrite saved accounts"
+    )
+if "Accounts.serialize(%s)" % name not in save_block:
+    raise SystemExit(
+        "test_service_source.sh: the guarded list must be the one that is written"
     )
 
 apply_start = save_end

--- a/tests/test_service_source.sh
+++ b/tests/test_service_source.sh
@@ -65,6 +65,14 @@ if "Accounts.hasSavedAccounts(%s)" % name not in save_block:
     raise SystemExit(
         "test_service_source.sh: first-run state must never overwrite saved accounts"
     )
+# The list-wide guard is satisfied by any one real mailbox in the payload,
+# which is why a freshly added account was enough to let a write through that
+# had dropped a different, working one. The per-row guard is what catches that,
+# and it has to be asked about the payload rather than about what is in memory.
+if "Accounts.dropsNamedMailbox(accountList, %s)" % name not in save_block:
+    raise SystemExit(
+        "test_service_source.sh: a write that drops a named mailbox must be refused"
+    )
 if "Accounts.serialize(%s)" % name not in save_block:
     raise SystemExit(
         "test_service_source.sh: the guarded list must be the one that is written"


### PR DESCRIPTION
This began as the mailbox that **Remove account** deleted by mistake, and grew
while following what that mailbox left behind. Five faults, each with its own
commit:

| | |
|---|---|
| 1 | Removing a mailbox from a setup page removed a different one, and the row left behind could not be selected, edited or removed |
| 2 | A mailbox whose address had been corrupted that way was then **deleted from disk** by the act of adding an unrelated one |
| 3 | Every refused folder was reported as a rejected password, so the one sentence a user could act on was the one thrown away |
| 4 | A mailbox on a server that requires RFC 2971's `ID` listed its folders and then loaded nothing from any of them |
| 5 | Any folder whose name is not printable US-ASCII was shown in its wire encoding — `&g0l6P3ux-` rather than `草稿箱` |

They are separable: 1–2 are the account list, 3–5 are IMAP. Say the word and I
will split 3–5 into their own PR — the commits are already clean along that
line.

## 1 · Remove acts on the wrong mailbox

Adding a mailbox and then pressing **Remove account** on the page of that new mailbox deleted a different, working mailbox. The row left behind could not be selected, edited or removed afterwards — not from the switcher, not from Settings, and not from the setup page that was still showing it. This fixes the two readers that disagreed about which row the page is editing, the form that let an address name no mailbox at all, and the two write guards that let the result reach disk.

### How to reproduce

Every sequence starts from one working IMAP mailbox, `ada@example.com`, signed in.

#### Remove acts on the wrong mailbox

1. Settings → **Add a mailbox…** → **IMAP**. The new empty row is what the page is now editing.
2. Press **Remove account** on that page.
3. The confirmation reads *Remove ada@example.com?* — the mailbox that was on screen before the add, not the empty row in front of you. Confirm it, and that mailbox is gone.

On its own this is survivable. The surviving row is empty, so `saveAccounts` refuses to persist it and the mailbox comes back from disk on the next read. The next sequence removes that protection.

#### …and then it cannot be undone

1. Settings → **Add a mailbox…** → **IMAP**.
2. In **Email address**, type something that is not an address — a bare `ada`, say, which is easy to do while the **Username** field just below is asking for the full `ada@example.com`. Enter the password and press **Sign in**. The address is saved before the password is tried, so the row is stored whatever the server then says.
3. Press **Remove account** to get rid of the row you have just made.
4. The confirmation names `ada@example.com` again. Confirm.

`~/.config/omamail/accounts.json` now holds a single account, `{"id":"","email":"ada",…}`, and the working mailbox is gone from it. That row cannot be recovered from inside the window: the switcher will not select it, **Remove account** does nothing at all, and **Edit…** opens something that looks like the add-a-mailbox form. Its keyring entry and its message cache are both still filed under the id the real address derives, so nothing outside the list was lost — the list simply no longer knows which mailbox this is.

#### Edit opens the wrong page

1. Settings → **Add a mailbox…** → **IMAP**, and leave that draft open.
2. Go back to Settings and press **Edit…** on `ada@example.com`.
3. The form that opens is the draft's, empty — not the mailbox that was clicked.

### Why

Two ideas of "the current account" had drifted apart. `activeId` names the mailbox on screen, and `activeIndex` overrides it for a row that has no id yet, because a draft cannot be named. Add account leaves both set, and the readers disagreed: `accountAddress` and `configureCurrentAccount` preferred `activeIndex`, while the Remove button asked `indexOfActiveAccount()` alone and so named whatever was on screen before the add. `switchToIndex` made the same divergence reachable from Settings by returning early without clearing `activeIndex`, which is the third sequence above.

The row that survived was unrecoverable because `Accounts.accountId` derives the account id from the address, and a username typed into the address field derives the empty id that every pending row carries. `indexOfId` deliberately never matches an empty id — that is what keeps a half-added mailbox out of every lookup — so select, switch, sign and remove all went with it. `Imap.validateSettings` could not have caught this: `setupSettings` folds the address into `username` and passes no address on at all.

That same row disarmed both write guards, in `Service.saveAccounts` and in `scripts/config-store.sh`, because each asked whether an address was non-empty rather than whether it was an address. `"ada"` is non-empty, so the list containing only that row read as a saved list and replaced the real one on disk.

### What changed

| | |
|---|---|
| `Service.editingIndex()` | One answer to which row the setup page is editing. `discardCurrentDraft`, `accountAddress`, `configureCurrentAccount` and `App.removeCurrentAccountFromEditor` all go through it. |
| `Service.switchToIndex()` | Its early return now clears `activeIndex`, the correction `switchTo` already made in the same situation. |
| `ImapSetupPage.validatedAddress()` | The form refuses an address that cannot name a mailbox, checked against the predicate that derives the id. |
| `Service.nameAccount()` | The other place an address reaches the list. A reported name that derives no id is refused rather than written over a working one. |
| `Accounts.hasSavedAccounts()` | Asks whether the address is an address, not whether it is non-empty. |
| `Accounts.savedOnly()` | New. `saveAccounts` writes only rows that are mailboxes, and applies its guard to that stripped list rather than to what is in memory, so the guard tests the bytes that are about to be written. `applyAccounts` compares the same way, so an open draft is not mistaken for an outside edit. |
| `scripts/config-store.sh` | The final write boundary asks the same question. Deliberately a coarse stand-in for `EMAIL_PATTERN`, not a mirror of it. |

`Remove account` on a draft now discards it and returns to Settings, rather than doing nothing: `removalRequest` refuses a row with no id — a draft has no identity for a confirmation to name — and the codebase's rule is already that a draft is cancelled rather than removed.

An install already in the broken state repairs itself. The unusable row no longer counts as a saved account, so **Add a mailbox… → IMAP** reuses it instead of appending another, and retyping the address restores the id its keyring entry and cache are already filed under. The first save after that drops the stray row from disk.

## 2 · …and adding a mailbox then deleted it

The row the sequence above leaves behind is worse than unusable. It is
**deleted from disk**, and not by anything that looks like a deletion.

`savedOnly` — added in the first commit to keep the setup form's own draft out
of the file — decided what a draft was by asking whether the row had an id.
That is the same question `accountId` answers by parsing the address, so a row
whose address had been corrupted looked exactly like a draft, and drafts are
not written.

On its own that changed nothing: with no real mailbox left in the payload,
`hasSavedAccounts` refused the write and the file stayed as it was. Adding an
unrelated mailbox is what completed it — one good account satisfied the guard,
the write went through, and the corrupted row was simply absent from it.

```
corrupted row alone   → savedOnly gives 0 rows → hasSavedAccounts false → no write
add an unrelated one  → savedOnly gives 1 row  → hasSavedAccounts true  → written,
                                                  and the other mailbox is gone
```

### What changed

| | |
|---|---|
| `Accounts.makeAccount()` | A draft says so — `pending` — rather than being inferred from a missing id. Kept true only while the row has no real address, so no caller has to clear a flag that `configureAccount` would otherwise copy forward for the life of the account. |
| `Accounts.repairedAddress()` | New, and applied by `load`. `setupSettings` folds the address into `imap.username` when no separate username was given, so a row that lost its address still carries it. A row that cannot be repaired is kept rather than deleted — a mailbox with a broken name is not an empty one — while a row holding nothing at all still goes. |
| `Accounts.dropsNamedMailbox()` | New. `hasSavedAccounts` asks about the list; this asks about every row. Nothing in the UI removes an account by writing a list that quietly omits it, so a missing id at the write boundary is a bug upstream and the write is refused. |

An install already in this state repairs itself on the next read: the address
comes back from the username, and the id it derives is the one the mailbox's
keyring entry and cache directory were already filed under, so nothing has to
be signed in again.

## 3 · Every refused folder read as a rejected password

curl spends exit **67** on both a denied login and a refused SELECT, with only
`Access denied` against `Select failed` beside it to tell them apart, and
`responseError` read the code alone. So a server that would not open a folder
was reported as one that had rejected the password — and the password had been
accepted.

The server had already said why. Its tagged `NO` is in the response even when
curl exits non-zero, and the failure path passed only curl's stderr on:

```
what the server sent   A003 NO SELECT Unsafe Login. Please contact kefu@188.com for help
what curl said         curl: (67) Select failed
what the user saw      The server rejected that username or password
```

`transportError` prefers the server's own words and falls back to the exit code
when there is no tagged failure to read. Exit **21**, a command answered `BAD`,
had no case at all and reached the user as
`curl: (21) Quote command returned error`.

This is not specific to any one provider: it is every SELECT failure on every
server.

## 4 · A mailbox that listed its folders and then loaded nothing

A Coremail server — 163.com and the mailboxes around it — answers every SELECT
with `Unsafe Login` until the client has sent RFC 2971's `ID`. Verifiable
without this plugin:

```
b001 OK LOGIN completed
b002 OK LIST Completed
b003 NO SELECT Unsafe Login. Please contact kefu@188.com for help

… and with ID first:
b002 OK ID completed
b003 OK [READ-WRITE] SELECT completed
```

Which is why the folders arrived and nothing in them did. Sending `ID` is
standard rather than a workaround for one host, and the decision is made from
the `CAPABILITY` the server itself advertised — Gmail advertises it too — never
from an address.

Getting it in front of the SELECT needs a transport mode rather than one more
command, for three reasons that are all curl's and none of them visible in this
repo's source:

1. curl opens the URL's path itself, **before** the first command it was handed,
   so nothing can precede that SELECT.
2. Dropping the path wins the order and loses the answer: curl hands a pathless
   request's reply to a different channel than the transport reads. Silently —
   exit 0, no error, an empty mailbox.
3. `--quote`, which sends commands ahead of an FTP transfer, is accepted and
   ignored for IMAP.

So `mail-transport.sh` gains an `imap-id` mode carrying two URLs: the opening
command runs against the server, the rest against the mailbox, and curl reuses
the connection across the sections, so one invocation still costs one LOGIN.
Its reply goes to `/dev/null` — `output` is per-section — because a single-UID
`BODY` FETCH is the one request whose own answer arrives on stdout, and a stray
line there is a message body that reads as empty.

`ID` is sent only to a server that advertised it: one that has never heard of
it answers `BAD`, and curl runs with `--fail-early`, so that single `BAD` would
take every command after it.

Those three curl behaviours are expensive to rediscover, so
`tests/test_imap_ordering.sh` pins them against a real curl and a local server,
alongside the command order and the message body that depend on them.

## 5 · Folder names shown in their wire encoding

RFC 3501 §5.1.3 carries anything outside printable US-ASCII in *modified
UTF-7*, and nothing decoded it, so every non-Latin mailbox showed the encoding
rather than the name:

```
&g0l6P3ux-        草稿箱
&V4NXPpCuTvY-     垃圾邮件
&dcVr0mWHTvZZOQ-  病毒文件夹
```

`decodeMailbox` is used for **display only**. The id is a cache key and
`rawName` is what goes back in a SELECT; both stay exactly as they arrived, so
there is no re-encoding step to get wrong and no round trip that can lose a
byte. Decoding either would make every non-ASCII folder unselectable, which is
subtle enough that a test asserts the shape. A name that does not decode is
passed through rather than dropped — a malformed name is not a reason to hide a
folder, and the undecoded form still selects it.

The last commit adds a `163.com` preset, which is there for its note and not
its servers: `imap.<domain>` already guesses those correctly. What no address
can imply is that the mailbox refuses the account password and wants the
authorisation code from its own settings — the same shape as the entries
already here for Google, Apple, Yahoo, Fastmail and Proton.

## Verification

`make validate` passes: 181 QML assertions, the node tests, the shell and
source regressions, `qmllint`, and `omarchy plugin validate`. `qmllint`'s
warning count is unchanged at 2042.

Every commit was checked out on its own and run through `make test-js
test-shell` and `make qml-check`; each is green in isolation, so the history
bisects.

New coverage beyond the first commit's: `tests/test_imap_ordering.sh` (new,
wired into `make test-shell`) drives the real `mail-transport.sh` against a
local IMAP server and asserts the command order, the single LOGIN, the message
body, and each of the three curl behaviours above; `tests/test_imap.js` covers
`transportError`, the two exit codes, `decodeMailbox` against the seven folder
names a real 163 mailbox lists plus malformed input and a surrogate pair, and
the label shape that keeps `id` and `rawName` undecoded; `tests/test_accounts.js`
covers the repair, `pending`, `carriesData` and `dropsNamedMailbox`, and replays
the corrupt-then-add sequence that deleted a mailbox.

Each fix was reverted on its own to confirm the test covering it fails without
it. Two did not, and were fixed rather than kept: the fake server answered `ID`
with a bare tagged `OK` where a real one answers untagged, which left stdout
empty and made the body assertion pass either way.

## Release Notes

- Removing a mailbox from a setup page removes the mailbox that page is showing. Adding a mailbox and then pressing **Remove account** on the new page deleted the mailbox you already had.
- A mailbox whose address was saved wrong is no longer deleted from disk when another mailbox is added. Its address is recovered from the username it was folded into, and the mailbox comes back without being signed in again.
- The IMAP form refuses an address that is not an email address, instead of saving a mailbox that could not afterwards be selected, edited or removed.
- Editing a mailbox while another one is part-way through being added opens the mailbox you clicked.
- A mailbox that is still being added is no longer written to disk, so abandoning **Add a mailbox…** no longer leaves an empty row behind for good.
- Mailboxes on servers that require the IMAP `ID` command — 163.com and the ones around it — now load their messages instead of listing empty folders.
- A folder the server refuses to open reports what the server said, rather than claiming the password was rejected.
- Folder names outside plain ASCII are shown as their names — `草稿箱`, not `&g0l6P3ux-`.
- Typing a 163.com address says that the mailbox wants its authorisation code rather than the account password, with the page that explains where to find it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
