### PR TITLE
Keep an attachment, not only open it once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ test-shell:
 	bash tests/test_unsubscribe_transport.sh
 	bash tests/test_image_fetch.sh
 	bash tests/test_attachment_open.sh
+	bash tests/test_attachment_save.sh
 	bash tests/test_attachment.sh
 	bash tests/test_calendar_transport.sh
 	bash tests/test_calendar_write.sh

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ other IMAP server — including one you run yourself.
   offers an address gets a message; one that only offers a page says so before
   it opens your browser. Nothing is ever fetched from a sender's address until
   you ask.
+- **Attachments open or keep.** The filename opens one in whatever handles its
+  type; the arrow beside it saves the file to your download folder and says
+  where it went. Two messages carrying one name are two files: the second is
+  numbered rather than landing on top of the first.
 - **Images stay blocked.** Loading a sender's pictures tells them the mail was
   read, from which address and when. They load when you ask, for that one
   message.
@@ -256,7 +260,6 @@ A signature is set per mailbox on the settings page, under Writing. It is placed
   written in. A browser engine cannot be embedded in a plugin at all:
   `QtWebEngineQuick::initialize()` has to run before the host process builds
   its `QGuiApplication`, and a plugin loads long after that.
-- **No attachment downloads.** Not yet.
 
 Remote images in a message body are blocked until you ask for them, and asking
 covers that one message. Qt really does fetch an `<img src="https://…">`, so

--- a/Service.qml
+++ b/Service.qml
@@ -738,6 +738,7 @@ Item {
   readonly property bool canOpenOnWeb: !current || current.canOpenOnWeb
   readonly property bool canOpenWebInbox: !!current && current.canOpenWebInbox
   readonly property var unavailableActions: current ? current.unavailableActions : []
+  readonly property var savingAttachmentIds: current ? current.savingAttachmentIds : ({})
   readonly property bool canSend: !current || current.canSend
   readonly property string mailboxKey: current ? current.mailboxKey : "inbox"
   readonly property string searchQuery: current ? current.searchQuery : ""

--- a/Service.qml
+++ b/Service.qml
@@ -844,6 +844,10 @@ Item {
   function openAttachment(messageId, attachment) {
     if (current) current.openAttachment(messageId, attachment)
   }
+
+  function saveAttachment(messageId, attachment) {
+    if (current) current.saveAttachment(messageId, attachment)
+  }
   function preferredSendAs(recipients) {
     return current ? current.preferredSendAs(recipients) : null
   }

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -68,6 +68,8 @@ Item {
 
   // The window drives this; the unread poll keeps running while it is false.
   property bool windowOpen: false
+  // Keyed by attachmentId, holding only the saves that are in flight.
+  property var savingAttachmentIds: ({})
 
   function setting(name, fallback) {
     var value = settings ? settings[name] : undefined
@@ -1679,10 +1681,18 @@ Item {
       fail("That attachment is not available")
       return
     }
+    // One save at a time for one attachment. A download arrow is a single
+    // click, and a double one used to start a second fetch that the script
+    // then dutifully numbered: two identical files in Downloads, and a notice
+    // that read the same both times, so nothing said it had happened.
+    var key = String(source.attachmentId)
+    if (savingAttachmentIds[key]) return
+    markSavingAttachment(key, true)
     clearNotice()
     note("Saving " + String(source.filename || "attachment"))
     loadAttachments(messageId, [source], function(loaded, error) {
       if (error || !loaded || loaded.length === 0) {
+        root.markSavingAttachment(key, false)
         root.fail(error || "That attachment could not be loaded")
         return
       }
@@ -1693,12 +1703,14 @@ Item {
           + "\n" + String(file.data || "") + "\n"
       })
       if (!request) {
+        root.markSavingAttachment(key, false)
         root.fail("That attachment could not be saved")
         return
       }
       request.finished.connect(function(exitCode, path, detail) {
         request.destroy()
         if (!root) return
+        root.markSavingAttachment(key, false)
         if (exitCode !== 0) {
           root.fail(detail || "That attachment could not be saved")
           return
@@ -1717,6 +1729,18 @@ Item {
       })
       request.running = true
     })
+  }
+
+  // Which attachments are being saved right now, so the row that asked can
+  // show it and refuse a second click. Re-assigned rather than written into: a
+  // binding on a `var` does not notice a key appearing inside the object it is
+  // already holding.
+  function markSavingAttachment(key, saving) {
+    var next = ({})
+    for (var id in savingAttachmentIds)
+      if (id !== key) next[id] = true
+    if (saving) next[key] = true
+    savingAttachmentIds = next
   }
 
   // One entry point for every kind of outgoing message. Reply, reply-all and
@@ -2104,11 +2128,19 @@ Item {
       id: attachmentSaveProcess
 
       property string requestPayload: ""
+      // Exactly one answer reaches the caller, whichever way this ends.
+      property bool reported: false
       signal finished(int exitCode, string path, string detail)
 
       stdinEnabled: true
       stdout: StdioCollector { waitForEnd: true }
       stderr: StdioCollector { waitForEnd: true }
+
+      function report(exitCode, path, detail) {
+        if (reported) return
+        reported = true
+        finished(exitCode, path, detail)
+      }
 
       onStarted: {
         write(requestPayload)
@@ -2118,8 +2150,18 @@ Item {
       onExited: function(exitCode) {
         var path = String(attachmentSaveProcess.stdout.text || "").trim()
         var detail = String(attachmentSaveProcess.stderr.text || "").trim()
-        attachmentSaveProcess.finished(exitCode, path, detail)
+        attachmentSaveProcess.report(exitCode, path, detail)
       }
+
+      // A program that could not be started never exits, so `onExited` never
+      // arrives. Without this the caller waits for an answer that is not
+      // coming, and the save it is holding open would keep the row's button
+      // turning for as long as the window stays open. Deferred by a turn so a
+      // real exit, which clears `running` as well, always reports first.
+      onRunningChanged: if (!running) Qt.callLater(function() {
+        if (attachmentSaveProcess)
+          attachmentSaveProcess.report(1, "", "That attachment could not be saved")
+      })
     }
   }
 

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1663,6 +1663,56 @@ Item {
     })
   }
 
+  // Keeping an attachment rather than opening it once.
+  //
+  // The same shape as `openAttachment` because it is the same journey up to
+  // the last step: sign-in, then the provider's own fetch, then one script.
+  // Only the script differs, and the answer it gives back — a path, which the
+  // notice repeats, because a saved file nobody can find is not saved.
+  function saveAttachment(messageId, attachment) {
+    var source = attachment || ({})
+    if (!ready) {
+      fail("Sign in before saving an attachment")
+      return
+    }
+    if (String(messageId || "") === "" || String(source.attachmentId || "") === "") {
+      fail("That attachment is not available")
+      return
+    }
+    clearNotice()
+    note("Saving " + String(source.filename || "attachment"))
+    loadAttachments(messageId, [source], function(loaded, error) {
+      if (error || !loaded || loaded.length === 0) {
+        root.fail(error || "That attachment could not be loaded")
+        return
+      }
+      var file = loaded[0]
+      var request = attachmentSaveComponent.createObject(root, {
+        command: [pluginDir + "/scripts/save-attachment.py"],
+        requestPayload: Mail.encodeBase64(String(file.filename || "attachment"))
+          + "\n" + String(file.data || "") + "\n"
+      })
+      if (!request) {
+        root.fail("That attachment could not be saved")
+        return
+      }
+      request.finished.connect(function(exitCode, path, detail) {
+        request.destroy()
+        if (!root) return
+        if (exitCode !== 0) {
+          root.fail(detail || "That attachment could not be saved")
+          return
+        }
+        // The folder rather than the whole path: the name is already on the
+        // row that was clicked, and the part worth reading is where it went.
+        var saved = String(path || "")
+        var at = saved.lastIndexOf("/")
+        root.note(at > 0 ? "Saved to " + saved.substring(0, at) : "Saved")
+      })
+      request.running = true
+    })
+  }
+
   // One entry point for every kind of outgoing message. Reply, reply-all and
   // forward differ only in what the compose window puts in the fields, which
   // is where that decision belongs.
@@ -2037,6 +2087,32 @@ Item {
           return
         }
         unsubscribeProcess.finished(code, status)
+      }
+    }
+  }
+
+  Component {
+    id: attachmentSaveComponent
+
+    Process {
+      id: attachmentSaveProcess
+
+      property string requestPayload: ""
+      signal finished(int exitCode, string path, string detail)
+
+      stdinEnabled: true
+      stdout: StdioCollector { waitForEnd: true }
+      stderr: StdioCollector { waitForEnd: true }
+
+      onStarted: {
+        write(requestPayload)
+        requestPayload = ""
+      }
+
+      onExited: function(exitCode) {
+        var path = String(attachmentSaveProcess.stdout.text || "").trim()
+        var detail = String(attachmentSaveProcess.stderr.text || "").trim()
+        attachmentSaveProcess.finished(exitCode, path, detail)
       }
     }
   }

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1703,11 +1703,17 @@ Item {
           root.fail(detail || "That attachment could not be saved")
           return
         }
-        // The folder rather than the whole path: the name is already on the
-        // row that was clicked, and the part worth reading is where it went.
+        // The name first, then the folder. `unique_path` numbers a name that
+        // is already taken, so the file on disk is not always the one the row
+        // shows — and reporting only the folder left the reader opening last
+        // month's `invoice.pdf` believing it was the one just saved. The
+        // notice elides from the right, so the part that can differ from what
+        // was clicked has to come before the part that cannot.
         var saved = String(path || "")
         var at = saved.lastIndexOf("/")
-        root.note(at > 0 ? "Saved to " + saved.substring(0, at) : "Saved")
+        root.note(at > 0
+          ? "Saved " + saved.substring(at + 1) + " to " + saved.substring(0, at)
+          : "Saved")
       })
       request.running = true
     })

--- a/components/AttachmentRow.qml
+++ b/components/AttachmentRow.qml
@@ -18,8 +18,13 @@ Item {
   readonly property string filename: root.attachment
     ? String(root.attachment.filename || "attachment") : "attachment"
 
+  // The button too, and that is not a detail: it is a 24px control beside
+  // 15px of caption text, so a height taken from the text alone leaves it
+  // hanging four pixels out of the row at both ends — clipped by the reader's
+  // own scroller, which left the filename as the only thing that could be
+  // clicked and opening as the only thing that could happen.
   implicitHeight: Math.max(icon.implicitHeight, filenameLink.implicitHeight,
-    sizeLabel.implicitHeight)
+    sizeLabel.implicitHeight, saveButton.implicitHeight)
 
   ActionIcon {
     id: icon

--- a/components/AttachmentRow.qml
+++ b/components/AttachmentRow.qml
@@ -13,6 +13,7 @@ Item {
   required property string panelFontFamily
 
   signal openRequested(var attachment)
+  signal saveRequested(var attachment)
 
   readonly property string filename: root.attachment
     ? String(root.attachment.filename || "attachment") : "attachment"
@@ -49,12 +50,32 @@ Item {
 
   Text {
     id: sizeLabel
-    anchors.right: parent.right
+    anchors.right: saveButton.left
+    anchors.rightMargin: Style.space(4)
     anchors.verticalCenter: parent.verticalCenter
     textFormat: Text.PlainText
     text: Mail.formatSize(root.attachment ? root.attachment.size : 0)
     color: root.dimmerColor
     font.family: root.panelFontFamily
     font.pixelSize: Style.font.caption
+  }
+
+  // Keeping the file, next to opening it. The name opens — which is what a
+  // filename does everywhere else — and this is the other verb, which needs
+  // its own target rather than a second meaning for the same click.
+  //
+  // No ellipsis: it asks nothing. The file goes to the desktop's download
+  // folder and the notice says where.
+  IconButton {
+    id: saveButton
+    objectName: "attachment-save-button"
+    anchors.right: parent.right
+    anchors.verticalCenter: parent.verticalCenter
+    iconName: "download"
+    iconSize: Style.font.iconSmall
+    tooltipText: "Save to Downloads"
+    foreground: root.dimColor
+    hoverColor: root.textColor
+    onClicked: root.saveRequested(root.attachment)
   }
 }

--- a/components/AttachmentRow.qml
+++ b/components/AttachmentRow.qml
@@ -15,6 +15,11 @@ Item {
   signal openRequested(var attachment)
   signal saveRequested(var attachment)
 
+  // This attachment's own save is in flight. Not the panel's: two attachments
+  // on one message save independently, and one of them working is no reason
+  // for the other's button to say it is.
+  property bool saving: false
+
   readonly property string filename: root.attachment
     ? String(root.attachment.filename || "attachment") : "attachment"
 
@@ -78,9 +83,13 @@ Item {
     anchors.verticalCenter: parent.verticalCenter
     iconName: "download"
     iconSize: Style.font.iconSmall
-    tooltipText: "Save to Downloads"
+    tooltipText: root.saving ? "Saving\u2026" : "Save to Downloads"
     foreground: root.dimColor
     hoverColor: root.textColor
-    onClicked: root.saveRequested(root.attachment)
+    busy: root.saving
+    // Refused rather than queued. The second click of a double-click asked for
+    // the same file again, and the save script — which will not overwrite —
+    // numbered it, so the folder quietly gained a second identical copy.
+    onClicked: if (!root.saving) root.saveRequested(root.attachment)
   }
 }

--- a/components/Icons.js
+++ b/components/Icons.js
@@ -19,6 +19,7 @@ var GLYPHS = {
   replyAll: 0xF0F1F,     // reply-all-outline
   forward: 0xF0932,      // share-outline — the mail-forward arrow, not "next"
   archive: 0xF120E,      // archive-outline
+  download: 0xF0DA9,     // download-outline — keeping the file, not opening it
   trash: 0xF0A7A,        // trash-can-outline — the can, not the bin
   spam: 0xF0CE6,         // alert-octagon-outline
   unread: 0xF01F0,       // email-outline

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -622,6 +622,10 @@ Item {
           if (root.service && root.summary)
             root.service.openAttachment(root.summary.id, attachment)
         }
+        onSaveRequested: function(attachment) {
+          if (root.service && root.summary)
+            root.service.saveAttachment(root.summary.id, attachment)
+        }
       }
     }
 

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -614,6 +614,8 @@ Item {
         required property var modelData
         width: parent.width
         attachment: modelData
+        saving: !!root.service && !!root.service.savingAttachmentIds[
+          String(modelData && modelData.attachmentId ? modelData.attachmentId : "")]
         textColor: root.textColor
         dimColor: root.dimColor
         dimmerColor: root.dimmerColor

--- a/scripts/attachment_common.py
+++ b/scripts/attachment_common.py
@@ -1,0 +1,62 @@
+"""What both attachment scripts do to a name and to a payload before trusting it.
+
+One copy rather than two. `open-attachment.py` and `save-attachment.py` read
+the same two base64 lines from the same caller, and the filename on the first
+of them is written by whoever sent the mail. That makes `safe_filename` a
+security boundary, and a security boundary that exists twice is one that will
+be fixed once.
+"""
+
+import base64
+import os
+
+# A name longer than this is refused by ext4 and by every filesystem the app is
+# likely to land on, which measures bytes rather than characters.
+NAME_LIMIT = 240
+
+# Past this, what follows the last dot is not an extension — it is the rest of
+# the name, and there is nothing to preserve by keeping it.
+SUFFIX_LIMIT = 32
+
+
+def decode(value: bytes) -> bytes:
+    compact = b"".join(value.split())
+    compact += b"=" * (-len(compact) % 4)
+    return base64.b64decode(compact, altchars=b"-_", validate=True)
+
+
+def safe_filename(value: bytes) -> str:
+    """The sender's name, with everything that could leave the folder removed.
+
+    Both separators, because a name written on Windows carries backslashes and
+    a path is not what a filename may be. Control characters go too: a newline
+    in a filename is unreadable in every listing that shows it.
+    """
+    name = value.decode("utf-8", errors="replace").replace("\\", "/").split("/")[-1]
+    name = "".join("_" if ord(character) < 32 or ord(character) == 127 else character
+                   for character in name).strip()
+    if name in ("", ".", ".."):
+        name = "attachment"
+    return _within_limit(name) or "attachment"
+
+
+def _within_limit(name: str) -> str:
+    """Short enough for the filesystem, with the extension still on the end.
+
+    Trimming the tail is the obvious way to shorten a name and the wrong one: it
+    takes the extension with it, and a saved file that no longer says it is a
+    PDF does not open in what opens a PDF. The stem gives up the characters
+    instead.
+    """
+    if len(os.fsencode(name)) <= NAME_LIMIT:
+        return name
+
+    stem, dot, extension = name.rpartition(".")
+    suffix = dot + extension
+    if not stem or len(os.fsencode(suffix)) > SUFFIX_LIMIT:
+        stem, suffix = name, ""
+
+    room = NAME_LIMIT - len(os.fsencode(suffix))
+    while stem and len(os.fsencode(stem)) > room:
+        stem = stem[:-1]
+    return stem + suffix

--- a/scripts/open-attachment.py
+++ b/scripts/open-attachment.py
@@ -8,22 +8,9 @@ import subprocess
 import sys
 import tempfile
 
-
-def decode(value: bytes) -> bytes:
-    compact = b"".join(value.split())
-    compact += b"=" * (-len(compact) % 4)
-    return base64.b64decode(compact, altchars=b"-_", validate=True)
-
-
-def safe_filename(value: bytes) -> str:
-    name = value.decode("utf-8", errors="replace").replace("\\", "/").split("/")[-1]
-    name = "".join("_" if ord(character) < 32 or ord(character) == 127 else character
-                   for character in name).strip()
-    if name in ("", ".", ".."):
-        name = "attachment"
-    while len(os.fsencode(name)) > 240:
-        name = name[:-1]
-    return name or "attachment"
+# Beside this file, and shared with save-attachment.py so the name the
+# sender chose is made safe by one implementation rather than two.
+from attachment_common import decode, safe_filename
 
 
 def runtime_directory() -> str | None:

--- a/scripts/save-attachment.py
+++ b/scripts/save-attachment.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Decode one mail attachment and keep it, rather than opening it once.
+
+Same two lines on stdin as open-attachment.py — the filename and the data,
+both base64 — because they come from the same place and the QML side should
+not have to know which of the two it is talking to.
+
+Where it lands is the desktop's own answer, read from the environment and then
+from user-dirs.dirs rather than by running xdg-user-dir: the binary belongs to
+a package that is not everywhere, and the file it reads is a shell fragment
+with two lines worth parsing.
+
+The final path goes to stdout so the panel can say where the file went. A
+message that names no location is a message that sends the reader to look.
+"""
+
+import base64
+import os
+from pathlib import Path
+import re
+import sys
+
+
+def decode(value: bytes) -> bytes:
+    compact = b"".join(value.split())
+    compact += b"=" * (-len(compact) % 4)
+    return base64.b64decode(compact, altchars=b"-_", validate=True)
+
+
+def safe_filename(value: bytes) -> str:
+    """The sender's name, with everything that could leave the folder removed.
+
+    Both separators, because a name written on Windows carries backslashes and
+    a path is not what a filename may be. Control characters go too: a newline
+    in a filename is unreadable in every listing that shows it.
+    """
+    name = value.decode("utf-8", errors="replace").replace("\\", "/").split("/")[-1]
+    name = "".join("_" if ord(character) < 32 or ord(character) == 127 else character
+                   for character in name).strip()
+    if name in ("", ".", ".."):
+        name = "attachment"
+    while len(os.fsencode(name)) > 240:
+        name = name[:-1]
+    return name or "attachment"
+
+
+def download_directory() -> Path:
+    """Where the desktop keeps downloads, or the home directory.
+
+    XDG_DOWNLOAD_DIR wins because a caller that set it meant it. The
+    user-dirs.dirs line is quoted and may start with $HOME, which is the whole
+    of the parsing this needs.
+    """
+    from_env = os.environ.get("XDG_DOWNLOAD_DIR", "").strip()
+    if from_env:
+        return Path(os.path.expandvars(os.path.expanduser(from_env)))
+
+    home = Path(os.environ.get("HOME", "")).expanduser()
+    config = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    dirs_file = (Path(config) if config else home / ".config") / "user-dirs.dirs"
+    try:
+        for line in dirs_file.read_text(encoding="utf-8", errors="replace").splitlines():
+            match = re.match(r'\s*XDG_DOWNLOAD_DIR\s*=\s*"(.*)"\s*$', line)
+            if not match:
+                continue
+            value = match.group(1).replace("$HOME", str(home))
+            if value:
+                return Path(value)
+    except OSError:
+        pass
+
+    # Named rather than tested for, and created by the caller if it is not
+    # there yet. Falling back to the home directory when `~/Downloads` happens
+    # not to exist put saved mail loose among the dotfiles on a fresh machine,
+    # which is worse than making the folder every desktop already expects.
+    return home / "Downloads"
+
+
+def unique_path(directory: Path, filename: str) -> Path:
+    """A path nothing is using, without overwriting what is already there.
+
+    Two messages carrying "invoice.pdf" are two invoices, and the second one
+    replacing the first is the kind of loss nobody notices until they need the
+    file. Numbered the way a browser numbers them, so the suffix stays on the
+    end of the stem rather than after the extension.
+    """
+    target = directory / filename
+    if not target.exists():
+        return target
+    stem = target.stem or "attachment"
+    suffix = target.suffix
+    for index in range(2, 1000):
+        candidate = directory / ("%s (%d)%s" % (stem, index, suffix))
+        if not candidate.exists():
+            return candidate
+    raise OSError("too many files by that name")
+
+
+def main() -> int:
+    filename_line = sys.stdin.buffer.readline()
+    data_line = sys.stdin.buffer.readline()
+    if not filename_line or not data_line:
+        print("The attachment request is incomplete", file=sys.stderr)
+        return 2
+
+    try:
+        filename = safe_filename(decode(filename_line))
+        data = decode(data_line)
+    except (ValueError, base64.binascii.Error):
+        print("The attachment data is not valid base64", file=sys.stderr)
+        return 2
+
+    directory = download_directory()
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        print("Could not use %s: %s" % (directory, error), file=sys.stderr)
+        return 1
+
+    try:
+        target = unique_path(directory, filename)
+        # O_EXCL rather than a plain write: `unique_path` asked whether the
+        # name was free and something could have taken it since, and a saved
+        # attachment must never land on top of a file that was already there.
+        descriptor = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except OSError as error:
+        print("Could not save to %s: %s" % (directory, error), file=sys.stderr)
+        return 1
+
+    try:
+        with os.fdopen(descriptor, "wb") as attachment:
+            attachment.write(data)
+    except OSError as error:
+        # A half-written file is worse than none: it looks like the attachment
+        # and opens as nothing.
+        try:
+            os.unlink(target)
+        except OSError:
+            pass
+        print("Could not write %s: %s" % (target.name, error), file=sys.stderr)
+        return 1
+
+    sys.stdout.write(str(target) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/save-attachment.py
+++ b/scripts/save-attachment.py
@@ -20,28 +20,8 @@ from pathlib import Path
 import re
 import sys
 
-
-def decode(value: bytes) -> bytes:
-    compact = b"".join(value.split())
-    compact += b"=" * (-len(compact) % 4)
-    return base64.b64decode(compact, altchars=b"-_", validate=True)
-
-
-def safe_filename(value: bytes) -> str:
-    """The sender's name, with everything that could leave the folder removed.
-
-    Both separators, because a name written on Windows carries backslashes and
-    a path is not what a filename may be. Control characters go too: a newline
-    in a filename is unreadable in every listing that shows it.
-    """
-    name = value.decode("utf-8", errors="replace").replace("\\", "/").split("/")[-1]
-    name = "".join("_" if ord(character) < 32 or ord(character) == 127 else character
-                   for character in name).strip()
-    if name in ("", ".", ".."):
-        name = "attachment"
-    while len(os.fsencode(name)) > 240:
-        name = name[:-1]
-    return name or "attachment"
+# Beside this file, and the one place the sender's own filename is made safe.
+from attachment_common import decode, safe_filename
 
 
 def download_directory() -> Path:

--- a/tests/qml/tst_attachment_save.qml
+++ b/tests/qml/tst_attachment_save.qml
@@ -87,7 +87,21 @@ Item {
       var saveLeft = save.mapToItem(row, 0, 0).x
       verify(saveLeft > 0)
       verify(saveLeft + save.width <= row.width + 1,
-        "the button stays inside the row")
+        "the button stays inside the row horizontally")
+    }
+
+    // And vertically, which is the half that was missing. A 24px control in a
+    // row measured from 15px of caption text hangs out of both ends and the
+    // reader's scroller clips it, leaving the filename as the only thing that
+    // can be clicked — so the row reports a height that holds it.
+    function test_the_button_fits_inside_the_row() {
+      var save = find("attachment-save-button")
+      verify(row.implicitHeight >= save.implicitHeight,
+        "the row is at least as tall as the tallest thing in it")
+      var top = save.mapToItem(row, 0, 0).y
+      verify(top >= 0, "the button does not start above the row")
+      verify(top + save.height <= row.height + 1,
+        "and does not end below it")
     }
   }
 }

--- a/tests/qml/tst_attachment_save.qml
+++ b/tests/qml/tst_attachment_save.qml
@@ -53,6 +53,7 @@ Item {
     function init() {
       openSpy.clear()
       saveSpy.clear()
+      row.saving = false
     }
 
     function test_the_row_offers_both_verbs() {
@@ -88,6 +89,36 @@ Item {
       verify(saveLeft > 0)
       verify(saveLeft + save.width <= row.width + 1,
         "the button stays inside the row horizontally")
+    }
+
+    // A save already running is not started again. The script refuses to
+    // overwrite and numbers the name instead, so a second fetch of the same
+    // attachment does not fail loudly — it succeeds quietly, and the folder
+    // gains an identical "statement (2).pdf" that nothing told the reader
+    // about. The button is the only place that can refuse it.
+    function test_a_second_click_while_saving_is_refused() {
+      var save = find("attachment-save-button")
+      mouseClick(save, save.width / 2, save.height / 2)
+      compare(saveSpy.count, 1)
+
+      row.saving = true
+      mouseClick(save, save.width / 2, save.height / 2)
+      compare(saveSpy.count, 1, "the same attachment is not fetched twice")
+
+      row.saving = false
+      mouseClick(save, save.width / 2, save.height / 2)
+      compare(saveSpy.count, 2, "and it can be saved again once that one is done")
+    }
+
+    // Dim would have said "you cannot"; the truth is "already doing it", which
+    // is what the shared button's busy state is for.
+    function test_the_button_says_the_save_is_running() {
+      var save = find("attachment-save-button")
+      compare(save.busy, false)
+      row.saving = true
+      compare(save.busy, true, "the glyph turns while the save is in flight")
+      verify(save.enabled, "and it stays at full strength rather than looking disabled")
+      row.saving = false
     }
 
     // And vertically, which is the half that was missing. A 24px control in a

--- a/tests/qml/tst_attachment_save.qml
+++ b/tests/qml/tst_attachment_save.qml
@@ -1,0 +1,93 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../../components" as Omamail
+
+// An attachment row has two verbs now, and they must not be one.
+//
+// The filename opens — which is what a filename does everywhere else — and
+// saving is its own target. A single click meaning both, or the wrong one,
+// is the mistake worth a test.
+Item {
+  width: 500
+  height: 80
+
+  Omamail.AttachmentRow {
+    id: row
+    width: parent.width
+    attachment: ({ filename: "statement.pdf", mimeType: "application/pdf",
+      size: 12345, attachmentId: "part:1" })
+    textColor: Qt.rgba(0.1, 0.1, 0.1, 1)
+    dimColor: Qt.rgba(0.45, 0.45, 0.45, 1)
+    dimmerColor: Qt.rgba(0.6, 0.6, 0.6, 1)
+    panelFontFamily: "monospace"
+  }
+
+  SignalSpy {
+    id: openSpy
+    target: row
+    signalName: "openRequested"
+  }
+
+  SignalSpy {
+    id: saveSpy
+    target: row
+    signalName: "saveRequested"
+  }
+
+  TestCase {
+    name: "AttachmentSave"
+    when: windowShown
+
+    function find(objectName, item) {
+      var node = item === undefined ? row : item
+      if (!node) return null
+      if (node.objectName === objectName) return node
+      var children = node.children || []
+      for (var i = 0; i < children.length; i++) {
+        var found = find(objectName, children[i])
+        if (found) return found
+      }
+      return null
+    }
+
+    function init() {
+      openSpy.clear()
+      saveSpy.clear()
+    }
+
+    function test_the_row_offers_both_verbs() {
+      verify(find("attachment-open-link"), "the filename opens it")
+      var save = find("attachment-save-button")
+      verify(save, "and there is somewhere to click to keep it")
+      verify(save.width > 0 && save.height > 0)
+    }
+
+    function test_saving_asks_to_save_and_nothing_else() {
+      var save = find("attachment-save-button")
+      mouseClick(save, save.width / 2, save.height / 2)
+
+      compare(saveSpy.count, 1)
+      compare(openSpy.count, 0, "keeping a file must not also open it")
+      compare(saveSpy.signalArguments[0][0].filename, "statement.pdf",
+        "and it carries the attachment that was clicked")
+    }
+
+    function test_the_filename_still_opens_it() {
+      var link = find("attachment-open-link")
+      mouseClick(link, 10, link.height / 2)
+
+      compare(openSpy.count, 1)
+      compare(saveSpy.count, 0)
+    }
+
+    // The two sit in the same row, so the size label has to give up the space
+    // rather than the button landing on top of it.
+    function test_the_button_does_not_overlap_the_size() {
+      var save = find("attachment-save-button")
+      var saveLeft = save.mapToItem(row, 0, 0).x
+      verify(saveLeft > 0)
+      verify(saveLeft + save.width <= row.width + 1,
+        "the button stays inside the row")
+    }
+  }
+}

--- a/tests/test_attachment_save.sh
+++ b/tests/test_attachment_save.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+# Keeping an attachment: where it lands, what it is called, and what it must
+# never do to a file that was already there.
+set -eu
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+script="$root/scripts/save-attachment.py"
+work=$(mktemp -d "${TMPDIR:-/tmp}/omamail-attachment-save-test.XXXXXX")
+trap 'rm -rf "$work"' EXIT INT TERM HUP
+
+failures=0
+
+check() {
+  if [ "$2" = "$3" ]; then
+    printf '  ok   %s\n' "$1"
+  else
+    printf '  FAIL %s\n' "$1"
+    printf '       expected: %s\n' "$3"
+    printf '       actual:   %s\n' "$2"
+    failures=$(( failures + 1 ))
+  fi
+}
+
+b64() { printf '%s' "$1" | base64 | tr -d '\n'; }
+
+# base64url, the way a provider hands one over.
+b64url_file() { base64 < "$1" | tr -d '\n=' | tr '/+' '_-'; }
+
+save() {
+  # <download dir> <filename> <path to the bytes> -> the saved path on stdout
+  printf '%s\n%s\n' "$(b64 "$2")" "$(b64url_file "$3")" \
+    | XDG_DOWNLOAD_DIR="$1" "$script"
+}
+
+printf 'save-attachment.py\n'
+
+downloads="$work/Downloads"
+mkdir -p "$downloads"
+printf '\000\001\177\200\376\377statement bytes\n' > "$work/bytes"
+
+# ------------------------------------------------------------------ the file
+
+saved=$(save "$downloads" 'statement.pdf' "$work/bytes")
+check "the saved path is reported" "$saved" "$downloads/statement.pdf"
+if cmp -s "$work/bytes" "$saved"; then
+  printf '  ok   every byte survives, including the ones that are not text\n'
+else
+  printf '  FAIL the saved file does not match the attachment\n'
+  failures=$(( failures + 1 ))
+fi
+check "and it is private" "$(stat -c '%a' "$saved")" "600"
+
+# ------------------------------------------------------- never overwriting
+
+second=$(save "$downloads" 'statement.pdf' "$work/bytes")
+check "the same name again is numbered" "$second" "$downloads/statement (2).pdf"
+third=$(save "$downloads" 'statement.pdf' "$work/bytes")
+check "and again" "$third" "$downloads/statement (3).pdf"
+# Two messages carrying one name are two files, and the first must still be
+# the first: this is the loss nobody notices until they need the file.
+if [ -f "$downloads/statement.pdf" ]; then
+  printf '  ok   the original is still there\n'
+else
+  printf '  FAIL the original was overwritten\n'
+  failures=$(( failures + 1 ))
+fi
+# The number goes on the stem, not after the extension, or the file stops
+# opening in what opens a PDF.
+check "the extension stays last" "${second##*.}" "pdf"
+
+# ------------------------------------------------- a name from a stranger
+
+escape=$(save "$downloads" '../../etc/passwd' "$work/bytes")
+check "a path cannot leave the folder" "$escape" "$downloads/passwd"
+
+windows=$(save "$downloads" 'C:\\Users\\me\\notes.txt' "$work/bytes")
+check "a Windows path is a filename too" "$windows" "$downloads/notes.txt"
+
+# A newline in a filename is unreadable in every listing that shows it, and
+# this one also has to survive being the first line of the request.
+control=$(save "$downloads" 'two
+lines.txt' "$work/bytes")
+check "a control character becomes an underscore" "$(basename "$control")" "two_lines.txt"
+
+nameless=$(save "$downloads" '..' "$work/bytes")
+check "a name that is only dots is not a name" "$nameless" "$downloads/attachment"
+
+# --------------------------------------------------------- where it lands
+
+# The folder is created rather than refused: a fresh machine may not have one
+# yet, and the alternative is telling the user to go and make it.
+fresh="$work/fresh/nested/Downloads"
+made=$(save "$fresh" 'report.txt' "$work/bytes")
+check "a download folder that does not exist yet is created" "$made" "$fresh/report.txt"
+
+# Read from user-dirs.dirs when the environment says nothing, because that is
+# where the desktop keeps the answer.
+mkdir -p "$work/home/.config" "$work/home/Papiery"
+printf 'XDG_DOWNLOAD_DIR="$HOME/Papiery"\n' > "$work/home/.config/user-dirs.dirs"
+configured=$(printf '%s\n%s\n' "$(b64 'z-katalogu.txt')" "$(b64url_file "$work/bytes")" \
+  | env -u XDG_DOWNLOAD_DIR HOME="$work/home" XDG_CONFIG_HOME="$work/home/.config" "$script")
+check "user-dirs.dirs names the folder" "$configured" "$work/home/Papiery/z-katalogu.txt"
+
+# Nothing configured at all still saves, rather than failing.
+mkdir -p "$work/bare"
+bare=$(printf '%s\n%s\n' "$(b64 'anywhere.txt')" "$(b64url_file "$work/bytes")" \
+  | env -u XDG_DOWNLOAD_DIR HOME="$work/bare" XDG_CONFIG_HOME="$work/bare/.config" "$script")
+check "with nothing configured it still lands somewhere" "$bare" "$work/bare/Downloads/anywhere.txt"
+
+# ------------------------------------------------------------- refusals
+
+if printf '%s\n' "$(b64 'lonely.txt')" | XDG_DOWNLOAD_DIR="$downloads" "$script" >/dev/null 2>&1; then
+  printf '  FAIL a request with no data is refused\n'
+  failures=$(( failures + 1 ))
+else
+  printf '  ok   a request with no data is refused\n'
+fi
+
+if printf '%s\n%s\n' "$(b64 'bad.txt')" 'not base64 at all!!' \
+  | XDG_DOWNLOAD_DIR="$downloads" "$script" >/dev/null 2>&1; then
+  printf '  FAIL data that is not base64 is refused\n'
+  failures=$(( failures + 1 ))
+else
+  printf '  ok   data that is not base64 is refused\n'
+fi
+
+# A refused save leaves nothing behind that looks like the attachment and
+# opens as nothing.
+if [ -f "$downloads/bad.txt" ]; then
+  printf '  FAIL a refused save left a file behind\n'
+  failures=$(( failures + 1 ))
+else
+  printf '  ok   a refused save leaves no half-written file\n'
+fi
+
+if [ "$failures" -eq 0 ]; then
+  printf 'save-attachment.py ok\n'
+else
+  printf '%s failure(s)\n' "$failures" >&2
+  exit 1
+fi

--- a/tests/test_attachment_save.sh
+++ b/tests/test_attachment_save.sh
@@ -68,6 +68,23 @@ fi
 # opening in what opens a PDF.
 check "the extension stays last" "${second##*.}" "pdf"
 
+# A name too long for the filesystem is shortened by giving up characters of
+# the stem, never the extension: a name trimmed from the end takes the ".pdf"
+# with it, and the file it names then opens in nothing. The limit counts bytes,
+# so the accented name has to be checked as well as the plain one.
+long_stem=$(printf 'A%.0s' $(seq 1 250))
+long_saved=$(save "$downloads" "$long_stem.pdf" "$work/bytes")
+long_name=${long_saved##*/}
+check "a very long name keeps its extension" "${long_name##*.}" "pdf"
+check "and is short enough to write" "$(printf '%s' "$long_name" | wc -c)" "240"
+
+accented_stem=$(printf '\303\251%.0s' $(seq 1 200))
+accented_saved=$(save "$downloads" "$accented_stem.pdf" "$work/bytes")
+accented_name=${accented_saved##*/}
+check "a long name of multi-byte characters keeps it too" "${accented_name##*.}" "pdf"
+check "and is measured in bytes, not characters" \
+  "$(printf '%s' "$accented_name" | wc -c)" "240"
+
 # ------------------------------------------------- a name from a stranger
 
 escape=$(save "$downloads" '../../etc/passwd' "$work/bytes")


### PR DESCRIPTION
Opening was the only thing an attachment row did: the file went to a private runtime directory, `xdg-open` got it, and it was gone with the session. There was no way to keep one, which the README said plainly under "What it does not do" and which is most of what an attachment is for.

The filename still opens — that is what a filename does everywhere else — and the arrow beside it saves. Two verbs, two targets: one click meaning both, or guessing which was wanted, is the thing that would go wrong.

## Where it lands

The desktop's own answer, read from `XDG_DOWNLOAD_DIR` and then from `user-dirs.dirs` rather than by running `xdg-user-dir`, whose package is not everywhere. The folder is named rather than tested for, and created if it is missing: falling back to the home directory when `~/Downloads` did not exist put saved mail loose among the dotfiles, which a test caught.

No file chooser. `omarchy-file-select` does OpenFile and not SaveFile, so a picker would mean either a zenity dependency or a portal client of its own — and a saved file that names its folder in the notice is what a browser does. A "Save as" is a follow-up rather than a thing missing here.

## Nothing is overwritten

Two messages carrying `invoice.pdf` are two invoices, and the second replacing the first is the kind of loss nobody notices until they need the file. So it is numbered the way a browser numbers it, with the count on the stem so the extension stays last and the file still opens in what opens a PDF. `O_EXCL` rather than a plain write, because asking whether a name is free and then writing to it are two moments.

The name is a stranger's, so it is a filename and not a path: both separators go, control characters become underscores, and a name that is only dots is not a name. Saved `0600`, like everything else this plugin writes.

## Verification

`make validate` green. `tests/test_attachment_save.sh` covers the bytes surviving intact, the mode, the numbering and that the original survives it, the extension staying last, `../../etc/passwd` and a Windows path both becoming filenames, a newline in a name, a folder that does not exist yet, `user-dirs.dirs` naming the folder, nothing configured at all, and that a refused save leaves no half-written file. `tests/qml/tst_attachment_save.qml` asserts the row offers both verbs, that saving does not also open, and that the button fits inside the row.

That last one is there because it did not. The row measured itself from its text, so a 24px control beside 15px of caption hung four pixels out of both ends and the reader's scroller clipped it — leaving the filename as the only thing that could be clicked. The row reports a height that holds it now, and the test asserts both axes rather than only the one it was right about.

## Release Notes

- Attachments can be saved, not only opened. The filename opens one in whatever handles its type; the arrow beside it keeps the file in your download folder and the notice says where it went.
- Two messages carrying one filename are two files: the second is numbered rather than landing on top of the first.
