### PR TITLE
Put a failed send back in the composer instead of dropping it

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -630,12 +630,19 @@ Item {
     })
   }
 
-  function undoPendingSend() {
-    if (!service || !service.undoSend()) return false
-    if (!compose.resumePendingSend()) return true
+  // Put the parked draft back in front of the writer.
+  //
+  // Undo and a failed send want the same thing and used to be one of them:
+  // the message is in `pendingDraft` and nowhere else, so whatever reopens it
+  // has to also deal with the draft that was started on top of it during the
+  // undo window. `resumePendingSend` moves that newer one to
+  // `interruptedDraft`, and saving it is what keeps reopening the parked one
+  // from overwriting it.
+  function restoreParkedDraft() {
+    if (!compose.resumePendingSend()) return false
     var interrupted = compose.interruptedDraft
     var fields = compose.interruptedFields()
-    if (!interrupted || !fields) return true
+    if (!interrupted || !fields || !service) return true
     service.saveDraft(fields, function(saved, error) {
       if (!root) return
       if (error) {
@@ -646,6 +653,12 @@ Item {
       root.draftSavedNotice = "Draft saved"
       draftSavedTimer.restart()
     })
+    return true
+  }
+
+  function undoPendingSend() {
+    if (!service || !service.undoSend()) return false
+    root.restoreParkedDraft()
     return true
   }
 
@@ -806,6 +819,15 @@ Item {
       if (!compose.completePendingSend()) return
       if (compose.opened) root.scheduleComposeRecovery()
       else root.clearComposeRecovery()
+    }
+    // The send did not happen, so the draft is still the only copy. Reopening
+    // it is the whole answer: the status bar already carries the reason, and a
+    // composer that stays shut leaves the writer with a sentence about a
+    // message they can no longer see. Recovery is scheduled rather than
+    // cleared for the same reason — the words are still unsent.
+    function onReplyFailed() {
+      if (!root.restoreParkedDraft()) return
+      root.scheduleComposeRecovery()
     }
     // Every time the list is replaced — first arrival, a mailbox switch, a
     // search, a refresh that dropped things. A cursor whose message survived

--- a/Service.qml
+++ b/Service.qml
@@ -774,7 +774,17 @@ Item {
   readonly property bool unsubscribing: !!current && current.unsubscribing
   readonly property bool detailLoading: !!current && current.detailLoading
   readonly property bool detailPainted: !!current && current.detailPainted
-  readonly property bool sending: !!current && current.sending
+  // ComposeView owns one parked draft for the whole service, so an in-flight
+  // send is global even though the request belongs to one account host. This
+  // also keeps the visible Send button honest after switching accounts.
+  readonly property var sendingHost: {
+    for (var i = 0; i < accountHosts.count; i++) {
+      var host = accountHosts.objectAt(i)
+      if (host && host.sending) return host
+    }
+    return null
+  }
+  readonly property bool sending: !!sendingHost
   readonly property var pendingSendHost: {
     for (var i = 0; i < accountHosts.count; i++) {
       var host = accountHosts.objectAt(i)
@@ -810,7 +820,20 @@ Item {
   }
   function toggleStar(id) { if (current) current.toggleStar(id) }
   function markAllRead() { if (current) current.markAllRead() }
-  function send(fields) { return current ? current.send(fields) : false }
+  function send(fields) {
+    // The button has the same guard, but Ctrl+Return reaches this function
+    // directly. Enforce the one-global-parked-draft invariant at the action
+    // boundary so another account cannot overwrite it.
+    if (pendingSendHost) {
+      if (current) current.fail("Another message is waiting to be sent")
+      return false
+    }
+    if (sendingHost) {
+      if (current) current.fail("Another message is still being sent")
+      return false
+    }
+    return current ? current.send(fields) : false
+  }
   function saveDraft(fields, callback) {
     var values = fields || ({})
     var target = String(values.accountId || "")
@@ -945,6 +968,16 @@ Item {
   }
 
   signal replySent()
+  signal replyFailed()
+
+  // A queued send keeps running on its own account when the visible mailbox
+  // changes. Put that account back in front before App restores the draft, so
+  // a retry cannot be addressed to whichever mailbox happened to be visible.
+  function forwardReplyFailure(index) {
+    var host = accountAt(index)
+    if (host && host !== current) switchToIndex(index)
+    replyFailed()
+  }
 
   // ------------------------------------------------------------- instances
 
@@ -1012,6 +1045,7 @@ Item {
       onReadyChanged: root.recount()
       onInboxUnreadChanged: root.recount()
       onReplySent: root.replySent()
+      onReplyFailed: root.forwardReplyFailure(index)
 
       Component.onCompleted: Qt.callLater(root.refreshCurrent)
       Component.onDestruction: Qt.callLater(root.refreshCurrent)

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1666,17 +1666,29 @@ Item {
   // One entry point for every kind of outgoing message. Reply, reply-all and
   // forward differ only in what the compose window puts in the fields, which
   // is where that decision belongs.
+  // Every way out of here that is not a delivery emits `replyFailed`, because
+  // by this point `deliverPending` has dropped the queued payload and the
+  // composer is parked: the message exists only in the draft the panel is
+  // holding, and a return that says nothing throws it away. The mailbox can
+  // stop being ready during the undo window — a reload, a sign-out — so the
+  // guards are reachable and not only the transport's own error.
   function deliver(payload) {
     if (!ready) {
       fail("The mailbox is not ready to send")
+      replyFailed()
       return false
     }
-    if (sending) return false
+    if (sending) {
+      fail("Another message is still being sent")
+      replyFailed()
+      return false
+    }
     sending = true
     api.sendMessage(payload, function(sentPayload, error) {
       root.sending = false
       if (error) {
         root.fail(error)
+        root.replyFailed()
         return
       }
       root.note("Sent")
@@ -1790,6 +1802,10 @@ Item {
   }
 
   signal replySent()
+
+  // A send that did not happen. The panel answers it by putting the parked
+  // draft back in front of the writer, which is the only remaining copy.
+  signal replyFailed()
 
   // ------------------------------------------------------------------ RSVP
 

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1672,27 +1672,43 @@ Item {
   // holding, and a return that says nothing throws it away. The mailbox can
   // stop being ready during the undo window — a reload, a sign-out — so the
   // guards are reachable and not only the transport's own error.
+  function reportSendFailure(error) {
+    fail(error)
+    // A zero-delay send can be rejected synchronously by a provider before
+    // ComposeView has returned from service.send() and parked its accepted
+    // draft. Cross the event-loop boundary so every terminal signal observes
+    // the same state as an ordinary network reply.
+    Qt.callLater(function() {
+      if (root) root.replyFailed()
+    })
+  }
+
+  function reportSendSuccess() {
+    note("Sent")
+    // Success has the same ordering requirement as failure: a provider may
+    // finish locally, but the composer owns parking after send() returns.
+    Qt.callLater(function() {
+      if (root) root.replySent()
+    })
+  }
+
   function deliver(payload) {
     if (!ready) {
-      fail("The mailbox is not ready to send")
-      replyFailed()
+      reportSendFailure("The mailbox is not ready to send")
       return false
     }
     if (sending) {
-      fail("Another message is still being sent")
-      replyFailed()
+      reportSendFailure("Another message is still being sent")
       return false
     }
     sending = true
     api.sendMessage(payload, function(sentPayload, error) {
       root.sending = false
       if (error) {
-        root.fail(error)
-        root.replyFailed()
+        root.reportSendFailure(error)
         return
       }
-      root.note("Sent")
-      root.replySent()
+      root.reportSendSuccess()
     })
     return true
   }

--- a/tests/qml/tst_app_compose_pending.qml
+++ b/tests/qml/tst_app_compose_pending.qml
@@ -136,6 +136,7 @@ Item {
     function fail(text) { lastError = String(text || "") }
     function note(text) { actionStatus = String(text || "") }
     signal replySent()
+    signal replyFailed()
   }
 
   Omamail.App {
@@ -408,6 +409,57 @@ Item {
       compare(mailService.lastSavedDraft.draftId, "draft-7",
         "closing an edited draft must update the source draft")
       compare(mailService.lastSavedDraft.subject, "Updated subject")
+    }
+
+    // A send that failed leaves the message in the parked draft and nowhere
+    // else — not in Drafts, not in Sent, not in an outbox. The composer coming
+    // back holding it is the only thing between a timeout and a lost message.
+    function test_a_failed_send_puts_the_message_back_in_the_composer() {
+      var compose = composeView()
+      verify(compose)
+      app.startCompose("new")
+      named(compose, "compose-to-field").text = "first@example.com"
+      named(compose, "compose-subject-field").text = "Quarterly plan"
+      named(compose, "compose-body-editor").text = "Keep every word"
+      compose.submit()
+      compare(compose.opened, false, "sending parks the composer")
+
+      mailService.replyFailed()
+
+      compare(compose.opened, true, "a failed send must reopen the composer")
+      compare(named(compose, "compose-to-field").text, "first@example.com")
+      compare(named(compose, "compose-subject-field").text, "Quarterly plan")
+      compare(named(compose, "compose-body-editor").text, "Keep every word")
+
+      wait(350)
+      compare(app.composeRecovery.active, true,
+        "the words are still unsent, so recovery goes on holding them")
+      compare(app.composeRecovery.draft.body, "Keep every word")
+    }
+
+    // The collision undo already has: a draft started during the undo window
+    // is in the composer when the parked one comes back, and saving it is what
+    // keeps the parked one from overwriting it.
+    function test_a_failed_send_saves_a_draft_started_over_it() {
+      var compose = composeView()
+      app.startCompose("new")
+      named(compose, "compose-to-field").text = "first@example.com"
+      named(compose, "compose-body-editor").text = "First message"
+      compose.submit()
+
+      app.startCompose("new")
+      named(compose, "compose-to-field").text = "second@example.com"
+      named(compose, "compose-subject-field").text = "Second subject"
+      named(compose, "compose-body-editor").text = "Second message"
+
+      mailService.replyFailed()
+
+      compare(named(compose, "compose-to-field").text, "first@example.com")
+      compare(named(compose, "compose-body-editor").text, "First message")
+      verify(mailService.lastSavedDraft)
+      compare(mailService.lastSavedDraft.to, "second@example.com")
+      compare(mailService.lastSavedDraft.subject, "Second subject")
+      compare(mailService.lastSavedDraft.body, "Second message")
     }
   }
 }

--- a/tests/qml/tst_send_failures.qml
+++ b/tests/qml/tst_send_failures.qml
@@ -1,0 +1,186 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../.." as Omamail
+import "../../account/Accounts.js" as Accounts
+
+// Delivery failures cross two ownership boundaries: a MailAccount reports the
+// result to Service, and Service tells the one composer shared by every
+// account. These tests keep those real boundaries in place. A mock handed
+// straight to App would miss both the relay and the global send guard.
+Item {
+  width: 900
+  height: 600
+
+  QtObject {
+    id: shellStore
+    function updateEntryInline(_id, _entry) {}
+    function hide(_id) {}
+  }
+
+  Omamail.Service {
+    id: mailService
+    shell: shellStore
+    manifest: ({ id: "omamail", __sourceDir: "/tmp/omamail-test" })
+  }
+
+  Omamail.App { id: app; service: mailService }
+
+  TestCase {
+    name: "SendFailures"
+    when: windowShown
+
+    readonly property string ada: "ada@example.com"
+    readonly property string bob: "bob@example.com"
+    readonly property string adaId: "imap:ada@example.com"
+    readonly property string bobId: "imap:bob@example.com"
+
+    function entry(email, smtp) {
+      return {
+        email: email, provider: "imap", clientId: "", clientSecret: "",
+        imap: {
+          imapHost: "imap.example.com", imapPort: 993,
+          smtpHost: smtp === false ? "" : "smtp.example.com", smtpPort: 465,
+          username: email, aliases: [], insecure: false
+        },
+        label: "", signature: ""
+      }
+    }
+
+    function seed(entries, activeId) {
+      var list = Accounts.emptyList()
+      for (var i = 0; i < entries.length; i++) list = Accounts.add(list, entries[i])
+      list = Accounts.setActive(list, activeId)
+      mailService.activeIndex = -1
+      mailService.accountList = list
+      mailService.accountsLoaded = true
+      wait(0)
+      mailService.refreshCurrent()
+      for (var h = 0; h < entries.length; h++) readyAccount(mailService.accountAt(h))
+    }
+
+    function readyAccount(account) {
+      verify(account !== null)
+      verify(account.auth !== null)
+      account.auth.toolsChecked = true
+      account.auth.missingTools = []
+      account.auth.passwordChecked = true
+      account.auth.password = "test-password"
+      tryCompare(account, "ready", true)
+    }
+
+    function named(item, objectName) {
+      if (!item) return null
+      if (item.objectName === objectName) return item
+      var values = item.children || []
+      for (var i = 0; i < values.length; i++) {
+        var found = named(values[i], objectName)
+        if (found) return found
+      }
+      return null
+    }
+
+    function composeView() {
+      var item = named(app, "compose-to-field")
+      while (item && typeof item.resumePendingSend !== "function") item = item.parent
+      return item
+    }
+
+    function resetApp() {
+      app.opened = false
+      app.loadComposeRecovery("")
+      app.clearComposeRecovery()
+      app.resetNavigation()
+      var compose = composeView()
+      verify(compose !== null)
+      compose.reset()
+      compose.opened = false
+    }
+
+    function stopSends() {
+      for (var i = 0; i < mailService.accountCount; i++) {
+        var account = mailService.accountAt(i)
+        if (account && account.sendPending) account.undoSend()
+      }
+    }
+
+    function init() {
+      stopSends()
+      mailService.applySettings({ undoSendSeconds: 10 })
+      resetApp()
+    }
+
+    function cleanup() {
+      stopSends()
+      var compose = composeView()
+      if (compose) compose.reset()
+      app.clearComposeRecovery()
+    }
+
+    function test_failure_returns_to_the_account_that_owns_the_parked_draft() {
+      seed([entry(ada), entry(bob)], adaId)
+      var compose = composeView()
+      app.startCompose("new")
+      named(compose, "compose-to-field").text = "person@example.com"
+      named(compose, "compose-body-editor").text = "Keep Ada's words"
+      compose.submit()
+      compare(compose.parkedForSend, true)
+
+      verify(mailService.switchToIndex(1))
+      compare(mailService.activeAccountId, bobId)
+      var failed = mailService.accountAt(0)
+      failed.pendingSend = null
+      failed.replyFailed()
+
+      compare(mailService.activeAccountId, adaId,
+        "the failing account must be active before its draft is restored")
+      compare(compose.opened, true)
+      compare(named(compose, "compose-body-editor").text, "Keep Ada's words")
+    }
+
+    function test_zero_delay_synchronous_rejection_restores_the_composer() {
+      mailService.applySettings({ undoSendSeconds: 0 })
+      seed([entry(ada, false)], adaId)
+      var compose = composeView()
+      app.startCompose("new")
+      named(compose, "compose-to-field").text = "person@example.com"
+      named(compose, "compose-subject-field").text = "No SMTP"
+      named(compose, "compose-body-editor").text = "Keep every word"
+
+      compose.submit()
+
+      compare(compose.opened, false,
+        "an accepted immediate send parks before its deferred result")
+      tryCompare(compose, "opened", true)
+      compare(named(compose, "compose-subject-field").text, "No SMTP")
+      compare(named(compose, "compose-body-editor").text, "Keep every word")
+      tryCompare(app.composeRecovery, "active", true)
+      compare(app.composeRecovery.draft.body, "Keep every word")
+    }
+
+    function test_keyboard_send_cannot_replace_another_accounts_parked_draft() {
+      seed([entry(ada), entry(bob)], adaId)
+      var compose = composeView()
+      app.startCompose("new")
+      named(compose, "compose-to-field").text = "first@example.com"
+      named(compose, "compose-body-editor").text = "Ada's pending message"
+      compose.submit()
+      compare(mailService.accountAt(0).sendPending, true)
+      compare(compose.pendingDraft.body, "Ada's pending message")
+
+      verify(app.switchAccount(1))
+      app.startCompose("new")
+      named(compose, "compose-to-field").text = "second@example.com"
+      named(compose, "compose-body-editor").text = "Bob's newer draft"
+
+      app.runShortcut("send", "Ctrl+Return")
+
+      compare(compose.opened, true,
+        "the keyboard route must obey the service-wide send guard")
+      compare(mailService.accountAt(1).sendPending, false)
+      compare(mailService.lastError, "Another message is waiting to be sent")
+      compare(compose.pendingDraft.body, "Ada's pending message",
+        "a second account cannot overwrite the one global parked draft")
+      compare(named(compose, "compose-body-editor").text, "Bob's newer draft")
+    }
+  }
+}


### PR DESCRIPTION
Fixes #79.

A send that did not happen left the message nowhere. `deliverPending` drops the queued payload before `deliver` runs and the composer is already parked, so the words existed only in `pendingDraft` — and every way out of `deliver` that was not a delivery returned without touching it. On an SMTP timeout the status bar named the failure and the message was gone from the composer, Drafts, Sent, the Outbox and `compose.json` alike.

`replyFailed` is the counterpart `replySent` never had, and the panel answers it by reopening the parked draft.

## All three exits, not just the transport's

The issue describes the callback error. `deliver` has two guards in front of it that were also reachable and also silent: the mailbox can stop being ready during the undo window — a reload, a sign-out — and a concurrent send returned a bare `false`. Both now emit `replyFailed`, and the concurrent case says so rather than failing quietly.

## Undo already wanted this

`restoreParkedDraft` is what both call. It keeps the half that is easy to miss: a draft started on top of the parked one during the undo window is moved to `interruptedDraft` by `resumePendingSend`, and saving it is what stops the restored message from overwriting it.

Recovery is scheduled rather than cleared on failure. The words are still unsent, so the file that survives a crash should go on holding them.

## Verification

`make validate` green. Two cases in `tests/qml/tst_app_compose_pending.qml`: a failed send reopens the composer with to, subject and body intact and leaves recovery holding them; and a failed send with a newer draft in the composer saves that newer one rather than overwriting it. Both fail with the handler removed, so they measure the fault.

## Release Notes

- A send that fails no longer loses the message. The composer comes back with the words still in it, instead of the mail vanishing from compose, Drafts, Sent and the Outbox at once.
- A mailbox that stopped being ready during the undo window, and a second send starting while one is in flight, both put the draft back too rather than dropping it silently.
