### PR TITLE
Send a message with its own Message-ID and Date

### DIFF
--- a/message/Message.js
+++ b/message/Message.js
@@ -934,6 +934,25 @@ function mimeBoundary(given) {
   return "=_Omamail_" + (new Date()).getTime().toString(36) + "_" + random
 }
 
+// The domain half of a Message-ID is the sender's own, so the id agrees with the address the message is from.
+function messageIdDomain(from) {
+  var address = headerSafe(from).trim()
+  var at = address.lastIndexOf("@")
+  var domain = at < 0 ? "" : address.substring(at + 1).replace(/[^A-Za-z0-9.-]/g, "")
+  // RFC 2606 reserves .invalid, so a message with no From borrows no domain that belongs to somebody else.
+  return domain === "" ? "omamail.invalid" : domain.substring(0, 128)
+}
+
+// Unique by the rule mimeBoundary already uses, and the caller may state one, which is what lets a test read it.
+function messageIdValue(given, from, nowMs) {
+  var stated = referenceValue(given).replace(/[^A-Za-z0-9<>@._+=-]/g, "")
+  // A stated id is this client's own choice rather than a stranger's, so one that is not an id is replaced.
+  if (stated.length <= 250 && /^<[^<>@\s]+@[A-Za-z0-9.-]+>$/.test(stated)) return stated
+  var now = Math.floor(Number(nowMs) || Date.now())
+  var random = Math.floor(Math.random() * 0x100000000).toString(36)
+  return "<" + now.toString(36) + "." + random + ".omamail@" + messageIdDomain(from) + ">"
+}
+
 // One method name, and nothing that could end the header early: this string
 // arrives from a calendar file somebody else wrote.
 function calendarMethod(value) {
@@ -1027,6 +1046,8 @@ function buildRawMessage(fields) {
     lines.push("In-Reply-To: " + inReplyTo)
     lines.push("References: " + (referenceValue(values.references) || inReplyTo))
   }
+  // RFC 5322 asks every message for an id, and a relay told not to add missing headers relays none.
+  lines.push("Message-ID: " + messageIdValue(values.messageId, values.from))
   lines.push("MIME-Version: 1.0")
 
   var calendar = values.calendar && String(values.calendar.text || "") !== ""

--- a/message/Message.js
+++ b/message/Message.js
@@ -940,14 +940,16 @@ function messageIdDomain(from) {
   var at = address.lastIndexOf("@")
   var domain = at < 0 ? "" : address.substring(at + 1).replace(/[^A-Za-z0-9.-]/g, "")
   // RFC 2606 reserves .invalid, so a message with no From borrows no domain that belongs to somebody else.
-  return domain === "" ? "omamail.invalid" : domain.substring(0, 128)
+  return domain === "" ? "omamail.invalid" : domain
 }
 
 // Unique by the rule mimeBoundary already uses, and the caller may state one, which is what lets a test read it.
 function messageIdValue(given, from, nowMs) {
-  var stated = referenceValue(given).replace(/[^A-Za-z0-9<>@._+=-]/g, "")
+  var stated = String(given === undefined || given === null ? "" : given)
   // A stated id is this client's own choice rather than a stranger's, so one that is not an id is replaced.
-  if (stated.length <= 250 && /^<[^<>@\s]+@[A-Za-z0-9.-]+>$/.test(stated)) return stated
+  if (stated.length <= 250
+      && /^<[A-Za-z0-9_+=-]+(?:\.[A-Za-z0-9_+=-]+)*@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*>$/.test(stated))
+    return stated
   var now = Math.floor(Number(nowMs) || Date.now())
   var random = Math.floor(Math.random() * 0x100000000).toString(36)
   return "<" + now.toString(36) + "." + random + ".omamail@" + messageIdDomain(from) + ">"
@@ -956,8 +958,11 @@ function messageIdValue(given, from, nowMs) {
 // The date a message states, in RFC 5322's own shape: a numeric zone rather than toUTCString's obsolete GMT.
 function sentDate(given, nowMs) {
   var stated = headerSafe(given).trim()
-  // A stated date has to parse back as one, or it is not a date.
-  if (stated !== "" && !isNaN((new Date(stated)).getTime())) return stated
+  // JavaScript also parses ISO dates and shorthand spellings that are not
+  // legal header values, so a stated date needs this client's canonical shape
+  // as well as an instant the engine recognises.
+  var canonical = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] [+-]([01][0-9]|2[0-3])[0-5][0-9]$/
+  if (canonical.test(stated) && !isNaN((new Date(stated)).getTime())) return stated
   var date = new Date(nowMs === undefined || nowMs === null ? Date.now() : Number(nowMs))
   if (isNaN(date.getTime())) date = new Date()
   var offset = -date.getTimezoneOffset()

--- a/message/Message.js
+++ b/message/Message.js
@@ -948,7 +948,7 @@ function messageIdValue(given, from, nowMs) {
   var stated = String(given === undefined || given === null ? "" : given)
   // A stated id is this client's own choice rather than a stranger's, so one that is not an id is replaced.
   if (stated.length <= 250
-      && /^<[A-Za-z0-9_+=-]+(?:\.[A-Za-z0-9_+=-]+)*@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*>$/.test(stated))
+      && /^<[A-Za-z0-9!#$%&'*+\/=?^_\x60{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+\/=?^_\x60{|}~-]+)*@[A-Za-z0-9!#$%&'*+\/=?^_\x60{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+\/=?^_\x60{|}~-]+)*>$/.test(stated))
     return stated
   var now = Math.floor(Number(nowMs) || Date.now())
   var random = Math.floor(Math.random() * 0x100000000).toString(36)
@@ -961,8 +961,17 @@ function sentDate(given, nowMs) {
   // JavaScript also parses ISO dates and shorthand spellings that are not
   // legal header values, so a stated date needs this client's canonical shape
   // as well as an instant the engine recognises.
-  var canonical = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] [+-]([01][0-9]|2[0-3])[0-5][0-9]$/
-  if (canonical.test(stated) && !isNaN((new Date(stated)).getTime())) return stated
+  var canonical = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([0-9]{4}) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] [+-]([01][0-9]|2[0-3])[0-5][0-9]$/
+  var parts = stated.match(canonical)
+  if (parts) {
+    var day = Number(parts[2])
+    var month = MONTHS.indexOf(parts[3])
+    var year = Number(parts[4])
+    var calendar = new Date(Date.UTC(year, month, day))
+    if (calendar.getUTCFullYear() === year && calendar.getUTCMonth() === month
+        && calendar.getUTCDate() === day && WEEKDAYS[calendar.getUTCDay()] === parts[1])
+      return stated
+  }
   var date = new Date(nowMs === undefined || nowMs === null ? Date.now() : Number(nowMs))
   if (isNaN(date.getTime())) date = new Date()
   var offset = -date.getTimezoneOffset()

--- a/message/Message.js
+++ b/message/Message.js
@@ -968,7 +968,7 @@ function sentDate(given, nowMs) {
     var month = MONTHS.indexOf(parts[3])
     var year = Number(parts[4])
     var calendar = new Date(Date.UTC(year, month, day))
-    if (calendar.getUTCFullYear() === year && calendar.getUTCMonth() === month
+    if (year >= 1900 && calendar.getUTCFullYear() === year && calendar.getUTCMonth() === month
         && calendar.getUTCDate() === day && WEEKDAYS[calendar.getUTCDay()] === parts[1])
       return stated
   }

--- a/message/Message.js
+++ b/message/Message.js
@@ -960,8 +960,8 @@ function sentDate(given, nowMs) {
   var stated = headerSafe(given).trim()
   // JavaScript also parses ISO dates and shorthand spellings that are not
   // legal header values, so a stated date needs this client's canonical shape
-  // as well as an instant the engine recognises.
-  var canonical = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([0-9]{4}) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] [+-]([01][0-9]|2[0-3])[0-5][0-9]$/
+  // and RFC 5322's semantic calendar constraints.
+  var canonical = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat), (0[1-9]|[12][0-9]|3[01]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([0-9]{4}) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] [+-][0-9]{2}[0-5][0-9]$/
   var parts = stated.match(canonical)
   if (parts) {
     var day = Number(parts[2])

--- a/message/Message.js
+++ b/message/Message.js
@@ -953,6 +953,21 @@ function messageIdValue(given, from, nowMs) {
   return "<" + now.toString(36) + "." + random + ".omamail@" + messageIdDomain(from) + ">"
 }
 
+// The date a message states, in RFC 5322's own shape: a numeric zone rather than toUTCString's obsolete GMT.
+function sentDate(given, nowMs) {
+  var stated = headerSafe(given).trim()
+  // A stated date has to parse back as one, or it is not a date.
+  if (stated !== "" && !isNaN((new Date(stated)).getTime())) return stated
+  var date = new Date(nowMs === undefined || nowMs === null ? Date.now() : Number(nowMs))
+  if (isNaN(date.getTime())) date = new Date()
+  var offset = -date.getTimezoneOffset()
+  var minutes = Math.abs(offset)
+  return WEEKDAYS[date.getDay()] + ", " + pad(date.getDate()) + " " + MONTHS[date.getMonth()]
+    + " " + date.getFullYear() + " " + pad(date.getHours()) + ":" + pad(date.getMinutes())
+    + ":" + pad(date.getSeconds()) + " " + (offset < 0 ? "-" : "+")
+    + pad(Math.floor(minutes / 60)) + pad(minutes % 60)
+}
+
 // One method name, and nothing that could end the header early: this string
 // arrives from a calendar file somebody else wrote.
 function calendarMethod(value) {
@@ -1046,6 +1061,8 @@ function buildRawMessage(fields) {
     lines.push("In-Reply-To: " + inReplyTo)
     lines.push("References: " + (referenceValue(values.references) || inReplyTo))
   }
+  // RFC 5322 requires a Date on a message this client originates, and the writer's clock is the one it means.
+  lines.push("Date: " + sentDate(values.date))
   // RFC 5322 asks every message for an id, and a relay told not to add missing headers relays none.
   lines.push("Message-ID: " + messageIdValue(values.messageId, values.from))
   lines.push("MIME-Version: 1.0")

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -615,10 +615,34 @@ assert.strictEqual(message.extractHtml({
   assert.strictEqual(message.messageIdDomain("nobody"), "omamail.invalid")
   assert.strictEqual(message.messageIdDomain(""), "omamail.invalid")
 
+  // Every label in this domain is legal, and the separator between its first
+  // two 63-character labels lands at the old arbitrary length ceiling. Cutting
+  // there would leave the id's domain ending in a dot.
+  const longDomain = "a".repeat(63) + "." + "b".repeat(63) + "."
+    + "c".repeat(63) + ".com"
+  const longDomainId = idOf(message.buildRawMessage({
+    from: "work@" + longDomain, to: "a@b.com", body: "x"
+  }))
+  assert.ok(longDomainId.endsWith("@" + longDomain + ">"),
+    "a valid sender domain survives whole in the generated id")
+
   // Stated by the caller, which is what lets a test read the message it built.
   assert.ok(message.buildRawMessage({
     from: "work@example.net", to: "a@b.com", body: "x", messageId: "<pinned@example.net>"
   }).indexOf("Message-ID: <pinned@example.net>\r\n") > 0)
+
+  // Validation judges the caller's original value. Removing a space first
+  // would silently turn this into a different, apparently valid id, while an
+  // empty dot-atom segment is not a legal id at all.
+  const repaired = idOf(message.buildRawMessage({
+    from: "work@example.net", to: "a@b.com", body: "x", messageId: "<a @example.com>"
+  }))
+  assert.notStrictEqual(repaired, "<a@example.com>",
+    "a malformed stated id is replaced rather than repaired")
+  assert.ok(/^<[^<>@\s]+@example\.net>$/.test(repaired), "the replacement is a generated id")
+  assert.notStrictEqual(idOf(message.buildRawMessage({
+    from: "work@example.net", to: "a@b.com", body: "x", messageId: "<a..b@example.com>"
+  })), "<a..b@example.com>", "an empty dot-atom segment is replaced")
 
   // A stated id is this client's own choice rather than a stranger's, so one
   // that is not an id is replaced instead of carried through mangled.
@@ -667,6 +691,15 @@ assert.strictEqual(message.extractHtml({
   }).indexOf("Date: Thu, 03 Sep 2026 12:04:31 +0200\r\n") > 0)
   assert.strictEqual(new Date(message.sentDate("Thu, 03 Sep 2026 10:04:31 +0000")).getTime(), clock,
     "a caller who wants no offset says so through the same field")
+
+  // JavaScript parses ISO dates and several shorthand spellings that are not
+  // RFC 5322 date-time values. A parseable but non-header-shaped override is
+  // replaced with this client's canonical form.
+  const nonRfc = message.sentDate("2026-09-03", clock)
+  assert.notStrictEqual(nonRfc, "2026-09-03", "an ISO-only override is not emitted verbatim")
+  assert.ok(/^[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} [+-]\d{4}$/.test(nonRfc),
+    nonRfc)
+  assert.strictEqual(new Date(nonRfc).getTime(), clock, "the replacement uses the stated build clock")
 
   // A stated value that is not a date is replaced, and a line break in one can
   // become neither a second header nor a mangled first one.

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -724,6 +724,20 @@ assert.strictEqual(message.extractHtml({
     "a weekday that disagrees with its date is replaced")
   assert.strictEqual(new Date(replacedWeekday).getTime(), clock)
 
+  // RFC 5322 permits years from 1900 onward. Its numeric zone has a
+  // two-digit hour and minute, so 23:59 is its last meaningful boundary.
+  const obsoleteYear = "Mon, 04 Sep 1899 10:04:31 +0000"
+  const replacedObsoleteYear = message.sentDate(obsoleteYear, clock)
+  assert.notStrictEqual(replacedObsoleteYear, obsoleteYear,
+    "a year below RFC 5322's lower bound is replaced")
+  assert.strictEqual(new Date(replacedObsoleteYear).getTime(), clock)
+  assert.strictEqual(message.sentDate("Tue, 04 Sep 1900 10:04:31 +0000", clock),
+    "Tue, 04 Sep 1900 10:04:31 +0000", "the first RFC 5322 year is preserved")
+  assert.strictEqual(message.sentDate("Thu, 03 Sep 2026 10:04:31 +2359", clock),
+    "Thu, 03 Sep 2026 10:04:31 +2359", "the greatest numeric zone is preserved")
+  assert.notStrictEqual(message.sentDate("Thu, 03 Sep 2026 10:04:31 +2360", clock),
+    "Thu, 03 Sep 2026 10:04:31 +2360", "a numeric zone minute cannot reach 60")
+
   // A stated value that is not a date is replaced, and a line break in one can
   // become neither a second header nor a mangled first one.
   const forged = message.buildRawMessage({

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -632,6 +632,57 @@ assert.strictEqual(message.extractHtml({
   assert.strictEqual(headerNames(forged).filter((name) => name === "Message-ID").length, 1)
 }
 
+// ------------------------------------------------------------------- Date
+//
+// RFC 5322 requires a Date on a message this client originates. Without one a
+// reader falls back to the time the message was delivered or stored, which is
+// not the time it was written — this client delays a send behind an undo
+// window, so those are not the same moment.
+{
+  const headerNames = (text) => text.split("\r\n\r\n")[0].split("\r\n")
+    .map((line) => line.split(":")[0])
+  const clock = Date.UTC(2026, 8, 3, 10, 4, 31)
+
+  const sent = message.buildRawMessage({
+    from: "work@example.net", to: "jane@example.com", subject: "s", body: "hi"
+  })
+  assert.strictEqual(headerNames(sent).filter((name) => name === "Date").length, 1,
+    "one Date, and only one")
+  assert.ok(sent.indexOf("From: work@example.net\r\n") === 0, "From still opens the message")
+
+  // The shape RFC 5322 §3.3 states, with a numeric zone rather than the
+  // obsolete GMT that toUTCString would give.
+  const stamped = message.sentDate("", clock)
+  assert.ok(/^[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} [+-]\d{4}$/.test(stamped),
+    stamped)
+  assert.strictEqual(new Date(stamped).getTime(), clock,
+    "a local-offset Date names the instant it was made from")
+  assert.strictEqual(
+    message.messageDate({ payload: { headers: [{ name: "Date", value: stamped }] } }).getTime(), clock,
+    "this file's own reader gets the instant back out of it")
+
+  // Stated by the caller, the way the id and the boundary already are.
+  assert.ok(message.buildRawMessage({
+    to: "a@b.com", body: "x", date: "Thu, 03 Sep 2026 12:04:31 +0200"
+  }).indexOf("Date: Thu, 03 Sep 2026 12:04:31 +0200\r\n") > 0)
+  assert.strictEqual(new Date(message.sentDate("Thu, 03 Sep 2026 10:04:31 +0000")).getTime(), clock,
+    "a caller who wants no offset says so through the same field")
+
+  // A stated value that is not a date is replaced, and a line break in one can
+  // become neither a second header nor a mangled first one.
+  const forged = message.buildRawMessage({
+    to: "a@b.com", body: "x", date: "not a date\r\nBcc: attacker@example.net"
+  })
+  assert.ok(headerNames(forged).indexOf("Bcc") < 0)
+  assert.ok(forged.indexOf("attacker@example.net") < 0, "nothing of the forged value survives")
+  assert.strictEqual(headerNames(forged).filter((name) => name === "Date").length, 1)
+
+  // The header survives a round trip through this file's own parser.
+  assert.strictEqual(message.parseRfc822(message.buildRawMessage({
+    to: "a@b.com", body: "x", date: stamped
+  })).headers.filter((header) => header.name === "Date").length, 1)
+}
+
 // ------------------------------------------------------ RFC 822 → payload
 //
 // The adapter that lets an IMAP message drive the same reader a Gmail message

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -724,8 +724,8 @@ assert.strictEqual(message.extractHtml({
     "a weekday that disagrees with its date is replaced")
   assert.strictEqual(new Date(replacedWeekday).getTime(), clock)
 
-  // RFC 5322 permits years from 1900 onward. Its numeric zone has a
-  // two-digit hour and minute, so 23:59 is its last meaningful boundary.
+  // RFC 5322 permits years from 1900 onward. A numeric zone has two digits
+  // each for hours and minutes, but only the minute pair is bounded to 00–59.
   const obsoleteYear = "Mon, 04 Sep 1899 10:04:31 +0000"
   const replacedObsoleteYear = message.sentDate(obsoleteYear, clock)
   assert.notStrictEqual(replacedObsoleteYear, obsoleteYear,
@@ -733,10 +733,13 @@ assert.strictEqual(message.extractHtml({
   assert.strictEqual(new Date(replacedObsoleteYear).getTime(), clock)
   assert.strictEqual(message.sentDate("Tue, 04 Sep 1900 10:04:31 +0000", clock),
     "Tue, 04 Sep 1900 10:04:31 +0000", "the first RFC 5322 year is preserved")
-  assert.strictEqual(message.sentDate("Thu, 03 Sep 2026 10:04:31 +2359", clock),
-    "Thu, 03 Sep 2026 10:04:31 +2359", "the greatest numeric zone is preserved")
-  assert.notStrictEqual(message.sentDate("Thu, 03 Sep 2026 10:04:31 +2360", clock),
-    "Thu, 03 Sep 2026 10:04:31 +2360", "a numeric zone minute cannot reach 60")
+  for (const zone of ["+2400", "+9959", "-9959"]) {
+    const zoned = "Thu, 03 Sep 2026 10:04:31 " + zone
+    assert.strictEqual(message.sentDate(zoned, clock), zoned,
+      "a numeric zone may use any two-digit hour: " + zone)
+  }
+  assert.notStrictEqual(message.sentDate("Thu, 03 Sep 2026 10:04:31 +9960", clock),
+    "Thu, 03 Sep 2026 10:04:31 +9960", "a numeric zone minute cannot reach 60")
 
   // A stated value that is not a date is replaced, and a line break in one can
   // become neither a second header nor a mangled first one.

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -579,6 +579,59 @@ assert.strictEqual(message.extractHtml({
     .indexOf("In-Reply-To") < 0)
 }
 
+// ------------------------------------------------------------- Message-ID
+//
+// RFC 5322 asks every message for an id, and a relay told not to add missing
+// headers relays none: Postfix logs `message-id=<>` for a message sent without
+// one, and a reply to it has nothing to thread on.
+{
+  const headerNames = (text) => text.split("\r\n\r\n")[0].split("\r\n")
+    .map((line) => line.split(":")[0])
+  const idOf = (text) => text.split("\r\n\r\n")[0].split("\r\n")
+    .filter((line) => line.indexOf("Message-ID: ") === 0)[0]
+    .substring("Message-ID: ".length)
+
+  const sent = message.buildRawMessage({
+    from: "work@example.net", to: "jane@example.com", subject: "s", body: "hi"
+  })
+
+  assert.strictEqual(headerNames(sent).filter((name) => name === "Message-ID").length, 1,
+    "one Message-ID, and only one")
+  assert.ok(/^<[^<>@\s]+@example\.net>$/.test(idOf(sent)), idOf(sent))
+  assert.ok(sent.indexOf("From: work@example.net\r\n") === 0, "From still opens the message")
+  assert.ok(message.buildRawMessage({ to: "a@b.com", body: "x" }).indexOf("To: a@b.com\r\n") === 0,
+    "a message with no From still opens with To")
+
+  const again = message.buildRawMessage({
+    from: "work@example.net", to: "jane@example.com", subject: "s", body: "hi"
+  })
+  assert.notStrictEqual(idOf(sent), idOf(again), "every message gets its own id")
+
+  // No From leaves no domain to take, and .invalid is reserved by RFC 2606 so
+  // the id cannot land in a namespace somebody else's uniqueness depends on.
+  assert.ok(/^<[^<>@\s]+@omamail\.invalid>$/.test(
+    idOf(message.buildRawMessage({ to: "a@b.com", body: "x" }))))
+  assert.strictEqual(message.messageIdDomain('"Jane" <jane@Example.COM>'), "Example.COM")
+  assert.strictEqual(message.messageIdDomain("nobody"), "omamail.invalid")
+  assert.strictEqual(message.messageIdDomain(""), "omamail.invalid")
+
+  // Stated by the caller, which is what lets a test read the message it built.
+  assert.ok(message.buildRawMessage({
+    from: "work@example.net", to: "a@b.com", body: "x", messageId: "<pinned@example.net>"
+  }).indexOf("Message-ID: <pinned@example.net>\r\n") > 0)
+
+  // A stated id is this client's own choice rather than a stranger's, so one
+  // that is not an id is replaced instead of carried through mangled.
+  const forged = message.buildRawMessage({
+    from: "work@example.net", to: "a@b.com", body: "x",
+    messageId: "<a@b>\r\nBcc: attacker@example.net"
+  })
+  assert.ok(headerNames(forged).indexOf("Bcc") < 0)
+  assert.ok(forged.indexOf("attacker@example.net") < 0, "nothing of the forged value survives")
+  assert.ok(/^<[^<>@\s]+@example\.net>$/.test(idOf(forged)), "a real id is minted instead")
+  assert.strictEqual(headerNames(forged).filter((name) => name === "Message-ID").length, 1)
+}
+
 // ------------------------------------------------------ RFC 822 → payload
 //
 // The adapter that lets an IMAP message drive the same reader a Gmail message

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -631,6 +631,14 @@ assert.strictEqual(message.extractHtml({
     from: "work@example.net", to: "a@b.com", body: "x", messageId: "<pinned@example.net>"
   }).indexOf("Message-ID: <pinned@example.net>\r\n") > 0)
 
+  // Dot-atom permits every RFC 5322 `atext` punctuation character on either
+  // side of the separator. A legal caller-stated id is preserved byte for byte.
+  const fullAtext = "<AZaz09!#$%&'*+-/=?^_`{|}~.next@AZaz09!#$%&'*+-/=?^_`{|}~.next>"
+  assert.ok(message.buildRawMessage({
+    from: "work@example.net", to: "a@b.com", body: "x", messageId: fullAtext
+  }).indexOf("Message-ID: " + fullAtext + "\r\n") > 0,
+    "every legal atext character survives in a stated id")
+
   // Validation judges the caller's original value. Removing a space first
   // would silently turn this into a different, apparently valid id, while an
   // empty dot-atom segment is not a legal id at all.
@@ -700,6 +708,21 @@ assert.strictEqual(message.extractHtml({
   assert.ok(/^[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} [+-]\d{4}$/.test(nonRfc),
     nonRfc)
   assert.strictEqual(new Date(nonRfc).getTime(), clock, "the replacement uses the stated build clock")
+
+  // JavaScript normalizes an impossible calendar date and ignores a weekday
+  // that disagrees with the date. Neither can be emitted as the caller stated
+  // it: RFC 5322 requires the written date to exist and the weekday to agree.
+  const impossible = "Tue, 31 Feb 2026 10:04:31 +0000"
+  const replacedImpossible = message.sentDate(impossible, clock)
+  assert.notStrictEqual(replacedImpossible, impossible,
+    "an impossible day in a real month is replaced rather than normalized")
+  assert.strictEqual(new Date(replacedImpossible).getTime(), clock)
+
+  const mismatchedWeekday = "Fri, 03 Sep 2026 10:04:31 +0000"
+  const replacedWeekday = message.sentDate(mismatchedWeekday, clock)
+  assert.notStrictEqual(replacedWeekday, mismatchedWeekday,
+    "a weekday that disagrees with its date is replaced")
+  assert.strictEqual(new Date(replacedWeekday).getTime(), clock)
 
   // A stated value that is not a date is replaced, and a line break in one can
   // become neither a second header nor a mangled first one.


### PR DESCRIPTION
Closes #84.

## Release Notes

- Messages sent from Omamail now carry a `Message-ID` and a `Date` header, so replies thread in the recipient's client, duplicates can be detected, and the time shown is when the message was written.

## What changes

`buildRawMessage` wrote neither field. A receiving server that does not manufacture missing headers — Postfix with `always_add_missing_headers = no` — relayed the message as it arrived and logged `message-id=<>`, and a reply to it had nothing to thread on. Both headers are now emitted on every shape the function produces: a flat `text/plain` body, a `multipart/mixed` message with attachments, and the `multipart/alternative` calendar reply. All four senders get them — `send`, `saveDraft`, `rsvp` and `unsubscribe` — because all four build their message here.

## Why here, and what stays true

Both values are generated inside `buildRawMessage` because that is the one place that knows the message is a single message. The same `raw` is submitted over SMTP, appended to Drafts and posted to Gmail's send endpoint; generating an identifier in any of those would let the three disagree. Gmail rewrites the `Message-ID` on its own path, so the practical effect is on IMAP and SMTP mailboxes, which is where the headers were missing.

`From` remains the first line of the message, which `tests/test_message.js` asserts by offset in five places, so both headers are emitted after `Subject` and the reference headers.

`values.messageId` and `values.date` state the values when the caller has them, exactly as `values.boundary` already states the MIME boundary, which is what lets a test read the message it built. A stated id is validated without changing it against the complete RFC 5322 atext alphabet and is replaced when it is not a legal dot-atom id — unlike `In-Reply-To`, whose value belongs to a stranger and must go back out verbatim to thread, an id this client authors is its own choice. A stated date must have the same canonical RFC 5322 shape this client emits, name a real calendar date in 1900 or later, carry the weekday that date implies, and keep the numeric zone's final minute pair in range. Both rules also mean a line break in a stated value can become neither a second header nor a mangled first one.

The id takes its complete domain from the `From` address, reduced to the characters a domain may hold without cutting a valid long domain at an arbitrary boundary. A message built without a `From` — the Gmail path, which supplies its own — takes `omamail.invalid`, reserved by RFC 2606, rather than a domain somebody else's uniqueness depends on.

The `Date` is formatted from the `WEEKDAYS`, `MONTHS` and `pad` this module already carries for rendering a received date, with a numeric zone rather than `toUTCString`'s obsolete `GMT`. It is stamped when the message is built rather than when it is submitted: a send here waits out an undo window first, so those are different moments, and the header is meant to say when the writer finished.

Drafts saved repeatedly mint a new id each time. That is deliberate for this change: the id that reaches a recipient is the one `send` mints, IMAP draft replacement keys on the folder and UID rather than on any header, and threading a stable id through the composer and the recovery snapshot would touch five more files for no effect on delivered mail.

## Verification

`make test` and `make validate` pass; the QML suite reports 127 passed and 0 failed, and `qmllint` exits zero with the usual unresolved `qs.Ui` / `qs.Commons` imports. `git diff --check` also passes.

Assertions in `tests/test_message.js` cover, for both headers: exactly one occurrence, the RFC 5322 shape, a caller-supplied override, a forged override with a line break in it, `From` still opening the message, and the emitted `Date` parsing back through this module's own reader. The id is additionally checked for preserving every RFC 5322 atext character, uniqueness across two builds, for taking the complete domain from `From`, for preserving a valid long domain, for replacing malformed supplied IDs without repairing them, and for the `.invalid` fallback when there is no `From`. The date tests also reject a JavaScript-parseable ISO value that is not an RFC 5322 header value, an impossible calendar date JavaScript would normalize, a weekday/date mismatch, a year before 1900, and numeric-zone minute overflow while preserving the valid 1900, `+2400`, `+9959`, and `-9959` boundaries.

Verified end to end against an IMAP/SMTP mailbox on a self-hosted Postfix + Dovecot server: the same send that previously produced `message-id=<>` in the server log now produces a populated id, and the delivered message carries both headers, with the `Date` reading eleven seconds earlier than the submission — the undo-send delay, which is the difference between when the message was written and when it went out.
