### PR TITLE
Find Exchange's Junk folder by the name Exchange gives it

### DIFF
--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -1055,7 +1055,10 @@ function specialFolders(folders) {
     if (!map["\\sent"] && /^sent( mail| items| messages)?$/.test(leaf)) map["\\sent"] = name
     if (!map["\\trash"] && /^(trash|deleted( items| messages)?)$/.test(leaf)) map["\\trash"] = name
     if (!map["\\drafts"] && /^drafts?$/.test(leaf)) map["\\drafts"] = name
-    if (!map["\\junk"] && /^(junk|spam|bulk mail)$/.test(leaf)) map["\\junk"] = name
+    // Exchange calls it "Junk Email", which is the one name in this list that
+    // the bare word cannot stand in for: every other fallback below happens to
+    // be what Exchange calls the folder anyway.
+    if (!map["\\junk"] && /^(junk([ -]?e-?mail)?|spam|bulk mail)$/.test(leaf)) map["\\junk"] = name
     if (!map["\\archive"] && /^(archive|all mail)$/.test(leaf)) map["\\archive"] = name
   }
   return map

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -504,6 +504,37 @@ assert.strictEqual(plainSpecial["\\sent"], "Sent")
 assert.strictEqual(plainSpecial["\\junk"], "Junk")
 assert.strictEqual(plainSpecial["\\archive"], "Archive")
 
+// Exchange Online's IMAP advertises no SPECIAL-USE either, so its folders are
+// found by name or not at all. Four of the five are what the bare-word
+// fallback would have guessed anyway; "Junk Email" is the one that is not, and
+// pointing the Junk mailbox at a folder the server does not have is the fault.
+const exchangeList = imap.parseList(
+  "* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n" +
+  "* LIST (\\HasNoChildren) \"/\" \"Sent Items\"\r\n" +
+  "* LIST (\\HasNoChildren) \"/\" \"Deleted Items\"\r\n" +
+  "* LIST (\\HasNoChildren) \"/\" \"Drafts\"\r\n" +
+  "* LIST (\\HasNoChildren) \"/\" \"Junk Email\"\r\n" +
+  "* LIST (\\HasNoChildren) \"/\" \"Archive\"\r\n")
+const exchange = imap.specialFolders(exchangeList)
+assert.strictEqual(imap.resolveFolder("\\Sent", exchange), "Sent Items")
+assert.strictEqual(imap.resolveFolder("\\Trash", exchange), "Deleted Items")
+assert.strictEqual(imap.resolveFolder("\\Drafts", exchange), "Drafts")
+assert.strictEqual(imap.resolveFolder("\\Archive", exchange), "Archive")
+assert.strictEqual(imap.resolveFolder("\\Junk", exchange), "Junk Email",
+  "the bare word names a folder Exchange does not have")
+
+// The other spellings of the same folder, and a folder that merely starts
+// with the word and is somebody's own.
+function junkNamed(name) {
+  const listed = imap.parseList("* LIST () \"/\" \"" + name + "\"\r\n")
+  return imap.specialFolders(listed)["\\junk"]
+}
+assert.strictEqual(junkNamed("Junk E-mail"), "Junk E-mail")
+assert.strictEqual(junkNamed("Junk E-Mail"), "Junk E-Mail")
+assert.strictEqual(junkNamed("Spam"), "Spam")
+assert.strictEqual(junkNamed("Junk Drawer"), undefined,
+  "an unrelated folder must not be adopted as Junk")
+
 // Flags win over names: a server that says so is not second-guessed.
 const conflicting = imap.parseList(
   "* LIST (\\Sent) \"/\" \"Verzonden\"\r\n" +


### PR DESCRIPTION
Exchange Online's IMAP advertises no SPECIAL-USE, so every special folder there is found by name or not at all. Four of the five already were: `Sent Items`, `Deleted Items`, `Drafts` and `Archive` all match a pattern written for other servers that happens to cover Exchange too.

`Junk Email` did not. The pattern asked for the bare word, so the Junk mailbox resolved to `Junk` — a folder Exchange does not have — and selecting it fails on the one row in the rail whose whole job is to be somewhere else.

Still only a gap-filler behind the flags, and still narrow enough that a folder which merely starts with the word is left alone: somebody's own `Junk Drawer` is not the junk folder.

## Verification

`make validate` green. `tests/test_imap.js` runs Exchange's own LIST reply — no SPECIAL-USE flags, `Sent Items` / `Deleted Items` / `Drafts` / `Junk Email` / `Archive` — through `parseList`, `specialFolders` and `resolveFolder`, and covers `Junk E-mail`, `Junk E-Mail` and `Spam` as well as refusing `Junk Drawer`. The Exchange case fails without the change.

Confirmed against the live server: `outlook.office365.com:993` answers `CAPABILITY IMAP4 IMAP4rev1 AUTH=PLAIN AUTH=XOAUTH2 SASL-IR UIDPLUS MOVE ID UNSELECT CHILDREN IDLE NAMESPACE LITERAL+` — no SPECIAL-USE and no LIST-EXTENDED.

## Release Notes

- The Junk mailbox opens on Exchange and Microsoft 365 accounts, which call the folder `Junk Email` rather than `Junk`.
