### PR TITLE
Add an All Mailboxes view

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -2036,7 +2036,8 @@ Item {
               // age follows it, and the line opens the account controls.
               text: {
                 if (!root.service || !root.ready) return "Not connected"
-                return Model.accountStatusLine(root.service.accountEmail, root.service.syncedLabel)
+                return Model.readingStatusLine(root.service.unified,
+                  root.service.accountEmail, root.service.syncedLabel)
               }
               color: accountMouse.containsMouse || accountControl.selected ? root.foreground : root.dim
               font.family: root.fontFamily

--- a/App.qml
+++ b/App.qml
@@ -713,7 +713,19 @@ Item {
   // checks the final action before its optimistic update.
   function openLabelPicker() {
     if (!service || cursorId === "") return false
-    if (service.refuseUnavailableAction("label:destination")) return false
+    // A merged list draws no labels, so there is nothing to offer and the
+    // picker would open empty on a destination list it cannot fill — and a
+    // chosen id would belong to whichever mailbox happened to be active
+    // rather than to the row. Refused where it cannot be honoured, which is
+    // the same rule every other unavailable action follows.
+    // Only the merged-list refusal belongs here. A single mailbox whose
+    // provider has no move verb is the provider guard's answer, and saying
+    // "needs one mailbox on screen" over it would name the wrong reason.
+    if (service.unified) {
+      service.fail("Moving to a label needs one mailbox on screen")
+      return false
+    }
+    if (service.refuseUnavailableAction("label:destination", cursorId)) return false
     labelPicker.open()
     return true
   }
@@ -1061,12 +1073,16 @@ Item {
     var keepCalendar = calendarVisible
     var mailbox = service.mailboxKey
     service.setUnifiedMailboxes(true)
+    // The rail row is chosen either way. Returning early with the calendar up
+    // left every mailbox on whatever it had been showing while the rail
+    // claimed one, so coming back from the calendar landed on a list that was
+    // not the row highlighted beside it.
+    var target = Model.mailboxAfterAccountSwitch(mailbox, service.mailboxes)
+    service.selectMailbox(target !== "" ? target : "inbox")
     if (keepCalendar) {
       showCalendar()
       return true
     }
-    var target = Model.mailboxAfterAccountSwitch(mailbox, service.mailboxes)
-    service.selectMailbox(target !== "" ? target : "inbox")
     backToList()
     return true
   }

--- a/App.qml
+++ b/App.qml
@@ -1053,10 +1053,32 @@ Item {
     }
   }
 
+  // Every mailbox at once. The rail it lands on has to be one they all have,
+  // so a row only some of them offered — Gmail's own Archive beside an IMAP
+  // mailbox — does not leave the list asking for something nothing can serve.
+  function chooseUnified() {
+    if (!service) return false
+    var keepCalendar = calendarVisible
+    var mailbox = service.mailboxKey
+    service.setUnifiedMailboxes(true)
+    if (keepCalendar) {
+      showCalendar()
+      return true
+    }
+    var target = Model.mailboxAfterAccountSwitch(mailbox, service.mailboxes)
+    service.selectMailbox(target !== "" ? target : "inbox")
+    backToList()
+    return true
+  }
+
   function switchAccount(index) {
     if (!service) return false
     var keepCalendar = calendarVisible
     var mailbox = service.mailboxKey
+    // Choosing one mailbox is choosing to be in it, so the combined view goes
+    // off. Leaving it on would have named an account in the bar and gone on
+    // showing every one of them.
+    if (service.unifiedMailboxes) service.setUnifiedMailboxes(false)
     if (service.switchToIndex(index) !== true) return false
     if (keepCalendar) {
       showCalendar()
@@ -2134,9 +2156,11 @@ Item {
         popupBorderColor: root.popupBorder
         panelFontFamily: root.fontFamily
         accounts: root.service ? root.service.accountSummaries : []
+        unifiedActive: !!root.service && root.service.unified
         onAccountChosen: function(index) {
           root.switchAccount(index)
         }
+        onUnifiedChosen: root.chooseUnified()
         onAddAccountRequested: root.addMailbox()
         onManageRequested: {
           root.openSettings()

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ test-js:
 	node tests/test_conversation.js
 	node tests/test_keymap.js
 	node tests/test_accounts.js
+	node tests/test_unified.js
 	node tests/test_aliases.js
 	node tests/test_menu.js
 	node tests/test_provider.js

--- a/Service.qml
+++ b/Service.qml
@@ -236,14 +236,38 @@ Item {
     // a half-added mailbox could never be the one on screen, and setup would
     // have nothing to run in.
     if (!next && accountHosts.count > 0) next = accountHosts.objectAt(0)
-    if (next === current) return
+    if (next !== current) current = next
+    applyLiveHosts()
+  }
+
+  // Which mailboxes are live, which is what earns a list.
+  //
+  // `active` gates every list load there is: `refresh` will not reload an
+  // already-loaded list without it, `onActiveChanged` is what asks for the
+  // first one, and the poll timer checks it before extending one. Leaving it
+  // on the visible account meant a merged list refreshed one mailbox's rows
+  // and left the others as they were — counts moved, mail did not. A merged
+  // view has every mailbox on screen at once, so every mailbox gets one.
+  //
+  // `windowOpen` travels with it for the same reason: `refresh` reloads a
+  // loaded list only for a mailbox the window is showing.
+  function applyLiveHosts() {
     for (var i = 0; i < accountHosts.count; i++) {
       var host = accountHosts.objectAt(i)
-      if (host) host.active = host === next
+      if (!host) continue
+      // A mailbox part-way through being added has no id and no rows to
+      // contribute, so it is live only when it is the one on screen — which
+      // is what setup runs in.
+      var live = host === current
+        || (unified && String(host.accountId || "") !== "")
+      host.active = live
+      if (live) host.windowOpen = windowOpen
     }
-    current = next
-    if (current) current.windowOpen = windowOpen
   }
+
+  // Turning the merged view on or off changes which mailboxes are live, and
+  // `refreshCurrent` does not run for it: the account on screen has not moved.
+  onUnifiedChanged: applyLiveHosts()
 
   // The whole point of switching is that it is instant, which it is because
   // each account keeps its own cache on disk. A queued send belongs to its
@@ -788,10 +812,32 @@ Item {
 
   // Which services are involved, which is what decides the rail and every
   // button on it. Two Gmail mailboxes ask one provider's questions.
-  readonly property var unifiedProviders: {
+  // What every mailbox in the merge can actually do, and which rail rows it
+  // has. Read off the hosts rather than their provider ids: each one has
+  // already narrowed its provider by the refusals its server reported and the
+  // mailboxes that turned out not to be there, and those arrive while the app
+  // is running. Reading them here is what makes the intersection follow them.
+  readonly property var unifiedAbilities: {
+    var _epoch = listEpoch
+    var out = []
     var accounts = accountList ? accountList.accounts : []
-    return Unified.providersOf(accounts)
+    for (var i = 0; i < accounts.length; i++) {
+      if (!accounts[i].id) continue
+      var host = accountHosts.objectAt(i)
+      out.push({
+        archive: !!(host && host.canArchive),
+        spam: !!(host && host.canReportSpam),
+        star: !!(host && host.canStar),
+        labels: !!(host && host.hasLabels),
+        web: !!(host && host.canOpenOnWeb),
+        move: !!(host && host.canMove),
+        conversations: !!(host && host.showsConversations),
+        mailboxes: host ? host.mailboxes : []
+      })
+    }
+    return out
   }
+
 
   readonly property var unifiedMessages: Unified.mergeMessages(unifiedSources)
 
@@ -858,7 +904,7 @@ Item {
 
   property bool windowOpen: false
   onWindowOpenChanged: {
-    if (current) current.windowOpen = windowOpen
+    applyLiveHosts()
     if (windowOpen) restoreWindow = false
     saveWindowPrefs()
   }
@@ -911,7 +957,7 @@ Item {
   // view cannot offer it: the picker would open on an empty list, and a chosen
   // id would belong to whichever mailbox happened to be active.
   readonly property bool canMoveToLabel: !unified
-    && Provider.can(providerId, "move")
+    && !!current && current.canMove
 
   // Which service the mailbox on screen is, what mailboxes it has, and what it
   // can be asked to do. Forwarded like everything else so a view never has to
@@ -920,28 +966,28 @@ Item {
   // `providerId` stays the *visible* mailbox's even in a merged view: it
   // decides what a query string means and what a setup page offers, both of
   // which belong to one account. What a merged list may *do* comes from
-  // `Unified.sharedCapability` rather than from here.
+  // `Unified.everyMailboxCan` rather than from here.
   readonly property string providerId: current ? current.providerId : Provider.DEFAULT_ID
   readonly property var mailboxes: unified
-    ? Unified.sharedMailboxes(unifiedProviders)
+    ? Unified.sharedMailboxRows(unifiedAbilities)
     : (current ? current.mailboxes : Provider.mailboxes(Provider.DEFAULT_ID))
   readonly property bool canArchive: unified
-    ? Unified.sharedCapability(unifiedProviders, "archive")
+    ? Unified.everyMailboxCan(unifiedAbilities, "archive")
     : (!current || current.canArchive)
   readonly property bool canReportSpam: unified
-    ? Unified.sharedCapability(unifiedProviders, "spam")
+    ? Unified.everyMailboxCan(unifiedAbilities, "spam")
     : (!current || current.canReportSpam)
   readonly property bool canStar: unified
-    ? Unified.sharedCapability(unifiedProviders, "star")
+    ? Unified.everyMailboxCan(unifiedAbilities, "star")
     : (!current || current.canStar)
   readonly property bool hasLabels: unified
-    ? Unified.sharedCapability(unifiedProviders, "labels")
+    ? Unified.everyMailboxCan(unifiedAbilities, "labels")
     : (!current || current.hasLabels)
   // Intersected like every other capability: a merged list holds rows from
   // mailboxes whose provider has no web UI at all, and "Open in browser" on
   // one of those is a button that cannot be honoured.
   readonly property bool canOpenOnWeb: unified
-    ? Unified.sharedCapability(unifiedProviders, "web")
+    ? Unified.everyMailboxCan(unifiedAbilities, "web")
     : (!current || current.canOpenOnWeb)
   readonly property bool canOpenWebInbox: !unified && !!current && current.canOpenWebInbox
   // A key is not a button: `e` and `s` are bound whatever mailbox is open, so
@@ -986,14 +1032,25 @@ Item {
   // account's threads beside a mailbox that has none would draw a member count
   // on the rows that happened to carry one and nothing on the rest.
   readonly property bool showsConversations: unified
-    ? Unified.sharedCapability(unifiedProviders, "conversations")
+    ? Unified.everyMailboxCan(unifiedAbilities, "conversations")
     : (!!current && current.showsConversations)
   // The rail and its members are about the message being read, so they come
   // from the mailbox holding the selection — the same place `selectedMessage`
   // and `detailPainted` come from.
   readonly property bool showsRail: !!reading && reading.showsRail
-  readonly property var selectedThread: reading ? reading.selectedThread : null
-  readonly property var memberSummaries: reading ? reading.memberSummaries : ({})
+  // Composed on the way out, like `selectedId` and for the same reason: the
+  // rail hands a member id back to `select` and to `act`, and compares the
+  // open one against `selectedId`. A raw one reached no mailbox at all.
+  readonly property var selectedThread: {
+    if (!reading) return null
+    if (!unified) return reading.selectedThread
+    return Unified.composeThread(reading.accountId, reading.selectedThread)
+  }
+  readonly property var memberSummaries: {
+    if (!reading) return ({})
+    if (!unified) return reading.memberSummaries
+    return Unified.composeMembers(reading.accountId, reading.memberSummaries)
+  }
   readonly property string mailboxKey: unified
     ? unifiedMailboxKey : (current ? current.mailboxKey : "inbox")
   // What `mailboxKey` means for a reader that is looking at a thread, which is
@@ -1237,11 +1294,50 @@ Item {
     // account and carries the id, so compose can already name one; this is the
     // routing it was missing.
     var values = fields || ({})
-    var target = String(values.accountId || "")
-    var host = target !== "" ? findAccount(target) : null
-    if (!host) host = senderFor(String(values.from || ""))
-    if (!host) host = current
-    return host ? host.send(values) : false
+    var host = sendHostFor(values)
+    return host ? host.send(withSourceDraftId(values)) : false
+  }
+
+  // The mailbox a submission is sent from.
+  //
+  // A named one is the answer, and a named one that is not here is a refusal
+  // rather than permission to guess: falling through to matching the address
+  // sent the message from whichever mailbox matched first, which for two that
+  // share a send-as alias is not the one the composer chose. The address is
+  // only consulted when nothing named a mailbox at all.
+  //
+  // Resolved in one place so the choice can be asserted, rather than inferred
+  // from what happened after it.
+  function sendHostFor(fields) {
+    var values = fields || ({})
+    var target = draftOwner(values)
+    if (target !== "") return findAccount(target)
+    var host = senderFor(String(values.from || ""))
+    return host ? host : current
+  }
+
+  // The mailbox a submission belongs to: the one it names, or — for a draft
+  // raised from a merged list — the one its id was composed from.
+  function draftOwner(values) {
+    var named = String(values.accountId || "")
+    if (named !== "") return named
+    return Unified.accountOf(String(values.draftId || ""))
+  }
+
+  // The same submission with its draft id as the owning provider issued it.
+  //
+  // Asked of the id rather than of `unified`, because the composer can be
+  // opened from a merged list and saved after the reader has left it — and a
+  // provider handed a composed id answers that the draft is no longer there
+  // and writes nothing. A bare id cannot hold the separator, so this is safe
+  // to ask of any of them.
+  function withSourceDraftId(values) {
+    var id = String(values.draftId || "")
+    if (Unified.accountOf(id) === "") return values
+    var out = ({})
+    for (var key in values) out[key] = values[key]
+    out.draftId = Unified.sourceIdOf(id)
+    return out
   }
 
   // Which mailbox owns an address, for a From that named no account. Asked of
@@ -1269,13 +1365,13 @@ Item {
   }
   function saveDraft(fields, callback) {
     var values = fields || ({})
-    var target = String(values.accountId || "")
+    var target = draftOwner(values)
     var host = target !== "" ? findAccount(target) : current
     if (!host) {
       if (typeof callback === "function") callback(null, "The mailbox for this draft is unavailable")
       return null
     }
-    return host.saveDraft(values, callback)
+    return host.saveDraft(withSourceDraftId(values), callback)
   }
   function fail(text) { if (current) current.fail(text) }
   function note(text) { if (current) current.note(text) }

--- a/Service.qml
+++ b/Service.qml
@@ -741,7 +741,11 @@ Item {
       out.push({
         id: accounts[i].id,
         label: Accounts.label(accounts[i]),
-        messages: host ? host.messages : []
+        messages: host ? host.messages : [],
+        // Whether this mailbox has more to come, which is what decides where
+        // the merge has to stop: a source still holding mail below its last
+        // row would leave a hole in the middle of the list.
+        hasMore: !!(host && host.hasMore)
       })
     }
     return out
@@ -884,11 +888,24 @@ Item {
     ? Unified.totalUnread(accountSummaries) : (current ? current.inboxUnread : 0)
   readonly property var messages: unified
     ? unifiedMessages : (current ? current.messages : [])
+  // A label belongs to one service and one mailbox within it, so a merged list
+  // has none to draw and #83's picker has nothing to offer: `v` is refused
+  // rather than opening an empty list, which is what `canMoveToLabel` says.
   readonly property var labels: unified ? [] : (current ? current.labels : [])
+  // #83's move needs a label list and a mailbox to take one from, so a merged
+  // view cannot offer it: the picker would open on an empty list, and a chosen
+  // id would belong to whichever mailbox happened to be active.
+  readonly property bool canMoveToLabel: !unified
+    && Provider.can(providerId, "move")
 
   // Which service the mailbox on screen is, what mailboxes it has, and what it
   // can be asked to do. Forwarded like everything else so a view never has to
   // reach past `service` to find out.
+  //
+  // `providerId` stays the *visible* mailbox's even in a merged view: it
+  // decides what a query string means and what a setup page offers, both of
+  // which belong to one account. What a merged list may *do* comes from
+  // `Unified.sharedCapability` rather than from here.
   readonly property string providerId: current ? current.providerId : Provider.DEFAULT_ID
   readonly property var mailboxes: unified
     ? Unified.sharedMailboxes(unifiedProviders)
@@ -938,6 +955,10 @@ Item {
     }
     return out
   }
+  // Whether a message can be written at all, which is a question about the
+  // mailbox it would be sent from — and compose picks that from the From
+  // address rather than from the list. Intersecting it would hide the compose
+  // button because one mailbox in the merge cannot send.
   readonly property bool canSend: !current || current.canSend
   // Whether this account's listing is one row per conversation, and everything
   // the reader's rail is drawn from. Forwarded like every other account fact:
@@ -967,17 +988,30 @@ Item {
   readonly property string viewedMailboxKey: unified
     ? Conversation.viewedMailboxKey(mailboxKey, searchQuery !== "")
     : (current ? current.viewedMailboxKey : "")
+  // The typed search and the query behind it. A merged search asks every
+  // mailbox the same words, so one account's copy is every account's — and
+  // reading it from the visible one keeps the box showing what was typed.
   readonly property string searchQuery: current ? current.searchQuery : ""
   readonly property string rawQuery: current ? current.rawQuery : ""
   // A unified view draws no labels, so it can never be showing one.
   readonly property string rawLabelId: unified || !current ? "" : current.rawLabelId
   readonly property bool listLoading: unified
     ? Unified.anyLoading(unifiedStates) : (!!current && current.listLoading)
+  // A mailbox that cannot load is not a mailbox still loading, which is the
+  // distinction `Unified.allLoaded` draws: requiring every one of them left a
+  // signed-out account holding the placeholder blank indefinitely.
   readonly property bool listLoaded: unified
     ? Unified.allLoaded(unifiedStates) : (!!current && current.listLoaded)
+  // Still coming from the server. Not intersected, because it drives a
+  // spinner beside the search box rather than the list's own state — which
+  // `listLoading` answers for every mailbox.
   readonly property bool serverSearchLoading: !!current && current.serverSearchLoading
   readonly property bool hasMore: unified
     ? Unified.anyHasMore(unifiedStates) : (!!current && current.hasMore)
+  // "12 results" for the visible mailbox. Left alone deliberately rather than
+  // summed: a merged count would have to wait for every mailbox to finish
+  // searching, and a number that keeps growing while it is read is worse than
+  // one that is honest about being one mailbox's.
   readonly property string resultSummary: current ? current.resultSummary : ""
   // ------------------------------------------------------- the open message
   //
@@ -1047,11 +1081,32 @@ Item {
     ? pendingSendHost.sendSecondsRemaining : 0
   readonly property string lastError: unified
     ? Unified.firstError(unifiedStates) : (current ? current.lastError : "")
-  readonly property string actionStatus: current ? current.actionStatus : ""
+  // The last thing a mailbox said it did, and the undo that goes with it. Read
+  // from `current` alone, archiving a row from a non-active mailbox in a merged
+  // list produced no confirmation and no undo affordance at all — so the most
+  // recent of them wins, which is the one the press just produced.
+  readonly property string actionStatus: {
+    if (!unified) return current ? current.actionStatus : ""
+    var _epoch = listEpoch
+    var newest = ""
+    var at = -1
+    for (var i = 0; i < accountHosts.count; i++) {
+      var host = accountHosts.objectAt(i)
+      if (!host || String(host.actionStatus || "") === "") continue
+      if (host.actionStatusAt > at) {
+        at = host.actionStatusAt
+        newest = String(host.actionStatus)
+      }
+    }
+    return newest
+  }
   readonly property string signInProgress: current ? current.signInProgress : ""
   // Whether the mailbox on screen has had its credential refused. The setup
   // page draws the re-entry card from this; nothing signs out over it.
   readonly property bool credentialsRejected: !!current && current.credentialsRejected
+  // How long ago the visible mailbox was checked. The status line does not
+  // draw this in a merged view — `Model.readingStatusLine` omits it, because
+  // an age from one mailbox is not a claim about all of them.
   readonly property string syncedLabel: current ? current.syncedLabel : ""
 
   function refresh() {
@@ -1212,7 +1267,9 @@ Item {
   function undoSend() {
     var host = pendingSendHost
     if (!host) return false
-    if (host !== current) {
+    // Same reason as `forwardReplyFailure`: the draft names its mailbox, so a
+    // merged view has no need to change what is on screen to undo a send.
+    if (host !== current && !unified) {
       for (var i = 0; i < accountHosts.count; i++) {
         if (accountHosts.objectAt(i) === host) {
           switchToIndex(i)
@@ -1236,8 +1293,22 @@ Item {
   function saveAttachment(messageId, attachment) {
     if (current) current.saveAttachment(messageId, attachment)
   }
+  // Asked of the mailbox the message arrived in rather than of the visible
+  // one. Replying from a merged list otherwise composed from whichever
+  // account was active underneath, with nothing on screen saying so — which
+  // is the failure a unified inbox most has to avoid.
   function preferredSendAs(recipients) {
-    return current ? current.preferredSendAs(recipients) : null
+    var host = reading || current
+    return host ? host.preferredSendAs(recipients) : null
+  }
+
+  // Which mailbox a draft raised from the current selection belongs to. The
+  // window seeds `ComposeView.accountId` from this rather than from
+  // `activeAccountId`, so a reply to a message that arrived in mailbox B is
+  // written and sent from B.
+  readonly property string composeAccountId: {
+    var host = reading || current
+    return host ? String(host.accountId || "") : ""
   }
   function signIn() { if (current) current.signIn() }
   function cancelSignIn() { if (current) current.cancelSignIn() }
@@ -1358,7 +1429,13 @@ Item {
   // a retry cannot be addressed to whichever mailbox happened to be visible.
   function forwardReplyFailure(index) {
     var host = accountAt(index)
-    if (host && host !== current) switchToIndex(index)
+    // Not in a merged list. The switch exists so a retry cannot be addressed
+    // to whichever mailbox happened to be visible, and in a merged view the
+    // draft already names its own — `composeAccountId` seeded it from the
+    // message it answers. Switching there would also drop the reader out of
+    // the combined view to report a failure, which is not what was asked for,
+    // and it would do it behind `App.switchAccount`'s back.
+    if (host && host !== current && !unified) switchToIndex(index)
     replyFailed()
   }
 

--- a/Service.qml
+++ b/Service.qml
@@ -7,6 +7,8 @@ import "calendar"
 
 import "account/Accounts.js" as Accounts
 import "account/Model.js" as Model
+import "account/Unified.js" as Unified
+import "account/Conversation.js" as Conversation
 import "compose/Senders.js" as Senders
 import "providers/Registry.js" as Provider
 import "bar/Preview.js" as Preview
@@ -65,7 +67,8 @@ Item {
     oauthPort: 9481,
     undoSendSeconds: 10,
     unifiedCalendarView: false,
-    showBarIcon: true
+    showBarIcon: true,
+    unifiedMailboxes: false
   })
   property var settings: defaultSettingValues
   readonly property int undoSendSeconds: Outbox.normalizeDelay(
@@ -80,6 +83,8 @@ Item {
     settings ? settings.contentDirection : null)
   readonly property bool unifiedCalendarView: !!settings
     && settings.unifiedCalendarView === true
+  readonly property bool unifiedMailboxes: !!settings
+    && settings.unifiedMailboxes === true
 
   // Whether the bar draws an envelope for this.
   //
@@ -154,6 +159,16 @@ Item {
 
   function setShowBarIcon(value) {
     persistSetting("showBarIcon", value === true)
+  }
+
+  // One list out of every mailbox, rather than the one that is on screen.
+  //
+  // Persisted rather than held for the session, because it is a way of reading
+  // mail rather than a place in the window: somebody who wants every mailbox
+  // at once wants it again tomorrow, and the switcher's own selection already
+  // survives a restart.
+  function setUnifiedMailboxes(value) {
+    persistSetting("unifiedMailboxes", value === true)
   }
 
   // ---------------------------------------------------------- the accounts
@@ -696,6 +711,102 @@ Item {
     return out
   }
 
+  // ------------------------------------------------------- every mailbox at once
+  //
+  // On, and there is more than one mailbox to combine. One account in a
+  // unified view is the account, and answering it through the merge would
+  // spend a copy of every row to arrive at the same list.
+  readonly property bool unified: unifiedMailboxes && accountCount > 1
+
+  // `Instantiator.objectAt` is not a property, so nothing below re-evaluates
+  // when a host's own list changes. `hostsEpoch` already exists for the same
+  // reason and is bumped when a mailbox signs in or its unread moves; this one
+  // is bumped by the delegate whenever a list, a load or an error changes,
+  // which is far more often and must not drag `sendIdentities` along with it.
+  property int listEpoch: 0
+
+  function bumpListEpoch() {
+    listEpoch += 1
+  }
+
+  // What the merge reads: one entry per mailbox, labelled so a row can say
+  // where it came from.
+  readonly property var unifiedSources: {
+    var _epoch = listEpoch
+    var out = []
+    var accounts = accountList ? accountList.accounts : []
+    for (var i = 0; i < accounts.length; i++) {
+      if (!accounts[i].id) continue
+      var host = accountHosts.objectAt(i)
+      out.push({
+        id: accounts[i].id,
+        label: Accounts.label(accounts[i]),
+        messages: host ? host.messages : []
+      })
+    }
+    return out
+  }
+
+  // What the merge reads for everything that is not a row: whether each
+  // mailbox is still working, has more to offer, or has something to say.
+  readonly property var unifiedStates: {
+    var _epoch = listEpoch
+    var out = []
+    var accounts = accountList ? accountList.accounts : []
+    for (var i = 0; i < accounts.length; i++) {
+      if (!accounts[i].id) continue
+      var host = accountHosts.objectAt(i)
+      out.push({
+        label: Accounts.label(accounts[i]),
+        loading: !!(host && host.listLoading),
+        loaded: !!(host && host.listLoaded),
+        hasMore: !!(host && host.hasMore),
+        error: host ? String(host.lastError || "") : ""
+      })
+    }
+    return out
+  }
+
+  // Which services are involved, which is what decides the rail and every
+  // button on it. Two Gmail mailboxes ask one provider's questions.
+  readonly property var unifiedProviders: {
+    var accounts = accountList ? accountList.accounts : []
+    return Unified.providersOf(accounts)
+  }
+
+  readonly property var unifiedMessages: Unified.mergeMessages(unifiedSources)
+
+  // The mailbox every account is showing. A unified view puts them all on the
+  // same rail row, so this is the row rather than one account's idea of it —
+  // and it survives a mailbox that has not finished switching.
+  property string unifiedMailboxKey: "inbox"
+
+  // The account that owns the open message. A reader shows one message, which
+  // belongs to one mailbox however many the list came from, so everything
+  // about the selection is forwarded from here rather than from `current`.
+  property var selectionHost: null
+
+  // Where an action goes. In a unified view the id says which mailbox owns the
+  // row; otherwise there is only one it could mean.
+  function hostForId(id) {
+    if (!unified) return current
+    var target = Unified.accountOf(id)
+    return target === "" ? null : findAccount(target)
+  }
+
+  // What that mailbox calls the same message.
+  function sourceIdFor(id) {
+    return unified ? Unified.sourceIdOf(id) : String(id === undefined || id === null ? "" : id)
+  }
+
+  // Every signed-in mailbox, for the actions that are not about one row.
+  function eachHost(callback) {
+    for (var i = 0; i < accountHosts.count; i++) {
+      var host = accountHosts.objectAt(i)
+      if (host) callback(host)
+    }
+  }
+
   readonly property var barMessages: {
     var accounts = []
     var values = accountList ? accountList.accounts : []
@@ -769,22 +880,33 @@ Item {
     var index = editingIndex()
     return index >= 0 && index < accounts.length ? String(accounts[index].email || "") : ""
   }
-  readonly property int inboxUnread: current ? current.inboxUnread : 0
-  readonly property var messages: current ? current.messages : []
-  readonly property var labels: current ? current.labels : []
+  readonly property int inboxUnread: unified
+    ? Unified.totalUnread(accountSummaries) : (current ? current.inboxUnread : 0)
+  readonly property var messages: unified
+    ? unifiedMessages : (current ? current.messages : [])
+  readonly property var labels: unified ? [] : (current ? current.labels : [])
 
   // Which service the mailbox on screen is, what mailboxes it has, and what it
   // can be asked to do. Forwarded like everything else so a view never has to
   // reach past `service` to find out.
   readonly property string providerId: current ? current.providerId : Provider.DEFAULT_ID
-  readonly property var mailboxes: current
-    ? current.mailboxes : Provider.mailboxes(Provider.DEFAULT_ID)
-  readonly property bool canArchive: !current || current.canArchive
-  readonly property bool canReportSpam: !current || current.canReportSpam
-  readonly property bool canStar: !current || current.canStar
-  readonly property bool hasLabels: !current || current.hasLabels
+  readonly property var mailboxes: unified
+    ? Unified.sharedMailboxes(unifiedProviders)
+    : (current ? current.mailboxes : Provider.mailboxes(Provider.DEFAULT_ID))
+  readonly property bool canArchive: unified
+    ? Unified.sharedCapability(unifiedProviders, "archive")
+    : (!current || current.canArchive)
+  readonly property bool canReportSpam: unified
+    ? Unified.sharedCapability(unifiedProviders, "spam")
+    : (!current || current.canReportSpam)
+  readonly property bool canStar: unified
+    ? Unified.sharedCapability(unifiedProviders, "star")
+    : (!current || current.canStar)
+  readonly property bool hasLabels: unified
+    ? Unified.sharedCapability(unifiedProviders, "labels")
+    : (!current || current.hasLabels)
   readonly property bool canOpenOnWeb: !current || current.canOpenOnWeb
-  readonly property bool canOpenWebInbox: !!current && current.canOpenWebInbox
+  readonly property bool canOpenWebInbox: !unified && !!current && current.canOpenWebInbox
   readonly property var unavailableActions: current ? current.unavailableActions : []
   readonly property var savingAttachmentIds: current ? current.savingAttachmentIds : ({})
   readonly property bool canSend: !current || current.canSend
@@ -793,50 +915,89 @@ Item {
   // the views are given one object and never reach past it, so a property the
   // facade does not name is a property the window reads as `undefined` — which
   // is what the conversation count on a row was doing.
-  readonly property bool showsConversations: !!current && current.showsConversations
-  readonly property bool showsRail: !!current && current.showsRail
-  readonly property var selectedThread: current ? current.selectedThread : null
-  readonly property var memberSummaries: current ? current.memberSummaries : ({})
-  readonly property string viewedMailboxKey: current ? current.viewedMailboxKey : ""
-  readonly property string mailboxKey: current ? current.mailboxKey : "inbox"
+  //
+  // `showsConversations` is `Provider.can(..., "conversations")`, so a merged
+  // list intersects it like every other capability: a list holding a JMAP
+  // account's threads beside a mailbox that has none would draw a member count
+  // on the rows that happened to carry one and nothing on the rest.
+  readonly property bool showsConversations: unified
+    ? Unified.sharedCapability(unifiedProviders, "conversations")
+    : (!!current && current.showsConversations)
+  // The rail and its members are about the message being read, so they come
+  // from the mailbox holding the selection — the same place `selectedMessage`
+  // and `detailPainted` come from.
+  readonly property bool showsRail: !!reading && reading.showsRail
+  readonly property var selectedThread: reading ? reading.selectedThread : null
+  readonly property var memberSummaries: reading ? reading.memberSummaries : ({})
+  readonly property string mailboxKey: unified
+    ? unifiedMailboxKey : (current ? current.mailboxKey : "inbox")
+  // What `mailboxKey` means for a reader that is looking at a thread, which is
+  // the same question of the merged list as of one mailbox — so it is asked of
+  // the service's own `mailboxKey` rather than of whichever account is
+  // underneath it.
+  readonly property string viewedMailboxKey: unified
+    ? Conversation.viewedMailboxKey(mailboxKey, searchQuery !== "")
+    : (current ? current.viewedMailboxKey : "")
   readonly property string searchQuery: current ? current.searchQuery : ""
   readonly property string rawQuery: current ? current.rawQuery : ""
-  readonly property string rawLabelId: current ? current.rawLabelId : ""
-  readonly property bool listLoading: !!current && current.listLoading
-  readonly property bool listLoaded: !!current && current.listLoaded
+  // A unified view draws no labels, so it can never be showing one.
+  readonly property string rawLabelId: unified || !current ? "" : current.rawLabelId
+  readonly property bool listLoading: unified
+    ? Unified.anyLoading(unifiedStates) : (!!current && current.listLoading)
+  readonly property bool listLoaded: unified
+    ? Unified.allLoaded(unifiedStates) : (!!current && current.listLoaded)
   readonly property bool serverSearchLoading: !!current && current.serverSearchLoading
-  readonly property bool hasMore: !!current && current.hasMore
+  readonly property bool hasMore: unified
+    ? Unified.anyHasMore(unifiedStates) : (!!current && current.hasMore)
   readonly property string resultSummary: current ? current.resultSummary : ""
-  readonly property string selectedId: current ? current.selectedId : ""
-  readonly property var selectedMessage: current ? current.selectedMessage : null
-  readonly property var selectedBody: current ? current.selectedBody : ({ text: "", source: "" })
-  readonly property string selectedHtml: current ? current.selectedHtml : ""
-  readonly property var selectedDocument: current ? current.selectedDocument : null
-  readonly property var selectedReaderDocument: current ? current.selectedReaderDocument : null
-  readonly property bool selectedReaderTooHeavy: !!current && current.selectedReaderTooHeavy
-  readonly property bool selectedReaderEmpty: !current || current.selectedReaderEmpty
-  readonly property int selectedReaderRemoteImages: current ? current.selectedReaderRemoteImages : 0
-  readonly property var selectedImages: current ? current.selectedImages : []
-  readonly property int selectedBlockedImages: current ? current.selectedBlockedImages : 0
-  readonly property int selectedRemoteImages: current ? current.selectedRemoteImages : 0
-  readonly property bool remoteImagesAllowed: !!current && current.remoteImagesAllowed
-  readonly property var selectedAttachments: current ? current.selectedAttachments : []
-  readonly property bool selectedTooHeavy: !!current && current.selectedTooHeavy
+  // ------------------------------------------------------- the open message
+  //
+  // A reader shows one message, and a message belongs to one mailbox however
+  // many the list was made of. `reading` is that mailbox: the one the
+  // selection was routed to in a unified view, and the visible one otherwise.
+  // Everything below forwards from it, so the reader, the invitation card and
+  // the attachment row never learn which of the two they are in.
+  readonly property var reading: unified ? selectionHost : current
+
+  // Composed on the way back out, because the panel compares this against the
+  // ids in the list it was given — and in a unified view those carry the
+  // mailbox. The account only ever knows its own.
+  readonly property string selectedId: {
+    if (!reading) return ""
+    if (!unified) return reading.selectedId
+    return Unified.unifiedId(reading.accountId, reading.selectedId)
+  }
+  readonly property var selectedMessage: reading ? reading.selectedMessage : null
+  readonly property var selectedBody: reading ? reading.selectedBody : ({ text: "", source: "" })
+  readonly property string selectedHtml: reading ? reading.selectedHtml : ""
+  readonly property var selectedDocument: reading ? reading.selectedDocument : null
+  readonly property var selectedReaderDocument: reading ? reading.selectedReaderDocument : null
+  readonly property bool selectedReaderTooHeavy: !!reading && reading.selectedReaderTooHeavy
+  readonly property bool selectedReaderEmpty: !reading || reading.selectedReaderEmpty
+  readonly property int selectedReaderRemoteImages: reading ? reading.selectedReaderRemoteImages : 0
+  readonly property var selectedImages: reading ? reading.selectedImages : []
+  readonly property int selectedBlockedImages: reading ? reading.selectedBlockedImages : 0
+  readonly property int selectedRemoteImages: reading ? reading.selectedRemoteImages : 0
+  readonly property bool remoteImagesAllowed: !!reading && reading.remoteImagesAllowed
+  readonly property var selectedAttachments: reading ? reading.selectedAttachments : []
+  readonly property bool selectedTooHeavy: !!reading && reading.selectedTooHeavy
   // The meeting inside the message, and this account's answer to it.
-  readonly property var selectedInvite: current ? current.selectedInvite : null
-  readonly property string selectedResponse: current ? current.selectedResponse : ""
-  readonly property bool canRespondToInvite: !!current && current.canRespondToInvite
-  readonly property bool rsvpSending: !!current && current.rsvpSending
+  readonly property var selectedInvite: reading ? reading.selectedInvite : null
+  readonly property string selectedResponse: reading ? reading.selectedResponse : ""
+  readonly property bool canRespondToInvite: !!reading && reading.canRespondToInvite
+  readonly property bool rsvpSending: !!reading && reading.rsvpSending
   // Empty when this message offers no way off a list, which is the answer for
   // everything that is not a newsletter.
-  readonly property string unsubscribeLabel: current ? current.unsubscribeLabel : ""
-  readonly property string unsubscribeDetail: current ? current.unsubscribeDetail : ""
-  readonly property bool unsubscribing: !!current && current.unsubscribing
-  readonly property bool detailLoading: !!current && current.detailLoading
-  readonly property bool detailPainted: !!current && current.detailPainted
+  readonly property string unsubscribeLabel: reading ? reading.unsubscribeLabel : ""
+  readonly property string unsubscribeDetail: reading ? reading.unsubscribeDetail : ""
+  readonly property bool unsubscribing: !!reading && reading.unsubscribing
+  readonly property bool detailLoading: !!reading && reading.detailLoading
+  readonly property bool detailPainted: !!reading && reading.detailPainted
   // ComposeView owns one parked draft for the whole service, so an in-flight
   // send is global even though the request belongs to one account host. This
-  // also keeps the visible Send button honest after switching accounts.
+  // also keeps the visible Send button honest after switching accounts — and
+  // in a merged list it is the reason the button goes busy for a send from a
+  // mailbox that is not the active one, which `current.sending` could not say.
   readonly property var sendingHost: {
     for (var i = 0; i < accountHosts.count; i++) {
       var host = accountHosts.objectAt(i)
@@ -855,7 +1016,8 @@ Item {
   readonly property bool sendPending: !!pendingSendHost
   readonly property int sendSecondsRemaining: pendingSendHost
     ? pendingSendHost.sendSecondsRemaining : 0
-  readonly property string lastError: current ? current.lastError : ""
+  readonly property string lastError: unified
+    ? Unified.firstError(unifiedStates) : (current ? current.lastError : "")
   readonly property string actionStatus: current ? current.actionStatus : ""
   readonly property string signInProgress: current ? current.signInProgress : ""
   // Whether the mailbox on screen has had its credential refused. The setup
@@ -863,31 +1025,103 @@ Item {
   readonly property bool credentialsRejected: !!current && current.credentialsRejected
   readonly property string syncedLabel: current ? current.syncedLabel : ""
 
-  function refresh() { if (current) current.refresh() }
-  function loadMore() { if (current) current.loadMore() }
-  function select(id) { if (current) current.select(id) }
-  function clearSelection() { if (current) current.clearSelection() }
+  function refresh() {
+    if (!unified) {
+      if (current) current.refresh()
+      return
+    }
+    eachHost(function(host) { host.refresh() })
+  }
+  // Every mailbox that still has more, rather than the one whose rows happen
+  // to be at the bottom: the merge cannot extend past the oldest row of the
+  // shortest source without leaving a gap in the middle of the list.
+  function loadMore() {
+    if (!unified) {
+      if (current) current.loadMore()
+      return
+    }
+    eachHost(function(host) { if (host.hasMore) host.loadMore() })
+  }
+  function select(id) {
+    if (!unified) {
+      if (current) current.select(id)
+      return
+    }
+    var host = hostForId(id)
+    if (!host) return
+    // Whatever was open elsewhere is no longer what the reader shows, and a
+    // second mailbox holding a selection would keep answering for the
+    // attachment row after the reader had moved on.
+    eachHost(function(other) { if (other !== host) other.clearSelection() })
+    selectionHost = host
+    host.select(sourceIdFor(id))
+  }
+  function clearSelection() {
+    if (!unified) {
+      if (current) current.clearSelection()
+      return
+    }
+    eachHost(function(host) { host.clearSelection() })
+    selectionHost = null
+  }
   // The notice's own button, which is the switch: what it turns on is every
   // message, and it says so.
   function showRemoteImages() { setAlwaysShowImages(true) }
-  function rsvp(response) { if (current) current.rsvp(response) }
-  function unsubscribe() { if (current) current.unsubscribe() }
+  function rsvp(response) { if (reading) reading.rsvp(response) }
+  function unsubscribe() { if (reading) reading.unsubscribe() }
   function cursorOffset(cursorId, delta) {
+    if (unified) return Unified.cursorOffset(unifiedMessages, cursorId, delta)
     return current ? current.cursorOffset(cursorId, delta) : ""
   }
-  function selectMailbox(key) { if (current) current.selectMailbox(key) }
-  function search(text) { if (current) current.search(text) }
-  function selectLabel(name, labelId) {
-    if (current) current.selectLabel(name, labelId)
+  function selectMailbox(key) {
+    if (!unified) {
+      if (current) current.selectMailbox(key)
+      return
+    }
+    unifiedMailboxKey = String(key)
+    clearSelection()
+    eachHost(function(host) { host.selectMailbox(key) })
   }
-  function refuseUnavailableAction(action) {
-    return current ? current.refuseUnavailableAction(action) : true
+  function search(text) {
+    if (!unified) {
+      if (current) current.search(text)
+      return
+    }
+    eachHost(function(host) { host.search(text) })
+  }
+  // Labels belong to one service and one mailbox within it, so a unified view
+  // draws none and this cannot be reached from one. `main`'s second argument
+  // is kept: dropping it would have left #83's picker unable to say which
+  // label a list is showing.
+  function selectLabel(name, labelId) {
+    if (current && !unified) current.selectLabel(name, labelId)
+  }
+  // Asked of the mailbox that owns the row rather than of the visible one: in
+  // a merged list `e` and `s` reach `act` for a message whose provider may not
+  // have the verb, and the refusal has to name that provider.
+  function refuseUnavailableAction(action, id) {
+    var host = id === undefined ? current : hostForId(id)
+    if (!host) host = current
+    return host ? host.refuseUnavailableAction(action) : true
   }
   function act(id, action, quiet, memberOnly) {
-    return current ? current.act(id, action, quiet, memberOnly) : false
+    var host = hostForId(id)
+    return host ? host.act(sourceIdFor(id), action, quiet, memberOnly) : false
   }
-  function toggleStar(id) { if (current) current.toggleStar(id) }
-  function markAllRead() { if (current) current.markAllRead() }
+  function toggleStar(id) {
+    var host = hostForId(id)
+    if (host) host.toggleStar(sourceIdFor(id))
+  }
+  function markAllRead() {
+    if (!unified) {
+      if (current) current.markAllRead()
+      return
+    }
+    eachHost(function(host) { host.markAllRead() })
+  }
+  // The mailbox the From address belongs to, which compose already names:
+  // `sendIdentities` spans every account and carries the id, so a unified
+  // view needed the routing rather than a new question.
   function send(fields) {
     // The button has the same guard, but Ctrl+Return reaches this function
     // directly. Enforce the one-global-parked-draft invariant at the action
@@ -900,7 +1134,39 @@ Item {
       if (current) current.fail("Another message is still being sent")
       return false
     }
-    return current ? current.send(fields) : false
+    // The mailbox the From address belongs to. `sendIdentities` spans every
+    // account and carries the id, so compose can already name one; this is the
+    // routing it was missing.
+    var values = fields || ({})
+    var target = String(values.accountId || "")
+    var host = target !== "" ? findAccount(target) : null
+    if (!host) host = senderFor(String(values.from || ""))
+    if (!host) host = current
+    return host ? host.send(values) : false
+  }
+
+  // Which mailbox owns an address, for a From that named no account. Asked of
+  // each host rather than of the saved entry, because an alias is something a
+  // signed-in mailbox reports and the entry does not carry.
+  function senderFor(address) {
+    var wanted = String(address || "").trim().toLowerCase()
+    if (wanted === "") return null
+    var i
+    for (i = 0; i < accountHosts.count; i++) {
+      var host = accountHosts.objectAt(i)
+      if (host && String(host.accountEmail || "").toLowerCase() === wanted) return host
+    }
+    for (i = 0; i < accountHosts.count; i++) {
+      var other = accountHosts.objectAt(i)
+      if (!other) continue
+      var aliases = other.availableSendAsAliases || []
+      for (var j = 0; j < aliases.length; j++) {
+        var alias = aliases[j]
+        var email = String((alias && alias.email) || alias || "").trim().toLowerCase()
+        if (email === wanted) return other
+      }
+    }
+    return null
   }
   function saveDraft(fields, callback) {
     var values = fields || ({})
@@ -928,12 +1194,14 @@ Item {
     return host.undoSend()
   }
   function loadAttachments(messageId, attachments, callback) {
-    if (current) return current.loadAttachments(messageId, attachments, callback)
+    var host = hostForId(messageId)
+    if (host) return host.loadAttachments(sourceIdFor(messageId), attachments, callback)
     if (typeof callback === "function") callback([], "No mailbox is selected")
     return null
   }
   function openAttachment(messageId, attachment) {
-    if (current) current.openAttachment(messageId, attachment)
+    var host = hostForId(messageId)
+    if (host) host.openAttachment(sourceIdFor(messageId), attachment)
   }
 
   function saveAttachment(messageId, attachment) {
@@ -1138,6 +1406,16 @@ Item {
       onInboxUnreadChanged: root.recount()
       onReplySent: root.replySent()
       onReplyFailed: root.forwardReplyFailure(index)
+
+      // What a merged list is made of, and everything a merged list says
+      // about itself. `recount` is not enough and is deliberately not used:
+      // it also drives `sendIdentities`, which would be rebuilt on every
+      // arriving row rather than when a mailbox signs in.
+      onMessagesChanged: root.bumpListEpoch()
+      onListLoadingChanged: root.bumpListEpoch()
+      onListLoadedChanged: root.bumpListEpoch()
+      onHasMoreChanged: root.bumpListEpoch()
+      onLastErrorChanged: root.bumpListEpoch()
 
       Component.onCompleted: Qt.callLater(root.refreshCurrent)
       Component.onDestruction: Qt.callLater(root.refreshCurrent)

--- a/Service.qml
+++ b/Service.qml
@@ -905,10 +905,39 @@ Item {
   readonly property bool hasLabels: unified
     ? Unified.sharedCapability(unifiedProviders, "labels")
     : (!current || current.hasLabels)
-  readonly property bool canOpenOnWeb: !current || current.canOpenOnWeb
+  // Intersected like every other capability: a merged list holds rows from
+  // mailboxes whose provider has no web UI at all, and "Open in browser" on
+  // one of those is a button that cannot be honoured.
+  readonly property bool canOpenOnWeb: unified
+    ? Unified.sharedCapability(unifiedProviders, "web")
+    : (!current || current.canOpenOnWeb)
   readonly property bool canOpenWebInbox: !unified && !!current && current.canOpenWebInbox
-  readonly property var unavailableActions: current ? current.unavailableActions : []
-  readonly property var savingAttachmentIds: current ? current.savingAttachmentIds : ({})
+  // A key is not a button: `e` and `s` are bound whatever mailbox is open, so
+  // the status row's hints are filtered by this. In a merged list the answer
+  // has to come from the same intersection the buttons use — one account's
+  // own list would offer an archive the mailbox the cursor is on refuses.
+  readonly property var unavailableActions: unified
+    ? Model.unavailableActions({
+        archive: canArchive, star: canStar, spam: canReportSpam })
+    : (current ? current.unavailableActions : [])
+
+  // #91's set of attachments being saved, keyed the way the panel addresses a
+  // row: an account keys its own by the id it issued, so in a merged list the
+  // sets are joined and re-keyed rather than read off whichever mailbox is
+  // active — which would have shown a spinner on the wrong row, or none.
+  readonly property var savingAttachmentIds: {
+    if (!unified) return current ? current.savingAttachmentIds : ({})
+    var _epoch = listEpoch
+    var out = ({})
+    var accounts = accountList ? accountList.accounts : []
+    for (var i = 0; i < accounts.length; i++) {
+      if (!accounts[i].id) continue
+      var host = accountHosts.objectAt(i)
+      var own = host ? host.savingAttachmentIds : ({})
+      for (var key in own) out[Unified.unifiedId(accounts[i].id, key)] = own[key]
+    }
+    return out
+  }
   readonly property bool canSend: !current || current.canSend
   // Whether this account's listing is one row per conversation, and everything
   // the reader's rail is drawn from. Forwarded like every other account fact:
@@ -1268,7 +1297,14 @@ Item {
     return activeIndex >= 0 ? activeIndex : indexOfActiveAccount()
   }
 
-  function openInBrowser(id) { if (current) current.openInBrowser(id) }
+  // Routed and taken apart like every other action on a row: the composed id
+  // names the mailbox, and the account builds the address out of its own
+  // half of it. Sent to `current` it built one Gmail URL out of another
+  // mailbox's id.
+  function openInBrowser(id) {
+    var host = hostForId(id)
+    if (host) host.openInBrowser(sourceIdFor(id))
+  }
   function openWebInbox() { if (current) current.openWebInbox() }
 
   // The service's own website, from the setup page's hero — where everything

--- a/Service.qml
+++ b/Service.qml
@@ -803,6 +803,7 @@ Item {
         label: Accounts.label(accounts[i]),
         loading: !!(host && host.listLoading),
         loaded: !!(host && host.listLoaded),
+        serverSearchLoading: !!(host && host.serverSearchLoading),
         hasMore: !!(host && host.hasMore),
         error: host ? String(host.lastError || "") : ""
       })
@@ -1074,10 +1075,11 @@ Item {
   // signed-out account holding the placeholder blank indefinitely.
   readonly property bool listLoaded: unified
     ? Unified.allLoaded(unifiedStates) : (!!current && current.listLoaded)
-  // Still coming from the server. Not intersected, because it drives a
-  // spinner beside the search box rather than the list's own state — which
-  // `listLoading` answers for every mailbox.
-  readonly property bool serverSearchLoading: !!current && current.serverSearchLoading
+  // Still coming from any server. A unified search asks every mailbox, so the
+  // spinner must remain visible while any of them is still answering.
+  readonly property bool serverSearchLoading: unified
+    ? Unified.anyServerSearchLoading(unifiedStates)
+    : (!!current && current.serverSearchLoading)
   readonly property bool hasMore: unified
     ? Unified.anyHasMore(unifiedStates) : (!!current && current.hasMore)
   // "12 results" for the visible mailbox. Left alone deliberately rather than

--- a/Service.qml
+++ b/Service.qml
@@ -183,9 +183,24 @@ Item {
   // Read here rather than in the compose view, so the window never reaches into
   // the account list itself. A pending account has no id and so no signature,
   // which is the same answer as having set none.
-  readonly property string activeSignature: {
-    var entry = Accounts.find(accountList, activeAccountId)
+  readonly property string activeSignature: signatureFor(activeAccountId)
+
+  // The sign-off and the address of a *named* mailbox, which is not always the
+  // one on screen: a draft belongs to the mailbox the message it answers
+  // arrived in, and in a merged list that is routinely not the active account.
+  // Signing B's reply with A's name, or leaving A on the Cc of a reply from B,
+  // puts one identity's details into another's outgoing mail.
+  //
+  // Kept here rather than in the compose view for the same reason
+  // `activeSignature` was: the window never reaches into the account list.
+  function signatureFor(accountId) {
+    var entry = Accounts.find(accountList, String(accountId || ""))
     return entry ? String(entry.signature || "") : ""
+  }
+
+  function accountEmailFor(accountId) {
+    var entry = Accounts.find(accountList, String(accountId || ""))
+    return entry ? String(entry.email || "") : ""
   }
   readonly property string calendarAccountId: current && String(current.accountId || "") !== ""
     ? String(current.accountId) : "__no_google_account__"
@@ -1291,7 +1306,24 @@ Item {
   }
 
   function saveAttachment(messageId, attachment) {
-    if (current) current.saveAttachment(messageId, attachment)
+    var host = hostForId(messageId)
+    if (host) host.saveAttachment(sourceIdFor(messageId), attachment)
+  }
+
+  // Whether this attachment of this message is being written out.
+  //
+  // The merged map is keyed by mailbox and attachment, because two mailboxes
+  // can be saving attachments whose ids collide — an IMAP part id is a number
+  // in a tree, not something unique across servers. A view holds an attachment
+  // and the message it hangs off; composing the key from those is the
+  // service's job, like every other id it issues.
+  function attachmentIsSaving(messageId, attachmentId) {
+    var key = String(attachmentId || "")
+    if (key === "") return false
+    if (!unified) return !!savingAttachmentIds[key]
+    var owner = Unified.accountOf(messageId)
+    if (owner === "") return false
+    return !!savingAttachmentIds[Unified.unifiedId(owner, key)]
   }
   // Asked of the mailbox the message arrived in rather than of the visible
   // one. Replying from a merged list otherwise composed from whichever

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -496,8 +496,13 @@ Item {
     actionStatus = ""
   }
 
+  // When it was said, so a merged view can show the most recent of several
+  // mailboxes' notices rather than whichever host it happened to ask first.
+  property double actionStatusAt: 0
+
   function note(text) {
     actionStatus = String(text || "")
+    actionStatusAt = actionStatus === "" ? 0 : Date.now()
     if (actionStatus !== "") noticeTimer.restart()
   }
 

--- a/account/Model.js
+++ b/account/Model.js
@@ -1047,6 +1047,23 @@ function syncedShort(syncLabel) {
   return match ? match[1] : label
 }
 
+// What is being read, at the foot of the rail and in the switcher. One string
+// in one place: the switcher names the row and the status line names what the
+// row selected, and two literals would drift apart.
+var UNIFIED_LABEL = "All mailboxes"
+
+// The foot of the rail, which says what is being read and how long ago it was
+// checked.
+//
+// A combined view has no address to give, and no age either: the sync label
+// belongs to one mailbox, and putting it after "All mailboxes" would be a
+// claim about every one of them made from whichever happened to be active
+// underneath.
+function readingStatusLine(unified, email, syncLabel) {
+  if (unified === true) return UNIFIED_LABEL
+  return accountStatusLine(email, syncLabel)
+}
+
 function accountStatusLine(email, syncLabel) {
   var address = String(email || "")
   if (address === "") return "Not connected"

--- a/account/Unified.js
+++ b/account/Unified.js
@@ -1,0 +1,288 @@
+.pragma library
+
+.import "../providers/Registry.js" as Provider
+
+// One list out of several mailboxes.
+//
+// The panel already reads every list, count and capability off `Service.qml`
+// rather than off an account, so a unified view is a different set of answers
+// from that same façade rather than a second panel. Nothing above it learns
+// that more than one mailbox is involved, which is the same seam
+// `Registry.js` is one layer down and the reason these rules are plain
+// JavaScript rather than part of the QML that holds the accounts.
+//
+// What a unified view may offer is decided by intersection throughout: a rail
+// row every mailbox has, a button every provider can honour. A row only two of
+// three accounts could answer is the promise `Registry.capabilities` exists to
+// stop being made, and it would fail after the user had committed to it.
+
+// ------------------------------------------------------------------ merging
+
+// A row's own idea of when it arrived. Providers disagree about the field: a
+// Gmail resource carries `internalDate` in milliseconds, an IMAP row the
+// INTERNALDATE it was given, and a summarised row a Date. All three sort
+// against each other here, so all three are read.
+function messageTime(item) {
+  var value = item ? item.date : null
+  if (value && typeof value.getTime === "function") return value.getTime()
+  var numeric = Number(value)
+  if (isFinite(numeric) && numeric > 0) return numeric
+  var parsed = Date.parse(String(value || ""))
+  if (isFinite(parsed) && parsed > 0) return parsed
+  return Number(item && item.internalDate) || 0
+}
+
+// Newest first, with ties broken by account and id so the order is total.
+// Without that second term two rows sharing a timestamp could swap places
+// between one merge and the next and the cursor would move on its own, which
+// is not hypothetical: one message copied to two of these mailboxes arrives
+// with the same date in both.
+function compareRows(left, right) {
+  var difference = messageTime(right) - messageTime(left)
+  if (difference !== 0) return difference
+  var leftKey = String(left && left.accountId || "") + " " + String(left && left.id || "")
+  var rightKey = String(right && right.accountId || "") + " " + String(right && right.id || "")
+  return leftKey < rightKey ? -1 : (leftKey > rightKey ? 1 : 0)
+}
+
+// ------------------------------------------------------------------- row ids
+//
+// A merged row is addressed by account *and* id, for the same reason an IMAP
+// message is addressed by folder and UID: an id is unique inside the thing
+// that issued it and nowhere else. Two accounts on one IMAP server number
+// their INBOXes from 1 apiece, so a bare "42" in a merged list names two
+// messages and every action on it is a coin toss.
+//
+// The panel treats an id as an opaque string — a cursor, a cache key, a
+// comparison — so composing one costs nothing above this file, and
+// `Service.qml` takes it apart again on the way down to an account. The
+// account never sees this shape.
+//
+// The separator is a space, which an address cannot contain: an unquoted
+// local part forbids it and no provider issues a quoted one. The id that
+// follows may contain anything, including spaces, so the split is on the
+// first one only.
+
+function unifiedId(accountId, messageId) {
+  var account = String(accountId === undefined || accountId === null ? "" : accountId)
+  var id = String(messageId === undefined || messageId === null ? "" : messageId)
+  if (account === "" || id === "") return ""
+  return account + " " + id
+}
+
+function splitUnifiedId(value) {
+  var text = String(value === undefined || value === null ? "" : value)
+  var at = text.indexOf(" ")
+  if (at <= 0) return { accountId: "", id: "" }
+  return { accountId: text.substring(0, at), id: text.substring(at + 1) }
+}
+
+// Each source is `{ id, label, messages }`. Rows come back copied rather than
+// referenced: the account that owns one goes on replacing its own list, and a
+// merged row that was the same object would change under the panel between a
+// click and the action it starts.
+//
+// The copy's own `id` is the composed one, so every id the panel holds in a
+// unified view addresses exactly one message. `sourceId` keeps what the
+// account calls it, `accountId` says whose it is, and `sourceLabel` is what
+// the row draws to name the mailbox it came from.
+function mergeMessages(sources) {
+  var values = Array.isArray(sources) ? sources : []
+  var out = []
+  var seen = ({})
+  for (var i = 0; i < values.length; i++) {
+    var source = values[i] || ({})
+    var accountId = String(source.id || "")
+    if (accountId === "") continue
+    var messages = Array.isArray(source.messages) ? source.messages : []
+    for (var j = 0; j < messages.length; j++) {
+      var item = messages[j]
+      if (!item || String(item.id || "") === "") continue
+      // An id is unique inside its own provider and nowhere else: a Gmail id
+      // and an IMAP "42:INBOX" have no reason to collide, and two IMAP
+      // accounts on one server have every reason to. The key is the pair.
+      var key = unifiedId(accountId, item.id)
+      if (seen[key] === true) continue
+      seen[key] = true
+      var copy = ({})
+      for (var field in item) copy[field] = item[field]
+      copy.sourceId = String(item.id)
+      copy.id = key
+      copy.accountId = accountId
+      copy.sourceLabel = String(source.label || "Mailbox")
+      out.push(copy)
+    }
+  }
+  out.sort(compareRows)
+  return out
+}
+
+// Which account a row belongs to. Read out of the id rather than looked up:
+// the id carries it, so this answers for a row that has since scrolled out of
+// the list or been replaced by a refresh — which an in-memory lookup could
+// not, and an action outliving its row is the ordinary case after an archive.
+function accountOf(id) {
+  return splitUnifiedId(id).accountId
+}
+
+// What the owning account calls the same message.
+function sourceIdOf(id) {
+  return splitUnifiedId(id).id
+}
+
+// The row itself, for the reader: a merged row carries the account it came
+// from and the account's own copy does not.
+function rowOf(messages, id) {
+  var values = Array.isArray(messages) ? messages : []
+  var wanted = String(id === undefined || id === null ? "" : id)
+  if (wanted === "") return null
+  for (var i = 0; i < values.length; i++) {
+    if (String(values[i] && values[i].id || "") === wanted) return values[i]
+  }
+  return null
+}
+
+// Where the cursor goes on a key press, over the merged order rather than any
+// one account's. `Model.js` answers this for a single mailbox and cannot
+// answer it here, because neither account knows what sits between its own
+// rows.
+function cursorOffset(messages, cursorId, delta) {
+  var values = Array.isArray(messages) ? messages : []
+  if (values.length === 0) return ""
+  var step = Math.floor(Number(delta)) || 0
+  var at = -1
+  var wanted = String(cursorId === undefined || cursorId === null ? "" : cursorId)
+  for (var i = 0; i < values.length; i++) {
+    if (String(values[i] && values[i].id || "") === wanted) {
+      at = i
+      break
+    }
+  }
+  // No cursor yet: the first press lands on an end rather than nowhere.
+  if (at < 0) return String(values[step < 0 ? values.length - 1 : 0].id || "")
+  var next = at + step
+  if (next < 0 || next >= values.length) return ""
+  return String(values[next].id || "")
+}
+
+// ------------------------------------------------------------------ the rail
+
+// The rows every one of these mailboxes has, in the order the first provider
+// lists them: a rail is a reading order rather than a set, and taking it from
+// one provider keeps Inbox first and Trash last however the others are
+// written.
+//
+// Asked of the provider rather than of the account, because which rows a
+// service has is a fact about the service. An account still loading would
+// otherwise drop rows out of the rail while it caught up.
+function sharedMailboxes(providerIds) {
+  var ids = Array.isArray(providerIds) ? providerIds : []
+  if (ids.length === 0) return []
+  var first = Provider.mailboxes(ids[0])
+  var out = []
+  for (var i = 0; i < first.length; i++) {
+    var key = String(first[i].key || "")
+    if (key === "") continue
+    var everyone = true
+    for (var j = 1; j < ids.length; j++) {
+      if (!Provider.hasMailbox(ids[j], key)) {
+        everyone = false
+        break
+      }
+    }
+    if (everyone) out.push(first[i])
+  }
+  return out
+}
+
+function hasSharedMailbox(providerIds, key) {
+  var rows = sharedMailboxes(providerIds)
+  for (var i = 0; i < rows.length; i++) {
+    if (String(rows[i].key || "") === String(key)) return true
+  }
+  return false
+}
+
+// A capability every provider declares. One only some of them have is a button
+// that fails on the rest, after the row has already moved.
+function sharedCapability(providerIds, capability) {
+  var ids = Array.isArray(providerIds) ? providerIds : []
+  if (ids.length === 0) return false
+  for (var i = 0; i < ids.length; i++) {
+    if (!Provider.can(ids[i], capability)) return false
+  }
+  return true
+}
+
+// The distinct providers behind a set of accounts, in the order they appear.
+// Two Gmail mailboxes ask one provider's questions, not two.
+function providersOf(accounts) {
+  var values = Array.isArray(accounts) ? accounts : []
+  var out = []
+  for (var i = 0; i < values.length; i++) {
+    var id = String(values[i] && values[i].provider || "")
+    if (id === "" || out.indexOf(id) >= 0) continue
+    out.push(id)
+  }
+  return out
+}
+
+// ------------------------------------------------------------------ counting
+
+// Every mailbox's unread, added up. The bar badge already says this; in a
+// unified view it is what the Inbox row says too.
+function totalUnread(summaries) {
+  var values = Array.isArray(summaries) ? summaries : []
+  var total = 0
+  for (var i = 0; i < values.length; i++) {
+    var count = Math.floor(Number(values[i] && values[i].unread))
+    if (isFinite(count) && count > 0) total += count
+  }
+  return total
+}
+
+// Loading while any of them is, because a list still gaining rows is still
+// loading however many have arrived.
+function anyLoading(states) {
+  var values = Array.isArray(states) ? states : []
+  for (var i = 0; i < values.length; i++) {
+    if (values[i] && values[i].loading === true) return true
+  }
+  return false
+}
+
+// Loaded only once all of them are: "nothing here" is a claim about every
+// mailbox, and one that has not answered is enough to make it wrong.
+function allLoaded(states) {
+  var values = Array.isArray(states) ? states : []
+  if (values.length === 0) return false
+  for (var i = 0; i < values.length; i++) {
+    if (!values[i] || values[i].loaded !== true) return false
+  }
+  return true
+}
+
+// More to fetch while any mailbox has more, since the merge cannot be complete
+// until every source is.
+function anyHasMore(states) {
+  var values = Array.isArray(states) ? states : []
+  for (var i = 0; i < values.length; i++) {
+    if (values[i] && values[i].hasMore === true) return true
+  }
+  return false
+}
+
+// The first error any mailbox reported, named with the mailbox it came from.
+// "Fastmail: the server refused that command" is actionable where a bare
+// sentence about a server is not, once three servers are involved.
+function firstError(states) {
+  var values = Array.isArray(states) ? states : []
+  for (var i = 0; i < values.length; i++) {
+    var state = values[i] || ({})
+    var text = String(state.error || "").trim()
+    if (text === "") continue
+    var label = String(state.label || "").trim()
+    return label === "" ? text : label + ": " + text
+  }
+  return ""
+}

--- a/account/Unified.js
+++ b/account/Unified.js
@@ -58,21 +58,32 @@ function compareRows(left, right) {
 // `Service.qml` takes it apart again on the way down to an account. The
 // account never sees this shape.
 //
-// The separator is a space, which an address cannot contain: an unquoted
-// local part forbids it and no provider issues a quoted one. The id that
-// follows may contain anything, including spaces, so the split is on the
-// first one only.
+// The separator is a unit separator, U+001F, because it has to be a character
+// no id can contain — otherwise a bare id reads as a composed one.
+//
+// A space was the first attempt and was wrong. An address cannot hold one, but
+// the *id* can: an IMAP message is `<uid>:<folder>` and a folder is called
+// things like "Sent Items", so `"42:Sent Items"` split at its first space into
+// the account `"42:Sent"` and the id `"Items"`. That failed safe only because
+// no account happens to be named that, which is luck rather than structure.
+//
+// A control character is structure. Gmail issues hex, HEY issues
+// `<posting>:<topic>`, and an IMAP folder cannot carry one — the protocol
+// forbids control characters in a mailbox name and `ImapProtocol.quote` drops
+// the two that would end a command. So an id containing U+001F is composed and
+// one without it is not, with nothing left to guess.
+var ID_SEPARATOR = "\u001f"
 
 function unifiedId(accountId, messageId) {
   var account = String(accountId === undefined || accountId === null ? "" : accountId)
   var id = String(messageId === undefined || messageId === null ? "" : messageId)
   if (account === "" || id === "") return ""
-  return account + " " + id
+  return account + ID_SEPARATOR + id
 }
 
 function splitUnifiedId(value) {
   var text = String(value === undefined || value === null ? "" : value)
-  var at = text.indexOf(" ")
+  var at = text.indexOf(ID_SEPARATOR)
   if (at <= 0) return { accountId: "", id: "" }
   return { accountId: text.substring(0, at), id: text.substring(at + 1) }
 }
@@ -86,6 +97,34 @@ function splitUnifiedId(value) {
 // unified view addresses exactly one message. `sourceId` keeps what the
 // account calls it, `accountId` says whose it is, and `sourceLabel` is what
 // the row draws to name the mailbox it came from.
+// The oldest row the merge can show without a hole in the middle of it.
+//
+// Every source is asked for its own page, and the pages do not end at the same
+// date. Drawing all of them puts the gap on screen rather than avoiding it: the
+// tail of the list is the deepest mailbox's mail with the shallowest one's
+// missing from among it, and the row that would have sat there arrives only
+// when somebody scrolls further.
+//
+// So the merge stops at the newest of the sources' own last rows — the
+// shallowest watermark. Everything above it is complete, because every source
+// has reported down to at least that date. A source that has run out entirely
+// sets no watermark: there is nothing more of it to come, so it cannot leave a
+// hole.
+function pageWatermark(sources) {
+  var values = Array.isArray(sources) ? sources : []
+  var watermark = 0
+  for (var i = 0; i < values.length; i++) {
+    var source = values[i] || ({})
+    var messages = Array.isArray(source.messages) ? source.messages : []
+    if (messages.length === 0) continue
+    // Complete sources cannot leave a gap, so they do not hold the list back.
+    if (source.hasMore !== true) continue
+    var oldest = messageTime(messages[messages.length - 1])
+    if (oldest > watermark) watermark = oldest
+  }
+  return watermark
+}
+
 function mergeMessages(sources) {
   var values = Array.isArray(sources) ? sources : []
   var out = []
@@ -114,7 +153,17 @@ function mergeMessages(sources) {
     }
   }
   out.sort(compareRows)
-  return out
+  // Truncated at the shallowest watermark, so the list has no hole in the
+  // middle of it. A merge of one source, or of sources that have all run out,
+  // keeps everything.
+  var floor = pageWatermark(values)
+  if (floor <= 0) return out
+  var complete = []
+  for (var k = 0; k < out.length; k++) {
+    if (messageTime(out[k]) < floor) break
+    complete.push(out[k])
+  }
+  return complete
 }
 
 // Which account a row belongs to. Read out of the id rather than looked up:
@@ -253,11 +302,24 @@ function anyLoading(states) {
 
 // Loaded only once all of them are: "nothing here" is a claim about every
 // mailbox, and one that has not answered is enough to make it wrong.
+// Whether the list is done, which is what decides between a skeleton, an
+// empty placeholder and neither.
+//
+// A mailbox that has stopped on an error has finished as far as the list is
+// concerned: it will never set `loaded`, and requiring it to held the panel on
+// a blank slot indefinitely — no skeleton, no "Nothing here", nothing — for as
+// long as one account stayed signed out. What went wrong is `firstError`'s to
+// say; this only answers whether anything is still on its way. A mailbox that
+// is loading *and* holding an earlier error is still on its way.
 function allLoaded(states) {
   var values = Array.isArray(states) ? states : []
   if (values.length === 0) return false
   for (var i = 0; i < values.length; i++) {
-    if (!values[i] || values[i].loaded !== true) return false
+    var state = values[i]
+    if (!state) return false
+    if (state.loaded === true) continue
+    if (state.loading !== true && String(state.error || "").trim() !== "") continue
+    return false
   }
   return true
 }

--- a/account/Unified.js
+++ b/account/Unified.js
@@ -125,6 +125,47 @@ function pageWatermark(sources) {
   return watermark
 }
 
+// A thread as the service hands it out, with its member ids composed.
+//
+// The rail steps from one member to the next and the reader compares the open
+// one against `selectedId`, so a raw member id reached no mailbox and the
+// comparison never matched: a merged conversation could be drawn and not
+// walked. The thread's own id is left alone — it is a provider's handle for a
+// conversation and is never routed to a mailbox.
+function composeThread(accountId, thread) {
+  if (!thread || typeof thread !== "object") return thread
+  if (!Array.isArray(thread.memberIds)) return thread
+  var out = ({})
+  for (var field in thread) out[field] = thread[field]
+  var composed = []
+  for (var i = 0; i < thread.memberIds.length; i++) {
+    composed.push(unifiedId(accountId, thread.memberIds[i]))
+  }
+  out.memberIds = composed
+  return out
+}
+
+// The rail's summaries, keyed and self-identifying the way every other row is.
+// A stop carries its own id onward to an open and an action, so the key alone
+// was not enough.
+function composeMembers(accountId, summaries) {
+  var source = summaries && typeof summaries === "object" ? summaries : ({})
+  var out = ({})
+  for (var key in source) {
+    var summary = source[key]
+    var copy = summary
+    if (summary && typeof summary === "object") {
+      copy = ({})
+      for (var field in summary) copy[field] = summary[field]
+      copy.sourceId = String(summary.id || "")
+      copy.id = unifiedId(accountId, summary.id)
+      if (summary.thread) copy.thread = composeThread(accountId, summary.thread)
+    }
+    out[unifiedId(accountId, key)] = copy
+  }
+  return out
+}
+
 function mergeMessages(sources) {
   var values = Array.isArray(sources) ? sources : []
   var out = []
@@ -148,6 +189,10 @@ function mergeMessages(sources) {
       copy.sourceId = String(item.id)
       copy.id = key
       copy.accountId = accountId
+      // A row's conversation members are addressed like the row: an archive
+      // asks whether the reader is showing one of them, against a `selectedId`
+      // that carries the mailbox.
+      if (item.thread) copy.thread = composeThread(accountId, item.thread)
       copy.sourceLabel = String(source.label || "Mailbox")
       out.push(copy)
     }
@@ -224,17 +269,37 @@ function cursorOffset(messages, cursorId, delta) {
 // Asked of the provider rather than of the account, because which rows a
 // service has is a fact about the service. An account still loading would
 // otherwise drop rows out of the rail while it caught up.
-function sharedMailboxes(providerIds) {
-  var ids = Array.isArray(providerIds) ? providerIds : []
-  if (ids.length === 0) return []
-  var first = Provider.mailboxes(ids[0])
+// Whether every mailbox in the merge offers this.
+//
+// Asked of the mailboxes rather than of their providers. A provider id is not
+// the whole answer: a host narrows it with the refusals the server reported
+// and the mailboxes it turned out not to have, so an account whose server has
+// no Archive folder answers `canArchive` false while its provider says yes.
+// Intersecting provider ids put that button back in a merged view, and the
+// account's own view is right to hide it.
+function everyMailboxCan(abilities, capability) {
+  var rows = Array.isArray(abilities) ? abilities : []
+  if (rows.length === 0) return false
+  for (var i = 0; i < rows.length; i++) {
+    if (!rows[i] || rows[i][capability] !== true) return false
+  }
+  return true
+}
+
+// The rail rows every mailbox has, in the first mailbox's order — from each
+// one's own directory, for the same reason: a provider row the server does not
+// have is a row that cannot be opened.
+function sharedMailboxRows(abilities) {
+  var rows = Array.isArray(abilities) ? abilities : []
+  if (rows.length === 0) return []
+  var first = rowsOf(rows[0])
   var out = []
   for (var i = 0; i < first.length; i++) {
     var key = String(first[i].key || "")
     if (key === "") continue
     var everyone = true
-    for (var j = 1; j < ids.length; j++) {
-      if (!Provider.hasMailbox(ids[j], key)) {
+    for (var j = 1; j < rows.length; j++) {
+      if (!holdsMailbox(rows[j], key)) {
         everyone = false
         break
       }
@@ -244,37 +309,21 @@ function sharedMailboxes(providerIds) {
   return out
 }
 
-function hasSharedMailbox(providerIds, key) {
-  var rows = sharedMailboxes(providerIds)
-  for (var i = 0; i < rows.length; i++) {
-    if (String(rows[i].key || "") === String(key)) return true
+function rowsOf(row) {
+  return row && Array.isArray(row.mailboxes) ? row.mailboxes : []
+}
+
+function holdsMailbox(row, key) {
+  var list = rowsOf(row)
+  for (var i = 0; i < list.length; i++) {
+    if (String(list[i].key || "") === key) return true
   }
   return false
 }
 
-// A capability every provider declares. One only some of them have is a button
-// that fails on the rest, after the row has already moved.
-function sharedCapability(providerIds, capability) {
-  var ids = Array.isArray(providerIds) ? providerIds : []
-  if (ids.length === 0) return false
-  for (var i = 0; i < ids.length; i++) {
-    if (!Provider.can(ids[i], capability)) return false
-  }
-  return true
-}
 
-// The distinct providers behind a set of accounts, in the order they appear.
-// Two Gmail mailboxes ask one provider's questions, not two.
-function providersOf(accounts) {
-  var values = Array.isArray(accounts) ? accounts : []
-  var out = []
-  for (var i = 0; i < values.length; i++) {
-    var id = String(values[i] && values[i].provider || "")
-    if (id === "" || out.indexOf(id) >= 0) continue
-    out.push(id)
-  }
-  return out
-}
+
+
 
 // ------------------------------------------------------------------ counting
 

--- a/account/Unified.js
+++ b/account/Unified.js
@@ -349,6 +349,23 @@ function anyLoading(states) {
   return false
 }
 
+// A unified search asks every mailbox, so its status stays busy until all
+// server-side searches have settled.
+function anyServerSearchLoading(states) {
+  var values = Array.isArray(states) ? states : []
+  for (var i = 0; i < values.length; i++) {
+    if (values[i] && values[i].serverSearchLoading === true) return true
+  }
+  return false
+}
+
+// Conversation support belongs to the row's source. A mixed unified list may
+// contain collapsed conversation rows beside ordinary message rows.
+function rowIsConversation(row) {
+  var thread = row && row.thread
+  return !!thread && Number(thread.count) >= 2
+}
+
 // Loaded only once all of them are: "nothing here" is a claim about every
 // mailbox, and one that has not answered is enough to make it wrong.
 // Whether the list is done, which is what decides between a skeleton, an

--- a/components/AccountSwitcher.qml
+++ b/components/AccountSwitcher.qml
@@ -38,7 +38,19 @@ Item {
   // the cursor back to whatever the pointer happened to rest on.
   property int cursorIndex: 0
 
+  // Whether the mailbox on screen is the merge of all of them, drawn the way
+  // an active account is drawn because it is the same kind of choice.
+  property bool unifiedActive: false
+
+  // One mailbox has nothing to combine, so the row is not offered: choosing it
+  // would land on the same list under a different name.
+  readonly property int accountRowCount: root.accounts ? root.accounts.length : 0
+  readonly property bool unifiedOffered: accountRowCount > 1
+  readonly property int rowOffset: unifiedOffered ? 1 : 0
+  readonly property int rowCount: accountRowCount + rowOffset
+
   signal accountChosen(int index)
+  signal unifiedChosen()
   signal addAccountRequested()
   signal manageRequested()
 
@@ -84,24 +96,32 @@ Item {
   function close() { menu.close() }
 
   function moveCursor(delta) {
-    var count = root.accounts ? root.accounts.length : 0
-    if (count === 0) return
-    cursorIndex = Model.wrappedIndex(cursorIndex, delta, count)
+    if (root.rowCount === 0) return
+    cursorIndex = Model.wrappedIndex(cursorIndex, delta, root.rowCount)
   }
 
+  // The combined row is first, so the accounts sit one further down than their
+  // own indices. Everything above this component still counts accounts.
   function chooseCursor() {
-    var count = root.accounts ? root.accounts.length : 0
-    if (cursorIndex < 0 || cursorIndex >= count) return
+    if (cursorIndex < 0 || cursorIndex >= root.rowCount) return
     menu.close()
-    root.accountChosen(cursorIndex)
+    if (root.unifiedOffered && cursorIndex === 0) {
+      root.unifiedChosen()
+      return
+    }
+    root.accountChosen(cursorIndex - root.rowOffset)
   }
 
   // Opening puts the keyboard on the mailbox you are already in, so the first
   // `j` is one step away from it rather than back at the top of the list.
   function restCursorOnActive() {
+    if (root.unifiedActive && root.unifiedOffered) {
+      cursorIndex = 0
+      return
+    }
     var accounts = root.accounts || []
     for (var i = 0; i < accounts.length; i++) {
-      if (accounts[i].active) { cursorIndex = i; return }
+      if (accounts[i].active) { cursorIndex = i + root.rowOffset; return }
     }
     cursorIndex = 0
   }
@@ -156,6 +176,83 @@ Item {
         // mechanism that closes it, and a second would be one too many.
       }
 
+      // Every mailbox at once, above the mailboxes it is made of: it is the
+      // widest of the choices here, and a list is read from the top.
+      Rectangle {
+        id: unifiedRow
+        visible: root.unifiedOffered
+
+        readonly property bool hasCursor: root.cursorIndex === 0
+
+        width: menu.width - menu.leftPadding - menu.rightPadding
+        implicitHeight: visible ? Style.space(40) : 0
+        radius: Style.cornerRadius
+        color: root.unifiedActive
+          ? Style.selectedFillFor(root.textColor, root.accentColor)
+          : (unifiedHover.hovered || hasCursor
+            ? Style.hoverFillFor(root.textColor, root.accentColor) : "transparent")
+        border.width: hasCursor ? Style.normalBorderWidth : 0
+        border.color: Style.hoverBorderFor(root.textColor, root.accentColor)
+
+        Rectangle {
+          id: unifiedAvatar
+          anchors.left: parent.left
+          anchors.leftMargin: Style.space(8)
+          anchors.verticalCenter: parent.verticalCenter
+          width: Style.space(22)
+          height: width
+          radius: width / 2
+          color: Style.selectedFillFor(root.textColor, root.accentColor)
+
+          // Not a letter: this row stands for no address, and an initial
+          // taken from one of them would claim it belonged to that mailbox.
+          ActionIcon {
+            anchors.centerIn: parent
+            name: "inbox"
+            color: root.textColor
+            iconSize: Style.font.caption
+          }
+        }
+
+        Column {
+          anchors.left: unifiedAvatar.right
+          anchors.leftMargin: Style.space(9)
+          anchors.right: parent.right
+          anchors.rightMargin: Style.space(10)
+          anchors.verticalCenter: parent.verticalCenter
+          spacing: Style.space(1)
+
+          Text {
+            width: parent.width
+            textFormat: Text.PlainText
+            text: "All mailboxes"
+            color: root.textColor
+            font.family: root.panelFontFamily
+            font.pixelSize: Style.font.bodySmall
+            font.bold: root.unifiedActive
+            elide: Text.ElideRight
+          }
+
+          Text {
+            width: parent.width
+            textFormat: Text.PlainText
+            text: root.accountRowCount + " mailboxes in one list"
+            color: root.dimColor
+            font.family: root.panelFontFamily
+            font.pixelSize: Style.font.caption
+            elide: Text.ElideRight
+          }
+        }
+
+        HoverHandler { id: unifiedHover }
+        TapHandler {
+          onTapped: {
+            menu.close()
+            root.unifiedChosen()
+          }
+        }
+      }
+
       Repeater {
         model: root.accounts
 
@@ -165,7 +262,7 @@ Item {
           required property var modelData
           required property int index
 
-          readonly property bool hasCursor: root.cursorIndex === row.index
+          readonly property bool hasCursor: root.cursorIndex === row.index + root.rowOffset
 
           // Whether this mailbox was given a name, which decides what the two
           // lines hold. `label` cannot answer it: it falls through to the

--- a/components/AccountSwitcher.qml
+++ b/components/AccountSwitcher.qml
@@ -290,10 +290,16 @@ Item {
             return row.named ? String(modelData.email || "") : ""
           }
 
+          // Whether this is the mailbox being read, which is not the same as
+          // being the active account: the combined view leaves one active
+          // underneath because compose still needs an address to send from.
+          // Drawing both as in use said the window was in two places.
+          readonly property bool inUse: modelData.active && !root.unifiedActive
+
           width: menu.width - menu.leftPadding - menu.rightPadding
           implicitHeight: Style.space(40)
           radius: Style.cornerRadius
-          color: modelData.active
+          color: row.inUse
             ? Style.selectedFillFor(root.textColor, root.accentColor)
             : (rowHover.hovered || hasCursor
               ? Style.hoverFillFor(root.textColor, root.accentColor) : "transparent")
@@ -351,7 +357,7 @@ Item {
               color: root.textColor
               font.family: root.panelFontFamily
               font.pixelSize: Style.font.bodySmall
-              font.bold: row.modelData.active
+              font.bold: row.inUse
               elide: Text.ElideMiddle
             }
 

--- a/components/AccountSwitcher.qml
+++ b/components/AccountSwitcher.qml
@@ -225,7 +225,8 @@ Item {
           Text {
             width: parent.width
             textFormat: Text.PlainText
-            text: "All mailboxes"
+            // The same string the status line shows, from one place.
+            text: Model.UNIFIED_LABEL
             color: root.textColor
             font.family: root.panelFontFamily
             font.pixelSize: Style.font.bodySmall

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -120,9 +120,13 @@ DropArea {
     return root.service.sendAsAliases
   }
 
+  // Filtered against the mailbox this draft belongs to rather than the visible
+  // one, so a reply raised from a merged list offers the aliases of the
+  // mailbox it arrived in.
   readonly property var fromIdentities: Senders.visible(
     root.service ? root.service.sendIdentities : [],
-    root.service ? String(root.service.activeAccountId || "") : "",
+    root.accountId !== "" ? root.accountId
+      : (root.service ? String(root.service.activeAccountId || "") : ""),
     root.mode)
 
   readonly property bool canChooseFrom: fromIdentities.length > 1
@@ -428,7 +432,12 @@ DropArea {
   function begin(nextMode, summary, bodyText, attachments) {
     clearCurrentDraft(true)
     mode = String(nextMode || "new")
-    accountId = root.service ? String(root.service.activeAccountId || "") : ""
+    // The mailbox the message being answered arrived in, not the one that
+    // happens to be active. In a merged list those differ, and a reply sent
+    // from the wrong mailbox with nothing on screen saying so is the failure
+    // this view most has to avoid. `composeAccountId` is the active account
+    // whenever there is no selection, so a new message is unchanged.
+    accountId = root.service ? String(root.service.composeAccountId || "") : ""
     opened = true
     var quoted = ""
 

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -46,11 +46,15 @@ DropArea {
   property string accountId: ""
   // The provider message that this form replaces when it is saved.
   property string sourceDraftId: ""
-  // The active account's sign-off, read when a draft is started rather than
-  // bound into the editor: the text is the user's to edit once it is in there,
-  // and a binding would overwrite what they had changed.
+  // The sign-off of the mailbox this draft belongs to, read when a draft is
+  // started rather than bound into the editor: the text is the user's to edit
+  // once it is in there, and a binding would overwrite what they had changed.
+  //
+  // The draft's own account, not the active one. `begin` sets `accountId`
+  // first, so a reply owned by B is signed by B even while A is on screen —
+  // otherwise one identity's name and contact details go out over another's.
   readonly property string accountSignature: root.service
-    ? String(root.service.activeSignature || "") : ""
+    ? String(root.service.signatureFor(root.accountId) || "") : ""
   // The body exactly as `placeBody` left it, plus whether the editor has seen a
   // user edit. Equality alone is not an edit history: somebody can type and
   // delete back to the same text. Together they separate an abandoned compose
@@ -345,9 +349,15 @@ DropArea {
 
   // Everyone on the original except this mailbox: replying to yourself is
   // never what reply-all was for.
+  //
+  // "This mailbox" is the one the draft is written from, not the one on
+  // screen. Reading the active account's address dropped the wrong name: a
+  // reply owned by B, to a message addressed to both, kept B on the Cc and
+  // removed A — copying the sender and losing a real recipient.
   function otherRecipients(summary) {
     if (!summary) return ""
-    var mine = String(root.service ? root.service.accountEmail : "").toLowerCase()
+    var mine = String(root.service
+      ? root.service.accountEmailFor(root.accountId) : "").toLowerCase()
     var list = Array.isArray(summary.to) ? summary.to : []
     var kept = []
     for (var i = 0; i < list.length; i++) {

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -705,6 +705,11 @@ DropArea {
     if (!opened || !service) return
     if (forwardAttachmentsLoading || forwardAttachmentError !== "") return
     var accepted = service.send(({
+      // The mailbox this draft belongs to, named rather than inferred. Without
+      // it the service fell back to matching `from` against each account in
+      // turn, so two mailboxes sharing a send-as alias sent B's draft from
+      // whichever of them came first.
+      accountId: root.accountId,
       from: root.fromEmail,
       to: toField.text,
       cc: ccField.text,

--- a/components/MessageList.qml
+++ b/components/MessageList.qml
@@ -2,6 +2,7 @@ import QtQuick
 import qs.Commons
 import qs.Ui
 import "../account/Model.js" as Model
+import "../account/Unified.js" as Unified
 
 // The message list. A Repeater in a Column rather than a ListView because the
 // panel already owns one Flickable and nesting a second scroller inside it
@@ -56,7 +57,7 @@ Column {
       hasCursor: root.cursorId === modelData.id
       selected: root.service.selectedId === modelData.id
       canArchive: root.service.canArchive
-      conversations: root.service.showsConversations
+      conversations: Unified.rowIsConversation(modelData)
       contentDirection: root.service.contentDirection
       onActivated: root.messageActivated(modelData.id)
       onStarToggled: root.service.toggleStar(modelData.id)

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -698,8 +698,11 @@ Item {
         required property var modelData
         width: parent.width
         attachment: modelData
-        saving: !!root.service && !!root.service.savingAttachmentIds[
-          String(modelData && modelData.attachmentId ? modelData.attachmentId : "")]
+        // Asked of the service by message and attachment rather than looked up
+        // by attachment alone: in a merged list the key is the mailbox's as
+        // well, and a bare id found nothing, so the row never went busy.
+        saving: !!root.service && root.service.attachmentIsSaving(root.selectedId,
+          modelData && modelData.attachmentId ? modelData.attachmentId : "")
         textColor: root.textColor
         dimColor: root.dimColor
         dimmerColor: root.dimmerColor
@@ -709,8 +712,11 @@ Item {
             root.service.openAttachment(root.selectedId, attachment)
         }
         onSaveRequested: function(attachment) {
+          // `selectedId`, like every other action on this message: `summary.id`
+          // is the id the owning account issued, which reaches no mailbox in a
+          // merged list and so saved from whichever one was active.
           if (root.service && root.summary)
-            root.service.saveAttachment(root.summary.id, attachment)
+            root.service.saveAttachment(root.selectedId, attachment)
         }
       }
     }

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -93,6 +93,14 @@ Item {
 
   readonly property var summary: service ? service.selectedMessage : null
 
+  // The id the service answers to, which is not always the one on the summary.
+  // A list made of several mailboxes addresses a row by mailbox and id, and the
+  // account that owns the message only ever knows its own half of that — so a
+  // call made with the summary's own id reaches no mailbox at all. This is the
+  // composed id where there is one and the same string everywhere else, which
+  // is what the list and the compose view already hand back.
+  readonly property string selectedId: service ? String(service.selectedId || "") : ""
+
   // Which way this message runs.
   //
   // The subject is asked separately from the body, and not as an optimisation:
@@ -302,7 +310,7 @@ Item {
       foreground: root.summary && root.summary.starred ? root.accentColor : root.dimColor
       hoverColor: root.accentColor
       fontFamily: root.panelFontFamily
-      onClicked: if (root.service && root.summary) root.service.toggleStar(root.summary.id)
+      onClicked: if (root.service && root.summary) root.service.toggleStar(root.selectedId)
     }
 
     Column {
@@ -456,7 +464,7 @@ Item {
       dimColor: root.dimColor
       accentColor: root.accentColor
       panelFontFamily: root.panelFontFamily
-      onActivated: if (root.service && root.summary) root.service.openInBrowser(root.summary.id)
+      onActivated: if (root.service && root.summary) root.service.openInBrowser(root.selectedId)
     }
 
     // Under the heavy-document notice when both are up: one says why the
@@ -698,7 +706,7 @@ Item {
         panelFontFamily: root.panelFontFamily
         onOpenRequested: function(attachment) {
           if (root.service && root.summary)
-            root.service.openAttachment(root.summary.id, attachment)
+            root.service.openAttachment(root.selectedId, attachment)
         }
         onSaveRequested: function(attachment) {
           if (root.service && root.summary)
@@ -889,7 +897,7 @@ Item {
           iconName: "browser"; tooltipText: "Open in browser"
           foreground: root.dimColor; hoverColor: root.textColor
           fontFamily: root.panelFontFamily
-          onClicked: if (root.service && root.summary) root.service.openInBrowser(root.summary.id)
+          onClicked: if (root.service && root.summary) root.service.openInBrowser(root.selectedId)
         }
       }
     }

--- a/components/MessageRow.qml
+++ b/components/MessageRow.qml
@@ -17,6 +17,10 @@ Rectangle {
   required property string panelFontFamily
   // Passed down rather than read off a service: a row draws one message and
   // has no other use for one.
+  // Which mailbox this row came from, present only on a merged summary.
+  readonly property string sourceLabel: root.summary && root.summary.sourceLabel !== undefined
+    ? String(root.summary.sourceLabel) : ""
+
   property bool canArchive: true
   // Whether this row stands for a conversation rather than for one message.
   // Grouping is a panel rule gated on the provider's `conversations`
@@ -148,6 +152,11 @@ Rectangle {
       }
     }
 
+    // The sender, the mailbox it arrived in where the list is made of several,
+    // and how long the conversation is. Both of the last two are optional and
+    // the sender takes what they leave: only a merged row carries
+    // `sourceLabel`, so a single-mailbox list is unchanged rather than gaining
+    // an empty column — naming the only mailbox there is says nothing.
     Item {
       width: parent.width
       implicitHeight: sender.implicitHeight
@@ -155,8 +164,9 @@ Rectangle {
       Text {
         id: sender
         anchors.left: parent.left
-        anchors.right: count.visible ? count.left : parent.right
-        anchors.rightMargin: count.visible ? Style.space(4) : 0
+        anchors.right: source.visible ? source.left
+          : (count.visible ? count.left : parent.right)
+        anchors.rightMargin: (source.visible || count.visible) ? Style.space(4) : 0
         textFormat: Text.PlainText
         text: root.summary.from.display
         color: root.dimColor
@@ -164,6 +174,27 @@ Rectangle {
         font.pixelSize: Style.font.bodySmall
         elide: Text.ElideRight
         horizontalAlignment: root.textAlignment
+      }
+
+      // Never colour alone: the mailbox is named in words, because a theme
+      // can put the accent close enough to the foreground that a tint says
+      // nothing at all.
+      //
+      // A third of the row at most. Nothing limits the length of a name a user
+      // can set, and a long one squeezed the sender to nothing.
+      Text {
+        id: source
+        anchors.right: count.visible ? count.left : parent.right
+        anchors.rightMargin: count.visible ? Style.space(4) : 0
+        anchors.baseline: sender.baseline
+        width: Math.min(implicitWidth, Math.floor(parent.width / 3))
+        visible: root.sourceLabel !== ""
+        textFormat: Text.PlainText
+        text: root.sourceLabel
+        color: root.accentColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        elide: Text.ElideRight
       }
 
       // How long the conversation is, beside who wrote it — where Gmail puts

--- a/components/MessageRow.qml
+++ b/components/MessageRow.qml
@@ -187,8 +187,13 @@ Rectangle {
         anchors.right: count.visible ? count.left : parent.right
         anchors.rightMargin: count.visible ? Style.space(4) : 0
         anchors.baseline: sender.baseline
-        width: Math.min(implicitWidth, Math.floor(parent.width / 3))
         visible: root.sourceLabel !== ""
+        // A ceiling, because `elide` on its own never fires: with only an
+        // implicit width the label is as wide as the name a user typed, and
+        // `sender` subtracts that — so a long one squeezed the sender to
+        // nothing and pushed the row past its own width. A third is enough to
+        // tell three mailboxes apart and leaves the sender the rest.
+        width: Math.min(implicitWidth, Math.floor(parent.width / 3))
         textFormat: Text.PlainText
         text: root.sourceLabel
         color: root.accentColor

--- a/tests/qml/tst_account_switcher.qml
+++ b/tests/qml/tst_account_switcher.qml
@@ -57,6 +57,19 @@ Item {
     name: "AccountSwitcher"
     when: windowShown
 
+    // The rows live inside the popup's content, which is built only once the
+    // menu has been opened.
+    function accountRows(item) {
+      var found = []
+      var node = item === undefined ? switcher.menuRows : item
+      if (!node) return found
+      if (node.objectName === "account-row") found.push(node)
+      var children = node.children || []
+      for (var i = 0; i < children.length; i++)
+        found = found.concat(accountRows(children[i]))
+      return found
+    }
+
     function init() {
       switcher.accounts = threeMailboxes
       switcher.unifiedActive = false
@@ -167,6 +180,25 @@ Item {
       switcher.chooseCursor()
       compare(chosenSpy.count, 0)
       compare(unifiedSpy.count, 0)
+    }
+
+    // -------------------------------------------------------- what is in use
+
+    // The combined view leaves an account active underneath, because compose
+    // still needs an address to send from. Drawing both as in use said the
+    // window was in two places at once.
+    function test_only_one_row_is_drawn_as_the_one_in_use() {
+      switcher.openCentered()
+      var rows = accountRows()
+      compare(rows.length, 3)
+      compare(rows[0].inUse, true, "the active account is in use on its own")
+      compare(rows[1].inUse, false)
+
+      switcher.unifiedActive = true
+      compare(rows[0].inUse, false,
+        "the account stays active underneath but is no longer what is read")
+      compare(rows[1].inUse, false)
+      compare(rows[2].inUse, false)
     }
 
     // ------------------------------------------------------------- the keys

--- a/tests/qml/tst_account_switcher.qml
+++ b/tests/qml/tst_account_switcher.qml
@@ -1,0 +1,204 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../../components" as Omamail
+
+// The mailbox list, and the row above it that stands for all of them.
+//
+// Two things here are worth a test rather than a reading. The combined row
+// shifts every account down by one, so the index this component reports and
+// the index it is given are no longer the same number — which is the kind of
+// arithmetic that looks right and is off by one. And the popup answers keys
+// itself, against the rule the rest of the window follows, so a `KeyRouter`
+// binding put here later would look live and never run.
+Item {
+  width: 600
+  height: 400
+
+  readonly property var threeMailboxes: [
+    { id: "a@example.org", email: "a@example.org", label: "Personal",
+      unread: 2, active: true, signedIn: true, busy: false, error: "" },
+    { id: "b@example.net", email: "b@example.net", label: "Work",
+      unread: 0, active: false, signedIn: true, busy: false, error: "" },
+    { id: "c@example.com", email: "c@example.com", label: "Other",
+      unread: 5, active: false, signedIn: true, busy: false, error: "" }
+  ]
+
+  readonly property var oneMailbox: [
+    { id: "a@example.org", email: "a@example.org", label: "Personal",
+      unread: 2, active: true, signedIn: true, busy: false, error: "" }
+  ]
+
+  Omamail.AccountSwitcher {
+    id: switcher
+    anchors.fill: parent
+    textColor: Qt.rgba(1, 1, 1, 1)
+    accentColor: Qt.rgba(1, 0.5, 0, 1)
+    urgentColor: Qt.rgba(1, 0.2, 0.2, 1)
+    dimColor: Qt.rgba(0.67, 0.67, 0.67, 1)
+    popupBackgroundColor: Qt.rgba(0.13, 0.13, 0.13, 1)
+    popupBorderColor: Qt.rgba(0.47, 0.47, 0.47, 1)
+    panelFontFamily: "monospace"
+    accounts: threeMailboxes
+  }
+
+  SignalSpy {
+    id: chosenSpy
+    target: switcher
+    signalName: "accountChosen"
+  }
+
+  SignalSpy {
+    id: unifiedSpy
+    target: switcher
+    signalName: "unifiedChosen"
+  }
+
+  TestCase {
+    name: "AccountSwitcher"
+    when: windowShown
+
+    function init() {
+      switcher.accounts = threeMailboxes
+      switcher.unifiedActive = false
+      switcher.close()
+      chosenSpy.clear()
+      unifiedSpy.clear()
+    }
+
+    function cleanup() {
+      switcher.close()
+    }
+
+    // ------------------------------------------------------- the row model
+
+    function test_the_combined_row_is_offered_only_when_there_is_more_than_one() {
+      compare(switcher.unifiedOffered, true)
+      compare(switcher.rowOffset, 1)
+      compare(switcher.rowCount, 4, "three mailboxes and the row for all of them")
+
+      switcher.accounts = oneMailbox
+      compare(switcher.unifiedOffered, false,
+        "one mailbox has nothing to combine")
+      compare(switcher.rowOffset, 0)
+      compare(switcher.rowCount, 1)
+
+      switcher.accounts = []
+      compare(switcher.unifiedOffered, false)
+      compare(switcher.rowCount, 0)
+    }
+
+    // ----------------------------------------------------------- the cursor
+
+    function test_the_cursor_walks_the_combined_row_with_the_rest() {
+      switcher.openCentered()
+      // Opening rests on the mailbox already in use, which is the first
+      // account — one row below the combined one.
+      compare(switcher.cursorIndex, 1)
+
+      switcher.moveCursor(-1)
+      compare(switcher.cursorIndex, 0, "up from the first mailbox is the combined row")
+
+      switcher.moveCursor(-1)
+      compare(switcher.cursorIndex, 3, "and up from there wraps to the last mailbox")
+
+      switcher.moveCursor(1)
+      compare(switcher.cursorIndex, 0, "which wraps back onto the combined row")
+    }
+
+    function test_opening_rests_on_the_combined_row_when_that_is_what_is_in_use() {
+      switcher.unifiedActive = true
+      switcher.openCentered()
+      compare(switcher.cursorIndex, 0)
+    }
+
+    function test_with_one_mailbox_the_cursor_never_leaves_it() {
+      switcher.accounts = oneMailbox
+      switcher.openCentered()
+      compare(switcher.cursorIndex, 0)
+      switcher.moveCursor(1)
+      compare(switcher.cursorIndex, 0, "one row wraps onto itself")
+    }
+
+    // ------------------------------------------------------- what is chosen
+
+    // The arithmetic worth testing: the row the keyboard is on is not the
+    // account index this reports.
+    function test_choosing_a_mailbox_reports_its_own_index_not_its_row() {
+      switcher.openCentered()
+      switcher.cursorIndex = 1
+      switcher.chooseCursor()
+
+      compare(unifiedSpy.count, 0)
+      compare(chosenSpy.count, 1)
+      compare(chosenSpy.signalArguments[0][0], 0,
+        "the first mailbox is account 0 even though it is row 1")
+
+      chosenSpy.clear()
+      switcher.openCentered()
+      switcher.cursorIndex = 3
+      switcher.chooseCursor()
+      compare(chosenSpy.signalArguments[0][0], 2, "the last mailbox is account 2")
+    }
+
+    function test_choosing_the_combined_row_asks_for_every_mailbox() {
+      switcher.openCentered()
+      switcher.cursorIndex = 0
+      switcher.chooseCursor()
+
+      compare(chosenSpy.count, 0, "no single mailbox was chosen")
+      compare(unifiedSpy.count, 1)
+    }
+
+    // Without the row there is no shift, and row 0 is account 0 again.
+    function test_with_one_mailbox_row_zero_is_account_zero() {
+      switcher.accounts = oneMailbox
+      switcher.openCentered()
+      switcher.cursorIndex = 0
+      switcher.chooseCursor()
+
+      compare(unifiedSpy.count, 0, "one mailbox is never the combined view")
+      compare(chosenSpy.count, 1)
+      compare(chosenSpy.signalArguments[0][0], 0)
+    }
+
+    function test_a_cursor_off_the_end_chooses_nothing() {
+      switcher.openCentered()
+      switcher.cursorIndex = 99
+      switcher.chooseCursor()
+      compare(chosenSpy.count, 0)
+      compare(unifiedSpy.count, 0)
+    }
+
+    // ------------------------------------------------------------- the keys
+
+    // The popup takes every key before the window's shortcut map sees it, so
+    // these handlers are the ones that run. This is the half of that the
+    // component's own comment promises is tested.
+    function test_the_open_menu_answers_its_own_keys() {
+      switcher.openCentered()
+      compare(switcher.opened, true)
+      compare(switcher.cursorIndex, 1)
+
+      keyClick(Qt.Key_J)
+      compare(switcher.cursorIndex, 2, "j moves down inside the popup")
+
+      keyClick(Qt.Key_K)
+      compare(switcher.cursorIndex, 1)
+
+      keyClick(Qt.Key_Up)
+      compare(switcher.cursorIndex, 0, "and the arrows reach the combined row too")
+
+      keyClick(Qt.Key_Return)
+      compare(unifiedSpy.count, 1, "Enter takes the row the cursor is on")
+      compare(switcher.opened, false, "and closes the menu")
+    }
+
+    function test_o_opens_the_row_the_cursor_is_on() {
+      switcher.openCentered()
+      switcher.cursorIndex = 2
+      keyClick(Qt.Key_O)
+      compare(chosenSpy.count, 1)
+      compare(chosenSpy.signalArguments[0][0], 1)
+    }
+  }
+}

--- a/tests/qml/tst_compose_identity.qml
+++ b/tests/qml/tst_compose_identity.qml
@@ -67,10 +67,15 @@ Item {
       return ""
     }
 
+    // What `submit()` handed over, so the account it named can be asserted.
+    property var submitted: null
     function preferredSendAs(_recipients) { return null }
     function switchTo(_id) { return true }
     function refreshRecipientContacts() {}
-    function send(_fields) { return true }
+    function send(fields) {
+      submitted = fields
+      return true
+    }
     function setAlwaysShowImages(_value) {}
     function setAlwaysRenderHeavyMessages(_value) {}
     function setUndoSendSeconds(_value) {}
@@ -167,6 +172,24 @@ Item {
       verify(cc.indexOf(adaId) >= 0, "A was on the original and stays on the Cc")
       compare(cc.indexOf(bobId) < 0, true,
         "B is writing it, so B is not copied on it")
+    }
+
+    // ------------------------------------------------------- the send
+
+    // The service can only route a submission to the mailbox that owns it if
+    // the submission says which that is. Without it the service fell back to
+    // matching the From address against each account in turn, so two
+    // mailboxes sharing a send-as alias sent B's draft from whichever came
+    // first — and that fallback cannot tell the difference.
+    function test_a_submission_names_the_mailbox_it_belongs_to() {
+      mailService.composeAccountId = bobId
+      mailService.submitted = null
+      compose.begin("reply", incoming(), "Original body", [])
+      compose.submit()
+
+      verify(mailService.submitted, "the draft was submitted")
+      compare(String(mailService.submitted.accountId), bobId,
+        "and it names B, which is the only thing that can route it")
     }
 
     function test_reply_all_from_the_active_mailbox_is_unchanged() {

--- a/tests/qml/tst_compose_identity.qml
+++ b/tests/qml/tst_compose_identity.qml
@@ -1,0 +1,181 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../../components" as Omamail
+
+// Whose identity a draft writes with, when the mailbox it belongs to is not
+// the mailbox on screen.
+//
+// `begin` gets the owner right — `accountId` comes from `composeAccountId` —
+// and then two things went on asking the *active* account instead: the
+// sign-off placed in the body, and the address reply-all leaves off the Cc.
+// Both put one identity's details into another identity's outgoing mail, so
+// they are held here rather than in tst_signature.qml, which has one account
+// and cannot tell the two apart.
+Item {
+  width: 900
+  height: 600
+
+  readonly property string adaId: "ada@example.org"
+  readonly property string bobId: "bob@example.net"
+
+  QtObject {
+    id: mailAuth
+    property bool signedIn: true
+  }
+
+  // Two mailboxes, A active. The draft under test belongs to B.
+  QtObject {
+    id: mailService
+    property bool sendPending: false
+    property bool sending: false
+    property int sendSecondsRemaining: 10
+    property var lastSent: null
+    property var recipientContacts: []
+    property var sendAsAliases: []
+    property var sendIdentities: []
+    property var auth: mailAuth
+    property bool alwaysShowImages: false
+    property bool alwaysRenderHeavyMessages: false
+    property int undoSendSeconds: 10
+
+    property string activeAccountId: adaId
+    property string accountEmail: adaId
+    property string activeSignature: "Ada\nada.example.org"
+
+    // Which mailbox the next draft belongs to. The window seeds this from the
+    // message being answered; here it is set by the test.
+    property string composeAccountId: adaId
+
+    property var accountSignatures: [
+      ({ id: adaId, email: adaId, signature: "Ada\nada.example.org" }),
+      ({ id: bobId, email: bobId, signature: "Bob\nbob.example.net" })
+    ]
+
+    function signatureFor(id) {
+      var want = String(id || "")
+      for (var i = 0; i < accountSignatures.length; i++)
+        if (accountSignatures[i].id === want)
+          return String(accountSignatures[i].signature || "")
+      return ""
+    }
+
+    function accountEmailFor(id) {
+      var want = String(id || "")
+      for (var i = 0; i < accountSignatures.length; i++)
+        if (accountSignatures[i].id === want)
+          return String(accountSignatures[i].email || "")
+      return ""
+    }
+
+    function preferredSendAs(_recipients) { return null }
+    function switchTo(_id) { return true }
+    function refreshRecipientContacts() {}
+    function send(_fields) { return true }
+    function setAlwaysShowImages(_value) {}
+    function setAlwaysRenderHeavyMessages(_value) {}
+    function setUndoSendSeconds(_value) {}
+    function setAccountSignature(_id, _text) {}
+  }
+
+  Omamail.ComposeView {
+    id: compose
+    anchors.fill: parent
+    service: mailService
+    textColor: Qt.rgba(1, 1, 1, 1)
+    backgroundColor: Qt.rgba(0.06, 0.06, 0.06, 1)
+    accentColor: Qt.rgba(1, 0.5, 0, 1)
+    dimColor: Qt.rgba(0.67, 0.67, 0.67, 1)
+    dimmerColor: Qt.rgba(0.47, 0.47, 0.47, 1)
+    popupBackgroundColor: Qt.rgba(0.13, 0.13, 0.13, 1)
+    popupBorderColor: Qt.rgba(0.53, 0.53, 0.53, 1)
+    panelFontFamily: "monospace"
+  }
+
+  TestCase {
+    name: "ComposeIdentity"
+    when: windowShown
+
+    function init() {
+      mailService.composeAccountId = adaId
+      compose.reset()
+      compose.opened = false
+    }
+
+    function named(item, objectName) {
+      if (!item) return null
+      if (item.objectName === objectName) return item
+      var values = item.children || []
+      for (var i = 0; i < values.length; i++) {
+        var found = named(values[i], objectName)
+        if (found) return found
+      }
+      return null
+    }
+
+    function bodyText() { return named(compose, "compose-body-editor").text }
+    function ccText() { return named(compose, "compose-cc-field").text.toLowerCase() }
+
+    // A message addressed to both mailboxes, from somebody else.
+    function incoming() {
+      return {
+        id: "1",
+        threadId: "t1",
+        messageId: "<m1@example.com>",
+        subject: "Invoice",
+        from: { email: "sender@example.com", display: "Sender" },
+        to: [{ email: bobId, display: "Bob" }, { email: adaId, display: "Ada" }],
+        cc: [],
+        date: 1000
+      }
+    }
+
+    // ------------------------------------------------------- the sign-off
+
+    function test_a_draft_is_signed_by_the_mailbox_it_belongs_to() {
+      mailService.composeAccountId = bobId
+      compose.begin("reply", incoming(), "Original body", [])
+
+      compare(compose.accountId, bobId, "the draft belongs to B")
+      compare(compose.accountSignature, "Bob\nbob.example.net",
+        "and is signed by B, not by whichever mailbox is on screen")
+      verify(bodyText().indexOf("Bob") >= 0, "B's sign-off reaches the body")
+      compare(bodyText().indexOf("Ada") < 0, true,
+        "A's name and address are nowhere in a message A is not sending")
+    }
+
+    // The single-mailbox case, which is every account's own reply and must
+    // keep working: owner and active are the same, and the answer is the same.
+    function test_a_draft_from_the_active_mailbox_is_signed_by_it() {
+      mailService.composeAccountId = adaId
+      compose.begin("reply", incoming(), "Original body", [])
+
+      compare(compose.accountId, adaId)
+      compare(compose.accountSignature, "Ada\nada.example.org")
+    }
+
+    // ------------------------------------------------------- reply-all
+
+    // The original went to both mailboxes. Replying from B, the Cc is
+    // everybody except B — so A stays on it and B comes off. Reading the
+    // active account's address inverted exactly that: it dropped A, the real
+    // recipient, and copied B, the sender.
+    function test_reply_all_drops_the_sender_rather_than_the_active_mailbox() {
+      mailService.composeAccountId = bobId
+      compose.begin("replyAll", incoming(), "Original body", [])
+
+      var cc = ccText()
+      verify(cc.indexOf(adaId) >= 0, "A was on the original and stays on the Cc")
+      compare(cc.indexOf(bobId) < 0, true,
+        "B is writing it, so B is not copied on it")
+    }
+
+    function test_reply_all_from_the_active_mailbox_is_unchanged() {
+      mailService.composeAccountId = adaId
+      compose.begin("replyAll", incoming(), "Original body", [])
+
+      var cc = ccText()
+      verify(cc.indexOf(bobId) >= 0)
+      compare(cc.indexOf(adaId) < 0, true)
+    }
+  }
+}

--- a/tests/qml/tst_message_attachment.qml
+++ b/tests/qml/tst_message_attachment.qml
@@ -11,6 +11,12 @@ Item {
 
     property string openedMessageId: ""
     property var openedAttachment: null
+    property string starredId: ""
+    property string browsedId: ""
+    // What the service answers to. It is the summary's own id in a single
+    // mailbox and the mailbox plus that id in a list made of several, and the
+    // reader has to hand back this one rather than the one on the summary.
+    property string selectedId: "message-4"
     property var selectedMessage: ({
       id: "message-4",
       subject: "Forwarded report",
@@ -48,6 +54,9 @@ Item {
       openedMessageId = messageId
       openedAttachment = attachment
     }
+
+    function toggleStar(id) { starredId = String(id) }
+    function openInBrowser(id) { browsedId = String(id) }
   }
 
   Omamail.MessageReader {
@@ -91,6 +100,27 @@ Item {
       link.activated()
       compare(mailService.openedMessageId, "message-4")
       compare(mailService.openedAttachment.attachmentId, "att-7")
+    }
+
+    // A row in a list made of several mailboxes is addressed by mailbox and
+    // id. The account that owns the message knows only its own half of that,
+    // so a reader that called back with `selectedMessage.id` named no mailbox
+    // and the star, the attachment and the browser link all did nothing.
+    function test_the_reader_answers_with_the_id_the_service_gave_it() {
+      mailService.selectedId = "b@example.net message-4"
+
+      mailService.openedMessageId = ""
+      var link = named(reader, "attachment-open-link")
+      verify(link)
+      link.activated()
+      compare(mailService.openedMessageId, "b@example.net message-4")
+
+      var web = named(reader, "openWebButton")
+      verify(web, "the browser link has to be there to be pressed")
+      web.clicked()
+      compare(mailService.browsedId, "b@example.net message-4")
+
+      mailService.selectedId = "message-4"
     }
   }
 }

--- a/tests/qml/tst_message_attachment.qml
+++ b/tests/qml/tst_message_attachment.qml
@@ -50,9 +50,28 @@ Item {
       attachmentId: "att-7"
     })]
 
+    property string savedMessageId: ""
+    property var savedAttachment: null
+
+    // Keyed by mailbox and attachment on the real service, because two
+    // mailboxes can be saving parts whose ids collide. Empty here, so a reader
+    // that looks up a bare attachment id finds nothing — which is what it did.
+    property var savingAttachmentIds: ({})
+    property string savingFor: ""
+
     function openAttachment(messageId, attachment) {
       openedMessageId = messageId
       openedAttachment = attachment
+    }
+
+    function saveAttachment(messageId, attachment) {
+      savedMessageId = messageId
+      savedAttachment = attachment
+    }
+
+    function attachmentIsSaving(messageId, attachmentId) {
+      return savingFor !== "" && String(messageId) === savingFor
+        && String(attachmentId) === "att-7"
     }
 
     function toggleStar(id) { starredId = String(id) }
@@ -120,6 +139,45 @@ Item {
       web.clicked()
       compare(mailService.browsedId, "b@example.net message-4")
 
+      mailService.selectedId = "message-4"
+    }
+
+    // Saving was the one that kept `selectedMessage.id`, so the file came down
+    // from whichever mailbox was active — and on two IMAP accounts a part id
+    // is a number in a tree, so A's part could arrive under B's filename.
+    function test_saving_answers_with_the_id_the_service_gave_it() {
+      mailService.selectedId = "b@example.net message-4"
+      mailService.savedMessageId = ""
+
+      var save = named(reader, "attachment-save-button")
+      verify(save, "the save control has to be there to be pressed")
+      save.clicked()
+
+      compare(mailService.savedMessageId, "b@example.net message-4")
+      compare(mailService.savedAttachment.attachmentId, "att-7")
+
+      mailService.selectedId = "message-4"
+    }
+
+    // And the spinner is asked the same way. The service keys it by mailbox,
+    // so a lookup by attachment alone found nothing and the row stayed idle
+    // through the whole save.
+    function test_the_row_goes_busy_for_the_mailbox_that_owns_it() {
+      mailService.selectedId = "b@example.net message-4"
+      var row = named(reader, "attachment-save-button").parent
+      verify(row, "the save control sits in the row it belongs to")
+
+      mailService.savingFor = ""
+      compare(row.saving, false)
+
+      mailService.savingFor = "b@example.net message-4"
+      compare(row.saving, true,
+        "asked by mailbox and attachment, which is how the service holds it")
+
+      mailService.savingFor = "a@example.org message-4"
+      compare(row.saving, false, "another mailbox's save is not this row's")
+
+      mailService.savingFor = ""
       mailService.selectedId = "message-4"
     }
   }

--- a/tests/qml/tst_service_settings.qml
+++ b/tests/qml/tst_service_settings.qml
@@ -66,5 +66,47 @@ Item {
       verify(shellStore.updatedEntry !== null)
       compare(shellStore.updatedEntry.unifiedCalendarView, true)
     }
+
+    function test_unified_mailboxes_setting_defaults_off_and_persists_changes() {
+      mailService.applySettings({})
+      compare(mailService.unifiedMailboxes, false)
+
+      mailService.setUnifiedMailboxes(true)
+      compare(mailService.unifiedMailboxes, true)
+      compare(shellStore.updatedId, "omamail")
+      verify(shellStore.updatedEntry !== null)
+      compare(shellStore.updatedEntry.unifiedMailboxes, true)
+    }
+
+    // The setting is what the user asked for; `unified` is whether it means
+    // anything. One mailbox combined with nothing is the mailbox, and merging
+    // would spend a copy of every row to arrive at the same list.
+    function test_one_mailbox_is_never_combined_whatever_the_setting_says() {
+      mailService.applySettings({ unifiedMailboxes: true })
+      compare(mailService.unifiedMailboxes, true)
+      compare(mailService.accountCount, 0)
+      compare(mailService.unified, false)
+    }
+
+    // With nothing to merge the façade still answers, and answers as the
+    // single-mailbox view it is: an empty list rather than a broken binding.
+    function test_the_combined_answers_hold_up_with_no_mailboxes() {
+      mailService.applySettings({ unifiedMailboxes: true })
+      compare(mailService.messages.length, 0)
+      compare(mailService.inboxUnread, 0)
+      compare(mailService.lastError, "")
+      compare(mailService.selectedId, "")
+      compare(mailService.mailboxKey, "inbox")
+      verify(mailService.mailboxes.length > 0,
+        "the rail still has rows to draw before a mailbox is added")
+    }
+
+    // Composed ids are the service's own vocabulary, so an action naming one
+    // reaches no mailbox rather than the wrong one.
+    function test_an_action_for_a_mailbox_that_is_not_here_reaches_nothing() {
+      mailService.applySettings({ unifiedMailboxes: true })
+      compare(mailService.act("gone@example.org 42", "archive"), false)
+      compare(mailService.hostForId("gone@example.org 42"), null)
+    }
   }
 }

--- a/tests/qml/tst_service_settings.qml
+++ b/tests/qml/tst_service_settings.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtTest 1.3
 import "../.." as Omamail
+import "../../account/Unified.js" as Unified
 
 Item {
   width: 400
@@ -102,11 +103,18 @@ Item {
     }
 
     // Composed ids are the service's own vocabulary, so an action naming one
-    // reaches no mailbox rather than the wrong one.
+    // reaches no mailbox rather than the wrong one, and reaching none is a
+    // refusal rather than a throw.
+    //
+    // That a *bare* id is not mistaken for a composed one is the separator's
+    // own property and is measured in tests/test_unified.js, against the id
+    // shapes the three providers actually issue — there is no account here for
+    // a wrong split to land on, so this file could not tell the difference.
     function test_an_action_for_a_mailbox_that_is_not_here_reaches_nothing() {
       mailService.applySettings({ unifiedMailboxes: true })
-      compare(mailService.act("gone@example.org 42", "archive"), false)
-      compare(mailService.hostForId("gone@example.org 42"), null)
+      var absent = Unified.unifiedId("gone@example.org", "42")
+      compare(mailService.act(absent, "archive"), false)
+      compare(mailService.hostForId(absent), null)
     }
   }
 }

--- a/tests/qml/tst_signature.qml
+++ b/tests/qml/tst_signature.qml
@@ -67,6 +67,29 @@ Item {
     function setAlwaysRenderHeavyMessages(_value) {}
     function setUndoSendSeconds(_value) {}
 
+    // A draft belongs to the mailbox it answers. With one account that is the
+    // active one, which is why these tests can go on setting `activeSignature`
+    // — tst_compose_identity.qml is where the two come apart.
+    property string composeAccountId: activeAccountId
+
+    function signatureFor(id) {
+      var want = String(id || "")
+      if (want === activeAccountId) return activeSignature
+      for (var i = 0; i < accountSignatures.length; i++)
+        if (accountSignatures[i].id === want)
+          return String(accountSignatures[i].signature || "")
+      return ""
+    }
+
+    function accountEmailFor(id) {
+      var want = String(id || "")
+      if (want === activeAccountId) return accountEmail
+      for (var i = 0; i < accountSignatures.length; i++)
+        if (accountSignatures[i].id === want)
+          return String(accountSignatures[i].email || "")
+      return ""
+    }
+
     function setAccountSignature(id, text) {
       savedId = String(id || "")
       savedText = String(text || "")

--- a/tests/qml/tst_unified_routing.qml
+++ b/tests/qml/tst_unified_routing.qml
@@ -1,0 +1,199 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../.." as Omamail
+import "../../account/Unified.js" as Unified
+
+// The service routing a merged list, against a real `Service` with real
+// account hosts.
+//
+// This is the gap the review named: `select`, `hostForId`, `sourceIdFor` on
+// real messages, `chooseUnified`, the capability intersection and the
+// per-mailbox properties had no test at all, and every defect found landed in
+// exactly those gaps.
+//
+// The hosts are real `MailAccount`s with no credentials, so nothing is fetched
+// and nothing is sent; what is asserted is which of them the service asked.
+Item {
+  width: 1200
+  height: 700
+
+  QtObject {
+    id: fakeShell
+    property var written: []
+    function updateEntryInline(id, entry) {
+      var next = written.slice()
+      next.push({ id: id, entry: entry })
+      written = next
+    }
+    function hide(_id) {}
+  }
+
+  Omamail.Service {
+    id: service
+    shell: fakeShell
+    manifest: ({ id: "omamail", __sourceDir: "/tmp/omamail-unified-test" })
+  }
+
+  TestCase {
+    name: "UnifiedRouting"
+    when: windowShown
+
+    readonly property string adaId: "ada@example.org"
+    readonly property string bobId: "bob@example.net"
+
+    function seed() {
+      service.applySettings({ unifiedMailboxes: true })
+      service.applyAccounts(JSON.stringify({
+        version: 1,
+        activeId: adaId,
+        accounts: [
+          { id: adaId, email: adaId, provider: "gmail" },
+          { id: bobId, email: bobId, provider: "gmail" }
+        ]
+      }))
+      wait(50)
+    }
+
+    function ada() { return service.findAccount(adaId) }
+    function bob() { return service.findAccount(bobId) }
+
+    // A summary shaped the way a provider hands one over, so `mergeMessages`
+    // has real fields to copy and sort.
+    function row(id, date, subject) {
+      return { id: id, subject: subject, unread: true, starred: false,
+        inInbox: true, inTrash: false, isDraft: false, labelIds: ["INBOX"],
+        from: { email: "sender@example.com", display: "Sender" },
+        snippet: "", time: "now", fullTime: "today", date: date }
+    }
+
+    function init() {
+      seed()
+      ada().messages = [row("1", 3000, "ada newest"), row("2", 1000, "ada oldest")]
+      bob().messages = [row("1", 2000, "bob middle")]
+      service.bumpListEpoch()
+      wait(20)
+    }
+
+    // ------------------------------------------------------------ the merge
+
+    function test_two_mailboxes_become_one_list() {
+      compare(service.unified, true)
+      compare(service.messages.length, 3)
+      deepCompare(service.messages.map(function(m) { return m.subject }),
+        ["ada newest", "bob middle", "ada oldest"])
+    }
+
+    function deepCompare(actual, expected) {
+      compare(actual.join(" | "), expected.join(" | "))
+    }
+
+    // Two mailboxes numbering their own messages from 1 is the collision the
+    // composed id exists for.
+    function test_each_row_is_addressed_by_its_own_mailbox() {
+      var ids = service.messages.map(function(m) { return m.id })
+      compare(ids[0], Unified.unifiedId(adaId, "1"))
+      compare(ids[1], Unified.unifiedId(bobId, "1"))
+      compare(ids[2], Unified.unifiedId(adaId, "2"))
+      compare(ids[0] === ids[1], false, "three rows, three distinct ids")
+    }
+
+    function test_one_mailbox_is_not_merged() {
+      service.applyAccounts(JSON.stringify({
+        version: 1, activeId: adaId,
+        accounts: [{ id: adaId, email: adaId, provider: "gmail" }]
+      }))
+      wait(50)
+      compare(service.accountCount, 1)
+      compare(service.unified, false,
+        "a merged view of one mailbox is the mailbox")
+    }
+
+    // ---------------------------------------------------------- the routing
+
+    function test_an_id_names_the_mailbox_that_owns_it() {
+      compare(service.hostForId(Unified.unifiedId(adaId, "1")), ada())
+      compare(service.hostForId(Unified.unifiedId(bobId, "1")), bob())
+      compare(service.sourceIdFor(Unified.unifiedId(bobId, "42:Sent Items")),
+        "42:Sent Items", "a folder with a space in it survives the trip")
+    }
+
+    // An id for a mailbox that is not here reaches none rather than the wrong
+    // one — which a bare id, read as composed, could have done.
+    function test_an_id_for_a_mailbox_that_is_not_here_reaches_nothing() {
+      compare(service.hostForId(Unified.unifiedId("gone@example.com", "1")), null)
+      compare(service.hostForId("42:Sent Items"), null,
+        "a bare IMAP id is not a composed one")
+      compare(service.act("42:Sent Items", "archive"), false)
+    }
+
+    // Selecting routes to the owning mailbox, and clears the others: a second
+    // mailbox still holding a selection goes on answering for the reader.
+    function test_selecting_clears_every_other_mailbox() {
+      service.select(Unified.unifiedId(bobId, "1"))
+      compare(bob().selectedId, "1")
+      compare(ada().selectedId, "", "whatever was open elsewhere is not what is shown")
+      compare(service.selectedId, Unified.unifiedId(bobId, "1"),
+        "and it comes back composed, because the panel compares it against the list")
+
+      service.select(Unified.unifiedId(adaId, "2"))
+      compare(ada().selectedId, "2")
+      compare(bob().selectedId, "")
+    }
+
+    // A reply is written from the mailbox the message arrived in.
+    function test_compose_belongs_to_the_mailbox_the_message_arrived_in() {
+      service.select(Unified.unifiedId(bobId, "1"))
+      compare(service.composeAccountId, bobId,
+        "not the account that happens to be active")
+
+      service.select(Unified.unifiedId(adaId, "1"))
+      compare(service.composeAccountId, adaId)
+    }
+
+    function test_clearing_the_selection_clears_all_of_them() {
+      service.select(Unified.unifiedId(bobId, "1"))
+      service.clearSelection()
+      compare(bob().selectedId, "")
+      compare(ada().selectedId, "")
+      compare(service.selectedId, "")
+    }
+
+    // ------------------------------------------------------- the properties
+
+    function test_the_rail_is_what_every_mailbox_has() {
+      var keys = service.mailboxes.map(function(m) { return m.key })
+      compare(keys.indexOf("inbox") >= 0, true)
+      compare(keys.indexOf("spam") >= 0, true, "two Gmail mailboxes share Gmail's rail")
+    }
+
+    function test_a_label_cannot_be_shown_or_moved_to() {
+      compare(service.labels.length, 0, "a label belongs to one mailbox")
+      compare(service.rawLabelId, "")
+      compare(service.canMoveToLabel, false,
+        "so there is nothing for the picker to offer")
+    }
+
+    function test_the_unread_count_is_every_mailbox() {
+      ada().inboxUnread = 3
+      bob().inboxUnread = 4
+      service.recount()
+      wait(20)
+      compare(service.inboxUnread, 7)
+    }
+
+    // The rail row is chosen even with the calendar up, or every mailbox stays
+    // on whatever it was showing while the rail claims one.
+    function test_a_rail_row_reaches_every_mailbox() {
+      service.selectMailbox("sent")
+      compare(service.mailboxKey, "sent")
+      compare(ada().mailboxKey, "sent")
+      compare(bob().mailboxKey, "sent")
+    }
+
+    function test_a_search_reaches_every_mailbox() {
+      service.search("invoice")
+      compare(ada().searchQuery, "invoice")
+      compare(bob().searchQuery, "invoice")
+    }
+  }
+}

--- a/tests/qml/tst_unified_routing.qml
+++ b/tests/qml/tst_unified_routing.qml
@@ -190,6 +190,42 @@ Item {
       compare(bob().mailboxKey, "sent")
     }
 
+    // ------------------------------------------------------- attachments
+
+    // Saving reached whichever mailbox was active, so the file that came down
+    // was A's part id under B's filename — and on an IMAP pair, where a part
+    // id is a number in a tree rather than anything unique, the two collide
+    // routinely. Neither host can actually fetch here, so what is asserted is
+    // which of them was asked: the refusal lands on the mailbox that owns the
+    // message and nowhere else.
+    function test_saving_an_attachment_asks_the_mailbox_that_owns_it() {
+      ada().lastError = ""
+      bob().lastError = ""
+      compare(service.activeAccountId, adaId, "A is the active mailbox")
+
+      service.saveAttachment(Unified.unifiedId(bobId, "1"),
+        { attachmentId: "2", filename: "invoice.pdf" })
+
+      verify(bob().lastError !== "", "B was asked, because the message is B's")
+      compare(ada().lastError, "", "and A was not asked at all")
+    }
+
+    // The spinner is keyed by mailbox and attachment, and the reader holds
+    // only an attachment id — so composing the key is the service's job. It
+    // was looked up bare, found nothing, and the row never went busy.
+    function test_the_saving_row_is_the_owning_mailboxs_row() {
+      bob().markSavingAttachment("2", true)
+
+      compare(service.attachmentIsSaving(Unified.unifiedId(bobId, "1"), "2"), true)
+      compare(service.attachmentIsSaving(Unified.unifiedId(adaId, "1"), "2"), false,
+        "A is not saving anything, whatever B is doing")
+      compare(service.attachmentIsSaving("", "2"), false)
+      compare(service.attachmentIsSaving(Unified.unifiedId(bobId, "1"), ""), false)
+
+      bob().markSavingAttachment("2", false)
+      compare(service.attachmentIsSaving(Unified.unifiedId(bobId, "1"), "2"), false)
+    }
+
     function test_a_search_reaches_every_mailbox() {
       service.search("invoice")
       compare(ada().searchQuery, "invoice")

--- a/tests/qml/tst_unified_routing.qml
+++ b/tests/qml/tst_unified_routing.qml
@@ -226,6 +226,163 @@ Item {
       compare(service.attachmentIsSaving(Unified.unifiedId(bobId, "1"), "2"), false)
     }
 
+    // ------------------------------------------- every mailbox is live
+
+    // `active` is what earns a mailbox a list: `refresh` will not reload one
+    // without it, and neither will the poll. Leaving it on the visible account
+    // meant a merged list refreshed one mailbox's rows and left the others as
+    // they were — the counts moved and the mail did not.
+    function test_every_merged_mailbox_is_given_a_list() {
+      compare(service.unified, true)
+      compare(ada().active, true)
+      compare(bob().active, true, "B is on screen too, so B gets a list")
+      compare(bob().windowOpen, ada().windowOpen,
+        "and the same answer about the window, which refresh also asks")
+    }
+
+    // Turning it off puts the list back on the one mailbox being shown.
+    function test_leaving_the_merged_view_stands_the_others_down() {
+      service.applySettings({ unifiedMailboxes: false })
+      wait(30)
+      compare(service.unified, false)
+      compare(ada().active, true, "A is the mailbox on screen")
+      compare(bob().active, false, "and B is no longer being drawn")
+    }
+
+    // ------------------------------------------------- the sending identity
+
+    // Two mailboxes can share a send-as alias, and the address alone then
+    // names both. Whichever host answered first got the message.
+    function test_a_draft_is_sent_from_the_mailbox_it_names() {
+      compare(service.sendHostFor({ accountId: bobId, from: "shared@example.com" }),
+        bob(), "the mailbox the composer named, not the one the address matched")
+
+      // The collision itself: one address, both mailboxes claiming it. Named
+      // still decides, and the first match no longer does.
+      ada().profile = { email: "shared@example.com" }
+      bob().profile = { email: "shared@example.com" }
+      compare(service.sendHostFor({ from: "shared@example.com" }), ada(),
+        "with nothing named the first match is all there is to go on")
+      compare(service.sendHostFor({ accountId: bobId, from: "shared@example.com" }),
+        bob(), "and naming one is what settles it")
+      ada().profile = null
+      bob().profile = null
+
+      // With neither, the mailbox on screen.
+      compare(service.sendHostFor({}), service.current)
+    }
+
+    // A draft raised from a merged list names its mailbox in its own id, so a
+    // submission that carries only that still reaches the right one.
+    function test_a_draft_id_alone_names_the_sending_mailbox() {
+      compare(service.sendHostFor({ draftId: Unified.unifiedId(bobId, "d1") }), bob())
+    }
+
+    // A named mailbox that is not here is a refusal rather than permission to
+    // fall back to matching the address.
+    function test_a_draft_naming_a_mailbox_that_is_gone_is_not_sent() {
+      ada().lastError = ""
+      bob().lastError = ""
+      compare(service.sendHostFor({ accountId: "gone@example.com", from: adaId }), null,
+        "A matches the address, and is still not asked")
+      compare(service.send({ accountId: "gone@example.com",
+        from: adaId, to: "her@example.com", subject: "x", body: "y" }), false)
+      compare(ada().lastError, "", "nothing was sent from anywhere")
+      compare(bob().lastError, "")
+    }
+
+    // ------------------------------------------------------- the draft id
+
+    // A draft opened from a merged list carries a composed id, and a provider
+    // handed one answers that the draft is gone and writes nothing.
+    function test_a_draft_is_saved_under_the_id_its_provider_issued() {
+      compare(service.draftOwner({ draftId: Unified.unifiedId(bobId, "d1") }), bobId,
+        "the owner is readable from the id alone")
+      compare(service.withSourceDraftId(
+        { draftId: Unified.unifiedId(bobId, "d1") }).draftId, "d1")
+
+      // Named account wins, and a bare id is left exactly as it is.
+      compare(service.draftOwner({ accountId: adaId, draftId: Unified.unifiedId(bobId, "d1") }),
+        adaId)
+      compare(service.withSourceDraftId({ draftId: "d1" }).draftId, "d1")
+    }
+
+    // Not gated on the merged view still being on: the composer can be opened
+    // from one and saved after the reader has left it.
+    function test_a_composed_draft_id_is_decoded_after_the_view_changes() {
+      service.applySettings({ unifiedMailboxes: false })
+      wait(30)
+      compare(service.unified, false)
+      compare(service.withSourceDraftId(
+        { draftId: Unified.unifiedId(bobId, "d1") }).draftId, "d1")
+      compare(service.draftOwner({ draftId: Unified.unifiedId(bobId, "d1") }), bobId)
+    }
+
+    // ----------------------------------------------- what a merge may do
+
+    // What the intersection is taken over: one row per mailbox, each row that
+    // mailbox's own answer.
+    //
+    // A host narrows its provider by the refusals its server reported and the
+    // mailboxes it turned out not to have, so a merged list that asks the
+    // provider ids puts back an Archive the account's own view hides. The
+    // narrowing itself arrives through `api`, which is a read-only loader
+    // item and cannot be injected here — so what is asserted is that every
+    // row is the host's answer and not a provider's. `everyMailboxCan` and
+    // `sharedMailboxRows` are held to the divergent case in
+    // tests/test_unified.js, and test_source.sh guards the call sites.
+    function test_the_intersection_is_taken_over_the_mailboxes_themselves() {
+      var rows = service.unifiedAbilities
+      compare(rows.length, 2, "one row per mailbox in the merge")
+
+      var hosts = [ada(), bob()]
+      for (var i = 0; i < hosts.length; i++) {
+        compare(rows[i].archive, hosts[i].canArchive)
+        compare(rows[i].spam, hosts[i].canReportSpam)
+        compare(rows[i].star, hosts[i].canStar)
+        compare(rows[i].labels, hosts[i].hasLabels)
+        compare(rows[i].web, hosts[i].canOpenOnWeb)
+        compare(rows[i].move, hosts[i].canMove)
+        compare(rows[i].conversations, hosts[i].showsConversations)
+        compare(rows[i].mailboxes.length, hosts[i].mailboxes.length)
+      }
+
+      compare(service.canArchive,
+        Unified.everyMailboxCan(rows, "archive"),
+        "and the offered verb is that intersection, nothing else")
+    }
+
+    // ------------------------------------------------ conversation members
+
+    // The rail steps from one member to the next and hands the id back to
+    // `select` and `act`. A raw member id reached no mailbox, so a merged
+    // conversation could be drawn and not walked.
+    function test_a_conversation_member_is_addressed_like_every_other_row() {
+      bob().selectedThread = { id: "t1", count: 2, unread: false, flagged: false,
+        memberIds: ["1", "2"] }
+      bob().memberSummaries = ({
+        "1": { id: "1", unread: true, labelIds: ["UNREAD"] },
+        "2": { id: "2", unread: false, labelIds: [] }
+      })
+      service.select(Unified.unifiedId(bobId, "1"))
+
+      deepCompare(service.selectedThread.memberIds,
+        [Unified.unifiedId(bobId, "1"), Unified.unifiedId(bobId, "2")])
+      compare(service.selectedThread.id, "t1",
+        "the thread's own handle is not a message id and is left alone")
+
+      var key = Unified.unifiedId(bobId, "2")
+      verify(service.memberSummaries[key], "the summaries are keyed the same way")
+      compare(service.memberSummaries[key].id, key,
+        "and a stop carries that id onward to an open")
+
+      // Which is what makes the next stop reachable.
+      compare(service.hostForId(service.selectedThread.memberIds[1]), bob())
+
+      bob().selectedThread = null
+      bob().memberSummaries = ({})
+    }
+
     function test_a_search_reaches_every_mailbox() {
       service.search("invoice")
       compare(ada().searchQuery, "invoice")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -1008,3 +1008,23 @@ const binned = model.applyLabelChange(
 assert.strictEqual(binned.isSent, false)
 assert.strictEqual(binned.isDraft, false)
 assert.strictEqual(binned.inTrash, false)
+
+// -------------------------------------------------- what is being read
+
+// The foot of the rail names the mailbox and how long ago it was checked.
+assert.strictEqual(model.readingStatusLine(false, "me@example.org", "Synced 2 min ago"),
+  "me@example.org · 2 min ago")
+assert.strictEqual(model.readingStatusLine(false, "me@example.org", ""), "me@example.org")
+
+// A combined view has no address to give, and no age either: the sync label
+// belongs to one mailbox, so putting it after "All mailboxes" would be a claim
+// about every one of them made from whichever was active underneath.
+assert.strictEqual(model.readingStatusLine(true, "me@example.org", "Synced 2 min ago"),
+  "All mailboxes")
+assert.strictEqual(model.readingStatusLine(true, "", ""), "All mailboxes")
+
+// One string in one place, because the switcher names the row and this names
+// what the row selected.
+assert.strictEqual(model.UNIFIED_LABEL, "All mailboxes")
+
+assert.strictEqual(model.readingStatusLine(false, "", ""), "Not connected")

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -1219,4 +1219,37 @@ for word in ("secret", "password", "token"):
         )
 PY2
 
+python3 - <<'UNIFIEDCAPS'
+import re
+from pathlib import Path
+
+source = Path("Service.qml").read_text()
+
+# A merged list may offer only what every mailbox in it can honour, and a
+# mailbox is not its provider: a host narrows the provider by the refusals its
+# server reported and the mailboxes it turned out not to have. Asking the
+# provider ids reintroduced an Archive button for an account whose own view
+# hides it, so the intersection is taken over the hosts' own answers.
+block = re.search(r"readonly property var unifiedAbilities: \{(.*?)\n  \}", source, re.S)
+if not block:
+    raise SystemExit("test_source.sh: the merged capabilities must be read off the hosts "
+                     "(`unifiedAbilities`), not derived from provider ids")
+for verb in ("canArchive", "canReportSpam", "canStar", "hasLabels",
+             "canOpenOnWeb", "canMove", "showsConversations", "mailboxes"):
+    if "host." + verb not in block.group(1):
+        raise SystemExit("test_source.sh: `unifiedAbilities` must read host.%s, "
+                         "or a mailbox's own refusal is dropped in a merged list" % verb)
+
+for name in ("canArchive", "canReportSpam", "canStar", "hasLabels", "canOpenOnWeb"):
+    offered = re.search(r"readonly property bool " + name + r": unified\s*\n\s*\?([^\n]*)",
+                        source)
+    if not offered or "unifiedAbilities" not in offered.group(1):
+        raise SystemExit("test_source.sh: %s in a merged list must intersect "
+                         "`unifiedAbilities`" % name)
+
+if re.search(r"Unified\.(sharedCapability|sharedMailboxes|hasSharedMailbox)\b", source):
+    raise SystemExit("test_source.sh: the provider-only intersection is gone; "
+                     "use `Unified.everyMailboxCan` / `sharedMailboxRows`")
+UNIFIEDCAPS
+
 printf 'test_source.sh ok\n'

--- a/tests/test_unified.js
+++ b/tests/test_unified.js
@@ -7,27 +7,47 @@ const unified = load("account/Unified.js")
 
 // A merged row is addressed by account and id together, because an id is
 // unique inside the thing that issued it and nowhere else.
-assert.strictEqual(unified.unifiedId("me@example.org", "42"), "me@example.org 42")
+// The separator is U+001F, named here so the tests read as intent rather than
+// as a control character nobody can see in a diff.
+const SEP = "\u001f"
+
+assert.strictEqual(unified.unifiedId("me@example.org", "42"), "me@example.org" + SEP + "42")
 assert.strictEqual(unified.unifiedId("", "42"), "", "an id with no account addresses nothing")
 assert.strictEqual(unified.unifiedId("me@example.org", ""), "")
 
-deepEqual(unified.splitUnifiedId("me@example.org 42"),
+deepEqual(unified.splitUnifiedId("me@example.org" + SEP + "42"),
   { accountId: "me@example.org", id: "42" })
 
-// An IMAP id is "<uid>:<folder>" and a folder name may contain spaces, so the
-// split is on the first space only.
-deepEqual(unified.splitUnifiedId("me@fastmail.com 42:Sent Items"),
-  { accountId: "me@fastmail.com", id: "42:Sent Items" })
+// It has to be a character no id can hold. An IMAP folder cannot carry a
+// control character — the protocol forbids it — and Gmail issues hex.
+assert.strictEqual(unified.unifiedId("a@b.com", "42:Sent Items").indexOf(SEP), 7,
+  "the only separator in a composed id is the one that was put there")
+assert.strictEqual(
+  unified.unifiedId("a@b.com", "42:Sent Items").split(SEP).length, 2)
 
 // Anything that is not a composed id addresses nothing rather than being
 // guessed at.
 deepEqual(unified.splitUnifiedId("42"), { accountId: "", id: "" })
 deepEqual(unified.splitUnifiedId(""), { accountId: "", id: "" })
-deepEqual(unified.splitUnifiedId(" 42"), { accountId: "", id: "" },
-  "an empty account is not an account")
+deepEqual(unified.splitUnifiedId(unified.unifiedId("", "42")),
+  { accountId: "", id: "" }, "an empty account is not an account")
 
-assert.strictEqual(unified.accountOf("me@example.org 42"), "me@example.org")
-assert.strictEqual(unified.sourceIdOf("me@example.org 42"), "42")
+// The case that made the separator a control character. "42:Sent Items" is a
+// whole IMAP id, and a space separator read it as the account "42:Sent" — safe
+// only because nothing is named that.
+deepEqual(unified.splitUnifiedId("42:Sent Items"), { accountId: "", id: "" },
+  "a bare IMAP id is not a composed one")
+assert.strictEqual(unified.accountOf("42:Sent Items"), "")
+assert.strictEqual(unified.sourceIdOf("42:Sent Items"), "")
+deepEqual(unified.splitUnifiedId("1a0682969660774e"), { accountId: "", id: "" },
+  "nor is a bare Gmail id")
+
+// And a folder with a space in it survives being carried.
+deepEqual(unified.splitUnifiedId(unified.unifiedId("me@fastmail.com", "42:Sent Items")),
+  { accountId: "me@fastmail.com", id: "42:Sent Items" })
+
+assert.strictEqual(unified.accountOf("me@example.org" + SEP + "42"), "me@example.org")
+assert.strictEqual(unified.sourceIdOf("me@example.org" + SEP + "42"), "42")
 assert.strictEqual(unified.accountOf("42"), "")
 
 // ---------------------------------------------------------------- merging
@@ -50,7 +70,7 @@ deepEqual(merged.map(function(row) { return row.subject }),
 // Two accounts numbering their own messages from 1 is the collision this
 // addressing exists for: three rows, three distinct ids.
 deepEqual(merged.map(function(row) { return row.id }),
-  ["a@example.org 1", "b@example.net 1", "a@example.org 2"])
+  [unified.unifiedId("a@example.org", "1"), unified.unifiedId("b@example.net", "1"), unified.unifiedId("a@example.org", "2")])
 deepEqual(merged.map(function(row) { return row.sourceId }), ["1", "1", "2"])
 
 // The row says which mailbox it came from, and keeps everything the provider
@@ -97,35 +117,35 @@ const tied = unified.mergeMessages([
   { id: "b@example.net", messages: [{ id: "x", date: 1000 }] },
   { id: "a@example.org", messages: [{ id: "x", date: 1000 }] }
 ])
-deepEqual(tied.map(function(row) { return row.id }), ["a@example.org x", "b@example.net x"])
+deepEqual(tied.map(function(row) { return row.id }), [unified.unifiedId("a@example.org", "x"), unified.unifiedId("b@example.net", "x")])
 deepEqual(unified.mergeMessages([
   { id: "a@example.org", messages: [{ id: "x", date: 1000 }] },
   { id: "b@example.net", messages: [{ id: "x", date: 1000 }] }
-]).map(function(row) { return row.id }), ["a@example.org x", "b@example.net x"],
+]).map(function(row) { return row.id }), [unified.unifiedId("a@example.org", "x"), unified.unifiedId("b@example.net", "x")],
   "the same rows in the other order merge to the same order")
 
 // ----------------------------------------------------------------- cursor
 
 // Over the merged order, which neither account can answer for: neither knows
 // what sits between its own rows.
-assert.strictEqual(unified.cursorOffset(merged, "a@example.org 1", 1), "b@example.net 1")
-assert.strictEqual(unified.cursorOffset(merged, "b@example.net 1", 1), "a@example.org 2")
-assert.strictEqual(unified.cursorOffset(merged, "b@example.net 1", -1), "a@example.org 1")
+assert.strictEqual(unified.cursorOffset(merged, unified.unifiedId("a@example.org", "1"), 1), unified.unifiedId("b@example.net", "1"))
+assert.strictEqual(unified.cursorOffset(merged, unified.unifiedId("b@example.net", "1"), 1), unified.unifiedId("a@example.org", "2"))
+assert.strictEqual(unified.cursorOffset(merged, unified.unifiedId("b@example.net", "1"), -1), unified.unifiedId("a@example.org", "1"))
 
 // Off either end is nowhere, rather than wrapping.
-assert.strictEqual(unified.cursorOffset(merged, "a@example.org 1", -1), "")
-assert.strictEqual(unified.cursorOffset(merged, "a@example.org 2", 1), "")
+assert.strictEqual(unified.cursorOffset(merged, unified.unifiedId("a@example.org", "1"), -1), "")
+assert.strictEqual(unified.cursorOffset(merged, unified.unifiedId("a@example.org", "2"), 1), "")
 
 // No cursor yet lands on an end rather than nowhere, so the first press moves.
-assert.strictEqual(unified.cursorOffset(merged, "", 1), "a@example.org 1")
-assert.strictEqual(unified.cursorOffset(merged, "", -1), "a@example.org 2")
+assert.strictEqual(unified.cursorOffset(merged, "", 1), unified.unifiedId("a@example.org", "1"))
+assert.strictEqual(unified.cursorOffset(merged, "", -1), unified.unifiedId("a@example.org", "2"))
 assert.strictEqual(unified.cursorOffset([], "anything", 1), "")
 
 // A row that has gone — archived, or dropped by a refresh — is not a cursor,
 // and the next press starts over rather than doing nothing.
-assert.strictEqual(unified.cursorOffset(merged, "gone@example.org 9", 1), "a@example.org 1")
+assert.strictEqual(unified.cursorOffset(merged, "gone@example.org 9", 1), unified.unifiedId("a@example.org", "1"))
 
-deepEqual(unified.rowOf(merged, "b@example.net 1").subject, "middle")
+deepEqual(unified.rowOf(merged, unified.unifiedId("b@example.net", "1")).subject, "middle")
 assert.strictEqual(unified.rowOf(merged, "nothing"), null)
 assert.strictEqual(unified.rowOf(merged, ""), null)
 
@@ -195,6 +215,23 @@ assert.strictEqual(unified.allLoaded([{ loaded: true }, { loaded: true }]), true
 assert.strictEqual(unified.allLoaded([{ loaded: true }, { loaded: false }]), false)
 assert.strictEqual(unified.allLoaded([]), false, "no mailboxes have not loaded")
 
+// A signed-out mailbox never loads, and holding the list open for it left the
+// panel on nothing: no skeleton, because loading had stopped, and no "Nothing
+// here", because nothing had loaded. An error is a finished mailbox.
+assert.strictEqual(
+  unified.allLoaded([{ loaded: true }, { loaded: false, error: "Not signed in" }]),
+  true,
+  "a mailbox that cannot load is not a mailbox still loading")
+
+// Retrying is not settled, even holding the error from the last attempt.
+assert.strictEqual(
+  unified.allLoaded([{ loaded: true }, { loading: true, error: "Not signed in" }]),
+  false)
+
+// And a blank error is no error, or a mailbox that has simply not started
+// would count as done.
+assert.strictEqual(unified.allLoaded([{ loaded: false, error: "   " }]), false)
+
 assert.strictEqual(unified.anyHasMore([{ hasMore: false }, { hasMore: true }]), true)
 assert.strictEqual(unified.anyHasMore([{ hasMore: false }]), false)
 
@@ -209,3 +246,49 @@ assert.strictEqual(unified.firstError([{ error: "" }]), "")
 assert.strictEqual(unified.firstError([]), "")
 
 console.log("Unified.js ok")
+
+// ------------------------------------------------------------- paging
+
+// Every source is asked for its own page and the pages do not end at the same
+// date, so drawing all of them puts the gap on screen rather than avoiding it:
+// the tail is the deepest mailbox's mail with the shallowest one's missing
+// from among it.
+const deepAndShallow = [
+  { id: "a@example.org", hasMore: true, messages: [
+    { id: "1", date: 900 }, { id: "2", date: 800 },
+    { id: "3", date: 300 }, { id: "4", date: 200 } ] },
+  { id: "b@example.net", hasMore: true, messages: [
+    { id: "1", date: 850 }, { id: "2", date: 700 } ] }
+]
+
+// The newest of the sources' own last rows. Above it every source has
+// reported, so the list is complete.
+assert.strictEqual(unified.pageWatermark(deepAndShallow), 700)
+deepEqual(unified.mergeMessages(deepAndShallow).map(function(row) { return row.date }),
+  [900, 850, 800, 700],
+  "everything at or above the watermark, and nothing that would have a hole under it")
+
+// A source that has run out cannot leave a hole, so it does not hold the list
+// back — otherwise one finished mailbox would truncate every other.
+const oneFinished = [
+  { id: "a@example.org", hasMore: false, messages: [
+    { id: "1", date: 900 }, { id: "2", date: 200 } ] },
+  { id: "b@example.net", hasMore: false, messages: [{ id: "1", date: 500 }] }
+]
+assert.strictEqual(unified.pageWatermark(oneFinished), 0)
+deepEqual(unified.mergeMessages(oneFinished).map(function(row) { return row.date }),
+  [900, 500, 200], "nothing is withheld once every source is complete")
+
+// A finished source beside one that is not: only the unfinished one sets the
+// floor.
+assert.strictEqual(unified.pageWatermark([
+  { id: "a@example.org", hasMore: false, messages: [{ id: "1", date: 100 }] },
+  { id: "b@example.net", hasMore: true, messages: [{ id: "1", date: 600 }] }
+]), 600)
+
+// An empty source sets no floor, so a mailbox that has not answered yet does
+// not empty the list.
+assert.strictEqual(unified.pageWatermark([
+  { id: "a@example.org", hasMore: true, messages: [] },
+  { id: "b@example.net", hasMore: true, messages: [{ id: "1", date: 600 }] }
+]), 600)

--- a/tests/test_unified.js
+++ b/tests/test_unified.js
@@ -1,0 +1,206 @@
+const assert = require("assert")
+const { load, deepEqual } = require("./load")
+
+const unified = load("account/Unified.js")
+
+// --------------------------------------------------------------- row ids
+
+// A merged row is addressed by account and id together, because an id is
+// unique inside the thing that issued it and nowhere else.
+assert.strictEqual(unified.unifiedId("me@example.org", "42"), "me@example.org 42")
+assert.strictEqual(unified.unifiedId("", "42"), "", "an id with no account addresses nothing")
+assert.strictEqual(unified.unifiedId("me@example.org", ""), "")
+
+deepEqual(unified.splitUnifiedId("me@example.org 42"),
+  { accountId: "me@example.org", id: "42" })
+
+// An IMAP id is "<uid>:<folder>" and a folder name may contain spaces, so the
+// split is on the first space only.
+deepEqual(unified.splitUnifiedId("me@fastmail.com 42:Sent Items"),
+  { accountId: "me@fastmail.com", id: "42:Sent Items" })
+
+// Anything that is not a composed id addresses nothing rather than being
+// guessed at.
+deepEqual(unified.splitUnifiedId("42"), { accountId: "", id: "" })
+deepEqual(unified.splitUnifiedId(""), { accountId: "", id: "" })
+deepEqual(unified.splitUnifiedId(" 42"), { accountId: "", id: "" },
+  "an empty account is not an account")
+
+assert.strictEqual(unified.accountOf("me@example.org 42"), "me@example.org")
+assert.strictEqual(unified.sourceIdOf("me@example.org 42"), "42")
+assert.strictEqual(unified.accountOf("42"), "")
+
+// ---------------------------------------------------------------- merging
+
+const sources = [
+  { id: "a@example.org", label: "Personal", messages: [
+    { id: "1", date: 3000, subject: "newest" },
+    { id: "2", date: 1000, subject: "oldest" }
+  ]},
+  { id: "b@example.net", label: "Work", messages: [
+    { id: "1", date: 2000, subject: "middle" }
+  ]}
+]
+const merged = unified.mergeMessages(sources)
+
+assert.strictEqual(merged.length, 3)
+deepEqual(merged.map(function(row) { return row.subject }),
+  ["newest", "middle", "oldest"], "newest first, across mailboxes")
+
+// Two accounts numbering their own messages from 1 is the collision this
+// addressing exists for: three rows, three distinct ids.
+deepEqual(merged.map(function(row) { return row.id }),
+  ["a@example.org 1", "b@example.net 1", "a@example.org 2"])
+deepEqual(merged.map(function(row) { return row.sourceId }), ["1", "1", "2"])
+
+// The row says which mailbox it came from, and keeps everything the provider
+// put on it.
+assert.strictEqual(merged[0].accountId, "a@example.org")
+assert.strictEqual(merged[0].sourceLabel, "Personal")
+assert.strictEqual(merged[1].sourceLabel, "Work")
+assert.strictEqual(merged[0].subject, "newest", "the provider's own fields survive")
+
+// Copied, not referenced: the account goes on replacing its own list, and a
+// row that was the same object would change under the panel between a click
+// and the action it starts.
+sources[0].messages[0].subject = "changed underneath"
+assert.strictEqual(merged[0].subject, "newest")
+
+// A source with no id cannot address its rows, so it contributes none.
+deepEqual(unified.mergeMessages([{ label: "Nameless", messages: [{ id: "1" }] }]), [])
+// And a row with no id of its own is not addressable either.
+assert.strictEqual(unified.mergeMessages(
+  [{ id: "a@example.org", messages: [{ subject: "no id" }] }]).length, 0)
+
+// The same message offered twice by one account is one row.
+assert.strictEqual(unified.mergeMessages([
+  { id: "a@example.org", messages: [{ id: "1", date: 1 }, { id: "1", date: 1 }] }
+]).length, 1)
+
+deepEqual(unified.mergeMessages(null), [])
+deepEqual(unified.mergeMessages([]), [])
+
+// Providers disagree about which field carries the time, and all of them have
+// to sort against each other.
+const mixedTimes = unified.mergeMessages([
+  { id: "a@example.org", messages: [{ id: "date-object", date: new Date(5000) }] },
+  { id: "b@example.net", messages: [{ id: "internal", internalDate: 9000 }] },
+  { id: "c@example.com", messages: [{ id: "string", date: "1970-01-01T00:00:07Z" }] }
+])
+deepEqual(mixedTimes.map(function(row) { return row.sourceId }),
+  ["internal", "string", "date-object"])
+
+// A tie is broken by account and id so the order is total: one message copied
+// to two of these mailboxes arrives with the same date in both, and a cursor
+// must not move on its own between one merge and the next.
+const tied = unified.mergeMessages([
+  { id: "b@example.net", messages: [{ id: "x", date: 1000 }] },
+  { id: "a@example.org", messages: [{ id: "x", date: 1000 }] }
+])
+deepEqual(tied.map(function(row) { return row.id }), ["a@example.org x", "b@example.net x"])
+deepEqual(unified.mergeMessages([
+  { id: "a@example.org", messages: [{ id: "x", date: 1000 }] },
+  { id: "b@example.net", messages: [{ id: "x", date: 1000 }] }
+]).map(function(row) { return row.id }), ["a@example.org x", "b@example.net x"],
+  "the same rows in the other order merge to the same order")
+
+// ----------------------------------------------------------------- cursor
+
+// Over the merged order, which neither account can answer for: neither knows
+// what sits between its own rows.
+assert.strictEqual(unified.cursorOffset(merged, "a@example.org 1", 1), "b@example.net 1")
+assert.strictEqual(unified.cursorOffset(merged, "b@example.net 1", 1), "a@example.org 2")
+assert.strictEqual(unified.cursorOffset(merged, "b@example.net 1", -1), "a@example.org 1")
+
+// Off either end is nowhere, rather than wrapping.
+assert.strictEqual(unified.cursorOffset(merged, "a@example.org 1", -1), "")
+assert.strictEqual(unified.cursorOffset(merged, "a@example.org 2", 1), "")
+
+// No cursor yet lands on an end rather than nowhere, so the first press moves.
+assert.strictEqual(unified.cursorOffset(merged, "", 1), "a@example.org 1")
+assert.strictEqual(unified.cursorOffset(merged, "", -1), "a@example.org 2")
+assert.strictEqual(unified.cursorOffset([], "anything", 1), "")
+
+// A row that has gone — archived, or dropped by a refresh — is not a cursor,
+// and the next press starts over rather than doing nothing.
+assert.strictEqual(unified.cursorOffset(merged, "gone@example.org 9", 1), "a@example.org 1")
+
+deepEqual(unified.rowOf(merged, "b@example.net 1").subject, "middle")
+assert.strictEqual(unified.rowOf(merged, "nothing"), null)
+assert.strictEqual(unified.rowOf(merged, ""), null)
+
+// ------------------------------------------------------------------ rails
+
+// Two mailboxes on one service ask one provider's questions, not two.
+deepEqual(unified.providersOf([
+  { provider: "gmail" }, { provider: "gmail" }, { provider: "imap" }
+]), ["gmail", "imap"])
+deepEqual(unified.providersOf([]), [])
+deepEqual(unified.providersOf([{ provider: "" }]), [])
+
+// One provider answers with its own whole rail.
+deepEqual(unified.sharedMailboxes(["gmail"]).map(function(row) { return row.key }),
+  ["inbox", "unread", "starred", "sent", "drafts", "all", "spam", "trash"])
+
+// Several answer with the rows all of them have, in the first one's order —
+// a rail is a reading order, not a set.
+const shared = unified.sharedMailboxes(["gmail", "imap"]).map(function(row) { return row.key })
+deepEqual(shared, ["inbox", "unread", "starred", "sent", "drafts", "spam", "trash"])
+
+// HEY has neither a starred box nor a sent one it can serve, so a rail beside
+// it loses both rather than offering a row that answers for two mailboxes out
+// of three.
+const withHey = unified.sharedMailboxes(["gmail", "hey"]).map(function(row) { return row.key })
+assert.ok(withHey.indexOf("inbox") >= 0)
+assert.ok(withHey.indexOf("starred") < 0, "HEY has no star, so a unified rail beside it has no starred row")
+assert.ok(withHey.indexOf("sent") < 0, "the HEY client serves no Sent box")
+
+assert.strictEqual(unified.hasSharedMailbox(["gmail", "imap"], "spam"), true)
+assert.strictEqual(unified.hasSharedMailbox(["gmail", "hey"], "starred"), false)
+deepEqual(unified.sharedMailboxes([]), [])
+
+// ----------------------------------------------------------- capabilities
+
+// A capability only some of them declare is a button that fails on the rest,
+// after the row has already moved.
+assert.strictEqual(unified.sharedCapability(["gmail"], "spam"), true)
+assert.strictEqual(unified.sharedCapability(["gmail", "imap"], "spam"), false,
+  "IMAP cannot teach a server anything by moving a message, so nothing may offer it")
+assert.strictEqual(unified.sharedCapability(["gmail", "imap"], "archive"), true)
+assert.strictEqual(unified.sharedCapability(["gmail", "hey"], "star"), false)
+assert.strictEqual(unified.sharedCapability(["gmail", "imap"], "search"), true)
+assert.strictEqual(unified.sharedCapability([], "search"), false,
+  "no mailboxes can honour nothing")
+
+// -------------------------------------------------------------- the state
+
+assert.strictEqual(unified.totalUnread([{ unread: 3 }, { unread: 0 }, { unread: 7 }]), 10)
+assert.strictEqual(unified.totalUnread([{ unread: -1 }, { unread: "4" }]), 4)
+assert.strictEqual(unified.totalUnread(null), 0)
+
+// Still loading while any of them is: a list gaining rows is still loading
+// however many have arrived.
+assert.strictEqual(unified.anyLoading([{ loading: false }, { loading: true }]), true)
+assert.strictEqual(unified.anyLoading([{ loading: false }]), false)
+assert.strictEqual(unified.anyLoading([]), false)
+
+// Loaded only once all of them are: "nothing here" is a claim about every
+// mailbox, and one that has not answered makes it wrong.
+assert.strictEqual(unified.allLoaded([{ loaded: true }, { loaded: true }]), true)
+assert.strictEqual(unified.allLoaded([{ loaded: true }, { loaded: false }]), false)
+assert.strictEqual(unified.allLoaded([]), false, "no mailboxes have not loaded")
+
+assert.strictEqual(unified.anyHasMore([{ hasMore: false }, { hasMore: true }]), true)
+assert.strictEqual(unified.anyHasMore([{ hasMore: false }]), false)
+
+// An error names the mailbox it came from, because a bare sentence about a
+// server says nothing once three servers are involved.
+assert.strictEqual(unified.firstError([
+  { label: "Personal", error: "" },
+  { label: "Fastmail", error: "the server refused that command" }
+]), "Fastmail: the server refused that command")
+assert.strictEqual(unified.firstError([{ error: "no label to give" }]), "no label to give")
+assert.strictEqual(unified.firstError([{ error: "" }]), "")
+assert.strictEqual(unified.firstError([]), "")
+
+console.log("Unified.js ok")

--- a/tests/test_unified.js
+++ b/tests/test_unified.js
@@ -169,6 +169,11 @@ assert.strictEqual(unified.sharedCapability(["gmail", "imap"], "spam"), false,
 assert.strictEqual(unified.sharedCapability(["gmail", "imap"], "archive"), true)
 assert.strictEqual(unified.sharedCapability(["gmail", "hey"], "star"), false)
 assert.strictEqual(unified.sharedCapability(["gmail", "imap"], "search"), true)
+// Opening a message on the web is a capability like any other. An IMAP
+// mailbox has no address this plugin could know, so a list holding one of
+// its rows must not draw the button beside every row in it.
+assert.strictEqual(unified.sharedCapability(["gmail", "imap"], "web"), false)
+assert.strictEqual(unified.sharedCapability(["gmail", "hey"], "web"), true)
 assert.strictEqual(unified.sharedCapability([], "search"), false,
   "no mailboxes can honour nothing")
 

--- a/tests/test_unified.js
+++ b/tests/test_unified.js
@@ -200,6 +200,17 @@ assert.strictEqual(unified.anyLoading([{ loading: false }, { loading: true }]), 
 assert.strictEqual(unified.anyLoading([{ loading: false }]), false)
 assert.strictEqual(unified.anyLoading([]), false)
 
+assert.strictEqual(unified.anyServerSearchLoading([
+  { serverSearchLoading: false }, { serverSearchLoading: true }
+]), true, "a search in any mailbox keeps the unified search busy")
+assert.strictEqual(unified.anyServerSearchLoading([{ serverSearchLoading: false }]), false)
+assert.strictEqual(unified.anyServerSearchLoading([]), false)
+
+assert.strictEqual(unified.rowIsConversation({ thread: { count: 2 } }), true,
+  "a collapsed row keeps its own conversation count")
+assert.strictEqual(unified.rowIsConversation({ thread: { count: 0 } }), false,
+  "a message row does not inherit a conversation capability from another mailbox")
+
 // Loaded only once all of them are: "nothing here" is a claim about every
 // mailbox, and one that has not answered makes it wrong.
 assert.strictEqual(unified.allLoaded([{ loaded: true }, { loaded: true }]), true)

--- a/tests/test_unified.js
+++ b/tests/test_unified.js
@@ -151,51 +151,42 @@ assert.strictEqual(unified.rowOf(merged, ""), null)
 
 // ------------------------------------------------------------------ rails
 
-// Two mailboxes on one service ask one provider's questions, not two.
-deepEqual(unified.providersOf([
-  { provider: "gmail" }, { provider: "gmail" }, { provider: "imap" }
-]), ["gmail", "imap"])
-deepEqual(unified.providersOf([]), [])
-deepEqual(unified.providersOf([{ provider: "" }]), [])
+// The rail rows and the verbs every mailbox in the merge has, asked of the
+// mailboxes rather than of their providers.
+//
+// A host narrows its provider by the refusals its server reported and the
+// mailboxes it turned out not to have. Intersecting provider ids reintroduced
+// an Archive button for an account whose own view hides it, because its server
+// has no Archive folder — the account is right and the provider is generic.
+const gmailish = { archive: true, spam: true, star: true, web: true,
+  mailboxes: [{ key: "inbox" }, { key: "spam" }, { key: "sent" }] }
+const noArchive = { archive: false, spam: true, star: true, web: false,
+  mailboxes: [{ key: "inbox" }, { key: "spam" }] }
 
-// One provider answers with its own whole rail.
-deepEqual(unified.sharedMailboxes(["gmail"]).map(function(row) { return row.key }),
-  ["inbox", "unread", "starred", "sent", "drafts", "all", "spam", "trash"])
+assert.strictEqual(unified.everyMailboxCan([gmailish], "archive"), true)
+assert.strictEqual(unified.everyMailboxCan([gmailish, noArchive], "archive"), false,
+  "one mailbox that cannot archive is a merged list that does not offer it")
+assert.strictEqual(unified.everyMailboxCan([gmailish, noArchive], "spam"), true)
+assert.strictEqual(unified.everyMailboxCan([gmailish, noArchive], "web"), false)
 
-// Several answer with the rows all of them have, in the first one's order —
-// a rail is a reading order, not a set.
-const shared = unified.sharedMailboxes(["gmail", "imap"]).map(function(row) { return row.key })
-deepEqual(shared, ["inbox", "unread", "starred", "sent", "drafts", "spam", "trash"])
+// A verb nobody named is not a verb anybody has.
+assert.strictEqual(unified.everyMailboxCan([gmailish], "labels"), false)
+assert.strictEqual(unified.everyMailboxCan([], "archive"), false,
+  "no mailboxes cannot do anything")
+assert.strictEqual(unified.everyMailboxCan([gmailish, null], "archive"), false,
+  "a mailbox that has not answered yet is not a yes")
 
-// HEY has neither a starred box nor a sent one it can serve, so a rail beside
-// it loses both rather than offering a row that answers for two mailboxes out
-// of three.
-const withHey = unified.sharedMailboxes(["gmail", "hey"]).map(function(row) { return row.key })
-assert.ok(withHey.indexOf("inbox") >= 0)
-assert.ok(withHey.indexOf("starred") < 0, "HEY has no star, so a unified rail beside it has no starred row")
-assert.ok(withHey.indexOf("sent") < 0, "the HEY client serves no Sent box")
+// The rail is the rows they share, in the first one's order.
+deepEqual(unified.sharedMailboxRows([gmailish]).map(function(row) { return row.key }),
+  ["inbox", "spam", "sent"])
+deepEqual(unified.sharedMailboxRows([gmailish, noArchive]).map(function(row) { return row.key }),
+  ["inbox", "spam"], "a row one server does not have is a row that cannot be opened")
+deepEqual(unified.sharedMailboxRows([]), [])
+deepEqual(unified.sharedMailboxRows([{ mailboxes: [] }, gmailish]), [])
 
-assert.strictEqual(unified.hasSharedMailbox(["gmail", "imap"], "spam"), true)
-assert.strictEqual(unified.hasSharedMailbox(["gmail", "hey"], "starred"), false)
-deepEqual(unified.sharedMailboxes([]), [])
-
-// ----------------------------------------------------------- capabilities
-
-// A capability only some of them declare is a button that fails on the rest,
-// after the row has already moved.
-assert.strictEqual(unified.sharedCapability(["gmail"], "spam"), true)
-assert.strictEqual(unified.sharedCapability(["gmail", "imap"], "spam"), false,
-  "IMAP cannot teach a server anything by moving a message, so nothing may offer it")
-assert.strictEqual(unified.sharedCapability(["gmail", "imap"], "archive"), true)
-assert.strictEqual(unified.sharedCapability(["gmail", "hey"], "star"), false)
-assert.strictEqual(unified.sharedCapability(["gmail", "imap"], "search"), true)
-// Opening a message on the web is a capability like any other. An IMAP
-// mailbox has no address this plugin could know, so a list holding one of
-// its rows must not draw the button beside every row in it.
-assert.strictEqual(unified.sharedCapability(["gmail", "imap"], "web"), false)
-assert.strictEqual(unified.sharedCapability(["gmail", "hey"], "web"), true)
-assert.strictEqual(unified.sharedCapability([], "search"), false,
-  "no mailboxes can honour nothing")
+// A row with no key is not a row.
+deepEqual(unified.sharedMailboxRows([{ mailboxes: [{ key: "" }, { key: "inbox" }] },
+  gmailish]).map(function(row) { return row.key }), ["inbox"])
 
 // -------------------------------------------------------------- the state
 


### PR DESCRIPTION
## Summary

Add an **All mailboxes** view that combines the inbox, spam, sent, and trash mailboxes from every configured account into one readable list.

## Behaviour

- Rows are sorted across mailboxes and carry their owning mailbox identity.
- Selecting or opening a row routes actions to the mailbox that owns it.
- Replies and new drafts keep the correct sending mailbox.
- Search runs across all mailboxes and keeps its loading state until every source settles.
- Capabilities are limited to actions supported by every mailbox in the combined view.
- Conversation counts are shown only on rows whose own source provides conversation members.
- Paging stops at the shallowest source page so the merged list does not contain gaps.
- Selecting an individual account leaves the existing single-mailbox behaviour unchanged.

## Validation

- Added unit coverage for merge ordering, composed IDs, paging, capability intersection, search state, and row-level conversation handling.
- Added QML coverage for account switching, routing, compose identity, attachments, and unified service behaviour.
- `node tests/test_unified.js`
- `bash tests/test_source.sh`

The full `make validate` suite is currently blocked on macOS because `tests/test_config_store.sh` uses the GNU `stat -c` option.
