### PR TITLE
Move a message to a label or folder with `v`

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -657,13 +657,15 @@ Item {
   }
 
   // Opened on the cursor rather than on the selection, the way every other
-  // acting key works: `m` in the list means the row under the cursor, and in
-  // the reader there is only one message it could mean. A provider that cannot
-  // move is not checked for here -- `act` refuses the verb, and says which
-  // provider refused it, which is the one place that answer belongs.
+  // acting key works: `v` in the list means the row under the cursor, and in
+  // the reader there is only one message it could mean. Refuse an unavailable
+  // move before asking for a destination, through the same provider guard that
+  // checks the final action before its optimistic update.
   function openLabelPicker() {
-    if (!service || cursorId === "") return
+    if (!service || cursorId === "") return false
+    if (service.refuseUnavailableAction("label:destination")) return false
     labelPicker.open()
+    return true
   }
 
   // Acting on the open message closes it: it is about to leave this list.
@@ -673,7 +675,8 @@ Item {
     var wasOpen = currentView === "reader" && service.selectedId === acted
     // Worked out before the action, while the row still has neighbours.
     var next = Model.cursorAfterRemoval(service.messages, acted)
-    var leaves = !Model.survivesAction(service.mailboxKey, action)
+    var leaves = !Model.survivesAction(service.mailboxKey, action,
+      service.rawQuery)
     if (!service.act(acted, action)) return false
     if (!leaves) return true
     // The row is going and the cursor must not go with it: a cursor on a
@@ -707,7 +710,7 @@ Item {
     if (slot.kind === "mailbox") return goMailbox(slot.key)
     // Not a search: the provider decides what selecting a label means, and on
     // IMAP it is a folder rather than a term to look for.
-    service.selectLabel(slot.name)
+    service.selectLabel(slot.name, slot.id)
     backToList()
   }
 
@@ -1277,7 +1280,7 @@ Item {
           // Not a search: the provider decides what selecting a label means,
           // and on IMAP it is a folder rather than a term to look for.
           onLabelSelected: function(labelId, name) {
-            root.service.selectLabel(name)
+            root.service.selectLabel(name, labelId)
             root.backToList()
           }
         }
@@ -1947,6 +1950,7 @@ Item {
 
       LabelPicker {
         id: labelPicker
+        objectName: "label-picker"
         anchors.fill: parent
         textColor: root.foreground
         accentColor: root.accent

--- a/App.qml
+++ b/App.qml
@@ -1959,6 +1959,7 @@ Item {
         popupBorderColor: root.popupBorder
         panelFontFamily: root.fontFamily
         labels: root.service ? root.service.labels : []
+        currentLabelId: root.service ? String(root.service.rawLabelId || "") : ""
         onLabelChosen: function(labelId) {
           root.actOnCursor("label:" + labelId)
         }

--- a/App.qml
+++ b/App.qml
@@ -656,6 +656,16 @@ Item {
     onTriggered: root.draftSavedNotice = ""
   }
 
+  // Opened on the cursor rather than on the selection, the way every other
+  // acting key works: `m` in the list means the row under the cursor, and in
+  // the reader there is only one message it could mean. A provider that cannot
+  // move is not checked for here -- `act` refuses the verb, and says which
+  // provider refused it, which is the one place that answer belongs.
+  function openLabelPicker() {
+    if (!service || cursorId === "") return
+    labelPicker.open()
+  }
+
   // Acting on the open message closes it: it is about to leave this list.
   function actOnCursor(action) {
     if (!service || cursorId === "") return false
@@ -724,6 +734,7 @@ Item {
       if (service && cursorId !== "") service.toggleStar(cursorId)
       return
     }
+    if (id === "moveToLabel") return openLabelPicker()
     if (id === "markRead") return actOnCursor("markRead")
     if (id === "markUnread") return actOnCursor("markUnread")
     if (id === "reply") return composeFromCursor("reply")
@@ -1931,6 +1942,21 @@ Item {
         onAddAccountRequested: root.addMailbox()
         onManageRequested: {
           root.openSettings()
+        }
+      }
+
+      LabelPicker {
+        id: labelPicker
+        anchors.fill: parent
+        textColor: root.foreground
+        accentColor: root.accent
+        dimColor: root.dim
+        popupBackgroundColor: root.popupBackground
+        popupBorderColor: root.popupBorder
+        panelFontFamily: root.fontFamily
+        labels: root.service ? root.service.labels : []
+        onLabelChosen: function(labelId) {
+          root.actOnCursor("label:" + labelId)
         }
       }
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/ComposeView.qml \
 	components/RecipientSuggestions.qml \
 	components/ContactsPicker.qml \
+	components/LabelPicker.qml \
 	components/UndoSendToast.qml \
 	components/DraftSavedToast.qml \
 	components/SearchBar.qml \

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ other IMAP server — including one you run yourself.
   through the HEY CLI that 37signals publish, or add any IMAP mailbox with an
   address and an app password. Several accounts at once, each with its own
   inbox, cache and unread count.
-- **Keyboard-first.** `j`/`k` to move, `e` to archive, `s` to star, `r` to
+- **Keyboard-first.** `j`/`k` to move, `e` to archive, `v` to file, `s` to star, `r` to
   reply, `c` to compose, `Alt+1`…`0` for the mailboxes — hold Alt and the rail says
   which is which — `Alt+A` to switch account, `/` to search, `?` for the rest.
   A key the mailbox has no verb for says so instead of pretending: HEY has
@@ -231,6 +231,7 @@ and the client itself are console-only; there is no CLI for them.
 | `e` | Archive |
 | `d` | Move to trash |
 | `s` | Star or unstar |
+| `v` | Move to a label or folder |
 | `Shift+I` / `Shift+U` | Mark read / unread |
 | `r` / `a` / `f` | Reply, reply all, forward |
 | `c` | Compose |

--- a/Service.qml
+++ b/Service.qml
@@ -696,6 +696,7 @@ Item {
   readonly property string mailboxKey: current ? current.mailboxKey : "inbox"
   readonly property string searchQuery: current ? current.searchQuery : ""
   readonly property string rawQuery: current ? current.rawQuery : ""
+  readonly property string rawLabelId: current ? current.rawLabelId : ""
   readonly property bool listLoading: !!current && current.listLoading
   readonly property bool listLoaded: !!current && current.listLoaded
   readonly property bool serverSearchLoading: !!current && current.serverSearchLoading

--- a/Service.qml
+++ b/Service.qml
@@ -758,7 +758,12 @@ Item {
   }
   function selectMailbox(key) { if (current) current.selectMailbox(key) }
   function search(text) { if (current) current.search(text) }
-  function selectLabel(name) { if (current) current.selectLabel(name) }
+  function selectLabel(name, labelId) {
+    if (current) current.selectLabel(name, labelId)
+  }
+  function refuseUnavailableAction(action) {
+    return current ? current.refuseUnavailableAction(action) : true
+  }
   function act(id, action, quiet) {
     return current ? current.act(id, action, quiet) : false
   }

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -128,6 +128,10 @@ Item {
   // search — an IMAP folder wrapped in a TEXT search would go looking for the
   // folder's own name inside the inbox.
   property string rawQuery: ""
+  // The label id behind that raw query. Gmail needs it to make "Move to"
+  // remove the label supplying the current view; IMAP moves out of its source
+  // folder inherently and therefore never passes this into a label change.
+  property string rawLabelId: ""
   property var messages: []
   property var previewMessages: []
   property var labels: []
@@ -1285,6 +1289,13 @@ Item {
   // Every action moves the list immediately and reconciles afterwards. Waiting
   // for Google before the row moves makes the panel feel broken on a slow
   // connection, and the failure path puts the row back.
+  function refuseUnavailableAction(action) {
+    var needs = Model.actionCapability(action)
+    if (needs === "" || Provider.can(providerId, needs)) return false
+    note(Model.actionUnavailable(action, Provider.badge(providerId)))
+    return true
+  }
+
   function act(id, action, quiet) {
     var messageId = String(id || "")
     if (!ready || messageId === "") return false
@@ -1293,11 +1304,7 @@ Item {
     // honour reaches here even though the panel drew no button for it — and the
     // row would be moved, and the note would say "Archived", for a request no
     // server ever saw.
-    var needs = Model.actionCapability(action)
-    if (needs !== "" && !Provider.can(providerId, needs)) {
-      note(Model.actionUnavailable(action, Provider.badge(providerId)))
-      return false
-    }
+    if (refuseUnavailableAction(action)) return false
     if (pendingAction !== "") {
       if (quiet === true) {
         queueQuietAction(messageId, action, cacheKey)
@@ -1331,8 +1338,9 @@ Item {
       actionToken = ""
     }
     var before = index >= 0 ? messages[index] : previewMessages[previewIndex]
-    var updated = Model.applyLabelChange(before, action)
-    var survives = Model.survivesAction(mailboxKey, action)
+    var sourceLabelId = hasLabels ? rawLabelId : ""
+    var updated = Model.applyLabelChange(before, action, sourceLabelId)
+    var survives = Model.survivesAction(mailboxKey, action, rawQuery)
 
     if (action === "markRead" && before.unread) inboxUnread = Math.max(0, inboxUnread - 1)
     if (action === "markUnread" && !before.unread) inboxUnread = inboxUnread + 1
@@ -1444,7 +1452,7 @@ Item {
     if (action === "trash") api.trashMessage(messageId, done)
     else if (action === "untrash") api.untrashMessage(messageId, done)
     else {
-      var change = Model.labelChangesFor(action)
+      var change = Model.labelChangesFor(action, sourceLabelId)
       if (!change) {
         pendingAction = ""
         pendingActionQuery = ""
@@ -1490,7 +1498,7 @@ Item {
   }
 
   // A label id is what the provider wants and what the caches key on; a name
-  // is what the person who pressed `m` picked. Falling back to the id keeps a
+  // is what the person who pressed `v` picked. Falling back to the id keeps a
   // note honest when the label list has not arrived rather than printing
   // nothing where the destination should be -- and on IMAP the two are the
   // same string anyway, because a folder's id is its name.
@@ -2109,6 +2117,7 @@ Item {
     mailboxKey = String(key || "inbox")
     searchQuery = ""
     rawQuery = ""
+    rawLabelId = ""
     clearSelection()
     messages = []
     previewMessages = []
@@ -2122,6 +2131,7 @@ Item {
     searchQuery = query
     // Typing in the search box leaves whatever label was selected.
     rawQuery = ""
+    rawLabelId = ""
     clearSelection()
     messages = []
     listLoaded = false
@@ -2130,11 +2140,13 @@ Item {
 
   // A label on Gmail, a folder on IMAP. One entry point either way, because the
   // sidebar draws one kind of row.
-  function selectLabel(name) {
+  function selectLabel(name, labelId) {
     var query = Provider.labelQuery(providerId, name)
-    if (query === "" || query === rawQuery) return
+    var id = String(labelId || "")
+    if (query === "" || (query === rawQuery && id === rawLabelId)) return
     searchQuery = ""
     rawQuery = query
+    rawLabelId = id
     clearSelection()
     messages = []
     listLoaded = false

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1481,7 +1481,22 @@ Item {
     if (action === "markRead") return "Marked read"
     if (action === "markUnread") return "Marked unread"
     if (action === "spam") return "Reported as spam"
+    // Named, not "Moved": the destination was chosen a keystroke ago from a
+    // list of thirty, and a note that does not say which one leaves the only
+    // question the user has -- did it go where I meant? -- unanswered.
+    var target = Model.labelTarget(action)
+    if (target !== "") return "Moved to " + labelName(target)
     return "Done"
+  }
+
+  // A label id is what the provider wants and what the caches key on; a name
+  // is what the person who pressed `m` picked. Falling back to the id keeps a
+  // note honest when the label list has not arrived rather than printing
+  // nothing where the destination should be -- and on IMAP the two are the
+  // same string anyway, because a folder's id is its name.
+  function labelName(labelId) {
+    var index = Model.indexById(labels, labelId)
+    return index >= 0 ? labels[index].name : labelId
   }
 
   function toggleStar(id) {

--- a/account/Model.js
+++ b/account/Model.js
@@ -148,7 +148,7 @@ function labelTarget(action) {
   return verb.slice(MOVE_PREFIX.length)
 }
 
-function survivesAction(mailboxKey, action) {
+function survivesAction(mailboxKey, action, rawQuery) {
   var key = String(mailboxKey || "inbox")
   var verb = String(action || "")
   if (verb === "trash") return key === "trash"
@@ -156,6 +156,7 @@ function survivesAction(mailboxKey, action) {
   // A move takes INBOX away exactly as archive does, so it leaves exactly the
   // lists archive leaves. Said once, because two branches with the same answer
   // are two places for it to drift.
+  if (labelTarget(verb) !== "" && String(rawQuery || "") !== "") return false
   if (verb === "archive" || labelTarget(verb) !== "")
     return key !== "inbox" && key !== "unread"
   if (verb === "markRead") return key !== "unread"
@@ -163,7 +164,7 @@ function survivesAction(mailboxKey, action) {
   return true
 }
 
-function labelChangesFor(action) {
+function labelChangesFor(action, sourceLabelId) {
   if (action === "markRead") return { add: [], remove: ["UNREAD"] }
   if (action === "markUnread") return { add: ["UNREAD"], remove: [] }
   if (action === "star") return { add: ["STARRED"], remove: [] }
@@ -175,7 +176,13 @@ function labelChangesFor(action) {
   // a message in one is adding that label and taking INBOX away -- the same
   // pair archive already writes, with the destination filled in.
   var target = labelTarget(action)
-  if (target !== "") return { add: [target], remove: ["INBOX"] }
+  if (target !== "") {
+    var remove = ["INBOX"]
+    var source = String(sourceLabelId || "")
+    if (source !== "" && source !== target && remove.indexOf(source) < 0)
+      remove.push(source)
+    return { add: [target], remove: remove }
+  }
   return null
 }
 
@@ -245,9 +252,9 @@ function unavailableActions(capabilities) {
   return out
 }
 
-function applyLabelChange(summary, action) {
+function applyLabelChange(summary, action, sourceLabelId) {
   if (!summary) return summary
-  var change = labelChangesFor(action)
+  var change = labelChangesFor(action, sourceLabelId)
   if (!change) return summary
   var next = {}
   for (var key in summary) next[key] = summary[key]

--- a/account/Model.js
+++ b/account/Model.js
@@ -191,15 +191,20 @@ function labelChangesFor(action, sourceLabelId) {
 // System labels are left out: INBOX, SENT, SPAM and the rest are the mailboxes
 // the rail already draws, and offering them here would put two ways of saying
 // "archive" in a list whose whole job is the destinations that have no key of
-// their own. Sorted by name rather than by the order the provider returned,
-// which on Gmail is neither alphabetical nor stable between accounts.
-function movableLabels(labels, query) {
+// their own. The label or folder already on screen is not a destination: on
+// Gmail it would leave the source label attached while optimistically removing
+// its row, and IMAP would be asked to UID MOVE a message into the same folder.
+// Sorted by name rather than by the order the provider returned, which on
+// Gmail is neither alphabetical nor stable between accounts.
+function movableLabels(labels, query, currentLabelId) {
   var candidates = Array.isArray(labels) ? labels : []
   var typed = String(query || "").trim().toLowerCase()
+  var current = String(currentLabelId || "")
   var destinations = []
   for (var i = 0; i < candidates.length; i++) {
     var label = candidates[i]
     if (!label || label.system === true) continue
+    if (String(label.id || "") === current) continue
     var labelName = String(label.name || "")
     if (typed !== "" && labelName.toLowerCase().indexOf(typed) < 0) continue
     destinations.push(label)

--- a/account/Model.js
+++ b/account/Model.js
@@ -134,12 +134,30 @@ function setupActionLabel(state, provider, authKind) {
 // viewed. Archiving from Inbox removes the row; archiving from All mail does
 // not. Getting this wrong either strands a row that is gone or hides one that
 // is still there.
+// The label a move is aimed at, or "" for every other verb.
+//
+// The destination travels inside the action string rather than beside it
+// because `act` threads one verb through the capability guard, the optimistic
+// edit, the cache repair and the restore on failure. A second argument would
+// have had to be carried, and correctly put back, by all four.
+var MOVE_PREFIX = "label:"
+
+function labelTarget(action) {
+  var verb = String(action || "")
+  if (verb.indexOf(MOVE_PREFIX) !== 0) return ""
+  return verb.slice(MOVE_PREFIX.length)
+}
+
 function survivesAction(mailboxKey, action) {
   var key = String(mailboxKey || "inbox")
   var verb = String(action || "")
   if (verb === "trash") return key === "trash"
   if (verb === "untrash") return key !== "trash"
-  if (verb === "archive") return key !== "inbox" && key !== "unread"
+  // A move takes INBOX away exactly as archive does, so it leaves exactly the
+  // lists archive leaves. Said once, because two branches with the same answer
+  // are two places for it to drift.
+  if (verb === "archive" || labelTarget(verb) !== "")
+    return key !== "inbox" && key !== "unread"
   if (verb === "markRead") return key !== "unread"
   if (verb === "unstar") return key !== "starred"
   return true
@@ -153,7 +171,38 @@ function labelChangesFor(action) {
   if (action === "archive") return { add: [], remove: ["INBOX"] }
   if (action === "unarchive") return { add: ["INBOX"], remove: [] }
   if (action === "spam") return { add: ["SPAM"], remove: ["INBOX"] }
+  // A move is archive with somewhere to go. Where a folder is a label, putting
+  // a message in one is adding that label and taking INBOX away -- the same
+  // pair archive already writes, with the destination filled in.
+  var target = labelTarget(action)
+  if (target !== "") return { add: [target], remove: ["INBOX"] }
   return null
+}
+
+// The labels a message can be moved into, filtered by what has been typed.
+//
+// System labels are left out: INBOX, SENT, SPAM and the rest are the mailboxes
+// the rail already draws, and offering them here would put two ways of saying
+// "archive" in a list whose whole job is the destinations that have no key of
+// their own. Sorted by name rather than by the order the provider returned,
+// which on Gmail is neither alphabetical nor stable between accounts.
+function movableLabels(labels, query) {
+  var candidates = Array.isArray(labels) ? labels : []
+  var typed = String(query || "").trim().toLowerCase()
+  var destinations = []
+  for (var i = 0; i < candidates.length; i++) {
+    var label = candidates[i]
+    if (!label || label.system === true) continue
+    var labelName = String(label.name || "")
+    if (typed !== "" && labelName.toLowerCase().indexOf(typed) < 0) continue
+    destinations.push(label)
+  }
+  destinations.sort(function(left, right) {
+    var leftName = String(left.name || "").toLowerCase()
+    var rightName = String(right.name || "").toLowerCase()
+    return leftName < rightName ? -1 : (leftName > rightName ? 1 : 0)
+  })
+  return destinations
 }
 
 // Which capability an action needs, or "" for the ones every provider has.
@@ -168,6 +217,7 @@ function actionCapability(action) {
   if (verb === "archive" || verb === "unarchive") return "archive"
   if (verb === "star" || verb === "unstar") return "star"
   if (verb === "spam") return "spam"
+  if (labelTarget(verb) !== "") return "move"
   return ""
 }
 
@@ -180,6 +230,7 @@ function actionUnavailable(action, provider) {
   if (needs === "archive") return name + " has no archive"
   if (needs === "star") return name + " has no star"
   if (needs === "spam") return name + " has no junk verb to report to"
+  if (needs === "move") return name + " has no destination you can name"
   return ""
 }
 

--- a/components/LabelPicker.qml
+++ b/components/LabelPicker.qml
@@ -23,11 +23,15 @@ Item {
 
   // [{ id, name, system, unread, total }], as the provider reported them.
   property var labels: []
+  // The raw label or folder view already on screen, which cannot be its own
+  // move destination.
+  property string currentLabelId: ""
 
   property string searchQuery: ""
 
   readonly property bool opened: menu.opened
-  readonly property var matchingLabels: Model.movableLabels(root.labels, root.searchQuery)
+  readonly property var matchingLabels: Model.movableLabels(
+    root.labels, root.searchQuery, root.currentLabelId)
 
   // Where the keyboard is standing. Reset to the top on every keystroke
   // because the list underneath it has changed: holding an index still would

--- a/components/LabelPicker.qml
+++ b/components/LabelPicker.qml
@@ -26,6 +26,7 @@ Item {
 
   property string searchQuery: ""
 
+  readonly property bool opened: menu.opened
   readonly property var matchingLabels: Model.movableLabels(root.labels, root.searchQuery)
 
   // Where the keyboard is standing. Reset to the top on every keystroke

--- a/components/LabelPicker.qml
+++ b/components/LabelPicker.qml
@@ -1,0 +1,221 @@
+import QtQuick
+import QtQuick.Controls as QQC
+import qs.Commons
+import qs.Ui
+import "../account/Model.js" as Model
+
+// Where a message goes when it leaves the inbox with somewhere to be.
+//
+// The rail already names the mailboxes a key can reach; this is the rest of
+// them, and on an account with thirty labels a list is only usable if it is
+// narrowed by typing. So the field owns the focus from the moment it opens and
+// the keyboard walks the list underneath it -- the destination is picked by
+// typing three letters and pressing Return, never by arrowing through thirty.
+Item {
+  id: root
+
+  required property color textColor
+  required property color accentColor
+  required property color dimColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
+  required property string panelFontFamily
+
+  // [{ id, name, system, unread, total }], as the provider reported them.
+  property var labels: []
+
+  property string searchQuery: ""
+
+  readonly property var matchingLabels: Model.movableLabels(root.labels, root.searchQuery)
+
+  // Where the keyboard is standing. Reset to the top on every keystroke
+  // because the list underneath it has changed: holding an index still would
+  // leave the cursor on whatever row happened to inherit that position.
+  property int cursorIndex: 0
+
+  signal labelChosen(string labelId)
+
+  anchors.fill: parent
+  z: 50
+
+  function open() {
+    searchField.text = ""
+    root.searchQuery = ""
+    root.cursorIndex = 0
+    menu.open()
+    place()
+    searchField.forceActiveFocus()
+  }
+
+  // A Popup does not build its contents until it is first opened, so on the
+  // first open its height is still zero and centring it lands it high. Placing
+  // again on every height change is what makes the first open sit where all
+  // the later ones do, and it re-centres the card as typing shortens the list.
+  function place() {
+    if (!menu.visible) return
+    var menuHeight = menu.height > 0 ? menu.height : menu.implicitHeight
+    menu.x = Math.max(Style.space(8), (root.width - menu.width) / 2)
+    menu.y = Math.max(Style.space(8), (root.height - menuHeight) / 3)
+  }
+
+  function moveCursor(delta) {
+    var matchCount = root.matchingLabels.length
+    if (matchCount === 0) return
+    cursorIndex = Model.wrappedIndex(cursorIndex, delta, matchCount)
+  }
+
+  function chooseCursor() {
+    var matchCount = root.matchingLabels.length
+    if (root.cursorIndex < 0 || root.cursorIndex >= matchCount) return
+    var chosenLabel = root.matchingLabels[root.cursorIndex]
+    menu.close()
+    root.labelChosen(String(chosenLabel.id || ""))
+  }
+
+  QQC.Popup {
+    id: menu
+    width: Math.min(Style.space(340), root.width - Style.space(24))
+    implicitHeight: card.implicitHeight + Style.space(16)
+    padding: Style.space(8)
+    modal: false
+    focus: true
+    closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
+    onHeightChanged: root.place()
+    onOpened: root.place()
+
+    background: Rectangle {
+      radius: Style.cornerRadius
+      color: root.popupBackgroundColor
+      border.width: 1
+      border.color: root.popupBorderColor
+    }
+
+    contentItem: Column {
+      id: card
+      spacing: Style.space(8)
+
+      Row {
+        width: parent.width
+        spacing: Style.space(8)
+
+        Text {
+          text: "Move to"
+          color: root.textColor
+          font.family: root.panelFontFamily
+          font.pixelSize: Style.font.bodySmall
+          font.bold: true
+          anchors.verticalCenter: parent.verticalCenter
+        }
+
+        Text {
+          text: "(" + root.matchingLabels.length + ")"
+          color: root.dimColor
+          font.family: root.panelFontFamily
+          font.pixelSize: Style.font.caption
+          anchors.verticalCenter: parent.verticalCenter
+        }
+      }
+
+      // The field answers the keys itself. Inside an open `QQC.Popup` a
+      // `KeyRouter` binding is the thing that would look live and never run --
+      // the popup takes every key before the shortcut map sees it -- and this
+      // one has to intercept the arrows and Return before the text cursor
+      // does, while leaving every printable key to the filter.
+      TextField {
+        id: searchField
+        width: parent.width
+        foreground: root.textColor
+        accent: root.accentColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        placeholderText: "Filter labels..."
+        onTextChanged: {
+          root.searchQuery = text
+          root.cursorIndex = 0
+        }
+        Keys.onPressed: function(event) {
+          if (event.key === Qt.Key_Down) {
+            root.moveCursor(1)
+            event.accepted = true
+          } else if (event.key === Qt.Key_Up) {
+            root.moveCursor(-1)
+            event.accepted = true
+          } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+            root.chooseCursor()
+            event.accepted = true
+          }
+          // Escape is not here: the popup's own CloseOnEscape is already the
+          // one mechanism that closes it, and a second would be one too many.
+        }
+      }
+
+      ListView {
+        id: labelList
+        width: parent.width
+        implicitHeight: Math.min(contentHeight, Style.space(280))
+        clip: true
+        model: root.matchingLabels
+        currentIndex: root.cursorIndex
+        highlightMoveDuration: 0
+        // Keeps the keyboard's row on screen once the list is longer than the
+        // card, which is the case this whole component exists for.
+        onCurrentIndexChanged: positionViewAtIndex(currentIndex, ListView.Contain)
+        QQC.ScrollBar.vertical: QQC.ScrollBar { policy: QQC.ScrollBar.AsNeeded }
+
+        delegate: Rectangle {
+          id: labelRow
+          required property var modelData
+          required property int index
+
+          readonly property bool hasCursor: root.cursorIndex === labelRow.index
+
+          width: labelList.width
+          implicitHeight: Style.space(34)
+          radius: Style.cornerRadius
+          color: labelRow.hasCursor || rowHover.hovered
+            ? Style.hoverFillFor(root.textColor, root.accentColor) : "transparent"
+          border.width: labelRow.hasCursor ? Style.normalBorderWidth : 0
+          border.color: Style.hoverBorderFor(root.textColor, root.accentColor)
+
+          Text {
+            anchors.left: parent.left
+            anchors.leftMargin: Style.space(10)
+            anchors.right: parent.right
+            anchors.rightMargin: Style.space(10)
+            anchors.verticalCenter: parent.verticalCenter
+            textFormat: Text.PlainText
+            text: String(labelRow.modelData.name || "")
+            color: root.textColor
+            font.family: root.panelFontFamily
+            font.pixelSize: Style.font.bodySmall
+            elide: Text.ElideRight
+          }
+
+          HoverHandler { id: rowHover }
+
+          TapHandler {
+            onTapped: {
+              root.cursorIndex = labelRow.index
+              root.chooseCursor()
+            }
+          }
+        }
+      }
+
+      // An account with no labels yet -- and a provider that has none at all --
+      // would otherwise open an empty card that looks broken rather than
+      // empty, and typing past every match is the same picture arrived at a
+      // different way.
+      Text {
+        width: parent.width
+        visible: root.matchingLabels.length === 0
+        textFormat: Text.PlainText
+        text: root.searchQuery === ""
+          ? "No labels to move into" : "No label matches that"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+      }
+    }
+  }
+}

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -92,6 +92,7 @@ used to exist, and they had.
 | `archive` | `e` | mail | Archive |
 | `trash` | `d` | mail | Move to trash |
 | `star` | `s` | mail | Star or unstar |
+| `moveToLabel` | `v` | mail | Move to |
 | `markRead` | `Shift+I` | mail | Mark read |
 | `markUnread` | `Shift+U` | mail | Mark unread |
 | `reply` | `r` | mail | Reply |

--- a/keys/Keymap.js
+++ b/keys/Keymap.js
@@ -51,6 +51,15 @@ var BINDINGS = [
     hint: { reader: "trash" } },
   { id: "star", keys: ["s"], contexts: MAIL,
     group: "Acting", label: "Star or unstar" },
+  // `v` because that is the key Gmail moves a message with, and issue #58 asks
+  // for those shortcuts one for one. Not `m`: free here, but Gmail's `m` mutes
+  // a conversation, and taking it for a move would be the one binding somebody
+  // arriving from Gmail has to unlearn.
+  //
+  // "Move to" rather than "Move to a label" because the destination is a label
+  // on Gmail and a folder on IMAP, and the sheet has no provider to ask.
+  { id: "moveToLabel", keys: ["v"], contexts: MAIL,
+    group: "Acting", label: "Move to" },
   { id: "markRead", keys: ["Shift+I"], contexts: MAIL,
     group: "Acting", label: "Mark read" },
   { id: "markUnread", keys: ["Shift+U"], contexts: MAIL,

--- a/providers/Gmail.js
+++ b/providers/Gmail.js
@@ -29,6 +29,8 @@ var MARK = "gmail.png"
 
 var CAPABILITIES = {
   labels: true,
+  // Adding a label and taking INBOX away, which is archive with a destination.
+  move: true,
   threads: true,
   archive: true,
   spam: true,

--- a/providers/Hey.js
+++ b/providers/Hey.js
@@ -42,6 +42,10 @@ var LOGO = "hey.png"
 var CAPABILITIES = {
   // HEY files a thread under any number of labels, and `hey labels` lists them.
   labels: true,
+  // HEY moves a message to the Imbox, the Feed or the Paper Trail and nowhere
+  // else. Those are not destinations the user names, so the key that asks for
+  // one is refused rather than quietly doing nothing.
+  move: false,
   // A topic id, which is HEY's own conversation.
   threads: true,
   // Deliberately off. HEY has no archive: a thread is moved to another box, or

--- a/providers/Imap.js
+++ b/providers/Imap.js
@@ -18,6 +18,10 @@ var CAPABILITIES = {
   // No labels: a message is in one folder. The reader hides the label strip
   // rather than showing an empty one.
   labels: false,
+  // One folder per message is what makes a move the plain thing to do here:
+  // `labels: false` is about the strip the reader draws, not about whether a
+  // message can be put somewhere else.
+  move: true,
   // No server-side conversation id. Threading falls back to References, which
   // is what every other IMAP client does.
   threads: false,

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -1005,39 +1005,42 @@ function flagPlanForLabels(addLabelIds, removeLabelIds, special) {
     return false
   }
 
+  // A move always adds its named destination while taking INBOX away. Read it
+  // before interpreting Gmail's system ids: an ordinary IMAP folder may itself
+  // be named "Starred", "Unread", "Trash", or "Spam".
+  var destination = folderTarget(added, removed)
+
   // The inversion again: Gmail's UNREAD is a label you add, IMAP's \Seen is a
   // flag you remove. Getting this backwards marks read what the user just
   // marked unread.
-  if (has(added, "UNREAD")) plan.remove.push("\\Seen")
+  if (destination === "" && has(added, "UNREAD")) plan.remove.push("\\Seen")
   if (has(removed, "UNREAD")) plan.add.push("\\Seen")
-  if (has(added, "STARRED")) plan.add.push("\\Flagged")
+  if (destination === "" && has(added, "STARRED")) plan.add.push("\\Flagged")
   if (has(removed, "STARRED")) plan.remove.push("\\Flagged")
 
   if (has(removed, "INBOX")) plan.move = map["\\archive"] || ""
-  if (has(added, "INBOX")) plan.move = "INBOX"
-  if (has(added, "TRASH")) plan.move = map["\\trash"] || ""
-  if (has(added, "SPAM")) plan.move = map["\\junk"] || ""
+  if (destination === "" && has(added, "INBOX")) plan.move = "INBOX"
+  if (destination === "" && has(added, "TRASH")) plan.move = map["\\trash"] || ""
+  if (destination === "" && has(added, "SPAM")) plan.move = map["\\junk"] || ""
 
   // A named destination, which is the one case where the request is already
   // IMAP: `getLabels` reports folder names as label ids, so a move asks for
   // the folder by the name the server gave it. It is read last because such a
   // request also removes INBOX -- the archive above is the default for "out of
   // the inbox", and this is the same message with somewhere better to be.
-  var destination = folderTarget(added)
   if (destination !== "") plan.move = destination
   return plan
 }
 
-// The added id that is not one of the flags this file speaks for. Gmail's
-// vocabulary reaches here as system label ids in capitals; anything else came
-// from `getLabels`, where an IMAP folder's id is its own name.
-function folderTarget(addLabelIds) {
-  for (var i = 0; i < addLabelIds.length; i++) {
-    var labelId = String(addLabelIds[i])
-    var systemName = labelId.toUpperCase()
-    if (systemName === "UNREAD" || systemName === "STARRED") continue
-    if (systemName === "INBOX" || systemName === "TRASH" || systemName === "SPAM") continue
-    return labelId
+// The destination carried by a move. `labelChangesFor` shapes one as a label
+// added while INBOX is removed; preserving that shape is what keeps a folder
+// named like a Gmail system id from being mistaken for the system operation.
+function folderTarget(addLabelIds, removeLabelIds) {
+  var added = Array.isArray(addLabelIds) ? addLabelIds : []
+  var removed = Array.isArray(removeLabelIds) ? removeLabelIds : []
+  if (added.length === 0) return ""
+  for (var i = 0; i < removed.length; i++) {
+    if (String(removed[i]).toUpperCase() === "INBOX") return String(added[0])
   }
   return ""
 }

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -1017,7 +1017,29 @@ function flagPlanForLabels(addLabelIds, removeLabelIds, special) {
   if (has(added, "INBOX")) plan.move = "INBOX"
   if (has(added, "TRASH")) plan.move = map["\\trash"] || ""
   if (has(added, "SPAM")) plan.move = map["\\junk"] || ""
+
+  // A named destination, which is the one case where the request is already
+  // IMAP: `getLabels` reports folder names as label ids, so a move asks for
+  // the folder by the name the server gave it. It is read last because such a
+  // request also removes INBOX -- the archive above is the default for "out of
+  // the inbox", and this is the same message with somewhere better to be.
+  var destination = folderTarget(added)
+  if (destination !== "") plan.move = destination
   return plan
+}
+
+// The added id that is not one of the flags this file speaks for. Gmail's
+// vocabulary reaches here as system label ids in capitals; anything else came
+// from `getLabels`, where an IMAP folder's id is its own name.
+function folderTarget(addLabelIds) {
+  for (var i = 0; i < addLabelIds.length; i++) {
+    var labelId = String(addLabelIds[i])
+    var systemName = labelId.toUpperCase()
+    if (systemName === "UNREAD" || systemName === "STARRED") continue
+    if (systemName === "INBOX" || systemName === "TRASH" || systemName === "SPAM") continue
+    return labelId
+  }
+  return ""
 }
 
 // -------------------------------------------------------------- the errors

--- a/providers/Registry.js
+++ b/providers/Registry.js
@@ -34,6 +34,10 @@ function capabilities(values) {
   return {
     // Several labels on one message, rather than one folder holding it.
     labels: raw.labels === true,
+    // A destination the user names. A different question from `labels`: a
+    // mailbox with one folder per message cannot label anything and can still
+    // be told where to put it, which is IMAP exactly.
+    move: raw.move === true,
     // A server-side conversation id.
     threads: raw.threads === true,
     // "Archive" means something.

--- a/tests/qml/tst_app_navigation.qml
+++ b/tests/qml/tst_app_navigation.qml
@@ -108,6 +108,7 @@ Item {
 
     property var log: []
     property var lastSavedDraft: null
+    property bool refuseMove: false
 
     signal accountAdded()
     signal replySent()
@@ -187,6 +188,12 @@ Item {
     function refresh() {}
     function fail(text) { lastError = String(text || "") }
     function note(text) { actionStatus = String(text || "") }
+    function refuseUnavailableAction(action) {
+      record("guard:" + String(action || ""))
+      if (!refuseMove) return false
+      note("HEY has no destination you can name")
+      return true
+    }
   }
 
   Omamail.App {
@@ -239,6 +246,7 @@ Item {
     function init() {
       mailService.log = []
       mailService.lastSavedDraft = null
+      mailService.refuseMove = false
       mailService.accountCount = 1
       mailService.providerId = "imap"
       mailService.hasSavedAccounts = true
@@ -459,6 +467,18 @@ Item {
       app.back()
       compare(kinds(), "list,settings")
       compare(mailService.count("discard"), 0)
+    }
+
+    function test_an_unavailable_move_is_refused_before_the_picker_opens() {
+      mailService.refuseMove = true
+      app.cursorId = "message-1"
+
+      app.runShortcut("moveToLabel", "v")
+
+      compare(mailService.count("guard:label:destination"), 1,
+        "the provider guard answers the key before a destination is requested")
+      compare(named(app, "label-picker").opened, false)
+      compare(mailService.actionStatus, "HEY has no destination you can name")
     }
   }
 }

--- a/tests/qml/tst_move_wiring.qml
+++ b/tests/qml/tst_move_wiring.qml
@@ -1,0 +1,162 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../.." as Omamail
+
+// The move route through the real objects. Unit tests own each rule; this one
+// catches a forwarding argument or property dropped between App, Service and
+// MailAccount before the rule can see it.
+Item {
+  width: 900
+  height: 600
+
+  QtObject {
+    id: fakeShell
+    function hide(_id) {}
+  }
+
+  Omamail.Service {
+    id: mailService
+    shell: fakeShell
+    manifest: ({ id: "omamail", __sourceDir: "" })
+  }
+
+  Omamail.App {
+    id: app
+    service: mailService
+    shell: fakeShell
+  }
+
+  TestCase {
+    name: "MoveWiring"
+    when: windowShown
+
+    function named(item, objectName) {
+      if (!item) return null
+      if (item.objectName === objectName) return item
+      var values = item.children || []
+      for (var i = 0; i < values.length; i++) {
+        var found = named(values[i], objectName)
+        if (found) return found
+      }
+      return null
+    }
+
+    function installAccount(provider, id, email) {
+      mailService.accountsLoaded = true
+      mailService.accountList = ({
+        version: 1,
+        accounts: [{ id: id, email: email, provider: provider }],
+        activeId: id
+      })
+      tryCompare(mailService, "accountCount", 1)
+      tryVerify(function() { return mailService.current !== null }, 1000,
+        "the real Service creates its MailAccount")
+      wait(0)
+      return mailService.current
+    }
+
+    function labelSlot(labelId) {
+      var slots = app.sidebarSlots
+      for (var i = 0; i < slots.length; i++) {
+        if (slots[i].kind === "label" && slots[i].id === labelId) return i
+      }
+      return -1
+    }
+
+    function ids(labels) {
+      var result = []
+      for (var i = 0; i < labels.length; i++) result.push(labels[i].id)
+      return result.join(",")
+    }
+
+    function init() {
+      app.opened = true
+      app.cursorId = ""
+      mailService.accountList = ({ version: 1, accounts: [], activeId: "" })
+      wait(0)
+    }
+
+    function cleanup() {
+      mailService.accountList = ({ version: 1, accounts: [], activeId: "" })
+      wait(0)
+    }
+
+    function test_gmail_label_identity_reaches_the_picker_and_move_model() {
+      var account = installAccount("gmail", "me@example.com", "me@example.com")
+      account.mailboxKey = "starred"
+      account.labels = [
+        { id: "Label_3", name: "Work", rawName: "Work", system: false, unread: 0 },
+        { id: "Label_7", name: "Receipts", rawName: "Receipts", system: false, unread: 0 }
+      ]
+
+      var slot = labelSlot("Label_3")
+      verify(slot >= 0)
+      app.goSlot(slot)
+
+      compare(account.rawLabelId, "Label_3")
+      compare(mailService.rawLabelId, "Label_3")
+      compare(mailService.rawQuery, "label:Work")
+      compare(ids(named(app, "label-picker").matchingLabels), "Label_7",
+        "the current label cannot trigger an optimistic removal that leaves it attached")
+
+      account.auth.credentials = ({
+        clientId: "123-test.apps.googleusercontent.com",
+        clientSecret: "test",
+        projectId: "test"
+      })
+      account.auth.toolsChecked = true
+      account.auth.missingTools = []
+      account.auth.loggedIn = true
+      // Hold the transport below the real action pipeline: the test needs the
+      // optimistic result, not a request to Google.
+      account.auth.refreshBusy = true
+      tryCompare(account, "ready", true)
+      account.messages = [
+        { id: "one", labelIds: ["INBOX", "Label_3"], unread: false, starred: true,
+          inInbox: true, subject: "One", time: "now", from: { display: "Sender" }, snippet: "First" },
+        { id: "two", labelIds: ["INBOX", "Label_3"], unread: false, starred: true,
+          inInbox: true, subject: "Two", time: "now", from: { display: "Sender" }, snippet: "Second" }
+      ]
+      app.cursorId = "one"
+      app.openMessage("one")
+      compare(app.currentView, "reader")
+      compare(mailService.selectedId, "one")
+
+      verify(app.actOnCursor("label:Label_7"))
+
+      compare(mailService.selectedId, "two",
+        "the reader follows the action to the same next message as the cursor")
+      compare(app.cursorId, "two",
+        "App uses the raw query even though the old mailbox key is Starred")
+      compare(account.messages.length, 1,
+        "MailAccount uses the raw query to remove the row from the label view")
+      compare(account.messages[0].id, "two")
+    }
+
+    function test_hey_refusal_crosses_the_real_service_before_the_picker() {
+      installAccount("hey", "hey:me@hey.com", "me@hey.com")
+      app.cursorId = "message-1"
+
+      compare(app.openLabelPicker(), false)
+
+      compare(named(app, "label-picker").opened, false)
+      compare(mailService.actionStatus, "HEY has no destination you can name")
+    }
+
+    function test_imap_current_folder_is_not_a_uid_move_destination() {
+      var account = installAccount("imap", "imap:me@example.com", "me@example.com")
+      account.labels = [
+        { id: "Receipts", name: "Receipts", rawName: "Receipts", system: false, unread: 0 },
+        { id: "Archive", name: "Archive", rawName: "Archive", system: false, unread: 0 }
+      ]
+
+      var slot = labelSlot("Receipts")
+      verify(slot >= 0)
+      app.goSlot(slot)
+
+      compare(account.rawLabelId, "Receipts")
+      compare(ids(named(app, "label-picker").matchingLabels), "Archive",
+        "the current folder cannot become a same-folder UID MOVE")
+    }
+  }
+}

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -582,6 +582,16 @@ deepEqual(imap.flagPlanForLabels([], ["STARRED"], {}),
 // same request is a move.
 deepEqual(imap.flagPlanForLabels([], ["INBOX"], { "\\archive": "Archive" }),
   { add: [], remove: [], move: "Archive" })
+// A named destination is the same shape as archive -- out of the inbox -- so
+// it has to win over the archive default rather than be overwritten by it.
+deepEqual(imap.flagPlanForLabels(["Receipts"], ["INBOX"], { "\\archive": "Archive" }),
+  { add: [], remove: [], move: "Receipts" }, "a chosen folder beats the archive default")
+deepEqual(imap.flagPlanForLabels(["Receipts/2026"], ["INBOX"], {}),
+  { add: [], remove: [], move: "Receipts/2026" }, "a nested folder is a name like any other")
+// Marking read on the way is still a flag, not a move.
+deepEqual(imap.flagPlanForLabels(["Receipts"], ["INBOX", "UNREAD"], {}),
+  { add: ["\\Seen"], remove: [], move: "Receipts" })
+
 deepEqual(imap.flagPlanForLabels(["INBOX"], [], {}),
   { add: [], remove: [], move: "INBOX" }, "unarchiving is a move back")
 deepEqual(imap.flagPlanForLabels([], ["INBOX"], {}),

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -588,6 +588,18 @@ deepEqual(imap.flagPlanForLabels(["Receipts"], ["INBOX"], { "\\archive": "Archiv
   { add: [], remove: [], move: "Receipts" }, "a chosen folder beats the archive default")
 deepEqual(imap.flagPlanForLabels(["Receipts/2026"], ["INBOX"], {}),
   { add: [], remove: [], move: "Receipts/2026" }, "a nested folder is a name like any other")
+deepEqual(imap.flagPlanForLabels(["Starred"], ["INBOX"], { "\\archive": "Archive" }),
+  { add: [], remove: [], move: "Starred" },
+  "a named folder does not become the Gmail flag with the same spelling")
+deepEqual(imap.flagPlanForLabels(["Unread"], ["INBOX"], {}),
+  { add: [], remove: [], move: "Unread" },
+  "a named folder does not become Gmail's unread state")
+deepEqual(imap.flagPlanForLabels(["Trash"], ["INBOX"], { "\\trash": "Deleted Items" }),
+  { add: [], remove: [], move: "Trash" },
+  "a regular folder does not become the server's special Trash folder")
+deepEqual(imap.flagPlanForLabels(["Spam"], ["INBOX"], { "\\junk": "Junk Mail" }),
+  { add: [], remove: [], move: "Spam" },
+  "a regular folder does not become the server's special Spam folder")
 // Marking read on the way is still a flag, not a move.
 deepEqual(imap.flagPlanForLabels(["Receipts"], ["INBOX", "UNREAD"], {}),
   { add: ["\\Seen"], remove: [], move: "Receipts" })

--- a/tests/test_keymap.js
+++ b/tests/test_keymap.js
@@ -329,6 +329,22 @@ for (const count of [1, 2, 3, 4]) {
     count + ": no column runs away with the sheet (" + heaviest + ")")
 }
 
+// `v` is Gmail's own move key, which is what issue #58 asks these to match.
+// `m` mutes there, so a move on `m` would be the one binding somebody arriving
+// from Gmail has to unlearn -- pinned here because "it was free" is exactly the
+// reasoning that would put it back.
+const move = keymap.BINDINGS.filter(b => b.id === "moveToLabel")
+assert.strictEqual(move.length, 1, "one move row")
+deepEqual(move[0].keys, ["v"], "Gmail moves with v")
+assert.ok(keymap.BINDINGS.every(b => b.keys.indexOf("m") < 0 || b.contexts.indexOf("calendar") >= 0),
+  "m stays out of the mailbox, where Gmail means mute by it")
+
+// Bound where a message is, and nowhere else: the calendar has no message to
+// move, and a row added to the wrong context list would bind it there silently.
+deepEqual(keymap.bindingsFor("list").filter(b => b.id === "moveToLabel").length, 1)
+deepEqual(keymap.bindingsFor("reader").filter(b => b.id === "moveToLabel").length, 1)
+deepEqual(keymap.bindingsFor("calendar").filter(b => b.id === "moveToLabel").length, 0)
+
 // A count that is not a count still has to draw something.
 deepEqual(keymap.helpColumns(0), [keymap.helpGroups()])
 deepEqual(keymap.helpColumns(-3), [keymap.helpGroups()])

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -61,9 +61,46 @@ assert.strictEqual(model.survivesAction("inbox", "trash"), false)
 assert.strictEqual(model.survivesAction("trash", "trash"), true)
 assert.strictEqual(model.survivesAction("trash", "untrash"), false)
 
+// A move is archive with a destination, so it leaves the same lists archive
+// leaves. Reading a user label goes through `rawQuery` and keeps this key on
+// "inbox", which is why moving between two labels takes the row away.
+assert.strictEqual(model.survivesAction("inbox", "label:Label_7"), false)
+assert.strictEqual(model.survivesAction("unread", "label:Label_7"), false)
+assert.strictEqual(model.survivesAction("all", "label:Label_7"), true, "All mail still contains a moved message")
+
 deepEqual(model.labelChangesFor("archive"), { add: [], remove: ["INBOX"] })
 deepEqual(model.labelChangesFor("star"), { add: ["STARRED"], remove: [] })
 assert.strictEqual(model.labelChangesFor("trash"), null, "trash is its own endpoint, not a label change")
+
+// The destination rides inside the verb, so the pipeline that carries one
+// string carries the move too.
+deepEqual(model.labelChangesFor("label:Label_7"), { add: ["Label_7"], remove: ["INBOX"] })
+assert.strictEqual(model.labelTarget("label:Label_7"), "Label_7")
+assert.strictEqual(model.labelTarget("archive"), "", "a verb that is not a move names no label")
+assert.strictEqual(model.labelChangesFor("label:"), null, "a move with no destination is not a change")
+
+// Not the `labels` capability, which is about the strip the reader draws: a
+// mailbox with one folder per message is the case where moving is the plain
+// thing to do. What the guard in `act` asks is whether the destination is the
+// user's to name, which on HEY it is not.
+assert.strictEqual(model.actionCapability("label:Label_7"), "move")
+assert.strictEqual(model.actionUnavailable("label:Label_7", "HEY"), "HEY has no destination you can name")
+
+// ------------------------------------------------------- movable labels
+//
+// The rail draws the system labels, so offering them here would put a second
+// archive in a list whose job is the destinations with no key of their own.
+const labelSet = [
+  { id: "L2", name: "zebra" },
+  { id: "S1", name: "Inbox", system: true },
+  { id: "L1", name: "Archive notes" },
+  { id: "L3", name: "banana" }
+]
+deepEqual(model.movableLabels(labelSet, "").map(l => l.id), ["L1", "L3", "L2"])
+deepEqual(model.movableLabels(labelSet, "an").map(l => l.id), ["L3"], "filtering is case-insensitive and matches anywhere")
+deepEqual(model.movableLabels(labelSet, "  ZEB  ").map(l => l.id), ["L2"], "a typed query is trimmed")
+deepEqual(model.movableLabels(labelSet, "inbox").map(l => l.id), [], "a system label is not a destination")
+deepEqual(model.movableLabels(null, ""), [])
 
 // The optimistic update has to move the derived flags too, or a row shows a
 // filled star with `starred: false` underneath it until the next refresh.

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -67,6 +67,8 @@ assert.strictEqual(model.survivesAction("trash", "untrash"), false)
 assert.strictEqual(model.survivesAction("inbox", "label:Label_7"), false)
 assert.strictEqual(model.survivesAction("unread", "label:Label_7"), false)
 assert.strictEqual(model.survivesAction("all", "label:Label_7"), true, "All mail still contains a moved message")
+assert.strictEqual(model.survivesAction("starred", "label:Label_7", "folder:Receipts"), false,
+  "a selected folder leaves even when the previous mailbox key was Starred")
 
 deepEqual(model.labelChangesFor("archive"), { add: [], remove: ["INBOX"] })
 deepEqual(model.labelChangesFor("star"), { add: ["STARRED"], remove: [] })
@@ -75,6 +77,9 @@ assert.strictEqual(model.labelChangesFor("trash"), null, "trash is its own endpo
 // The destination rides inside the verb, so the pipeline that carries one
 // string carries the move too.
 deepEqual(model.labelChangesFor("label:Label_7"), { add: ["Label_7"], remove: ["INBOX"] })
+deepEqual(model.labelChangesFor("label:Label_7", "Label_3"),
+  { add: ["Label_7"], remove: ["INBOX", "Label_3"] },
+  "moving from a Gmail label removes the label that supplied the current view")
 assert.strictEqual(model.labelTarget("label:Label_7"), "Label_7")
 assert.strictEqual(model.labelTarget("archive"), "", "a verb that is not a move names no label")
 assert.strictEqual(model.labelChangesFor("label:"), null, "a move with no destination is not a change")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -105,6 +105,8 @@ deepEqual(model.movableLabels(labelSet, "").map(l => l.id), ["L1", "L3", "L2"])
 deepEqual(model.movableLabels(labelSet, "an").map(l => l.id), ["L3"], "filtering is case-insensitive and matches anywhere")
 deepEqual(model.movableLabels(labelSet, "  ZEB  ").map(l => l.id), ["L2"], "a typed query is trimmed")
 deepEqual(model.movableLabels(labelSet, "inbox").map(l => l.id), [], "a system label is not a destination")
+deepEqual(model.movableLabels(labelSet, "", "L3").map(l => l.id), ["L1", "L2"],
+  "the current Gmail label or IMAP folder is not a move destination")
 deepEqual(model.movableLabels(null, ""), [])
 
 // The optimistic update has to move the derived flags too, or a row shows a

--- a/tests/test_provider.js
+++ b/tests/test_provider.js
@@ -31,6 +31,13 @@ assert.strictEqual(provider.exists("imap"), true)
 
 assert.strictEqual(provider.can("gmail", "labels"), true)
 assert.strictEqual(provider.can("imap", "labels"), false)
+// Separate questions. `labels` is whether a message can carry several at once,
+// which is what the reader's strip draws; `move` is whether the user gets to
+// say where it goes. IMAP answers no and yes -- one folder per message is the
+// very thing that makes a move the plain operation there.
+assert.strictEqual(provider.can("gmail", "move"), true)
+assert.strictEqual(provider.can("imap", "move"), true)
+assert.strictEqual(provider.can("hey", "move"), false, "HEY's destinations are its own")
 assert.strictEqual(provider.can("gmail", "spam"), true)
 assert.strictEqual(provider.can("imap", "spam"), false, "IMAP has no junk verb worth offering")
 assert.strictEqual(provider.can("gmail", "threads"), true)


### PR DESCRIPTION
Towards #58.

`v` on a message opens a card of every destination the mailbox has, narrowed as you type; Return puts the message there. Gmail adds the chosen label and removes INBOX, while IMAP moves the message to the chosen folder. The label or folder already on screen is omitted because it is not a meaningful move destination.

## Move context

The destination id rides inside the action as `label:<id>`, so the existing capability guard, optimistic edit, cache repair, restore, and provider call still share one action value. A selected Gmail label now keeps its id beside the provider query so moving to another label removes both INBOX and the source label. A raw label or folder view also participates in row-survival decisions, keeping the reader and keyboard cursor on the same message after a move removes the current row.

The picker receives that same raw identity through App, Service, and MailAccount. It excludes the current Gmail label so the UI cannot remove a row optimistically while leaving its source label attached, and excludes the current IMAP folder so no same-folder `UID MOVE` can be requested.

## Provider boundaries

The guard asks the provider's `move` capability rather than its `labels` capability: IMAP can move a message despite having one folder rather than several labels, while HEY has no named destination. The same guard now refuses HEY before opening the picker and before any optimistic update.

IMAP recognizes a named move from its add-destination/remove-INBOX shape before interpreting Gmail system ids. A real folder named `Starred`, `Unread`, `Trash`, or `Spam` therefore remains that literal folder instead of becoming a flag or special-use operation.

`v` rather than `m` follows Gmail's move key and keeps `m` available for the mute behavior requested by #58; a keymap test pins `m` out of the mailbox contexts.

## Verification

- `node tests/test_model.js`
- `node tests/test_imap.js`
- `bash tests/test_service_source.sh`
- `qmltestrunner -input tests/qml/tst_move_wiring.qml` — 5 passed
- `make test-qml` — 178 passed
- `make test`
- `make validate`
- `git diff --check`

## Release Notes

- Move a message to a Gmail label or IMAP folder with `v`.
- Keep the reader and keyboard cursor aligned when a move removes the current row.
- Preserve literal IMAP folder names, remove the source Gmail label, and leave the current label or folder out of move destinations.
- Explain immediately when the active provider, including HEY, has no named move destination.
