### PR TITLE
Scroll as far as the wheel was turned

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -1368,8 +1368,6 @@ Item {
           Flickable {
             id: listFlick
 
-            // The Flickable's own wheel handling is a flick per event, which a
-            // high-resolution wheel turns into a seventh of the distance.
             WheelScroller { view: listFlick }
             anchors.fill: parent
             contentWidth: width
@@ -1603,8 +1601,6 @@ Item {
         Flickable {
           id: setupFlick
 
-          // The Flickable's own wheel handling is a flick per event, which a
-          // high-resolution wheel turns into a seventh of the distance.
           WheelScroller { view: setupFlick }
           anchors.fill: parent
           anchors.margins: Style.space(18)
@@ -1708,8 +1704,6 @@ Item {
         Flickable {
           id: settingsFlick
 
-          // The Flickable's own wheel handling is a flick per event, which a
-          // high-resolution wheel turns into a seventh of the distance.
           WheelScroller { view: settingsFlick }
           // The whole width, rail included: the wheel scrolls the page from
           // anywhere in the block, and the scrollbar keeps the window's edge.

--- a/App.qml
+++ b/App.qml
@@ -1367,6 +1367,10 @@ Item {
           // viewport, which would push the bar inward with it.
           Flickable {
             id: listFlick
+
+            // The Flickable's own wheel handling is a flick per event, which a
+            // high-resolution wheel turns into a seventh of the distance.
+            WheelScroller { view: listFlick }
             anchors.fill: parent
             contentWidth: width
             contentHeight: list.implicitHeight + Style.space(16)
@@ -1598,6 +1602,10 @@ Item {
         // the mailbox is connected.
         Flickable {
           id: setupFlick
+
+          // The Flickable's own wheel handling is a flick per event, which a
+          // high-resolution wheel turns into a seventh of the distance.
+          WheelScroller { view: setupFlick }
           anchors.fill: parent
           anchors.margins: Style.space(18)
           anchors.topMargin: parent.pageTop
@@ -1699,6 +1707,10 @@ Item {
 
         Flickable {
           id: settingsFlick
+
+          // The Flickable's own wheel handling is a flick per event, which a
+          // high-resolution wheel turns into a seventh of the distance.
+          WheelScroller { view: settingsFlick }
           // The whole width, rail included: the wheel scrolls the page from
           // anywhere in the block, and the scrollbar keeps the window's edge.
           anchors.left: parent.left

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/MessageMenu.qml \
 	components/MenuActionRow.qml components/MenuSeparatorLine.qml \
 	components/KeyRouter.qml \
+	components/WheelScroller.qml \
 	components/ActionIcon.qml \
 	components/IconButton.qml \
 	components/IconTextButton.qml \

--- a/account/Model.js
+++ b/account/Model.js
@@ -842,6 +842,50 @@ function settingsContentHeight(sections, pageHeight, viewportHeight) {
   return Math.max(page, known[known.length - 1].y + viewport)
 }
 
+// ------------------------------------------------------------------ the wheel
+//
+// How far a wheel turn moves a Flickable, which the Flickable itself gets
+// wrong on a mouse that reports finely.
+//
+// A Flickable answers a wheel event with a *flick* — a velocity it then
+// decelerates — so the distance depends on how the turn was chopped up rather
+// than on how far the wheel went. One notch arrives as `angleDelta` 120 and
+// moves about 43 pixels; a high-resolution wheel reports the same physical
+// notch as eight deltas of 15, each starting and damping its own little
+// flick, and the same turn of the same wheel moves about 6. Seven times less
+// for the same gesture, which is what "slower than every other app" is.
+//
+// Rotation is the thing that does not change: `angleDelta` is eighths of a
+// degree, a notch is 15 degrees, and eight fractions of a notch still add up
+// to 15. So the distance is computed from rotation and nothing else.
+//
+// 8 pixels per degree puts a notch at 120, which is what three lines of text
+// comes to and what a GTK application moves for the same turn.
+var WHEEL_PIXELS_PER_DEGREE = 8
+
+// A notch is 15 degrees, so this is the ceiling on one *event* rather than on
+// one gesture: a touchpad's flung two-finger scroll arrives as a stream of
+// large deltas, and without a bound a single one of them can cross a long list
+// in a jump nobody asked for.
+var WHEEL_MAX_DEGREES_PER_EVENT = 60
+
+function wheelDistance(angleDelta) {
+  var degrees = (Number(angleDelta) || 0) / 8
+  var limit = WHEEL_MAX_DEGREES_PER_EVENT
+  if (degrees > limit) degrees = limit
+  if (degrees < -limit) degrees = -limit
+  return degrees * WHEEL_PIXELS_PER_DEGREE
+}
+
+// Where the view lands, clamped to what it can reach. A list shorter than its
+// own viewport cannot scroll at all, and answering with a negative limit would
+// let it drift above its first row.
+function wheelScrollTarget(contentY, angleDelta, contentHeight, viewportHeight) {
+  var limit = Math.max(0, (Number(contentHeight) || 0) - (Number(viewportHeight) || 0))
+  var next = (Number(contentY) || 0) - wheelDistance(angleDelta)
+  return Math.max(0, Math.min(limit, next))
+}
+
 // Where a click on a section name scrolls to: its heading, clamped into the
 // range the page can actually reach, so the last section lands at the end of
 // the page rather than asking for a gap under it. -1 for a name the page does

--- a/account/Model.js
+++ b/account/Model.js
@@ -591,22 +591,22 @@ function cursorAfterReload(list, cursorId) {
 // Unchanged while the row is already visible. Recentring on every press would
 // drag the list under someone who is only stepping one row down it.
 function contentYToReveal(contentY, viewportHeight, itemY, itemHeight,
-                          contentHeight, margin) {
+                          contentHeight, margin, originY, topMargin, bottomMargin) {
   var top = Number(contentY) || 0
   var view = Number(viewportHeight) || 0
   var y = Number(itemY) || 0
   var height = Number(itemHeight) || 0
   var pad = Number(margin) || 0
-  var furthest = Math.max(0, (Number(contentHeight) || 0) - view)
   var next = top
   // A row that cannot fit shows its beginning. Aligning its bottom, which is
   // what the off-the-bottom rule would do, pushes the part being read away.
   if (height + pad + pad > view) next = y - pad
   else if (y - pad < top) next = y - pad
   else if (y + height + pad > top + view) next = y + height + pad - view
-  if (next < 0) next = 0
-  if (next > furthest) next = furthest
-  return next
+  // The same range the wheel is held to. Callers that scroll a plain
+  // Flickable pass no origin or margins and get the range they had.
+  return clampContentY(next, contentYBounds(originY, contentHeight, view,
+    topMargin, bottomMargin))
 }
 
 function unreadCount(list) {
@@ -842,6 +842,41 @@ function settingsContentHeight(sections, pageHeight, viewportHeight) {
   return Math.max(page, known[known.length - 1].y + viewport)
 }
 
+// --------------------------------------------------- what a scroller can reach
+//
+// `contentY` does not run from 0 to `contentHeight - height`, which is what
+// three separate clamps in this repository assumed.
+//
+// `originY` moves the start: a `ListView` with a 200-tall header reports
+// `originY == -200`, and a clamp with a floor of 0 makes the header
+// unreachable and turns the first notch into a 200-pixel jump. Measured, not
+// inferred — that view settles at exactly `originY` and at
+// `originY + contentHeight - height`.
+//
+// Margins extend both ends: a `Flickable` with a `topMargin` rests at
+// `-topMargin` with its content below the gap, and a clamp with a floor of 0
+// answers a scroll *up* at the top by moving *down* to 0, after which the
+// margin can never be seen again. (`StopAtBounds` does not correct a
+// programmatic assignment, so this end comes from Qt's documented semantics
+// rather than from a probe like the `originY` one.)
+function contentYBounds(originY, contentHeight, viewportHeight, topMargin, bottomMargin) {
+  var origin = Number(originY) || 0
+  var content = Number(contentHeight) || 0
+  var view = Number(viewportHeight) || 0
+  var top = Number(topMargin) || 0
+  var bottom = Number(bottomMargin) || 0
+  var min = origin - top
+  // Content shorter than its own view has one position rather than a negative
+  // range, and that position is the top of it.
+  var max = Math.max(min, origin + content + bottom - view)
+  return { min: min, max: max }
+}
+
+function clampContentY(value, bounds) {
+  var limits = bounds || { min: 0, max: 0 }
+  return Math.max(limits.min, Math.min(limits.max, Number(value) || 0))
+}
+
 // ------------------------------------------------------------------ the wheel
 //
 // How far a wheel turn moves a Flickable, which the Flickable itself gets
@@ -850,40 +885,39 @@ function settingsContentHeight(sections, pageHeight, viewportHeight) {
 // A Flickable answers a wheel event with a *flick* — a velocity it then
 // decelerates — so the distance depends on how the turn was chopped up rather
 // than on how far the wheel went. One notch arrives as `angleDelta` 120 and
-// moves about 43 pixels; a high-resolution wheel reports the same physical
+// moves about 72 pixels; a high-resolution wheel reports the same physical
 // notch as eight deltas of 15, each starting and damping its own little
-// flick, and the same turn of the same wheel moves about 6. Seven times less
+// flick, and the same turn of the same wheel moves about 9. Eight times less
 // for the same gesture, which is what "slower than every other app" is.
 //
 // Rotation is the thing that does not change: `angleDelta` is eighths of a
 // degree, a notch is 15 degrees, and eight fractions of a notch still add up
-// to 15. So the distance is computed from rotation and nothing else.
+// to 15. So the distance is computed from rotation and nothing else, in
+// notches rather than in degrees — a notch is the unit a hand turns and 120
+// pixels is three lines of text, which is what a GTK application moves for it.
 //
-// 8 pixels per degree puts a notch at 120, which is what three lines of text
-// comes to and what a GTK application moves for the same turn.
-var WHEEL_PIXELS_PER_DEGREE = 8
+// Nothing is capped. A cap on one *event* would put the chunking dependence
+// straight back at the coarse end: an MX Master in free spin delivers ten
+// notches as one event, and a bound would move it a notch and a half while
+// the same ten notches arriving as ten events moved ten. A bound worth having
+// would be per unit time, and no bound at all is honest — the wheel was
+// turned that far.
+var WHEEL_UNITS_PER_NOTCH = 120
+var WHEEL_PIXELS_PER_NOTCH = 120
 
-// A notch is 15 degrees, so this is the ceiling on one *event* rather than on
-// one gesture: a touchpad's flung two-finger scroll arrives as a stream of
-// large deltas, and without a bound a single one of them can cross a long list
-// in a jump nobody asked for.
-var WHEEL_MAX_DEGREES_PER_EVENT = 60
-
+// Numerically the identity at these two values, and written as a ratio anyway:
+// the constant that matters is "a notch moves 120 pixels", and it is the one a
+// reader changes.
 function wheelDistance(angleDelta) {
-  var degrees = (Number(angleDelta) || 0) / 8
-  var limit = WHEEL_MAX_DEGREES_PER_EVENT
-  if (degrees > limit) degrees = limit
-  if (degrees < -limit) degrees = -limit
-  return degrees * WHEEL_PIXELS_PER_DEGREE
+  return (Number(angleDelta) || 0) / WHEEL_UNITS_PER_NOTCH * WHEEL_PIXELS_PER_NOTCH
 }
 
-// Where the view lands, clamped to what it can reach. A list shorter than its
-// own viewport cannot scroll at all, and answering with a negative limit would
-// let it drift above its first row.
-function wheelScrollTarget(contentY, angleDelta, contentHeight, viewportHeight) {
-  var limit = Math.max(0, (Number(contentHeight) || 0) - (Number(viewportHeight) || 0))
-  var next = (Number(contentY) || 0) - wheelDistance(angleDelta)
-  return Math.max(0, Math.min(limit, next))
+// Where the view lands, inside what it can actually reach.
+function wheelScrollTarget(contentY, angleDelta, contentHeight, viewportHeight,
+                           originY, topMargin, bottomMargin) {
+  var bounds = contentYBounds(originY, contentHeight, viewportHeight,
+    topMargin, bottomMargin)
+  return clampContentY((Number(contentY) || 0) - wheelDistance(angleDelta), bounds)
 }
 
 // Where a click on a section name scrolls to: its heading, clamped into the

--- a/components/CalendarEventComposer.qml
+++ b/components/CalendarEventComposer.qml
@@ -171,8 +171,6 @@ Rectangle {
   Flickable {
     id: composerFlick
 
-    // The Flickable's own wheel handling is a flick per event, which a
-    // high-resolution wheel turns into a seventh of the distance.
     WheelScroller { view: composerFlick }
 
     anchors.fill: parent

--- a/components/CalendarEventComposer.qml
+++ b/components/CalendarEventComposer.qml
@@ -169,6 +169,12 @@ Rectangle {
   }
 
   Flickable {
+    id: composerFlick
+
+    // The Flickable's own wheel handling is a flick per event, which a
+    // high-resolution wheel turns into a seventh of the distance.
+    WheelScroller { view: composerFlick }
+
     anchors.fill: parent
     anchors.margins: Style.space(18)
     contentWidth: width

--- a/components/CalendarEventDetail.qml
+++ b/components/CalendarEventDetail.qml
@@ -85,6 +85,12 @@ Rectangle {
   }
 
   Flickable {
+    id: detailFlick
+
+    // The Flickable's own wheel handling is a flick per event, which a
+    // high-resolution wheel turns into a seventh of the distance.
+    WheelScroller { view: detailFlick }
+
     anchors.fill: parent
     anchors.margins: Style.space(18)
     contentWidth: width

--- a/components/CalendarEventDetail.qml
+++ b/components/CalendarEventDetail.qml
@@ -87,8 +87,6 @@ Rectangle {
   Flickable {
     id: detailFlick
 
-    // The Flickable's own wheel handling is a flick per event, which a
-    // high-resolution wheel turns into a seventh of the distance.
     WheelScroller { view: detailFlick }
 
     anchors.fill: parent

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -1448,6 +1448,8 @@ DropArea {
 
     contentItem: ListView {
       id: fromRows
+
+      WheelScroller { view: fromRows }
       implicitHeight: contentHeight
       clip: true
       model: root.fromIdentities
@@ -1534,6 +1536,8 @@ DropArea {
   // window ground; the rows above already carry the structure.
   Flickable {
     id: bodyFlick
+
+    WheelScroller { view: bodyFlick }
     objectName: "compose-body"
     anchors.top: fields.bottom
     anchors.left: parent.left
@@ -1594,6 +1598,8 @@ DropArea {
 
     Flickable {
       id: attachFlick
+
+      WheelScroller { view: attachFlick }
       anchors.fill: parent
       anchors.leftMargin: Style.space(18)
       anchors.rightMargin: Style.space(18)

--- a/components/ContactsPicker.qml
+++ b/components/ContactsPicker.qml
@@ -138,6 +138,8 @@ Item {
 
       ListView {
         id: contactsList
+
+        WheelScroller { view: contactsList }
         width: parent.width
         implicitHeight: Math.min(contentHeight, Style.space(280))
         clip: true

--- a/components/LabelPicker.qml
+++ b/components/LabelPicker.qml
@@ -156,6 +156,8 @@ Item {
 
       ListView {
         id: labelList
+
+        WheelScroller { view: labelList }
         width: parent.width
         implicitHeight: Math.min(contentHeight, Style.space(280))
         clip: true

--- a/components/MailboxSidebar.qml
+++ b/components/MailboxSidebar.qml
@@ -53,6 +53,8 @@ Item {
 
   Flickable {
     id: flick
+
+    WheelScroller { view: flick }
     anchors.left: parent.left
     anchors.right: edge.left
     anchors.top: parent.top

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -435,6 +435,8 @@ Item {
 
   Flickable {
     id: bodyFlick
+
+    WheelScroller { view: bodyFlick }
     anchors.top: notices.bottom
     anchors.left: parent.left
     anchors.right: parent.right

--- a/components/RecipientSuggestions.qml
+++ b/components/RecipientSuggestions.qml
@@ -49,6 +49,8 @@ Rectangle {
 
   ListView {
     id: suggestions
+
+    WheelScroller { view: suggestions }
     anchors.fill: parent
     anchors.margins: Style.space(2)
     clip: true

--- a/components/ShortcutHelp.qml
+++ b/components/ShortcutHelp.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls
 import qs.Commons
 import qs.Ui
 import "../keys/Keymap.js" as Keymap
+import "../account/Model.js" as Model
 
 // The reference sheet behind ?. A plain list rather than a dialog because it
 // never needs an answer — Esc, ? again, or a click puts it away.
@@ -29,11 +30,15 @@ Rectangle {
   // The keyboard's answer to a sheet that scrolls. `j`/`k` survive the overlay
   // for this and nothing else, so the reference sheet is not the one screen in
   // the window that needs a mouse to read.
+  // The third copy of the same clamp, and now the same one the wheel and
+  // `contentYToReveal` use: a range that knows about margins and `originY`
+  // rather than assuming 0 to `contentHeight - height`.
   function scrollBy(steps) {
     if (!scroller.interactive) return
-    var limit = scroller.contentHeight - scroller.height
-    scroller.contentY = Math.max(0, Math.min(limit,
-      scroller.contentY + steps * Style.space(20)))
+    scroller.contentY = Model.clampContentY(
+      scroller.contentY + steps * Style.space(20),
+      Model.contentYBounds(scroller.originY, scroller.contentHeight,
+        scroller.height, scroller.topMargin, scroller.bottomMargin))
   }
 
   // How wide one column of keys and their labels wants to be, and how many of
@@ -62,6 +67,8 @@ Rectangle {
 
   Flickable {
     id: scroller
+
+    WheelScroller { view: scroller }
     // Filling the sheet rather than hugging the content is the whole of the
     // scrollbar fix: a Flickable sized to its column puts the bar at that
     // column's edge, which on a wide window is the middle of the screen.

--- a/components/WeekCalendarView.qml
+++ b/components/WeekCalendarView.qml
@@ -167,6 +167,8 @@ Item {
 
   Flickable {
     id: timeline
+
+    WheelScroller { view: timeline }
     anchors.left: parent.left
     anchors.right: parent.right
     anchors.top: root.allDayCount > 0 ? allDayLane.bottom : dayHeaders.bottom

--- a/components/WheelScroller.qml
+++ b/components/WheelScroller.qml
@@ -6,9 +6,9 @@ import "../account/Model.js" as Model
 //
 // A Flickable answers each wheel event with a flick it then decelerates, so
 // the distance depends on how the turn was chopped up rather than on how far
-// the wheel went: one notch as a single delta moves about 43 pixels, and the
+// the wheel went: one notch as a single delta moves about 72 pixels, and the
 // same notch reported as eight fractions by a high-resolution wheel moves
-// about 6. `Model.wheelScrollTarget` reads the rotation instead, which is the
+// about 9. `Model.wheelScrollTarget` reads the rotation instead, which is the
 // part that does not change.
 //
 // A handler rather than an Item wrapping one. A Flickable reparents its
@@ -21,15 +21,30 @@ WheelHandler {
 
   required property Flickable view
 
-  // Vertical only. A horizontal wheel and a touchpad's side-scroll both report
-  // `y === 0`, and reading either as a scroll down is how a sideways gesture
-  // ends up moving the list.
+  // A mouse only, said out loud rather than left to the default.
+  //
+  // A touchpad reports `pixelDelta` and its own momentum, and a Flickable
+  // tracks fingers with it properly. Driving one from a derived `angleDelta`
+  // at a fixed distance per notch would replace a gesture that follows the
+  // hand with a series of jumps, so where Qt can tell a touchpad apart this
+  // stays out of the way and the native behaviour survives.
+  acceptedDevices: PointerDevice.Mouse
+
+  // Vertical only, which is also why there is no `angleDelta.y === 0` guard in
+  // here: Qt filters a horizontal-only wheel before the signal fires, so such
+  // a guard is unreachable and a test for it passes with this whole component
+  // removed.
+  orientation: Qt.Vertical
+
   onWheel: function(event) {
-    if (!root.view || event.angleDelta.y === 0) return
+    if (!root.view) return
     root.view.contentY = Model.wheelScrollTarget(root.view.contentY,
-      event.angleDelta.y, root.view.contentHeight, root.view.height)
-    // A flick still in flight would go on decelerating from where it started
-    // and fight every turn after this one.
+      event.angleDelta.y, root.view.contentHeight, root.view.height,
+      root.view.originY, root.view.topMargin, root.view.bottomMargin)
+    // Not dead despite `blocking` defaulting true, which stops the Flickable
+    // starting a flick from *this* event: a flick already in flight from a
+    // drag goes on decelerating from where it was and fights every turn
+    // after this one.
     root.view.cancelFlick()
   }
 }

--- a/components/WheelScroller.qml
+++ b/components/WheelScroller.qml
@@ -1,0 +1,35 @@
+import QtQuick
+import "../account/Model.js" as Model
+
+// Wheel scrolling for a Flickable, because the Flickable's own is wrong on a
+// mouse that reports finely.
+//
+// A Flickable answers each wheel event with a flick it then decelerates, so
+// the distance depends on how the turn was chopped up rather than on how far
+// the wheel went: one notch as a single delta moves about 43 pixels, and the
+// same notch reported as eight fractions by a high-resolution wheel moves
+// about 6. `Model.wheelScrollTarget` reads the rotation instead, which is the
+// part that does not change.
+//
+// A handler rather than an Item wrapping one. A Flickable reparents its
+// visual children into its content, so an Item dropped inside would be a
+// zero-sized thing scrolling along with the list and its handler would never
+// see a wheel event. A handler is not reparented: it attaches to the
+// Flickable, which is exactly what has to be got in front of.
+WheelHandler {
+  id: root
+
+  required property Flickable view
+
+  // Vertical only. A horizontal wheel and a touchpad's side-scroll both report
+  // `y === 0`, and reading either as a scroll down is how a sideways gesture
+  // ends up moving the list.
+  onWheel: function(event) {
+    if (!root.view || event.angleDelta.y === 0) return
+    root.view.contentY = Model.wheelScrollTarget(root.view.contentY,
+      event.angleDelta.y, root.view.contentHeight, root.view.height)
+    // A flick still in flight would go on decelerating from where it started
+    // and fight every turn after this one.
+    root.view.cancelFlick()
+  }
+}

--- a/tests/qml/tst_settings_sidebar.qml
+++ b/tests/qml/tst_settings_sidebar.qml
@@ -256,6 +256,23 @@ Item {
       return -1
     }
 
+    // The wheel, at a real call site rather than against a Flickable a test
+    // built. `WheelScroller` is dropped into a dozen scrollers now and nothing
+    // covered any of them; this is the one with a fixture already.
+    function test_the_settings_page_scrolls_a_notch_at_a_time() {
+      app.openSettings()
+      wait(50)
+      var view = flick()
+      verify(view, "the page scrolls inside a Flickable")
+      view.contentY = 0
+
+      mouseWheel(view, view.width / 2, view.height / 2, 0, -120)
+      compare(view.contentY, 120, "one notch, in the real hierarchy")
+
+      mouseWheel(view, view.width / 2, view.height / 2, 0, 120)
+      compare(view.contentY, 0)
+    }
+
     function test_the_rail_lists_the_pages_sections_in_order() {
       var rail = named(app, "settings-sidebar")
       verify(rail && rail.visible, "a wide window has a rail")

--- a/tests/qml/tst_wheel_scroll.qml
+++ b/tests/qml/tst_wheel_scroll.qml
@@ -1,0 +1,104 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../../components" as Omamail
+
+// Wheel scrolling, against a real Flickable.
+//
+// The numbers here are the fault: a Flickable answers each wheel event with
+// its own flick, so the same turn of the same wheel moves a seventh as far
+// when a high-resolution mouse reports it as eight small deltas instead of
+// one. Asserting the two are equal is asserting the bug is gone.
+Item {
+  width: 400
+  height: 800
+
+  Flickable {
+    id: view
+    // Not filling the parent: the second Flickable below has to sit clear of
+    // this one, or it covers it and takes the wheel events aimed at it.
+    x: 0
+    y: 0
+    width: 400
+    height: 300
+    contentWidth: width
+    contentHeight: 5000
+    boundsBehavior: Flickable.StopAtBounds
+
+    Omamail.WheelScroller { view: view }
+  }
+
+  Flickable {
+    id: shortView
+    x: 0
+    y: 400
+    width: 400
+    height: 300
+    contentWidth: width
+    contentHeight: 100
+    boundsBehavior: Flickable.StopAtBounds
+
+    Omamail.WheelScroller { view: shortView }
+  }
+
+  TestCase {
+    name: "WheelScroll"
+    when: windowShown
+
+    function init() {
+      view.contentY = 0
+      shortView.contentY = 0
+    }
+
+    function test_one_notch_moves_three_lines_worth() {
+      mouseWheel(view, 200, 150, 0, -120)
+      compare(view.contentY, 120,
+        "a notch is 15 degrees, and 8 pixels a degree is what a GTK app moves")
+    }
+
+    // The whole point. A high-resolution wheel reports one notch as many
+    // fractions of a degree, and they have to add up to the same distance.
+    function test_a_finely_reporting_wheel_moves_the_same_distance() {
+      for (var i = 0; i < 8; i++) mouseWheel(view, 200, 150, 0, -15)
+      compare(view.contentY, 120,
+        "eight fractions of a notch are still one notch")
+    }
+
+    function test_three_notches_move_three_notches() {
+      mouseWheel(view, 200, 150, 0, -360)
+      compare(view.contentY, 360)
+    }
+
+    function test_it_scrolls_back_up() {
+      view.contentY = 500
+      mouseWheel(view, 200, 150, 0, 120)
+      compare(view.contentY, 380)
+    }
+
+    function test_it_stops_at_the_top() {
+      mouseWheel(view, 200, 150, 0, 240)
+      compare(view.contentY, 0, "there is nothing above the first row")
+    }
+
+    function test_it_stops_at_the_bottom() {
+      view.contentY = 4700
+      mouseWheel(view, 200, 150, 0, -240)
+      compare(view.contentY, 4700, "4700 is the last position a 300-tall view can reach")
+    }
+
+    // A list shorter than its own viewport has nowhere to go, and a negative
+    // limit would let it drift above its first row.
+    function test_content_shorter_than_the_view_does_not_move() {
+      mouseWheel(shortView, 200, 150, 0, -240)
+      compare(shortView.contentY, 0)
+      mouseWheel(shortView, 200, 150, 0, 240)
+      compare(shortView.contentY, 0)
+    }
+
+    // A sideways gesture reports y === 0, and reading it as a scroll down is
+    // how a horizontal wheel ends up moving the list.
+    function test_a_sideways_wheel_is_not_a_scroll() {
+      mouseWheel(view, 200, 150, -120, 0)
+      compare(view.contentY, 0)
+    }
+  }
+}

--- a/tests/qml/tst_wheel_scroll.qml
+++ b/tests/qml/tst_wheel_scroll.qml
@@ -2,24 +2,23 @@ import QtQuick 2.15
 import QtTest 1.3
 import "../../components" as Omamail
 
-// Wheel scrolling, against a real Flickable.
+// Wheel scrolling, against real scrollers.
 //
-// The numbers here are the fault: a Flickable answers each wheel event with
-// its own flick, so the same turn of the same wheel moves a seventh as far
-// when a high-resolution mouse reports it as eight small deltas instead of
-// one. Asserting the two are equal is asserting the bug is gone.
+// Every assertion here is paired with a bare scroller of the same shape and no
+// handler, and asserts the two *differ*. Four of the first round of these
+// passed with the component removed — they read `contentY` synchronously after
+// `mouseWheel`, before a bare Flickable had advanced a frame, so "it stopped at
+// the top" was true of nothing having happened yet. A control that has to move
+// differently is the only way to tell the two apart.
 Item {
-  width: 400
-  height: 800
+  width: 500
+  height: 1400
+
+  // ------------------------------------------------------------- handled
 
   Flickable {
     id: view
-    // Not filling the parent: the second Flickable below has to sit clear of
-    // this one, or it covers it and takes the wheel events aimed at it.
-    x: 0
-    y: 0
-    width: 400
-    height: 300
+    x: 0; y: 0; width: 400; height: 300
     contentWidth: width
     contentHeight: 5000
     boundsBehavior: Flickable.StopAtBounds
@@ -28,16 +27,36 @@ Item {
   }
 
   Flickable {
-    id: shortView
-    x: 0
-    y: 400
-    width: 400
-    height: 300
+    id: margined
+    x: 0; y: 350; width: 400; height: 300
     contentWidth: width
-    contentHeight: 100
+    contentHeight: 5000
+    topMargin: 50
+    bottomMargin: 70
     boundsBehavior: Flickable.StopAtBounds
 
-    Omamail.WheelScroller { view: shortView }
+    Omamail.WheelScroller { view: margined }
+  }
+
+  ListView {
+    id: headed
+    x: 0; y: 700; width: 400; height: 300
+    model: 100
+    boundsBehavior: Flickable.StopAtBounds
+    header: Item { width: 400; height: 200 }
+    delegate: Item { width: 400; height: 40 }
+
+    Omamail.WheelScroller { view: headed }
+  }
+
+  // --------------------------------------------------- the same, unhandled
+
+  Flickable {
+    id: bare
+    x: 0; y: 1050; width: 400; height: 300
+    contentWidth: width
+    contentHeight: 5000
+    boundsBehavior: Flickable.StopAtBounds
   }
 
   TestCase {
@@ -46,26 +65,45 @@ Item {
 
     function init() {
       view.contentY = 0
-      shortView.contentY = 0
+      margined.contentY = -margined.topMargin
+      headed.contentY = headed.originY
+      bare.contentY = 0
     }
+
+    // ------------------------------------------------------- the distance
 
     function test_one_notch_moves_three_lines_worth() {
       mouseWheel(view, 200, 150, 0, -120)
-      compare(view.contentY, 120,
-        "a notch is 15 degrees, and 8 pixels a degree is what a GTK app moves")
+      compare(view.contentY, 120)
     }
 
     // The whole point. A high-resolution wheel reports one notch as many
-    // fractions of a degree, and they have to add up to the same distance.
+    // fractions, and they have to add up to the same distance — which is
+    // where a bare Flickable is eight times short.
     function test_a_finely_reporting_wheel_moves_the_same_distance() {
       for (var i = 0; i < 8; i++) mouseWheel(view, 200, 150, 0, -15)
-      compare(view.contentY, 120,
-        "eight fractions of a notch are still one notch")
+      compare(view.contentY, 120, "eight fractions of a notch are still one notch")
+
+      for (var j = 0; j < 8; j++) mouseWheel(bare, 200, 150, 0, -15)
+      wait(400)
+      verify(bare.contentY < 60,
+        "the same turn on a bare Flickable moves a fraction of it, which is the fault")
     }
 
     function test_three_notches_move_three_notches() {
       mouseWheel(view, 200, 150, 0, -360)
       compare(view.contentY, 360)
+    }
+
+    // Uncapped: ten notches as one event and as ten events agree. A per-event
+    // cap put the chunking dependence back at the coarse end.
+    function test_a_free_spinning_wheel_is_not_capped() {
+      mouseWheel(view, 200, 150, 0, -1200)
+      compare(view.contentY, 1200)
+
+      view.contentY = 0
+      for (var i = 0; i < 10; i++) mouseWheel(view, 200, 150, 0, -120)
+      compare(view.contentY, 1200, "however the ten notches arrive")
     }
 
     function test_it_scrolls_back_up() {
@@ -74,31 +112,42 @@ Item {
       compare(view.contentY, 380)
     }
 
-    function test_it_stops_at_the_top() {
-      mouseWheel(view, 200, 150, 0, 240)
-      compare(view.contentY, 0, "there is nothing above the first row")
+    // ------------------------------------------------------- the bounds
+
+    // A margined view resting in its top margin, scrolled up. The old clamp
+    // had a floor of 0, so this moved *down* to 0 in answer to a scroll up and
+    // the margin could never be reached again.
+    function test_a_scroll_up_in_the_top_margin_stays_there() {
+      compare(margined.contentY, -50)
+      mouseWheel(margined, 200, 150, 0, 120)
+      compare(margined.contentY, -50, "up from the top is not down to zero")
+    }
+
+    function test_the_bottom_margin_is_reachable() {
+      margined.contentY = 4700
+      mouseWheel(margined, 200, 150, 0, -120)
+      compare(margined.contentY, 4770,
+        "contentHeight + bottomMargin - height, not contentHeight - height")
+    }
+
+    // A ListView with a header starts at a negative originY, where the old
+    // clamp turned the first notch into a jump to 0 — the height of the header
+    // rather than a notch — and then never let it back.
+    function test_a_header_does_not_make_the_first_notch_a_jump() {
+      compare(headed.originY, -200)
+      compare(headed.contentY, -200)
+
+      mouseWheel(headed, 200, 150, 0, -120)
+      compare(headed.contentY, -80, "one notch, not two hundred pixels")
+
+      mouseWheel(headed, 200, 150, 0, 120)
+      compare(headed.contentY, -200, "and the header comes back")
     }
 
     function test_it_stops_at_the_bottom() {
       view.contentY = 4700
       mouseWheel(view, 200, 150, 0, -240)
-      compare(view.contentY, 4700, "4700 is the last position a 300-tall view can reach")
-    }
-
-    // A list shorter than its own viewport has nowhere to go, and a negative
-    // limit would let it drift above its first row.
-    function test_content_shorter_than_the_view_does_not_move() {
-      mouseWheel(shortView, 200, 150, 0, -240)
-      compare(shortView.contentY, 0)
-      mouseWheel(shortView, 200, 150, 0, 240)
-      compare(shortView.contentY, 0)
-    }
-
-    // A sideways gesture reports y === 0, and reading it as a scroll down is
-    // how a horizontal wheel ends up moving the list.
-    function test_a_sideways_wheel_is_not_a_scroll() {
-      mouseWheel(view, 200, 150, -120, 0)
-      compare(view.contentY, 0)
+      compare(view.contentY, 4700)
     }
   }
 }

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -639,40 +639,81 @@ assert.strictEqual(model.settingsScrollTarget(sections, "reading", 400, 500), 0,
 assert.strictEqual(model.settingsScrollTarget(sections, "nope", 1200, 500), -1)
 assert.strictEqual(model.settingsScrollTarget(null, "reading", 1200, 500), -1)
 
+// --------------------------------------------- what a scroller can reach
+
+// `contentY` does not run from 0 to `contentHeight - height`, which is what
+// three clamps in this repository assumed.
+
+// A plain view is the range that assumption described.
+deepEqual(model.contentYBounds(0, 5000, 300, 0, 0), { min: 0, max: 4700 })
+
+// Margins extend both ends. A view resting at the top of its own top margin
+// sits at a negative contentY, and a floor of 0 answers a scroll *up* there by
+// moving *down*, after which the margin can never be seen again.
+deepEqual(model.contentYBounds(0, 5000, 300, 50, 70), { min: -50, max: 4770 })
+
+// `originY` moves the start. A ListView with a 200-tall header reports -200,
+// and a floor of 0 makes the header unreachable — measured against a real
+// ListView, which settles at exactly these two values.
+deepEqual(model.contentYBounds(-200, 4200, 300, 0, 0), { min: -200, max: 3700 })
+
+// Content shorter than its own view has one position rather than a negative
+// range, and that position is the top of it.
+deepEqual(model.contentYBounds(0, 100, 300, 0, 0), { min: 0, max: 0 })
+deepEqual(model.contentYBounds(0, 100, 300, 50, 70), { min: -50, max: -50 })
+
+assert.strictEqual(model.clampContentY(9999, { min: -50, max: 4770 }), 4770)
+assert.strictEqual(model.clampContentY(-9999, { min: -50, max: 4770 }), -50)
+assert.strictEqual(model.clampContentY(100, { min: -50, max: 4770 }), 100)
+
 // ------------------------------------------------------------- the wheel
 
 // A Flickable answers each wheel event with its own flick, so the distance
 // depends on how the turn was reported rather than on how far the wheel went.
-// Rotation is the part that does not change: angleDelta is eighths of a
-// degree, a notch is 15 degrees, and eight fractions of a notch still add up
-// to 15.
-assert.strictEqual(model.wheelDistance(-120), -120, "one notch, at 8px a degree")
-assert.strictEqual(model.wheelDistance(120), 120)
-assert.strictEqual(model.wheelDistance(-360), -360, "three notches")
+// Rotation is the part that does not change: a notch is 120 units of
+// angleDelta, and eight fractions of a notch still add up to one notch.
+const NOTCH = 120
+assert.strictEqual(model.wheelDistance(-NOTCH), -model.WHEEL_PIXELS_PER_NOTCH,
+  "a notch moves a notch's worth, whatever that is set to")
+assert.strictEqual(model.WHEEL_PIXELS_PER_NOTCH, 120,
+  "and it is three lines of text, which is what a GTK application moves")
 
 // The same turn, chopped up the way a high-resolution wheel reports it.
 let fine = 0
-for (let i = 0; i < 8; i++) fine += model.wheelDistance(-15)
+for (let i = 0; i < 8; i++) fine += model.wheelDistance(-NOTCH / 8)
 assert.strictEqual(fine, -120, "eight fractions of a notch are still one notch")
 
+assert.strictEqual(model.wheelDistance(-3 * NOTCH), -360, "three notches")
 assert.strictEqual(model.wheelDistance(0), 0)
 assert.strictEqual(model.wheelDistance(null), 0)
 
-// One event is bounded, not one gesture: a touchpad's flung scroll arrives as
-// a stream of large deltas and a single one of them must not cross a list.
-assert.strictEqual(model.wheelDistance(-4800), -480, "capped at 60 degrees")
-assert.strictEqual(model.wheelDistance(4800), 480)
+// Nothing is capped. A cap on one event would put the chunking dependence
+// straight back at the coarse end: a free-spinning wheel delivers ten notches
+// as one event, and a bound would have moved it a notch and a half while the
+// same ten notches arriving as ten events moved ten.
+assert.strictEqual(model.wheelDistance(-10 * NOTCH), -1200)
+let asTen = 0
+for (let i = 0; i < 10; i++) asTen += model.wheelDistance(-NOTCH)
+assert.strictEqual(asTen, model.wheelDistance(-10 * NOTCH),
+  "ten notches move the same distance however they arrive")
 
-// Where the view lands, clamped to what it can reach.
-assert.strictEqual(model.wheelScrollTarget(0, -120, 5000, 300), 120)
-assert.strictEqual(model.wheelScrollTarget(500, 120, 5000, 300), 380)
-assert.strictEqual(model.wheelScrollTarget(0, 240, 5000, 300), 0,
+// Where the view lands, inside what it can actually reach.
+assert.strictEqual(model.wheelScrollTarget(0, -NOTCH, 5000, 300), 120)
+assert.strictEqual(model.wheelScrollTarget(500, NOTCH, 5000, 300), 380)
+assert.strictEqual(model.wheelScrollTarget(0, 2 * NOTCH, 5000, 300), 0,
   "there is nothing above the first row")
-assert.strictEqual(model.wheelScrollTarget(4700, -240, 5000, 300), 4700,
-  "4700 is the last position a 300-tall view of 5000 can reach")
+assert.strictEqual(model.wheelScrollTarget(4700, -2 * NOTCH, 5000, 300), 4700)
+assert.strictEqual(model.wheelScrollTarget(0, -2 * NOTCH, 100, 300), 0,
+  "content shorter than its view cannot scroll")
 
-// Content shorter than its own view cannot scroll, and a negative limit would
-// let it drift above its first row.
-assert.strictEqual(model.wheelScrollTarget(0, -240, 100, 300), 0)
-assert.strictEqual(model.wheelScrollTarget(0, 240, 100, 300), 0)
-assert.strictEqual(model.wheelScrollTarget(0, -240, 0, 0), 0)
+// A margined view scrolled up at the top stays in its margin. With a floor of
+// 0 this moved *down* to 0 in answer to a scroll up.
+assert.strictEqual(model.wheelScrollTarget(-50, NOTCH, 5000, 300, 0, 50, 70), -50)
+assert.strictEqual(model.wheelScrollTarget(-50, -NOTCH, 5000, 300, 0, 50, 70), 70)
+assert.strictEqual(model.wheelScrollTarget(4770, -NOTCH, 5000, 300, 0, 50, 70), 4770,
+  "and the bottom margin is reachable rather than cut off")
+
+// A ListView with a header: one notch is one notch, not a jump to 0.
+assert.strictEqual(model.wheelScrollTarget(-200, -NOTCH, 4200, 300, -200, 0, 0), -80)
+assert.strictEqual(model.wheelScrollTarget(-200, NOTCH, 4200, 300, -200, 0, 0), -200,
+  "and the header stays reachable")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -638,3 +638,41 @@ assert.strictEqual(model.settingsScrollTarget(sections, "mailboxes", 1000, 500),
 assert.strictEqual(model.settingsScrollTarget(sections, "reading", 400, 500), 0, "a page shorter than its viewport does not scroll")
 assert.strictEqual(model.settingsScrollTarget(sections, "nope", 1200, 500), -1)
 assert.strictEqual(model.settingsScrollTarget(null, "reading", 1200, 500), -1)
+
+// ------------------------------------------------------------- the wheel
+
+// A Flickable answers each wheel event with its own flick, so the distance
+// depends on how the turn was reported rather than on how far the wheel went.
+// Rotation is the part that does not change: angleDelta is eighths of a
+// degree, a notch is 15 degrees, and eight fractions of a notch still add up
+// to 15.
+assert.strictEqual(model.wheelDistance(-120), -120, "one notch, at 8px a degree")
+assert.strictEqual(model.wheelDistance(120), 120)
+assert.strictEqual(model.wheelDistance(-360), -360, "three notches")
+
+// The same turn, chopped up the way a high-resolution wheel reports it.
+let fine = 0
+for (let i = 0; i < 8; i++) fine += model.wheelDistance(-15)
+assert.strictEqual(fine, -120, "eight fractions of a notch are still one notch")
+
+assert.strictEqual(model.wheelDistance(0), 0)
+assert.strictEqual(model.wheelDistance(null), 0)
+
+// One event is bounded, not one gesture: a touchpad's flung scroll arrives as
+// a stream of large deltas and a single one of them must not cross a list.
+assert.strictEqual(model.wheelDistance(-4800), -480, "capped at 60 degrees")
+assert.strictEqual(model.wheelDistance(4800), 480)
+
+// Where the view lands, clamped to what it can reach.
+assert.strictEqual(model.wheelScrollTarget(0, -120, 5000, 300), 120)
+assert.strictEqual(model.wheelScrollTarget(500, 120, 5000, 300), 380)
+assert.strictEqual(model.wheelScrollTarget(0, 240, 5000, 300), 0,
+  "there is nothing above the first row")
+assert.strictEqual(model.wheelScrollTarget(4700, -240, 5000, 300), 4700,
+  "4700 is the last position a 300-tall view of 5000 can reach")
+
+// Content shorter than its own view cannot scroll, and a negative limit would
+// let it drift above its first row.
+assert.strictEqual(model.wheelScrollTarget(0, -240, 100, 300), 0)
+assert.strictEqual(model.wheelScrollTarget(0, 240, 100, 300), 0)
+assert.strictEqual(model.wheelScrollTarget(0, -240, 0, 0), 0)


### PR DESCRIPTION
A `Flickable` answers each wheel event with a flick it then decelerates, so the distance depends on how the turn was chopped up rather than on how far the wheel went.

Measured against a real `Flickable`, one notch arriving as a single `angleDelta` of 120 moves about 72 pixels. The same notch from a high-resolution mouse, which reports it as eight deltas of 15, moves about 9 — each one starting and damping its own small flick. Eight times less for the same gesture, which is what "slower than every other application" turns out to be. Logitech's MX line reports this way, and so does a lot of recent hardware.

Rotation is the part that does not change: `angleDelta` is eighths of a degree, a notch is 15 degrees, and eight fractions of a notch still add up to 15. So the distance comes from rotation and nothing else — 120 pixels a notch, which is three lines of text and what a GTK application moves for the same turn.

Nothing is capped. A ceiling on one *event* would put the chunking dependence straight back at the coarse end: a free-spinning wheel delivers ten notches as one event, and a cap moves that a notch and a half while the same ten notches arriving as ten events move ten. A bound worth having would be per unit time.

## Which scrollers

Every vertical one: the message list, the reader, the settings page, the account setup page, the mailbox sidebar, the shortcut sheet, all three of compose's, the week grid, the contacts picker, the recipient suggestions, both calendar event sheets, and the label picker.

`MailboxTabs` is deliberately out — it is a horizontal strip, and a vertical wheel there is the wrong axis.

## What a scroller can reach

`contentY` does not run from 0 to `contentHeight - height`, which is what three separate clamps in this repository assumed.

Margins extend both ends, so a view resting in its top margin answered a scroll *up* by moving *down* to 0, after which the margin could never be seen again. And `originY` moves the start, so a `ListView` with a 200-tall header turned its first notch into a 200-pixel jump and could never wheel the header back into view.

`Model.contentYBounds` is the single answer now, and `contentYToReveal` and `ShortcutHelp.scrollBy` — the other two copies — ask it too. The `originY` half is measured: a `ListView` with a header settles at exactly `originY` and `originY + contentHeight - height`. The margin half is from Qt's documented semantics, since `StopAtBounds` does not correct a programmatic assignment and the same probe cannot reach it.

## Two choices worth stating

**A mouse only.** `acceptedDevices: PointerDevice.Mouse`, said out loud rather than left to the default. A touchpad reports `pixelDelta` and its own momentum and a `Flickable` tracks fingers with it properly, so where Qt can tell one apart this stays out of the way.

**An instant jump rather than an animated slide.** A wheel is a hand movement and should track it. The 160 ms animation elsewhere is for a jump to a section, which is a discontinuity the eye needs to follow; animating a wheel would also fight a repeating one, each event restarting an animation the next interrupts.

## Why the component is a handler

`WheelScroller` is a `WheelHandler` and not an `Item` holding one. A `Flickable` reparents its visual children into its content, so an `Item` dropped inside would be a zero-sized thing scrolling along with the list and its handler would never see a wheel event. A handler is not reparented — it attaches to the `Flickable`, which is what has to be got in front of.

## Verification

`make validate` green, 240 QML assertions.

`tests/test_model.js` covers the distance, that ten notches move the same however they arrive, and every bound — margins at both ends, a `ListView` header, and content shorter than its own view. `tests/qml/tst_wheel_scroll.qml` drives three real scrollers, each paired against a control that has to move differently. `tests/qml/tst_settings_sidebar.qml` covers a real call site in the real window hierarchy.

Mutation-checked two ways, because an earlier round of these tests passed for the wrong reason: with the component neutered 7 of 11 fail, and with the component intact but the bounds reverted to the old 0-floor clamp the 3 margin and header cases fail. Every assertion is caught by one or the other.

## Release Notes

- Scrolling moves as far as the wheel was turned. A notch now moves three lines of text, the same as other applications on the desktop, in every scrolling surface rather than some of them.
- High-resolution scroll wheels are no longer roughly eight times slower than the rest of the desktop, which is most recent hardware including Logitech's MX line.
- A view with margins, and a list with a header, can now be scrolled to their real ends rather than losing the first screenful.
