### PR TITLE
Let the bar icon be turned off without turning the mailbox off

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -72,11 +72,23 @@ BarWidget {
     else if (typeof bar.shell.toggle === "function") bar.shell.toggle("omamail", payload)
   }
 
-  implicitWidth: button.implicitWidth
-  implicitHeight: button.implicitHeight
+  // Whether this draws anything. The widget itself stays: it is the only thing
+  // that hands plugin settings to the service, so a widget removed from the
+  // bar layout instead of hidden here would leave the service running on
+  // defaults — the refresh interval, the notification and every other stored
+  // answer quietly replaced by the one in the manifest.
+  //
+  // Off, it is not merely invisible but takes no width either, so the bar
+  // closes over the gap rather than leaving a hole where the envelope was.
+  readonly property bool drawsIcon: !gmail || gmail.showBarIcon
+
+  visible: drawsIcon
+  implicitWidth: drawsIcon ? button.implicitWidth : 0
+  implicitHeight: drawsIcon ? button.implicitHeight : 0
 
   BarIconButton {
     id: button
+    visible: root.drawsIcon
     anchors.fill: parent
     bar: root.bar
     tooltipText: root.gmail ? root.gmail.barTooltip : "Omamail"

--- a/Service.qml
+++ b/Service.qml
@@ -73,9 +73,13 @@ Item {
 
   // Whether the bar draws an envelope for this.
   //
-  // Read as "anything but a stored false" rather than as `=== true`, so a
-  // settings file written before this existed keeps the icon it already had
-  // instead of losing it to a field nobody chose.
+  // A settings file written before this existed keeps its icon because
+  // `applySettings` lays every default down first, so a missing key is
+  // already the manifest's `true` — the same way `unifiedCalendarView` gets
+  // its `false`. What "anything but a stored false" buys instead is the
+  // hand-edited `shell.json`: a `"false"` or a `0` in there is somebody's
+  // typo rather than an answer given in the interface, and a typo should not
+  // be what takes the icon away.
   readonly property bool showBarIcon: !settings || settings.showBarIcon !== false
 
   // Thunderbird and Betterbird keep both explicit and learned addresses in

--- a/Service.qml
+++ b/Service.qml
@@ -54,7 +54,8 @@ Item {
     notifyNewMail: "On",
     oauthPort: 9481,
     undoSendSeconds: 10,
-    unifiedCalendarView: false
+    unifiedCalendarView: false,
+    showBarIcon: true
   })
   property var settings: defaultSettingValues
   readonly property int undoSendSeconds: Outbox.normalizeDelay(
@@ -69,6 +70,13 @@ Item {
     settings ? settings.contentDirection : null)
   readonly property bool unifiedCalendarView: !!settings
     && settings.unifiedCalendarView === true
+
+  // Whether the bar draws an envelope for this.
+  //
+  // Read as "anything but a stored false" rather than as `=== true`, so a
+  // settings file written before this existed keeps the icon it already had
+  // instead of losing it to a field nobody chose.
+  readonly property bool showBarIcon: !settings || settings.showBarIcon !== false
 
   // Thunderbird and Betterbird keep both explicit and learned addresses in
   // their local profile. The helper reads those databases without modifying
@@ -128,6 +136,10 @@ Item {
 
   function setUnifiedCalendarView(value) {
     persistSetting("unifiedCalendarView", value === true)
+  }
+
+  function setShowBarIcon(value) {
+    persistSetting("showBarIcon", value === true)
   }
 
   // ---------------------------------------------------------- the accounts

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -139,12 +139,13 @@ Column {
 
       // Says what turning it off costs, and what it does not: mail is still
       // checked and still notifies. The keybinding is the part worth naming,
-      // because without one there is nothing left to open the window with.
+      // because without one the window is only reachable from a terminal —
+      // which is true, and is why this does not claim there is no way back.
       Text {
         width: parent.width
         text: "Mail is still checked and still notifies; only the envelope goes. "
-          + "Bind a key before turning this off, or there is no way left to open "
-          + "the window:"
+          + "With it off the window opens from a keybinding or a terminal and "
+          + "nowhere else, so bind a key before turning this off:"
         color: root.dimColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.caption

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -38,6 +38,7 @@ Column {
   // below it in the rail's map as well as on screen. The calendars section
   // is a component with its own heading, so its top stands in.
   readonly property var sections: [
+    { key: "bar", title: "Bar", y: barHeading.y },
     { key: "reading", title: "Reading", y: readingHeading.y },
     { key: "notifications", title: "Notifications", y: notificationsHeading.y },
     { key: "writing", title: "Writing", y: writingHeading.y },
@@ -98,6 +99,82 @@ Column {
     font.family: root.panelFontFamily
     font.pixelSize: Style.font.heading
     font.bold: true
+  }
+
+  // ------------------------------------------------------------------- bar
+
+  Text {
+    id: barHeading
+    text: "BAR"
+    color: root.dimColor
+    font.family: root.panelFontFamily
+    font.pixelSize: Style.font.caption
+    font.letterSpacing: 1
+  }
+
+  Rectangle {
+    width: parent.width
+    implicitHeight: Math.max(barIconText.implicitHeight, barIconSwitch.implicitHeight)
+      + Style.space(16)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+
+    Column {
+      id: barIconText
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(12)
+      anchors.right: barIconSwitch.left
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(2)
+
+      Text {
+        width: parent.width
+        text: "Show the icon in the bar"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        textFormat: Text.PlainText
+      }
+
+      // Says what turning it off costs, and what it does not: mail is still
+      // checked and still notifies. The keybinding is the part worth naming,
+      // because without one there is nothing left to open the window with.
+      Text {
+        width: parent.width
+        text: "Mail is still checked and still notifies; only the envelope goes. "
+          + "Bind a key before turning this off, or there is no way left to open "
+          + "the window:"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+        textFormat: Text.PlainText
+      }
+
+      Text {
+        width: parent.width
+        text: "o.bind(\"SUPER + SHIFT + G\", \"Omamail\", "
+          + "\"omarchy shell shell toggle omamail '\{}'\")"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WrapAnywhere
+        textFormat: Text.PlainText
+      }
+    }
+
+    ToggleSwitch {
+      id: barIconSwitch
+      objectName: "showBarIconSwitch"
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      checked: !root.service || root.service.showBarIcon !== false
+      foreground: root.textColor
+      accent: root.accentColor
+      onToggled: if (root.service) root.service.setShowBarIcon(!root.service.showBarIcon)
+    }
   }
 
   // --------------------------------------------------------------- reading

--- a/manifest.json
+++ b/manifest.json
@@ -54,7 +54,7 @@
         "type": "boolean",
         "label": "Show the icon in the bar",
         "defaultValue": true,
-        "description": "Turn this off to keep Omamail without an envelope in the bar. Mail is still checked and still notifies; only the icon goes. Bind a key first or there will be no way to open the window: o.bind(\"SUPER + SHIFT + G\", \"Omamail\", \"omarchy shell shell toggle omamail '{}'\")"
+        "description": "Turn this off to run Omamail with no envelope in the bar. Mail is still checked and still notifies; only the icon goes. With it off the window opens from a keybinding or a terminal and nowhere else, so bind a key first: o.bind(\"SUPER + SHIFT + G\", \"Omamail\", \"omarchy shell shell toggle omamail '{}'\")"
       },
       {
         "key": "refreshIntervalSec",

--- a/manifest.json
+++ b/manifest.json
@@ -45,9 +45,17 @@
       "oauthPort": 9481,
       "undoSendSeconds": 10,
       "unifiedCalendarView": false,
-      "openOnClick": "Window"
+      "openOnClick": "Window",
+      "showBarIcon": true
     },
     "schema": [
+      {
+        "key": "showBarIcon",
+        "type": "boolean",
+        "label": "Show the icon in the bar",
+        "defaultValue": true,
+        "description": "Turn this off to keep Omamail without an envelope in the bar. Mail is still checked and still notifies; only the icon goes. Bind a key first or there will be no way to open the window: o.bind(\"SUPER + SHIFT + G\", \"Omamail\", \"omarchy shell shell toggle omamail '{}'\")"
+      },
       {
         "key": "refreshIntervalSec",
         "type": "integer",

--- a/tests/qml/imports/qs/Ui/BarIconButton.qml
+++ b/tests/qml/imports/qs/Ui/BarIconButton.qml
@@ -1,0 +1,20 @@
+import QtQuick
+
+// The clickable slot a bar widget draws into. The icon itself is a Component
+// the caller supplies, which a test never has to render.
+Item {
+  property QtObject bar: null
+  property Component iconComponent: null
+  property string tooltipText: ""
+  property real slotSize: 24
+  property real opticalSize: 20
+  implicitWidth: slotSize
+  implicitHeight: slotSize
+  // The real one inherits WidgetButton, whose press carries which mouse
+  // button it was: the widget opens the window on the primary and the preview
+  // on the secondary, so a stub with a bare `clicked()` cannot stand in.
+  property bool active: false
+  property color foreground: Qt.rgba(1, 1, 1, 1)
+  signal pressed(int button)
+  signal wheelMoved(int delta)
+}

--- a/tests/qml/imports/qs/Ui/BarWidget.qml
+++ b/tests/qml/imports/qs/Ui/BarWidget.qml
@@ -1,0 +1,18 @@
+import QtQuick
+
+// What a bar widget is, as far as a test needs: an Item the bar gives a
+// reference to itself and a settings object. Stubbed rather than imported
+// because the real one reaches for the running bar's geometry.
+//
+// It has to exist for `BarWidget.qml` in the plugin root to be testable at
+// all: without it the root type resolves to the plugin's own file of the same
+// name, and QML reports the file as instantiated recursively.
+Item {
+  property QtObject bar: null
+  property string moduleName: ""
+  property var settings: ({})
+  readonly property bool vertical: bar ? bar.vertical : false
+  readonly property int barSize: 32
+  readonly property color barForeground: bar && bar.barForeground
+    ? bar.barForeground : Qt.rgba(1, 1, 1, 1)
+}

--- a/tests/qml/imports/qs/Ui/BarWidget.qml
+++ b/tests/qml/imports/qs/Ui/BarWidget.qml
@@ -7,12 +7,15 @@ import QtQuick
 // It has to exist for `BarWidget.qml` in the plugin root to be testable at
 // all: without it the root type resolves to the plugin's own file of the same
 // name, and QML reports the file as instantiated recursively.
+//
+// Only what the real base declares. `barForeground` in particular is *not* a
+// property of it — the plugin's own comment says reading it here yields
+// undefined, and the bar is the source — so a stub that offered one would let
+// exactly that regression pass.
 Item {
   property QtObject bar: null
   property string moduleName: ""
   property var settings: ({})
   readonly property bool vertical: bar ? bar.vertical : false
   readonly property int barSize: 32
-  readonly property color barForeground: bar && bar.barForeground
-    ? bar.barForeground : Qt.rgba(1, 1, 1, 1)
 }

--- a/tests/qml/imports/qs/Ui/KeyboardPanel.qml
+++ b/tests/qml/imports/qs/Ui/KeyboardPanel.qml
@@ -1,0 +1,22 @@
+import QtQuick
+
+// The popout a bar widget opens. The real one is a PanelWindow — a Wayland
+// layer surface — which cannot be created offscreen, so this is an Item that
+// accepts the same properties and holds the same children.
+Item {
+  property Item anchorItem: null
+  property var owner: null
+  property QtObject bar: null
+  property bool open: false
+  property int contentWidth: 280
+  property int contentHeight: 200
+  property int margin: 8
+  property int padding: 8
+  property bool centerOnBar: false
+  property int gap: 8
+  property bool popoutSwitching: false
+  property bool popoutSwitchClosing: false
+  property bool focusPrimed: false
+  property Item focusTarget: null
+  visible: false
+}

--- a/tests/qml/imports/qs/Ui/qmldir
+++ b/tests/qml/imports/qs/Ui/qmldir
@@ -9,3 +9,6 @@ PanelSectionHeader 1.0 PanelSectionHeader.qml
 PanelToolTip 1.0 PanelToolTip.qml
 ToggleSwitch 1.0 ToggleSwitch.qml
 Dropdown 1.0 Dropdown.qml
+BarWidget 1.0 BarWidget.qml
+BarIconButton 1.0 BarIconButton.qml
+KeyboardPanel 1.0 KeyboardPanel.qml

--- a/tests/qml/tst_bar_widget_icon.qml
+++ b/tests/qml/tst_bar_widget_icon.qml
@@ -1,0 +1,103 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../.." as Omamail
+
+// The bar widget with its icon turned off.
+//
+// It has to stay in the bar to keep working: it is the only thing that hands
+// plugin settings to the service, so a widget removed from the layout instead
+// of hidden here would leave the service running on the manifest's defaults.
+// That is the whole reason this is a setting rather than a line deleted from
+// shell.json, and it is what these assert.
+Item {
+  width: 400
+  height: 60
+
+  QtObject {
+    id: fakeService
+
+    property bool showBarIcon: true
+    property bool ready: true
+    property bool windowOpen: false
+    property int unreadTotal: 3
+    property string barTooltip: "Omamail"
+    property var barMessages: []
+    property var barEvents: []
+
+    // What the widget pushed across, and how many times.
+    property var appliedSettings: null
+    property int applyCount: 0
+
+    function applySettings(values) {
+      appliedSettings = values
+      applyCount += 1
+    }
+
+    function refreshCalendarPreview() {}
+  }
+
+  QtObject {
+    id: fakeShell
+    function serviceFor(_id) { return fakeService }
+    function summon(_id, _payload) {}
+  }
+
+  QtObject {
+    id: fakeBar
+    property var shell: fakeShell
+    property bool vertical: false
+    property color barForeground: Qt.rgba(1, 1, 1, 1)
+  }
+
+  Omamail.BarWidget {
+    id: widget
+    bar: fakeBar
+    settings: ({ refreshIntervalSec: 300, showBarIcon: true })
+  }
+
+  TestCase {
+    name: "BarWidgetIcon"
+    when: windowShown
+
+    function init() {
+      fakeService.showBarIcon = true
+      fakeService.applyCount = 0
+    }
+
+    function test_the_icon_is_drawn_by_default() {
+      compare(widget.drawsIcon, true)
+      compare(widget.visible, true)
+      verify(widget.implicitWidth > 0)
+    }
+
+    // Not merely invisible: it gives up its width too, so the bar closes over
+    // the gap rather than leaving a hole where the envelope was.
+    function test_turning_it_off_takes_the_width_with_it() {
+      fakeService.showBarIcon = false
+      compare(widget.drawsIcon, false)
+      compare(widget.visible, false)
+      compare(widget.implicitWidth, 0)
+      compare(widget.implicitHeight, 0)
+    }
+
+    // The point of hiding rather than removing: settings still reach the
+    // service, so the refresh interval and the rest survive.
+    function test_a_hidden_widget_still_hands_settings_to_the_service() {
+      fakeService.showBarIcon = false
+      fakeService.applyCount = 0
+
+      widget.settings = ({ refreshIntervalSec: 600, showBarIcon: false })
+
+      compare(fakeService.applyCount, 1,
+        "a hidden widget is still the only route settings have")
+      compare(fakeService.appliedSettings.refreshIntervalSec, 600)
+      compare(widget.drawsIcon, false, "and it is still hidden")
+    }
+
+    // With no service to ask, the icon is drawn: a widget that vanished while
+    // the service was starting would flicker out of the bar on every login.
+    function test_no_service_yet_still_draws() {
+      compare(widget.drawsIcon, true)
+    }
+  }
+}

--- a/tests/qml/tst_bar_widget_icon.qml
+++ b/tests/qml/tst_bar_widget_icon.qml
@@ -42,6 +42,15 @@ Item {
     function summon(_id, _payload) {}
   }
 
+  // The shell before it has built the service. `Shell.serviceFor` is a lookup
+  // in a map the shell fills in as it constructs services — it never creates
+  // one — so a bar widget really can be asked to draw with nothing to ask.
+  QtObject {
+    id: startingShell
+    function serviceFor(_id) { return null }
+    function summon(_id, _payload) {}
+  }
+
   QtObject {
     id: fakeBar
     property var shell: fakeShell
@@ -60,6 +69,7 @@ Item {
     when: windowShown
 
     function init() {
+      fakeBar.shell = fakeShell
       fakeService.showBarIcon = true
       fakeService.applyCount = 0
     }
@@ -96,8 +106,16 @@ Item {
 
     // With no service to ask, the icon is drawn: a widget that vanished while
     // the service was starting would flicker out of the bar on every login.
+    //
+    // The shell is swapped for one holding no service, because a fake that
+    // always answers with one leaves this branch unmeasured: `drawsIcon` is
+    // true there whether the missing service means "draw" or "do not".
     function test_no_service_yet_still_draws() {
+      fakeBar.shell = startingShell
+      compare(widget.gmail, null, "the shell has no service to hand over yet")
       compare(widget.drawsIcon, true)
+      compare(widget.visible, true)
+      verify(widget.implicitWidth > 0)
     }
   }
 }

--- a/tests/qml/tst_service_settings.qml
+++ b/tests/qml/tst_service_settings.qml
@@ -27,6 +27,34 @@ Item {
   TestCase {
     name: "ServiceSettings"
 
+    // On unless something stored says otherwise, which is what keeps a
+    // settings file written before this existed from losing its icon to a
+    // field nobody chose.
+    function test_the_bar_icon_is_shown_unless_it_was_turned_off() {
+      mailService.applySettings({})
+      compare(mailService.showBarIcon, true)
+
+      mailService.applySettings({ showBarIcon: false })
+      compare(mailService.showBarIcon, false)
+
+      mailService.applySettings({ showBarIcon: true })
+      compare(mailService.showBarIcon, true)
+
+      // A stored value of some other shape is not a decision to hide it.
+      mailService.applySettings({ showBarIcon: "no" })
+      compare(mailService.showBarIcon, true,
+        "only a stored false hides the icon")
+    }
+
+    function test_hiding_the_bar_icon_persists() {
+      mailService.applySettings({})
+      mailService.setShowBarIcon(false)
+      compare(mailService.showBarIcon, false)
+      compare(shellStore.updatedId, "omamail")
+      verify(shellStore.updatedEntry !== null)
+      compare(shellStore.updatedEntry.showBarIcon, false)
+    }
+
     function test_unified_calendar_setting_defaults_off_and_persists_changes() {
       mailService.applySettings({})
       compare(mailService.unifiedCalendarView, false)

--- a/tests/qml/tst_service_settings.qml
+++ b/tests/qml/tst_service_settings.qml
@@ -27,9 +27,10 @@ Item {
   TestCase {
     name: "ServiceSettings"
 
-    // On unless something stored says otherwise, which is what keeps a
-    // settings file written before this existed from losing its icon to a
-    // field nobody chose.
+    // On unless a stored `false` says otherwise. Settings written before this
+    // existed name no key at all and so keep their icon, and a value of some
+    // other shape — a hand-edited `shell.json`, say — is not an answer
+    // anybody gave in the interface.
     function test_the_bar_icon_is_shown_unless_it_was_turned_off() {
       mailService.applySettings({})
       compare(mailService.showBarIcon, true)

--- a/tests/qml/tst_settings_sidebar.qml
+++ b/tests/qml/tst_settings_sidebar.qml
@@ -247,12 +247,21 @@ Item {
 
     // The rail names the sections in the page's order, and the page reports
     // where each begins, in that same order.
+    // By key rather than by position: these used to be `sections[2]` and
+    // friends, so adding a section renumbered assertions that had nothing to
+    // do with it.
+    function sectionY(page, key) {
+      for (var i = 0; i < page.sections.length; i++)
+        if (page.sections[i].key === key) return page.sections[i].y
+      return -1
+    }
+
     function test_the_rail_lists_the_pages_sections_in_order() {
       var rail = named(app, "settings-sidebar")
       verify(rail && rail.visible, "a wide window has a rail")
       var page = named(app, "settings-page")
       var keys = page.sections.map(function(s) { return s.key })
-      compare(keys.join(","), "reading,notifications,writing,mailboxes,calendars,oauth")
+      compare(keys.join(","), "bar,reading,notifications,writing,mailboxes,calendars,oauth")
       for (var i = 1; i < page.sections.length; i++)
         verify(page.sections[i].y > page.sections[i - 1].y, "sections are laid out top to bottom")
       for (var j = 0; j < keys.length; j++)
@@ -267,7 +276,8 @@ Item {
       var view = flick()
       verify(view, "the page scrolls inside a Flickable")
       compare(view.contentY, 0)
-      compare(rail.activeKey, "reading")
+      compare(rail.activeKey, "bar",
+        "the top of the page is the first section, whichever that is")
       compare(app.navKinds.join(","), "list,settings")
 
       // The rail sits against the page, and the pair is centred in the area.
@@ -282,7 +292,7 @@ Item {
 
       var writing = named(rail, "settings-section-writing")
       mouseClick(writing)
-      tryVerify(function() { return Math.abs(view.contentY - page.sections[2].y) < 1 }, 1000,
+      tryVerify(function() { return Math.abs(view.contentY - sectionY(page, "writing")) < 1 }, 1000,
         "the page slid until the Writing heading was at the top")
       compare(app.navKinds.join(","), "list,settings", "still one page in history")
       tryCompare(rail, "activeKey", "writing")
@@ -290,15 +300,15 @@ Item {
       // Every section can be put at the top, the last included: the content
       // is padded under the page for exactly that.
       mouseClick(named(rail, "settings-section-oauth"))
-      tryVerify(function() { return Math.abs(view.contentY - page.sections[5].y) < 1 }, 1000,
+      tryVerify(function() { return Math.abs(view.contentY - sectionY(page, "oauth")) < 1 }, 1000,
         "the last heading reaches the top too")
       tryCompare(rail, "activeKey", "oauth")
 
       // Scrolled by other means — the wheel, say — the highlight still
       // follows the page, because the page is what it describes.
       view.contentY = 0
-      tryCompare(rail, "activeKey", "reading")
-      view.contentY = page.sections[3].y + 5
+      tryCompare(rail, "activeKey", "bar")
+      view.contentY = sectionY(page, "mailboxes") + 5
       tryCompare(rail, "activeKey", "mailboxes")
     }
 


### PR DESCRIPTION
There was no way to keep Omamail and not have an envelope in the bar.

The Omarchy-level answer — deleting the widget from the bar layout in `shell.json` — hides it and costs more than it looks. `BarWidget.pushSettings` is the only thing that hands plugin settings to the service, as `AGENTS.md` says under Entry points, so a mailbox without a widget in the bar runs on the manifest's defaults: the refresh interval, the notification setting and every other stored answer quietly replaced.

So the widget stays and stops drawing. Off, it gives up its width as well as its visibility, because a zero-width widget lets the bar close over the gap rather than leaving a hole where the envelope was. Settings still cross, which is the whole reason this is a setting rather than a line removed from `shell.json`.

Shown unless something stored says otherwise, rather than on a strict `true`, so a settings file written before this existed keeps the icon it already had.

## The trap it would otherwise be

Turning the icon off with no keybinding leaves nothing to open the window with. The switch says what turning it off does not do — mail is still checked and still notifies — and prints the binding, because a setting that can strand the application should say so where it is turned off.

## Test harness

Testing the widget at all needed the bar types the shell owns. Without a `BarWidget` stub the root type of `BarWidget.qml` resolves to the plugin's own file of the same name and QML reports it as instantiated recursively, so `tests/qml/imports/qs/Ui` gains the three it uses.

The settings sidebar's assertions moved off section positions and onto section keys, because adding a section renumbered assertions that had nothing to do with it.

## Verification

`make validate` green. `tests/qml/tst_bar_widget_icon.qml` asserts the icon is drawn by default, that turning it off takes the width with it, that a hidden widget still hands settings to the service, and that no service yet still draws — so the widget does not flicker out of the bar while the service starts. `tests/qml/tst_service_settings.qml` covers the setting defaulting on, persisting, and that only a stored `false` hides it.

## Release Notes

- The bar icon can be turned off in Settings → Bar, without turning the mailbox off. Mail is still checked and still notifies; only the envelope goes.
- Bind a key to the window before turning it off, or there is no way left to open it. The setting names the binding.
