### PR TITLE
Decode base64 once: Qt.atob already returns text

### DIFF
--- a/message/Message.js
+++ b/message/Message.js
@@ -97,21 +97,20 @@ function bytesToLatin1(bytes) {
   return out
 }
 
-// Qt.atob is native C++ and skips the per-character base64 loop entirely; it
-// hands back a string of raw bytes, which still needs UTF-8 decoding. The pure
-// JS path stays for the node tests, and as the fallback anywhere Qt is absent.
-function binaryStringToUtf8(binary) {
-  var bytes = []
-  for (var i = 0; i < binary.length; i++) bytes.push(binary.charCodeAt(i) & 0xff)
-  return bytesToUtf8(bytes)
-}
-
+// Qt.atob is native C++ and skips the per-character base64 loop entirely. It
+// does not hand back raw bytes: Qt's implementation is QString::fromUtf8 over
+// the decoded bytes, so the result is already text. Measured on Qt 6.11 —
+// "Alex à l'école" comes back 14 characters with U+00E0 in it, not 16 bytes
+// with C3 A0. Decoding that text a second time as UTF-8 bytes is what turned
+// every accented calendar title and 8-bit mail body into CJK mojibake. The
+// pure JS path stays for the node tests, and as the fallback anywhere Qt is
+// absent.
 function decodeBase64Url(text) {
   var input = String(text || "")
   if (input === "") return ""
   if (typeof Qt !== "undefined" && typeof Qt.atob === "function") {
     try {
-      return binaryStringToUtf8(Qt.atob(input.replace(/-/g, "+").replace(/_/g, "/")))
+      return Qt.atob(input.replace(/-/g, "+").replace(/_/g, "/"))
     } catch (e) {
       // Fall through to the portable path rather than losing the message.
     }

--- a/tests/qml/tst_message_base64.qml
+++ b/tests/qml/tst_message_base64.qml
@@ -1,0 +1,13 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../../message/Message.js" as Message
+
+Item {
+  TestCase {
+    name: "MessageBase64"
+
+    function test_qt_atob_result_is_not_decoded_a_second_time() {
+      compare(Message.decodeBase64Url("QWxleCDDoCBsJ8OpY29sZQ=="), "Alex à l'école")
+    }
+  }
+}


### PR DESCRIPTION
## Results

Accented text reads correctly everywhere `decodeBase64Url` is used: calendar titles and locations from CalDAV, IMAP FETCH bodies sent as 8-bit, HEY message bodies. Before this, "Hypothèque" rendered as "Hypoth豅que" and "Alex à l'école" as "Alex ?飯le".

## Why

`decodeBase64Url` passed `Qt.atob`'s result through `binaryStringToUtf8`, on the assumption that `Qt.atob` hands back a string of raw bytes. It does not: Qt's implementation is `QString::fromUtf8` over the decoded bytes, so the result is already text. Decoding that a second time as UTF-8 takes each Latin-1 code point as a lead byte and swallows the characters after it — an `è` followed by `qu` becomes one CJK character.

The fix returns `Qt.atob`'s text as it is. The pure JS path (`base64ToBytes` + `bytesToUtf8`) is unchanged: it decodes bytes itself, for the node tests and any runtime without Qt. Only ASCII input was ever unaffected, which is why headers (RFC 2047) and base64/quoted-printable MIME parts looked fine and 8-bit parts did not.

## Verification

Measured, not inferred: in a scratch Quickshell on Qt 6.11.2, `Qt.atob("QWxleCDDoCBsJ8OpY29sZSBIeXBvdGjDqHF1ZQ==")` returns 25 characters with code points `e0`, `e9`, `e8` — `Alex à l'école Hypothèque` — not 28 bytes with `c3 a0`.

`make test` passes: node tests, source regressions, 182 QML tests. Live: three Nextcloud CalDAV calendars with French titles render correctly in the week view and the bar preview after the change; mojibake before.

## Release Notes

- Accented characters in calendar events and 8-bit mail bodies no longer render as mojibake.