### PR TITLE
Read a body as UTF-8 when the bytes say so and the header does not

### DIFF
--- a/message/Message.js
+++ b/message/Message.js
@@ -182,11 +182,67 @@ function decodeQuotedPrintableWord(text) {
   return bytes
 }
 
+// Whether these bytes are UTF-8 that a single-byte charset could not have
+// produced: at least one well-formed multi-byte sequence, and nothing
+// malformed anywhere.
+//
+// A charset header is a claim, and this is the evidence. Mail that declares
+// `us-ascii` or `iso-8859-1` while carrying UTF-8 is common enough that every
+// other client sniffs for it, and the two readings are never both plausible:
+// read as one byte each, the UTF-8 for "ń" is "Å" followed by a control
+// character, which is not something anybody wrote. Genuine Latin-1 and
+// Latin-2 text does not survive this test — a lone "ł" in ISO 8859-2 is 0xB3,
+// a continuation byte with no lead, which is malformed UTF-8 and hands the
+// decision back to the declaration.
+//
+// Strict on purpose. An overlong form, a surrogate or a truncated tail all
+// count as malformed, because each is likelier to be single-byte text that
+// happens to begin a sequence than UTF-8 worth trusting over the header.
+function looksLikeUtf8(bytes) {
+  var values = bytes || []
+  var multi = 0
+  var i = 0
+  while (i < values.length) {
+    var byte1 = values[i++]
+    if (byte1 < 0x80) continue
+    var needed = 0
+    var codePoint = 0
+    if (byte1 >= 0xc2 && byte1 <= 0xdf) {
+      needed = 1
+      codePoint = byte1 & 0x1f
+    } else if (byte1 >= 0xe0 && byte1 <= 0xef) {
+      needed = 2
+      codePoint = byte1 & 0x0f
+    } else if (byte1 >= 0xf0 && byte1 <= 0xf4) {
+      needed = 3
+      codePoint = byte1 & 0x07
+    } else {
+      // 0x80-0xc1 is a continuation with no lead, or an overlong two-byte
+      // form; 0xf5 and above is past the last code point.
+      return false
+    }
+    if (i + needed > values.length) return false
+    for (var n = 0; n < needed; n++) {
+      var next = values[i + n]
+      if (next < 0x80 || next > 0xbf) return false
+      codePoint = (codePoint << 6) | (next & 0x3f)
+    }
+    i += needed
+    if (needed === 1 && codePoint < 0x80) return false
+    if (needed === 2 && codePoint < 0x800) return false
+    if (needed === 3 && (codePoint < 0x10000 || codePoint > 0x10ffff)) return false
+    if (codePoint >= 0xd800 && codePoint <= 0xdfff) return false
+    multi += 1
+  }
+  return multi > 0
+}
+
 function decodeWordBytes(charset, bytes) {
   var name = String(charset || "").toLowerCase()
   if (name.indexOf("utf-8") === 0 || name.indexOf("utf8") === 0) return bytesToUtf8(bytes)
   if (name.indexOf("iso-8859") === 0 || name.indexOf("windows-125") === 0
-    || name.indexOf("us-ascii") === 0 || name === "") return bytesToLatin1(bytes)
+    || name.indexOf("us-ascii") === 0 || name === "")
+    return looksLikeUtf8(bytes) ? bytesToUtf8(bytes) : bytesToLatin1(bytes)
   // GB18030, Shift_JIS and friends need a table this plugin does not carry.
   // UTF-8 decoding degrades to Latin-1 per byte, which at least keeps the
   // ASCII parts of the header readable.

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -75,6 +75,56 @@ assert.ok(message.decodeHeaderValue("=?GB2312?B?1eLK1w==?=").length > 0)
 assert.strictEqual(message.decodeHeaderValue(""), "")
 assert.strictEqual(message.decodeHeaderValue(null), "")
 
+// ------------------------------------------- a charset that is not the truth
+
+// A charset header is a claim, and a sender that declares one and sends
+// another is common. Read as one byte each, the UTF-8 for "ń" is "Å" followed
+// by a control character — so the two readings are never both plausible and
+// the bytes decide.
+const polish = "Dzień dobry, zmieniła się wartość wskaźników"
+const polishData = b64url(polish)
+
+;["us-ascii", "iso-8859-1", "iso-8859-2", "windows-1250", "UTF-8"].forEach(function(charset) {
+  assert.strictEqual(message.decodePart({
+    mimeType: "text/plain",
+    headers: [{ name: "Content-Type", value: "text/plain; charset=" + charset }],
+    body: { data: polishData }
+  }), polish, charset + " must not turn UTF-8 into mojibake")
+})
+
+// Genuine single-byte text is left to its declaration. "ç" is 0xE7 in
+// Latin-1, which is a lead byte with no continuation after it — malformed
+// UTF-8, so the header keeps the decision.
+assert.strictEqual(message.decodePart({
+  mimeType: "text/plain",
+  headers: [{ name: "Content-Type", value: "text/plain; charset=iso-8859-1" }],
+  body: { data: Buffer.from([0x46, 0x72, 0x61, 0x6e, 0xe7, 0x61, 0x69, 0x73])
+    .toString("base64") }
+}), "Français")
+
+// The evidence, on its own. Only a well-formed multi-byte sequence counts:
+// everything else is likelier to be single-byte text that happens to begin
+// one than UTF-8 worth trusting over the header.
+assert.strictEqual(message.looksLikeUtf8([0x68, 0x69]), false,
+  "ASCII is both readings, so it is no evidence for either")
+assert.strictEqual(message.looksLikeUtf8([0xc5, 0x84]), true)
+assert.strictEqual(message.looksLikeUtf8([0x41, 0xb3, 0x42]), false,
+  "a continuation byte with no lead is how ISO 8859-2 writes ł")
+assert.strictEqual(message.looksLikeUtf8([0x41, 0xc5]), false, "a truncated tail")
+assert.strictEqual(message.looksLikeUtf8([0xc0, 0xaf]), false, "an overlong form")
+assert.strictEqual(message.looksLikeUtf8([0xed, 0xa0, 0x80]), false, "a surrogate")
+assert.strictEqual(message.looksLikeUtf8([0xf5, 0x80, 0x80, 0x80]), false,
+  "beyond the last code point")
+assert.strictEqual(message.looksLikeUtf8([]), false)
+assert.strictEqual(message.looksLikeUtf8(null), false)
+
+// A subject is decoded through the same door, so a mislabelled encoded word
+// comes out right too.
+assert.strictEqual(
+  message.decodeHeaderValue("=?iso-8859-1?B?"
+    + Buffer.from("wartość", "utf8").toString("base64") + "?="),
+  "wartość")
+
 // ------------------------------------------------------------- addresses
 
 deepEqual(message.parseAddress("Jane Doe <jane@example.com>"),


### PR DESCRIPTION
A charset header is a claim, and a sender that declares one charset while sending another is common. mBank's statements arrive as UTF-8 under a single-byte declaration, so `Dzień dobry` was decoded a byte at a time and reached the reader as `DzieÅ dobry` — and was cached that way, which is how one mailbox holds one message right and the next one wrong.

The two readings are never both plausible. Read as one byte each, the UTF-8 for `ń` is `Å` followed by a control character, which is not something anybody wrote. So the bytes decide: a declaration of `us-ascii`, `iso-8859-*` or `windows-125*` is believed only when the bytes could not be UTF-8.

Genuine single-byte text is untouched, and that is what the strictness is for. A lone `ł` in ISO 8859-2 is `0xB3` — a continuation byte with no lead, malformed UTF-8 — so the declaration keeps the decision. An overlong form, a surrogate and a truncated tail are all refused for the same reason: each is likelier to be single-byte text that happens to begin a sequence than UTF-8 worth believing over the header.

Subjects come through `decodeWordBytes` too, so a mislabelled encoded word is fixed with the bodies.

## What this does not do

It adds no ISO 8859-2 or windows-1250 tables. Mail that really is in one of those still shows the wrong accents, which is a separate gap and a larger one.

## Verification

`make validate` green. New cases in `tests/test_message.js`: the same Polish body declared `us-ascii`, `iso-8859-1`, `iso-8859-2`, `windows-1250` and `UTF-8` all decode identically; `Français` in real Latin-1 still decodes as `Français`; and `looksLikeUtf8` is asserted against ASCII, a lone continuation byte, a truncated tail, an overlong form, a surrogate and a codepoint past the last. Removing the sniff fails the first of those, so the tests measure the fault.

Diagnosed from two cached bodies in one mailbox: `Dzie C5 84` in the one that worked and `Dzie C3 85 C2 84` in the one that did not, which is `C5 84` read as two Latin-1 characters and re-encoded.

## Release Notes

- Mail that declares one character set and sends another now reads correctly. A message carrying UTF-8 under an `us-ascii` or Latin-1 header — which is how some banks and mailing lists send Polish, Czech and Turkish mail — no longer arrives as `DzieÅ dobry`.
- Subject lines are fixed the same way.
