### PR TITLE
Preview messages as the cursor moves

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -431,6 +431,9 @@ Item {
 
   function close() {
     closingFromHost = true
+    // A window that is gone shows nothing, so a dwell counting down in it has
+    // nothing left to be counting for.
+    markReadDwell.stop()
     if (compose.opened || compose.parkedForSend) saveComposeRecovery()
     opened = false
     if (service) service.windowOpen = false
@@ -544,6 +547,21 @@ Item {
     previewCursor()
   }
 
+  // Whether there is a preview on screen to be talking about.
+  //
+  // Never in a narrow window: there the reader takes the list's place, so
+  // every press would navigate away from the list being moved through and
+  // there would be nothing left to move. Never over a page, a draft or the
+  // calendar either, for the same reason — the list is not what is on screen.
+  //
+  // Asked twice, when the cursor moves and again when the dwell fires, because
+  // every part of it can change in between: a page opens, a draft is started,
+  // the window is dragged across the breakpoint. A message that is no longer
+  // being shown is not a message being read, however long the cursor has sat
+  // on its row.
+  readonly property bool canPreview: !!service && service.previewOnCursor
+    && !compact && !showPage && !composing && !calendarVisible
+
   // Moving is not opening, and this is the difference.
   //
   // It used to open whatever it landed on, which made stepping through a list
@@ -551,17 +569,16 @@ Item {
   // preview is off unless it was asked for, it pushes no history — Escape and
   // Back mean what they meant — and it does not mark anything read. A dwell
   // does that, which is what stops a held arrow key from reading a mailbox.
-  //
-  // Never in a narrow window: there the reader takes the list's place, so
-  // every press would navigate away from the list being moved through and
-  // there would be nothing left to move.
   function previewCursor() {
     markReadDwell.stop()
-    if (!service || !service.previewOnCursor || compact) return
-    if (cursorId === "" || showPage || composing || calendarVisible) return
+    if (!canPreview || cursorId === "") return
     // A message already open stays open on its own terms: it was opened, and
     // re-selecting it as a preview would take back the read mark it earned.
     if (currentView === "reader" && service.selectedId === cursorId) return
+    // Per message, the same as opening one. Insisting on a document the bounds
+    // refused is an answer about the message it was given for, and the row the
+    // cursor moved to is a different message.
+    reader.forceRichAnyway = false
     service.select(cursorId, true)
     if (service.markReadDelaySec <= 0) {
       service.markPreviewRead(cursorId)
@@ -582,7 +599,11 @@ Item {
     repeat: false
     onTriggered: {
       if (!root.service || dwelledOn === "") return
+      if (!root.canPreview) return
       if (root.cursorId !== dwelledOn) return
+      // And it has to still be the message on screen: a search and a mailbox
+      // switch both drop the selection without moving the cursor off the row.
+      if (root.service.selectedId !== dwelledOn) return
       root.service.markPreviewRead(dwelledOn)
     }
   }

--- a/App.qml
+++ b/App.qml
@@ -580,11 +580,18 @@ Item {
   // does that, which is what stops a held arrow key from reading a mailbox.
   function previewCursor() {
     markReadDwell.stop()
+    markReadDwell.dwelledOn = ""
     previewSettle.stop()
     if (!canPreview || cursorId === "") return
     // A message already open stays open on its own terms: it was opened, and
     // re-selecting it as a preview would take back the read mark it earned.
-    if (currentView === "reader" && service.selectedId === cursorId) return
+    //
+    // A *preview* of the same message is not that. Moving away and back
+    // inside the settle stops the dwell above and used to return here, so the
+    // message the cursor was sitting on never became read at all — the id
+    // matched, which is exactly what a preview does while not being open.
+    if (currentView === "reader" && service.selectedId === cursorId
+      && !service.selectionIsPreview) return
     // Per message, the same as opening one. Insisting on a document the bounds
     // refused is an answer about the message it was given for, and the row the
     // cursor moved to is a different message.
@@ -615,13 +622,40 @@ Item {
     if (id === "" || id !== cursorId || !canPreview) return
     if (currentView === "reader" && service.selectedId === id
       && !service.selectionIsPreview) return
-    service.select(id, true)
+    // Coming back to the message that is still the preview restarts its
+    // dwell rather than asking for it again.
+    if (service.selectedId !== id || !service.selectionIsPreview)
+      service.select(id, true)
+    markReadDwell.dwelledOn = id
+    armReadDwell()
+  }
+
+  // Whether the previewed message is actually on screen.
+  //
+  // The dwell measures time spent looking at something, so it cannot start
+  // before there is anything to look at. It began when the request went out,
+  // so a slow fetch spent the whole dwell loading and marked read a message
+  // whose body never appeared — worst at a zero dwell, which marked it read
+  // before the request had even been made. A fetch that fails never paints,
+  // so it never arms this at all.
+  readonly property bool previewShowing: !!service
+    && service.detailPainted && !service.detailLoading
+
+  onPreviewShowingChanged: if (previewShowing) armReadDwell()
+
+  function armReadDwell() {
+    if (!service || markReadDwell.dwelledOn === "") return
+    if (!canPreview || !previewShowing) return
+    // Still the message on screen: a search and a mailbox switch both drop the
+    // selection without moving the cursor off the row.
+    if (service.selectedId !== markReadDwell.dwelledOn) return
     if (service.markReadDelaySec <= 0) {
-      service.markPreviewRead(id)
+      var now = markReadDwell.dwelledOn
+      markReadDwell.dwelledOn = ""
+      service.markPreviewRead(now)
       return
     }
     markReadDwell.interval = service.markReadDelaySec * 1000
-    markReadDwell.dwelledOn = cursorId
     markReadDwell.restart()
   }
 

--- a/App.qml
+++ b/App.qml
@@ -446,6 +446,9 @@ Item {
   // override is a per-message decision about one specific message and does not.
   function openMessage(id) {
     if (!service) return
+    // Opening marks it read itself, so a dwell still counting down for the
+    // same message has nothing left to do.
+    markReadDwell.stop()
     pendingComposeMode = ""
     pendingDraftId = ""
     reader.forceRichAnyway = false
@@ -538,9 +541,50 @@ Item {
     if (next === "") return
     cursorId = next
     revealCursorRow()
-    // Moving is not opening. This used to open whatever it landed on while the
-    // reader was up, which made stepping through a list a way to mark half of
-    // it read without having looked at any of it. Enter and "o" open.
+    previewCursor()
+  }
+
+  // Moving is not opening, and this is the difference.
+  //
+  // It used to open whatever it landed on, which made stepping through a list
+  // a way to mark half of it read without having looked at any of it. So the
+  // preview is off unless it was asked for, it pushes no history — Escape and
+  // Back mean what they meant — and it does not mark anything read. A dwell
+  // does that, which is what stops a held arrow key from reading a mailbox.
+  //
+  // Never in a narrow window: there the reader takes the list's place, so
+  // every press would navigate away from the list being moved through and
+  // there would be nothing left to move.
+  function previewCursor() {
+    markReadDwell.stop()
+    if (!service || !service.previewOnCursor || compact) return
+    if (cursorId === "" || showPage || composing || calendarVisible) return
+    // A message already open stays open on its own terms: it was opened, and
+    // re-selecting it as a preview would take back the read mark it earned.
+    if (currentView === "reader" && service.selectedId === cursorId) return
+    service.select(cursorId, true)
+    if (service.markReadDelaySec <= 0) {
+      service.markPreviewRead(cursorId)
+      return
+    }
+    markReadDwell.interval = service.markReadDelaySec * 1000
+    markReadDwell.dwelledOn = cursorId
+    markReadDwell.restart()
+  }
+
+  // A previewed message counts as read once the cursor has stayed on it. The
+  // id is held rather than read back off the cursor when this fires: by then
+  // the cursor may have moved on, and the message that was read is the one to
+  // mark.
+  Timer {
+    id: markReadDwell
+    property string dwelledOn: ""
+    repeat: false
+    onTriggered: {
+      if (!root.service || dwelledOn === "") return
+      if (root.cursorId !== dwelledOn) return
+      root.service.markPreviewRead(dwelledOn)
+    }
   }
 
   // An answer needs the message it is answering, and opening one only starts

--- a/App.qml
+++ b/App.qml
@@ -431,9 +431,14 @@ Item {
 
   function close() {
     closingFromHost = true
-    // A window that is gone shows nothing, so a dwell counting down in it has
-    // nothing left to be counting for.
+    // A window that is gone shows nothing, so a dwell counting down in it —
+    // or a fetch about to be asked for — has nothing left to be for.
     markReadDwell.stop()
+    previewSettle.stop()
+    // Escape at the list root closes the window without clearing what the
+    // cursor had previewed, so it reopened showing a stale message beside the
+    // list. A preview is not a place the window was left in.
+    if (service && service.selectionIsPreview) service.clearSelection()
     if (compose.opened || compose.parkedForSend) saveComposeRecovery()
     opened = false
     if (service) service.windowOpen = false
@@ -559,8 +564,12 @@ Item {
   // the window is dragged across the breakpoint. A message that is no longer
   // being shown is not a message being read, however long the cursor has sat
   // on its row.
+  // #83's label picker is an `anchors.fill` overlay rather than a nav entry, so
+  // none of the state above notices it. Pressing `v` during a dwell otherwise
+  // let the timer mark read a message that was about to be moved.
   readonly property bool canPreview: !!service && service.previewOnCursor
     && !compact && !showPage && !composing && !calendarVisible
+    && !labelPicker.opened
 
   // Moving is not opening, and this is the difference.
   //
@@ -571,6 +580,7 @@ Item {
   // does that, which is what stops a held arrow key from reading a mailbox.
   function previewCursor() {
     markReadDwell.stop()
+    previewSettle.stop()
     if (!canPreview || cursorId === "") return
     // A message already open stays open on its own terms: it was opened, and
     // re-selecting it as a preview would take back the read mark it earned.
@@ -579,9 +589,35 @@ Item {
     // refused is an answer about the message it was given for, and the row the
     // cursor moved to is a different message.
     reader.forceRichAnyway = false
-    service.select(cursorId, true)
+    // Settled rather than fetched per keystroke. A held `j` starts a request
+    // for every row it crosses, and on IMAP each one is a curl process, a TLS
+    // handshake and a LOGIN — thirty rows was thirty connections, spawned and
+    // killed as the key repeated. Cancellation was already correct; this is
+    // about not asking. Short enough that a deliberate move still feels
+    // immediate, long enough that a repeat rate never gets through.
+    previewSettle.wanted = cursorId
+    previewSettle.restart()
+  }
+
+  Timer {
+    id: previewSettle
+    property string wanted: ""
+    interval: 180
+    repeat: false
+    onTriggered: root.previewSettled()
+  }
+
+  function previewSettled() {
+    var id = previewSettle.wanted
+    previewSettle.wanted = ""
+    // The cursor may have moved on, or left the state that allows a preview
+    // at all, in the time this waited.
+    if (id === "" || id !== cursorId || !canPreview) return
+    if (currentView === "reader" && service.selectedId === id
+      && !service.selectionIsPreview) return
+    service.select(id, true)
     if (service.markReadDelaySec <= 0) {
-      service.markPreviewRead(cursorId)
+      service.markPreviewRead(id)
       return
     }
     markReadDwell.interval = service.markReadDelaySec * 1000
@@ -688,7 +724,12 @@ Item {
   function composeFromCursor(mode) {
     if (!service || cursorId === "") return
     pendingComposeReturnTo = Nav.depth(nav)
-    if (service.selectedId !== cursorId) openMessage(cursorId)
+    // A preview satisfies the id test while pushing no `reader` entry, so
+    // without the second half `r` on a previewed row answered a message that
+    // was never opened: nothing marked it read, and closing the draft landed
+    // on the list instead of on the message being answered.
+    if (service.selectedId !== cursorId || service.selectionIsPreview)
+      openMessage(cursorId)
     startCompose(mode)
   }
 
@@ -804,7 +845,12 @@ Item {
     // showing a member of the acted row rather than the row itself, and
     // archiving from a member has to open the next row or go back rather than
     // leave a message that has just moved on screen.
-    var wasOpen = currentView === "reader"
+    //
+    // And a preview is not open at all. It satisfies "is this the selected
+    // one" without having been opened, which made `e` on a previewed row call
+    // `openMessage` on the *next* one — an archive that reads a message, which
+    // is the fault this feature exists to avoid.
+    var wasOpen = currentView === "reader" && !service.selectionIsPreview
       && (service.selectedId === acted || Model.rowHoldsMember(row, service.selectedId))
     // Worked out before the action, while the row still has neighbours.
     var next = Model.cursorAfterRemoval(service.messages, acted)

--- a/Service.qml
+++ b/Service.qml
@@ -1122,15 +1122,7 @@ Item {
   // one that is honest about being one mailbox's.
   readonly property bool selectionIsPreview: !!reading && reading.selectionIsPreview
 
-  // Whether the message on screen got there because the cursor passed over it
-  // rather than because somebody opened it.
-  //
-  // Above `MailAccount` because two decisions in the window turn on it and
-  // neither can be made from `selectedId` alone: a previewed message satisfies
-  // "is this the selected one" while not being open, which made an archive
-  // open its neighbour and a reply skip the open it needs.
-  readonly property bool selectionIsPreview: !!current && current.selectionIsPreview
-  
+
   readonly property string resultSummary: current ? current.resultSummary : ""
   // ------------------------------------------------------- the open message
   //
@@ -1247,7 +1239,7 @@ Item {
   }
   function select(id, previewOnly) {
     if (!unified) {
-      if (current) current.select(id)
+      if (current) current.select(id, previewOnly)
       return
     }
     var host = hostForId(id)

--- a/Service.qml
+++ b/Service.qml
@@ -106,8 +106,15 @@ Item {
   // How long the cursor has to stay before a previewed message counts as
   // read. Clamped rather than trusted: this is a hand-editable file, and a
   // negative interval on a Timer never fires at all.
+  //
+  // A number or nothing, because `Number` reads `null`, `false` and `""` as
+  // zero and zero is a real answer here — "mark it read the moment it is
+  // previewed". A settings file that lost the key, or holds a word where a
+  // count should be, must not be read as somebody having asked for that.
   readonly property int markReadDelaySec: {
-    var value = Math.floor(Number(settings ? settings.markReadDelaySec : 2))
+    var raw = settings ? settings.markReadDelaySec : 2
+    if (typeof raw !== "number") return 2
+    var value = Math.floor(raw)
     if (!isFinite(value) || value < 0) return 2
     return Math.min(30, value)
   }
@@ -190,9 +197,11 @@ Item {
     persistSetting("previewOnCursor", value === true)
   }
 
+  // The same rule on the way in: what cannot be read as a count is written as
+  // the default rather than as the shortest dwell there is.
   function setMarkReadDelaySec(value) {
     var next = Math.floor(Number(value))
-    if (!isFinite(next) || next < 0) next = 0
+    if (!isFinite(next) || next < 0) next = 2
     persistSetting("markReadDelaySec", Math.min(30, next))
   }
 

--- a/Service.qml
+++ b/Service.qml
@@ -1120,6 +1120,17 @@ Item {
   // summed: a merged count would have to wait for every mailbox to finish
   // searching, and a number that keeps growing while it is read is worse than
   // one that is honest about being one mailbox's.
+  readonly property bool selectionIsPreview: !!reading && reading.selectionIsPreview
+
+  // Whether the message on screen got there because the cursor passed over it
+  // rather than because somebody opened it.
+  //
+  // Above `MailAccount` because two decisions in the window turn on it and
+  // neither can be made from `selectedId` alone: a previewed message satisfies
+  // "is this the selected one" while not being open, which made an archive
+  // open its neighbour and a reply skip the open it needs.
+  readonly property bool selectionIsPreview: !!current && current.selectionIsPreview
+  
   readonly property string resultSummary: current ? current.resultSummary : ""
   // ------------------------------------------------------- the open message
   //

--- a/Service.qml
+++ b/Service.qml
@@ -68,7 +68,9 @@ Item {
     undoSendSeconds: 10,
     unifiedCalendarView: false,
     showBarIcon: true,
-    unifiedMailboxes: false
+    unifiedMailboxes: false,
+    previewOnCursor: false,
+    markReadDelaySec: 2
   })
   property var settings: defaultSettingValues
   readonly property int undoSendSeconds: Outbox.normalizeDelay(
@@ -96,6 +98,19 @@ Item {
   // typo rather than an answer given in the interface, and a typo should not
   // be what takes the icon away.
   readonly property bool showBarIcon: !settings || settings.showBarIcon !== false
+
+  // Whether the cursor reaching a message is enough to show it.
+  readonly property bool previewOnCursor: !!settings
+    && settings.previewOnCursor === true
+
+  // How long the cursor has to stay before a previewed message counts as
+  // read. Clamped rather than trusted: this is a hand-editable file, and a
+  // negative interval on a Timer never fires at all.
+  readonly property int markReadDelaySec: {
+    var value = Math.floor(Number(settings ? settings.markReadDelaySec : 2))
+    if (!isFinite(value) || value < 0) return 2
+    return Math.min(30, value)
+  }
 
   // Thunderbird and Betterbird keep both explicit and learned addresses in
   // their local profile. The helper reads those databases without modifying
@@ -169,6 +184,16 @@ Item {
   // survives a restart.
   function setUnifiedMailboxes(value) {
     persistSetting("unifiedMailboxes", value === true)
+  }
+
+  function setPreviewOnCursor(value) {
+    persistSetting("previewOnCursor", value === true)
+  }
+
+  function setMarkReadDelaySec(value) {
+    var next = Math.floor(Number(value))
+    if (!isFinite(next) || next < 0) next = 0
+    persistSetting("markReadDelaySec", Math.min(30, next))
   }
 
   // ---------------------------------------------------------- the accounts
@@ -1200,7 +1225,7 @@ Item {
     }
     eachHost(function(host) { if (host.hasMore) host.loadMore() })
   }
-  function select(id) {
+  function select(id, previewOnly) {
     if (!unified) {
       if (current) current.select(id)
       return
@@ -1212,7 +1237,7 @@ Item {
     // attachment row after the reader had moved on.
     eachHost(function(other) { if (other !== host) other.clearSelection() })
     selectionHost = host
-    host.select(sourceIdFor(id))
+    host.select(sourceIdFor(id), previewOnly)
   }
   function clearSelection() {
     if (!unified) {
@@ -1221,6 +1246,14 @@ Item {
     }
     eachHost(function(host) { host.clearSelection() })
     selectionHost = null
+  }
+  function markPreviewRead(id) {
+    if (!id) return false
+    if (unified) {
+      var host = hostForId(id)
+      return host ? host.markPreviewRead(sourceIdFor(id)) : false
+    }
+    return current ? current.markPreviewRead(id) : false
   }
   // The notice's own button, which is the switch: what it turns on is every
   // message, and it says so.

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1034,13 +1034,9 @@ Item {
     selectedReaderEmpty = true
     selectedReaderRemoteImages = 0
     sourceHtml = ""
-    // The standing "always show images" answer is an answer about a message
-    // somebody chose to read. Fetching one still tells its host that this
-    // address opened this mail at this moment — which is what the notice in
-    // the reader says out loud — and a cursor passing over a row has opened
-    // nothing. So a preview keeps the pictures blocked however that answer
-    // stands, and opening the message, or asking for them here, loads them.
-    remoteImagesAllowed = alwaysShowImages && !selectionIsPreview
+    // A preview never fetches them, whatever the standing answer is:
+    // `Model.showsRemoteImages` is where that is argued.
+    remoteImagesAllowed = Model.showsRemoteImages(alwaysShowImages, selectionIsPreview)
     remoteImagesLoading = false
     remoteImageData = ({})
     selectedRemoteImageSources = []
@@ -1175,26 +1171,19 @@ Item {
       root.loadMembers()
       // Opening a message is the one place Gmail's own clients mark it read
       // without being asked, and a reader that leaves it bold is confusing.
-      //
-      // A preview is not opening. Stepping down a list would otherwise mark
-      // every message it passed read without any of them having been looked
-      // at, which is the reason moving stopped opening in the first place —
-      // so the panel marks a previewed message read once the cursor has
-      // stayed on it, and this leaves it alone.
-      if (summary.unread && !root.selectionIsPreview)
+      // A preview is not opening: `Model.marksReadOnArrival` is where that
+      // is decided.
+      if (Model.marksReadOnArrival(summary, root.selectionIsPreview))
         root.act(messageId, "markRead", true)
     })
   }
 
   // What a dwell on a previewed message comes to. Asked of the message rather
-  // than of the selection, because the cursor may have moved on by the time
-  // the panel's timer fires and the one that was read is the one to mark.
+  // than of the selection: the cursor may have moved on by the time the
+  // panel's timer fires, and the one that was read is the one to mark.
   function markPreviewRead(id) {
-    var messageId = String(id || "")
-    if (messageId === "") return false
-    var index = Model.indexById(messages, messageId)
-    if (index < 0 || !messages[index].unread) return false
-    act(messageId, "markRead", true)
+    if (!Model.previewReadable(messages, id)) return false
+    act(String(id), "markRead", true)
     return true
   }
 

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1034,7 +1034,13 @@ Item {
     selectedReaderEmpty = true
     selectedReaderRemoteImages = 0
     sourceHtml = ""
-    remoteImagesAllowed = alwaysShowImages
+    // The standing "always show images" answer is an answer about a message
+    // somebody chose to read. Fetching one still tells its host that this
+    // address opened this mail at this moment — which is what the notice in
+    // the reader says out loud — and a cursor passing over a row has opened
+    // nothing. So a preview keeps the pictures blocked however that answer
+    // stands, and opening the message, or asking for them here, loads them.
+    remoteImagesAllowed = alwaysShowImages && !selectionIsPreview
     remoteImagesLoading = false
     remoteImageData = ({})
     selectedRemoteImageSources = []

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1008,12 +1008,18 @@ Item {
 
   // --------------------------------------------------------------- detail
 
-  function select(id) {
+  // Whether the message on screen got there because the cursor passed over it
+  // rather than because somebody opened it. A preview is drawn the same and
+  // marked read differently, and the detail callback is where that is decided.
+  property bool selectionIsPreview: false
+
+  function select(id, previewOnly) {
     var messageId = String(id || "")
     if (messageId === "") {
       clearSelection()
       return
     }
+    selectionIsPreview = previewOnly === true
     selectedId = messageId
     var serial = ++detailSerial
     abortRequest(detailHandle)
@@ -1163,8 +1169,27 @@ Item {
       root.loadMembers()
       // Opening a message is the one place Gmail's own clients mark it read
       // without being asked, and a reader that leaves it bold is confusing.
-      if (summary.unread) root.act(messageId, "markRead", true)
+      //
+      // A preview is not opening. Stepping down a list would otherwise mark
+      // every message it passed read without any of them having been looked
+      // at, which is the reason moving stopped opening in the first place —
+      // so the panel marks a previewed message read once the cursor has
+      // stayed on it, and this leaves it alone.
+      if (summary.unread && !root.selectionIsPreview)
+        root.act(messageId, "markRead", true)
     })
+  }
+
+  // What a dwell on a previewed message comes to. Asked of the message rather
+  // than of the selection, because the cursor may have moved on by the time
+  // the panel's timer fires and the one that was read is the one to mark.
+  function markPreviewRead(id) {
+    var messageId = String(id || "")
+    if (messageId === "") return false
+    var index = Model.indexById(messages, messageId)
+    if (index < 0 || !messages[index].unread) return false
+    act(messageId, "markRead", true)
+    return true
   }
 
   // ---------------------------------------------------------- the rail

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1008,9 +1008,7 @@ Item {
 
   // --------------------------------------------------------------- detail
 
-  // Whether the message on screen got there because the cursor passed over it
-  // rather than because somebody opened it. A preview is drawn the same and
-  // marked read differently, and the detail callback is where that is decided.
+  // True when the selected message is only a cursor preview.
   property bool selectionIsPreview: false
 
   function select(id, previewOnly) {
@@ -1034,8 +1032,6 @@ Item {
     selectedReaderEmpty = true
     selectedReaderRemoteImages = 0
     sourceHtml = ""
-    // A preview never fetches them, whatever the standing answer is:
-    // `Model.showsRemoteImages` is where that is argued.
     remoteImagesAllowed = Model.showsRemoteImages(alwaysShowImages, selectionIsPreview)
     remoteImagesLoading = false
     remoteImageData = ({})
@@ -1169,18 +1165,13 @@ Item {
         Conversation.threadAfterSelect(root.selectedThread, messageId, summary)
       root.rememberMember(summary)
       root.loadMembers()
-      // Opening a message is the one place Gmail's own clients mark it read
-      // without being asked, and a reader that leaves it bold is confusing.
-      // A preview is not opening: `Model.marksReadOnArrival` is where that
-      // is decided.
+      // A preview is not opening; only an opened message is marked read here.
       if (Model.marksReadOnArrival(summary, root.selectionIsPreview))
         root.act(messageId, "markRead", true)
     })
   }
 
-  // What a dwell on a previewed message comes to. Asked of the message rather
-  // than of the selection: the cursor may have moved on by the time the
-  // panel's timer fires, and the one that was read is the one to mark.
+  // Mark the message the dwell started on, if it is still unread.
   function markPreviewRead(id) {
     if (!Model.previewReadable(messages, id)) return false
     act(String(id), "markRead", true)

--- a/account/Model.js
+++ b/account/Model.js
@@ -1240,3 +1240,35 @@ function settingsScrollTarget(sections, key, contentHeight, viewportHeight) {
   }
   return -1
 }
+
+// Whether a message arriving in the reader should be marked read by the fact
+// of its arrival.
+//
+// A preview is not opening. Stepping down a list would otherwise mark every
+// message it passed read without any of them having been looked at, which is
+// the reason moving stopped opening in the first place — so the panel marks a
+// previewed message read once the cursor has stayed on it, and arrival leaves
+// it alone.
+function marksReadOnArrival(summary, isPreview) {
+  return !!summary && summary.unread === true && isPreview !== true
+}
+
+// Whether a dwell on a previewed message has anything to mark: it has to still
+// be in the list, and still be unread.
+function previewReadable(messages, id) {
+  var at = indexById(messages, id)
+  return at >= 0 && !!messages[at] && messages[at].unread === true
+}
+
+// Whether the sender's remote images may be fetched for the message now on
+// screen.
+//
+// The standing "always show images" answer is an answer about a message
+// somebody chose to read. Fetching one still tells its host that this address
+// opened this mail at this moment — which is what the notice in the reader
+// says out loud — and a cursor passing over a row has opened nothing. So a
+// preview keeps the pictures blocked however that answer stands, and opening
+// the message, or asking for them in the reader, loads them.
+function showsRemoteImages(alwaysShow, isPreview) {
+  return alwaysShow === true && isPreview !== true
+}

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -279,6 +279,120 @@ Column {
     }
   }
 
+  // Showing a message as the cursor reaches it, and the dwell that keeps that
+  // from reading a mailbox by holding an arrow key down.
+  Rectangle {
+    width: parent.width
+    implicitHeight: Math.max(previewText.implicitHeight, previewSwitch.implicitHeight)
+      + Style.space(16)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+
+    Column {
+      id: previewText
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(12)
+      anchors.right: previewSwitch.left
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(2)
+
+      Text {
+        width: parent.width
+        text: "Preview as the cursor moves"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        textFormat: Text.PlainText
+      }
+
+      Text {
+        width: parent.width
+        text: "Show a message as soon as j, k or an arrow reaches it, instead of "
+          + "waiting for Enter. A previewed message is marked read only once the "
+          + "cursor has stayed on it, so stepping through a list does not read it. "
+          + "Not applied in a narrow window, where the reader takes the list's place."
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+        textFormat: Text.PlainText
+      }
+    }
+
+    ToggleSwitch {
+      id: previewSwitch
+      objectName: "previewOnCursorSwitch"
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      checked: !!root.service && root.service.previewOnCursor
+      foreground: root.textColor
+      accent: root.accentColor
+      onToggled: if (root.service)
+        root.service.setPreviewOnCursor(!root.service.previewOnCursor)
+    }
+  }
+
+  Rectangle {
+    width: parent.width
+    visible: !!root.service && root.service.previewOnCursor
+    implicitHeight: Math.max(dwellText.implicitHeight, dwellSeconds.implicitHeight)
+      + Style.space(16)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+
+    Column {
+      id: dwellText
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(12)
+      anchors.right: dwellSeconds.left
+      anchors.rightMargin: Style.space(16)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(2)
+
+      Text {
+        width: parent.width
+        text: "Mark a previewed message read after"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        textFormat: Text.PlainText
+      }
+
+      Text {
+        width: parent.width
+        text: "How long the cursor has to stay before it counts as read. "
+          + "Set 0 to mark it read as soon as it is previewed. Enter always does."
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+        textFormat: Text.PlainText
+      }
+    }
+
+    NumberField {
+      id: dwellSeconds
+      objectName: "markReadDelayField"
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(12)
+      anchors.verticalCenter: parent.verticalCenter
+      label: "Seconds"
+      from: 0
+      to: 30
+      stepSize: 1
+      value: root.service ? root.service.markReadDelaySec : 2
+      foreground: root.textColor
+      accent: root.accentColor
+      fontFamily: root.panelFontFamily
+      fontSize: Style.font.bodySmall
+      onModified: function(next) {
+        if (root.service) root.service.setMarkReadDelaySec(next)
+      }
+    }
+  }
+
   Rectangle {
     width: parent.width
     implicitHeight: Math.max(heavyText.implicitHeight, heavySwitch.implicitHeight)

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -37,7 +37,7 @@ readonly property string keyContext:
 | Context | What it is | What it binds |
 |---|---|---|
 | `list` | The message list | The mailbox keys |
-| `reader` | A message open | The mailbox keys, plus reply/forward and zoom. `j`/`k` move the cursor without opening; `o` or `Enter` opens what they landed on |
+| `reader` | A message open | The mailbox keys, plus reply/forward and zoom. `j`/`k` move the cursor; `o` or `Enter` opens what they landed on. With *Preview as the cursor moves* on, moving also shows the message, and it counts as read once the cursor has stayed on it |
 | `search` | A query being typed | `Escape`, and the modified keys |
 | `compose` | A draft being written | `Escape`, `Ctrl+Return`, and the modified keys |
 | `page` | Setup or settings | `Escape`, and the modified keys |

--- a/manifest.json
+++ b/manifest.json
@@ -47,7 +47,9 @@
       "undoSendSeconds": 10,
       "unifiedCalendarView": false,
       "openOnClick": "Window",
-      "showBarIcon": true
+      "showBarIcon": true,
+      "previewOnCursor": false,
+      "markReadDelaySec": 2
     },
     "schema": [
       {
@@ -75,6 +77,23 @@
         "max": 100,
         "step": 5,
         "defaultValue": 25
+      },
+      {
+        "key": "previewOnCursor",
+        "type": "boolean",
+        "label": "Preview as the cursor moves",
+        "defaultValue": false,
+        "description": "Show a message as soon as the cursor reaches it, instead of waiting for Enter. Off by default because stepping through a list would otherwise mark every message it passed read; with this on, a previewed message is marked read only once the cursor has stayed on it. Not applied in a narrow window, where the reader takes the list's place."
+      },
+      {
+        "key": "markReadDelaySec",
+        "type": "integer",
+        "label": "Mark a previewed message read after (seconds)",
+        "min": 0,
+        "max": 30,
+        "step": 1,
+        "defaultValue": 2,
+        "description": "How long the cursor has to stay on a message before it counts as read. 0 marks it read as soon as it is previewed. Only applies while Preview as the cursor moves is on; Enter always marks it read."
       },
       {
         "key": "heavyMessageRendering",

--- a/tests/qml/tst_preview_on_cursor.qml
+++ b/tests/qml/tst_preview_on_cursor.qml
@@ -24,6 +24,7 @@ Item {
     property bool ready: true
     property bool anyAccountReady: true
     property bool previewOnCursor: true
+    property bool selectionIsPreview: false
     property int markReadDelaySec: 2
     property bool sendPending: false
     property bool sending: false
@@ -95,6 +96,9 @@ Item {
     function select(id, previewOnly) {
       selectedId = String(id || "")
       selectCount += 1
+      // What `MailAccount.select` records, because two decisions in the window
+      // now turn on it.
+      selectionIsPreview = previewOnly === true
       if (previewOnly === true) previewSelects += 1
       else openSelects += 1
     }
@@ -115,7 +119,10 @@ Item {
       return messages[next].id
     }
 
-    function clearSelection() { selectedId = "" }
+    function clearSelection() {
+      selectedId = ""
+      selectionIsPreview = false
+    }
     function refreshRecipientContacts() {}
     function preferredSendAs(_r) { return null }
     function loadAttachments(_i, _a, cb) { cb([], "") }
@@ -178,16 +185,32 @@ Item {
     function test_moving_the_cursor_shows_the_message() {
       app.moveCursor(1)
       compare(app.cursorId, "m1")
-      compare(mailService.selectedId, "m1", "the reader is given the message at once")
+      compare(mailService.selectCount, 0,
+        "nothing is asked for until the cursor has settled")
+      tryCompare(mailService, "selectedId", "m1", 1000)
       compare(mailService.previewSelects, 1)
       compare(mailService.openSelects, 0, "and it was a preview, not an open")
     }
 
+    // The settle is the point: a held key crosses rows without asking for any
+    // of them, which on IMAP is a curl process, a TLS handshake and a LOGIN
+    // per row.
+    function test_a_held_key_asks_for_one_message_not_thirty() {
+      for (var i = 0; i < 3; i++) app.moveCursor(1)
+      compare(app.cursorId, "m3")
+      compare(mailService.selectCount, 0)
+
+      tryCompare(mailService, "selectedId", "m3", 1000)
+      compare(mailService.selectCount, 1,
+        "one request for the row it stopped on, not one per row crossed")
+    }
+
     function test_moving_again_previews_the_next_one() {
       app.moveCursor(1)
+      tryCompare(mailService, "selectedId", "m1", 1000)
       app.moveCursor(1)
       compare(app.cursorId, "m2")
-      compare(mailService.selectedId, "m2")
+      tryCompare(mailService, "selectedId", "m2", 1000)
       compare(mailService.previewSelects, 2)
     }
 
@@ -257,7 +280,8 @@ Item {
     function test_a_zero_delay_reads_it_at_once() {
       mailService.markReadDelaySec = 0
       app.moveCursor(1)
-      compare(mailService.markedRead.indexOf("m1") >= 0, true)
+      tryVerify(function() { return mailService.markedRead.indexOf("m1") >= 0 }, 1000,
+        "at once meaning with the preview, not before it")
     }
 
     // Opening marks it read itself, so a dwell still counting has nothing to
@@ -314,11 +338,73 @@ Item {
     function test_a_dropped_selection_stops_the_dwell() {
       mailService.markReadDelaySec = 1
       app.moveCursor(1)
+      tryCompare(mailService, "selectedId", "m1", 1000)
       mailService.clearSelection()
       wait(1400)
       compare(mailService.markedRead.length, 0,
         "nothing is on screen to be read")
     }
+
+    // ------------------------------------- a preview is not an open, part two
+
+    // A previewed message satisfies "is this the selected one" without being
+    // open. Reading that as open made `e` on a previewed row archive it and
+    // then call `openMessage` on the *next* one — an archive that reads a
+    // message, which is the fault this feature exists to avoid.
+    function test_archiving_a_previewed_row_does_not_open_its_neighbour() {
+      app.openMessage("m1")
+      compare(app.currentView, "reader")
+      compare(mailService.openSelects, 1)
+
+      app.moveCursor(1)
+      tryCompare(mailService, "selectedId", "m2", 1000)
+      compare(mailService.selectionIsPreview, true)
+      var opensBefore = mailService.openSelects
+
+      app.actOnCursor("archive")
+
+      compare(mailService.openSelects, opensBefore,
+        "archiving a previewed row opens nothing")
+    }
+
+    // The mirror of it: a preview satisfies the id test while pushing no
+    // `reader` entry, so `r` answered a message that was never opened —
+    // nothing marked it read, and closing the draft landed on the list.
+    function test_replying_to_a_previewed_row_opens_it_first() {
+      app.moveCursor(1)
+      tryCompare(mailService, "selectedId", "m1", 1000)
+      compare(app.currentView, "list", "a preview is not a place")
+      compare(mailService.openSelects, 0)
+
+      app.composeFromCursor("reply")
+
+      compare(mailService.openSelects, 1, "answering a message opens it")
+      compare(mailService.selectionIsPreview, false,
+        "so it is no longer a preview")
+      compare(app.currentView, "reader",
+        "and the reader entry is on the stack, so closing the draft comes back to it")
+    }
+
+    // #83's label picker is an overlay rather than a nav entry, so none of the
+    // other guards notice it: `v` during a dwell let the timer mark read a
+    // message that was about to be moved.
+    function test_the_label_picker_stops_a_preview() {
+      var picker = having(app, function(it) {
+        return String(it.objectName || "") === "label-picker"
+      })
+      verify(picker, "the picker has to be there to be guarded against")
+      compare(app.canPreview, true)
+
+      picker.open()
+      wait(20)
+      compare(picker.opened, true)
+      compare(app.canPreview, false,
+        "an overlay that is not a nav entry still covers the window")
+
+      // It exposes no `close()` — the popup owns its own dismissal — so the
+      // assertion that matters is the one on the way in.
+    }
+
 
     // --------------------------------------------- what the reader carries
 

--- a/tests/qml/tst_preview_on_cursor.qml
+++ b/tests/qml/tst_preview_on_cursor.qml
@@ -141,6 +141,12 @@ Item {
       return having(app, function(it) { return it.title === "Omamail" })
     }
 
+    // The reader panel, found by the one property only it has. It draws no
+    // objectName and `children[0]` is not reliably anything.
+    function readerView() {
+      return having(app, function(it) { return it.forceRichAnyway !== undefined })
+    }
+
     function having(item, accept) {
       if (!item) return null
       if (accept(item)) return item
@@ -264,6 +270,69 @@ Item {
       wait(1400)
       compare(mailService.markedRead.length, 0,
         "the open path marks it read, not the dwell")
+    }
+
+    // ------------------------------------- the dwell against a gone preview
+    //
+    // The dwell is a claim about a message somebody is looking at. Everything
+    // that takes the message off the screen between the cursor arriving and
+    // the timer firing has to withdraw the claim, because by then nobody has
+    // looked at anything.
+
+    function test_a_page_over_the_list_stops_the_dwell() {
+      mailService.markReadDelaySec = 1
+      app.moveCursor(1)
+      app.openSettings()
+      wait(1400)
+      compare(mailService.markedRead.length, 0,
+        "a message behind Settings is not being read")
+    }
+
+    function test_narrowing_the_window_stops_the_dwell() {
+      mailService.markReadDelaySec = 1
+      app.moveCursor(1)
+      window().width = 700
+      waitForRendering(app)
+      compare(app.compact, true)
+      wait(1400)
+      compare(mailService.markedRead.length, 0,
+        "one column shows the list, so the preview is gone")
+    }
+
+    function test_closing_the_window_stops_the_dwell() {
+      mailService.markReadDelaySec = 1
+      app.moveCursor(1)
+      app.close()
+      wait(1400)
+      compare(mailService.markedRead.length, 0,
+        "a shut window shows nothing to have stayed on")
+    }
+
+    // The selection can be dropped without the cursor moving — a search and a
+    // mailbox switch both do it — and then the row under the cursor is no
+    // longer what the reader has.
+    function test_a_dropped_selection_stops_the_dwell() {
+      mailService.markReadDelaySec = 1
+      app.moveCursor(1)
+      mailService.clearSelection()
+      wait(1400)
+      compare(mailService.markedRead.length, 0,
+        "nothing is on screen to be read")
+    }
+
+    // --------------------------------------------- what the reader carries
+
+    // Insisting on a document the bounds refused is an answer about the
+    // message it was given for. Opening one clears it; so does previewing one,
+    // or the next row inherits a heavy layout nobody asked for.
+    function test_a_preview_does_not_inherit_the_heavy_override() {
+      var view = readerView()
+      verify(view, "the reader panel is there")
+      app.moveCursor(1)
+      view.forceRichAnyway = true
+      app.moveCursor(1)
+      compare(view.forceRichAnyway, false,
+        "the override belonged to the message before it")
     }
   }
 }

--- a/tests/qml/tst_preview_on_cursor.qml
+++ b/tests/qml/tst_preview_on_cursor.qml
@@ -1,0 +1,269 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../.." as Omamail
+
+// Showing a message as the cursor reaches it.
+//
+// This behaviour existed once and was taken out, because stepping through a
+// list marked half of it read without any of it having been looked at. So the
+// assertions that matter here are the ones about what a preview does *not*
+// do: it marks nothing read on arrival, it pushes no history, and it does not
+// happen at all in a narrow window where the reader takes the list's place.
+Item {
+  width: 1200
+  height: 700
+
+  QtObject {
+    id: fakeShell
+    function hide(_id) {}
+  }
+
+  QtObject {
+    id: mailService
+
+    property bool ready: true
+    property bool anyAccountReady: true
+    property bool previewOnCursor: true
+    property int markReadDelaySec: 2
+    property bool sendPending: false
+    property bool sending: false
+    property bool windowOpen: true
+    property bool sidebarCollapsed: false
+    property bool alwaysShowImages: false
+    property bool unifiedCalendarView: false
+    property bool selectedReaderEmpty: false
+    property bool selectedReaderTooHeavy: false
+    property bool selectedTooHeavy: false
+    property bool detailLoading: false
+    property bool detailPainted: true
+    property bool canOpenOnWeb: false
+    property bool canRespondToInvite: false
+    property bool rsvpSending: false
+    property bool canArchive: true
+    property bool canStar: true
+    property bool canSpam: true
+    property bool canTrash: true
+    property bool canMarkRead: true
+    property bool canMarkUnread: true
+    property bool accountDraftOpen: false
+    property int accountCount: 1
+    property int inboxUnread: 2
+    property real bodyZoom: 1
+    property string bodyMode: "reader"
+    property string providerId: "gmail"
+    property string pluginDir: ""
+    property string accountEmail: "me@example.com"
+    property string activeAccountId: "me@example.com"
+    property string mailboxKey: "inbox"
+    property string searchQuery: ""
+    property string rawQuery: ""
+    property string lastError: ""
+    property string actionStatus: ""
+    property string syncedLabel: ""
+    property string recipientContactStatus: ""
+    property var auth: null
+    property var accountSummaries: [{ provider: "gmail", email: "me@example.com" }]
+    property var accountSignatures: []
+    property var mailboxes: []
+    property var labels: []
+    property var selectedAttachments: []
+    property var selectedInvite: null
+    property var selectedResponse: ""
+    property var recipientContacts: []
+    property var sendAsAliases: []
+    property var sendIdentities: []
+    property var calendarController: null
+    property var selectedBody: ({ text: "body", source: "plain" })
+    property var selectedMessage: null
+
+    property var messages: [
+      { id: "m1", subject: "first", unread: true, from: { email: "a@x", display: "A" },
+        snippet: "one", time: "now", fullTime: "today", date: 3000 },
+      { id: "m2", subject: "second", unread: true, from: { email: "b@x", display: "B" },
+        snippet: "two", time: "now", fullTime: "today", date: 2000 },
+      { id: "m3", subject: "third", unread: true, from: { email: "c@x", display: "C" },
+        snippet: "three", time: "now", fullTime: "today", date: 1000 }
+    ]
+
+    // What the panel asked for.
+    property string selectedId: ""
+    property int selectCount: 0
+    property int previewSelects: 0
+    property int openSelects: 0
+    property var markedRead: []
+
+    function select(id, previewOnly) {
+      selectedId = String(id || "")
+      selectCount += 1
+      if (previewOnly === true) previewSelects += 1
+      else openSelects += 1
+    }
+
+    function markPreviewRead(id) {
+      var next = markedRead.slice()
+      next.push(String(id || ""))
+      markedRead = next
+      return true
+    }
+
+    function cursorOffset(id, delta) {
+      var at = -1
+      for (var i = 0; i < messages.length; i++) if (messages[i].id === id) at = i
+      if (at < 0) return delta < 0 ? messages[messages.length - 1].id : messages[0].id
+      var next = at + delta
+      if (next < 0 || next >= messages.length) return ""
+      return messages[next].id
+    }
+
+    function clearSelection() { selectedId = "" }
+    function refreshRecipientContacts() {}
+    function preferredSendAs(_r) { return null }
+    function loadAttachments(_i, _a, cb) { cb([], "") }
+    function fail(_t) {}
+    function note(_t) {}
+    function act(_i, _a, _q) { return true }
+    signal replySent()
+  }
+
+  Omamail.App {
+    id: app
+    service: mailService
+    shell: fakeShell
+  }
+
+  TestCase {
+    name: "PreviewOnCursor"
+    when: windowShown
+
+    // The FloatingWindow, found by its title the way the other App tests find
+    // it: `children[0]` is not reliably the window.
+    function window() {
+      return having(app, function(it) { return it.title === "Omamail" })
+    }
+
+    function having(item, accept) {
+      if (!item) return null
+      if (accept(item)) return item
+      var children = item.children || []
+      for (var i = 0; i < children.length; i++) {
+        var found = having(children[i], accept)
+        if (found) return found
+      }
+      return null
+    }
+
+    function init() {
+      window().width = 1200
+      window().height = 700
+      waitForRendering(app)
+      app.resetNavigation()
+      app.cursorId = ""
+      mailService.previewOnCursor = true
+      mailService.markReadDelaySec = 2
+      mailService.selectedId = ""
+      mailService.selectCount = 0
+      mailService.previewSelects = 0
+      mailService.openSelects = 0
+      mailService.markedRead = []
+    }
+
+    // ------------------------------------------------------------ the point
+
+    function test_moving_the_cursor_shows_the_message() {
+      app.moveCursor(1)
+      compare(app.cursorId, "m1")
+      compare(mailService.selectedId, "m1", "the reader is given the message at once")
+      compare(mailService.previewSelects, 1)
+      compare(mailService.openSelects, 0, "and it was a preview, not an open")
+    }
+
+    function test_moving_again_previews_the_next_one() {
+      app.moveCursor(1)
+      app.moveCursor(1)
+      compare(app.cursorId, "m2")
+      compare(mailService.selectedId, "m2")
+      compare(mailService.previewSelects, 2)
+    }
+
+    // ----------------------------------------------------- what it does not do
+
+    // The reason this was taken out the first time.
+    function test_a_preview_marks_nothing_read_on_arrival() {
+      app.moveCursor(1)
+      app.moveCursor(1)
+      app.moveCursor(1)
+      compare(mailService.markedRead.length, 0,
+        "stepping through a list must not read it")
+    }
+
+    // Escape and Back have to mean what they meant.
+    function test_a_preview_pushes_no_history() {
+      var before = app.navKinds.join(",")
+      app.moveCursor(1)
+      app.moveCursor(1)
+      compare(app.navKinds.join(","), before, "moving is not a place")
+      compare(app.currentView, "list", "and the list is still what is open")
+    }
+
+    // A narrow window swaps the list for the reader, so previewing would
+    // navigate away from the list being moved through.
+    function test_a_narrow_window_does_not_preview() {
+      window().width = 700
+      waitForRendering(app)
+      compare(app.compact, true)
+
+      app.moveCursor(1)
+      compare(app.cursorId, "m1", "the cursor still moves")
+      compare(mailService.selectCount, 0, "but nothing is shown")
+    }
+
+    function test_the_setting_off_is_the_old_behaviour() {
+      mailService.previewOnCursor = false
+      app.moveCursor(1)
+      compare(app.cursorId, "m1")
+      compare(mailService.selectCount, 0, "moving is not opening")
+    }
+
+    // ---------------------------------------------------------- the dwell
+
+    function test_staying_on_a_message_reads_it() {
+      mailService.markReadDelaySec = 1
+      app.moveCursor(1)
+      compare(mailService.markedRead.length, 0)
+      tryVerify(function() { return mailService.markedRead.indexOf("m1") >= 0 }, 3000,
+        "a message the cursor stayed on counts as read")
+    }
+
+    // The held arrow key: every message is previewed, none is dwelled on.
+    function test_moving_on_before_the_dwell_reads_nothing() {
+      mailService.markReadDelaySec = 1
+      app.moveCursor(1)
+      app.moveCursor(1)
+      app.moveCursor(1)
+      wait(1400)
+      compare(mailService.markedRead.indexOf("m1"), -1, "m1 was passed over")
+      compare(mailService.markedRead.indexOf("m2"), -1, "so was m2")
+      compare(mailService.markedRead.indexOf("m3") >= 0, true,
+        "only the one it stopped on")
+    }
+
+    // Zero is a decision, not a disabled dwell.
+    function test_a_zero_delay_reads_it_at_once() {
+      mailService.markReadDelaySec = 0
+      app.moveCursor(1)
+      compare(mailService.markedRead.indexOf("m1") >= 0, true)
+    }
+
+    // Opening marks it read itself, so a dwell still counting has nothing to
+    // do — and must not fire against a message that has since been opened.
+    function test_opening_takes_over_from_the_dwell() {
+      mailService.markReadDelaySec = 1
+      app.moveCursor(1)
+      app.openMessage("m1")
+      compare(mailService.openSelects, 1, "opening is not a preview")
+      wait(1400)
+      compare(mailService.markedRead.length, 0,
+        "the open path marks it read, not the dwell")
+    }
+  }
+}

--- a/tests/qml/tst_preview_on_cursor.qml
+++ b/tests/qml/tst_preview_on_cursor.qml
@@ -103,6 +103,25 @@ Item {
       else openSelects += 1
     }
 
+    // A body that has not landed. `select` puts the reader into this state on
+    // the real service; here the test says when it comes out of it, which is
+    // what a slow fetch and a failed one differ by.
+    function beginFetch() {
+      detailLoading = true
+      detailPainted = false
+    }
+
+    function finishFetch() {
+      detailLoading = false
+      detailPainted = true
+    }
+
+    // A fetch that failed: it stopped, and nothing was painted.
+    function failFetch() {
+      detailLoading = false
+      detailPainted = false
+    }
+
     function markPreviewRead(id) {
       var next = markedRead.slice()
       next.push(String(id || ""))
@@ -178,6 +197,7 @@ Item {
       mailService.previewSelects = 0
       mailService.openSelects = 0
       mailService.markedRead = []
+      mailService.finishFetch()
     }
 
     // ------------------------------------------------------------ the point
@@ -282,6 +302,82 @@ Item {
       app.moveCursor(1)
       tryVerify(function() { return mailService.markedRead.indexOf("m1") >= 0 }, 1000,
         "at once meaning with the preview, not before it")
+    }
+
+    // ------------------------------------------- the dwell and the body
+
+    // The dwell is time spent looking at a message. It began when the request
+    // went out, so a slow answer spent the whole of it loading and marked read
+    // a message whose body never appeared.
+    function test_a_body_that_has_not_landed_is_not_read() {
+      mailService.markReadDelaySec = 1
+      mailService.beginFetch()
+      app.moveCursor(1)
+
+      wait(1600)
+      compare(mailService.markedRead.indexOf("m1"), -1,
+        "nothing was on screen for the dwell to have been spent on")
+
+      // And when it does land, the dwell runs from there.
+      mailService.finishFetch()
+      tryVerify(function() { return mailService.markedRead.indexOf("m1") >= 0 }, 3000,
+        "the dwell starts at the body, not at the request")
+    }
+
+    // A fetch that fails never paints, so it never arms the dwell at all.
+    function test_a_body_that_never_arrives_is_never_read() {
+      mailService.markReadDelaySec = 1
+      mailService.beginFetch()
+      app.moveCursor(1)
+      wait(600)
+      mailService.failFetch()
+
+      wait(1600)
+      compare(mailService.markedRead.indexOf("m1"), -1,
+        "a message that could not be shown was not read")
+    }
+
+    // Zero is the acute form: it marked the message read before the request
+    // had even been made.
+    function test_a_zero_delay_still_waits_for_the_body() {
+      mailService.markReadDelaySec = 0
+      mailService.beginFetch()
+      app.moveCursor(1)
+
+      wait(500)
+      compare(mailService.markedRead.indexOf("m1"), -1,
+        "at once means with the preview, not before it")
+
+      mailService.finishFetch()
+      tryVerify(function() { return mailService.markedRead.indexOf("m1") >= 0 }, 1000)
+    }
+
+    // ------------------------------------------- coming back to a preview
+
+    // Away and back inside the settle. The dwell is stopped on the way out,
+    // and coming back matched `selectedId` and returned — which is what an
+    // *opened* message does, not a preview. The message the cursor ended up
+    // sitting on stayed unread for as long as it was left there.
+    function test_returning_to_a_preview_restarts_its_dwell() {
+      mailService.markReadDelaySec = 1
+      // Opened, so the window is on the reader — which is the state the early
+      // return is about. Previewing from the list never reaches it.
+      app.openMessage("m1")
+      compare(app.currentView, "reader")
+
+      app.moveCursor(1)
+      tryCompare(mailService, "selectedId", "m2", 1000)
+      compare(mailService.selectionIsPreview, true, "m2 was previewed, not opened")
+      mailService.markedRead = []
+
+      // Away and back inside the settle, so m2 is still the selection.
+      app.moveCursor(1)
+      wait(60)
+      app.moveCursor(-1)
+      compare(app.cursorId, "m2", "back on the message that was previewed")
+
+      tryVerify(function() { return mailService.markedRead.indexOf("m2") >= 0 }, 3000,
+        "sitting on it reads it, however it was arrived at")
     }
 
     // Opening marks it read itself, so a dwell still counting has nothing to

--- a/tests/qml/tst_service_settings.qml
+++ b/tests/qml/tst_service_settings.qml
@@ -116,5 +116,44 @@ Item {
       compare(mailService.act(absent, "archive"), false)
       compare(mailService.hostForId(absent), null)
     }
+
+    // Off, and a settings file written before it existed is not an opt-in.
+    function test_preview_on_cursor_is_off_until_it_is_asked_for() {
+      mailService.applySettings({})
+      compare(mailService.previewOnCursor, false)
+      mailService.applySettings({ previewOnCursor: "yes" })
+      compare(mailService.previewOnCursor, false, "only true is true")
+
+      mailService.setPreviewOnCursor(true)
+      compare(mailService.previewOnCursor, true)
+      compare(shellStore.updatedEntry.previewOnCursor, true)
+    }
+
+    // Zero is a real answer here — read it the instant it is previewed — so
+    // nothing that merely coerces to zero may be read as somebody asking for
+    // it. A file that lost the key, or holds a word, gets the default dwell.
+    function test_a_dwell_that_is_not_a_number_is_the_default() {
+      mailService.applySettings({})
+      compare(mailService.markReadDelaySec, 2, "a missing key is the default")
+
+      mailService.applySettings({ markReadDelaySec: null })
+      compare(mailService.markReadDelaySec, 2, "and so is null")
+
+      mailService.applySettings({ markReadDelaySec: "" })
+      compare(mailService.markReadDelaySec, 2, "and an empty string")
+
+      mailService.applySettings({ markReadDelaySec: "soon" })
+      compare(mailService.markReadDelaySec, 2, "and a word")
+
+      mailService.applySettings({ markReadDelaySec: -5 })
+      compare(mailService.markReadDelaySec, 2,
+        "a negative interval never fires at all")
+
+      mailService.applySettings({ markReadDelaySec: 0 })
+      compare(mailService.markReadDelaySec, 0, "but a typed zero is kept")
+
+      mailService.applySettings({ markReadDelaySec: 900 })
+      compare(mailService.markReadDelaySec, 30, "and a long one is clamped")
+    }
   }
 }

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -1028,3 +1028,33 @@ assert.strictEqual(model.readingStatusLine(true, "", ""), "All mailboxes")
 assert.strictEqual(model.UNIFIED_LABEL, "All mailboxes")
 
 assert.strictEqual(model.readingStatusLine(false, "", ""), "Not connected")
+
+// ------------------------------------------------ what a preview may do
+
+// Arrival marks an opened message read and leaves a previewed one alone.
+assert.strictEqual(model.marksReadOnArrival({ unread: true }, false), true)
+assert.strictEqual(model.marksReadOnArrival({ unread: true }, true), false,
+  "stepping down a list would otherwise read every message it passed")
+assert.strictEqual(model.marksReadOnArrival({ unread: false }, false), false)
+assert.strictEqual(model.marksReadOnArrival(null, false), false)
+
+// Only `true` is a preview, so a call that forgot the argument opens rather
+// than silently previewing — the safe way round for the read mark.
+assert.strictEqual(model.marksReadOnArrival({ unread: true }, undefined), true)
+
+// The sender learns nothing from a message nobody opened.
+assert.strictEqual(model.showsRemoteImages(true, false), true)
+assert.strictEqual(model.showsRemoteImages(true, true), false,
+  "the standing answer is about a message somebody chose to read")
+assert.strictEqual(model.showsRemoteImages(false, false), false)
+assert.strictEqual(model.showsRemoteImages(false, true), false)
+
+// A dwell has something to mark only while the message is still in the list
+// and still unread.
+const dwelt = [{ id: "m1", unread: true }, { id: "m2", unread: false }]
+assert.strictEqual(model.previewReadable(dwelt, "m1"), true)
+assert.strictEqual(model.previewReadable(dwelt, "m2"), false, "already read")
+assert.strictEqual(model.previewReadable(dwelt, "gone"), false,
+  "a search or a mailbox switch takes the row out from under the dwell")
+assert.strictEqual(model.previewReadable([], "m1"), false)
+assert.strictEqual(model.previewReadable(dwelt, ""), false)

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -128,6 +128,14 @@ grep -q 'command: \["python3", pluginDir + "/scripts/image-fetch.py"\]' account/
 grep -q 'command: \["python3", pluginDir + "/scripts/unsubscribe.py"\]' account/MailAccount.qml \
   || fail "one-click unsubscribe must use the public-IP-checked Python transport"
 # Redirect and DNS policy require behavioral tests, not a matching config line.
+
+# The standing "always show images" answer is an answer about a message
+# somebody chose to read. A preview is the cursor passing over a row, and
+# fetching a picture for one would tell the sender's host that this address
+# opened this mail at this moment — the very thing the reader's own notice
+# says out loud, and the reason the read mark waits for a dwell.
+grep -q 'remoteImagesAllowed = alwaysShowImages && !selectionIsPreview' account/MailAccount.qml \
+  || fail "a message the cursor merely previewed must not fetch the sender's images"
 grep -q 'property string bodyMode: "reader"' Service.qml \
   || fail "a message opens in reading mode"
 grep -q 'bodyMode: root.bodyMode' Service.qml \

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -1261,3 +1261,21 @@ if re.search(r"Unified\.(sharedCapability|sharedMailboxes|hasSharedMailbox)\b", 
 UNIFIEDCAPS
 
 printf 'test_source.sh ok\n'
+
+# A preview is drawn the same as an open and must be marked read differently.
+# The gate is one condition in the detail callback and it has no unit test that
+# can reach it — the panel-level test asserts only that a flag was passed.
+python3 - <<'PREVIEWREAD'
+import re
+from pathlib import Path
+
+source = Path("account/MailAccount.qml").read_text()
+
+# The read mark on arrival must ask whether this was a preview.
+mark = re.search(r"if \(summary\.unread[^)]*\)\s*\n?\s*root\.act\([^)]*markRead", source)
+if not mark:
+    raise SystemExit("test_source.sh: MailAccount must mark an opened message read")
+if "selectionIsPreview" not in mark.group(0):
+    raise SystemExit("test_source.sh: the read mark on arrival must skip a preview "
+                     "(`!root.selectionIsPreview`), or stepping a list reads it")
+PREVIEWREAD

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -134,7 +134,7 @@ grep -q 'command: \["python3", pluginDir + "/scripts/unsubscribe.py"\]' account/
 # fetching a picture for one would tell the sender's host that this address
 # opened this mail at this moment — the very thing the reader's own notice
 # says out loud, and the reason the read mark waits for a dwell.
-grep -q 'remoteImagesAllowed = alwaysShowImages && !selectionIsPreview' account/MailAccount.qml \
+grep -q 'remoteImagesAllowed = Model.showsRemoteImages(alwaysShowImages, selectionIsPreview)' account/MailAccount.qml \
   || fail "a message the cursor merely previewed must not fetch the sender's images"
 grep -q 'property string bodyMode: "reader"' Service.qml \
   || fail "a message opens in reading mode"
@@ -1271,11 +1271,14 @@ from pathlib import Path
 
 source = Path("account/MailAccount.qml").read_text()
 
-# The read mark on arrival must ask whether this was a preview.
-mark = re.search(r"if \(summary\.unread[^)]*\)\s*\n?\s*root\.act\([^)]*markRead", source)
+# The read mark on arrival must ask whether this was a preview. The decision
+# itself lives in `Model.marksReadOnArrival`, where it is unit-tested; what is
+# guarded here is that the call site still asks it.
+mark = re.search(r"if \(Model\.marksReadOnArrival\([^)]*\)\)\s*\n?\s*root\.act\([^)]*markRead",
+                 source)
 if not mark:
     raise SystemExit("test_source.sh: MailAccount must mark an opened message read")
 if "selectionIsPreview" not in mark.group(0):
     raise SystemExit("test_source.sh: the read mark on arrival must skip a preview "
-                     "(`!root.selectionIsPreview`), or stepping a list reads it")
+                     "(`root.selectionIsPreview`), or stepping a list reads it")
 PREVIEWREAD


### PR DESCRIPTION
## Summary

Allow users to preview a message as the list cursor moves, without opening it or marking it read immediately.

## Behaviour

- Preview is opt-in and disabled by default.
- `j`, `k`, and arrow keys show the message after a short settle period.
- A preview does not add reader history, mark the message read on arrival, or fetch remote images.
- The message is marked read only after the cursor remains on it for the configured dwell time.
- Enter still opens the message immediately and marks it read as before.
- Moving away cancels the pending dwell; returning to a preview restarts it.
- Preview is disabled in compact layouts and while another page, dialog, or composer is active.
- Existing single-mailbox and unified-mailbox routing remain account-owned.

## Validation

- Added regression coverage for delayed/failed bodies, zero and invalid dwell values, away-and-back previews, image privacy, read marking, compact layouts, and action routing.
- `node tests/test_model.js`
- `node tests/test_message.js`
- `node tests/test_unified.js`
- `bash tests/test_source.sh`

The local QML runner requires the Qt ICU library `libicui18n.74.dylib`, which is unavailable in the current macOS environment.
