### PR TITLE
Move a message back to the inbox, and out of the label it was filed under

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -688,8 +688,12 @@ Item {
     var wasOpen = currentView === "reader" && service.selectedId === acted
     // Worked out before the action, while the row still has neighbours.
     var next = Model.cursorAfterRemoval(service.messages, acted)
+    // The same four facts `MailAccount.act` decides with. Asking with three of
+    // them made the cursor repair disagree with the list it repairs: moving a
+    // message back to the inbox removes the row on a provider that moves, and
+    // this read it as staying.
     var leaves = !Model.survivesAction(service.mailboxKey, action,
-      service.rawQuery)
+      service.rawQuery, service.hasLabels)
     if (!service.act(acted, action)) return false
     if (!leaves) return true
     // The row is going and the cursor must not go with it: a cursor on a

--- a/App.qml
+++ b/App.qml
@@ -688,12 +688,12 @@ Item {
     var wasOpen = currentView === "reader" && service.selectedId === acted
     // Worked out before the action, while the row still has neighbours.
     var next = Model.cursorAfterRemoval(service.messages, acted)
-    // The same four facts `MailAccount.act` decides with. Asking with three of
+    // The same five facts `MailAccount.act` decides with. Asking with three of
     // them made the cursor repair disagree with the list it repairs: moving a
     // message back to the inbox removes the row on a provider that moves, and
     // this read it as staying.
     var leaves = !Model.survivesAction(service.mailboxKey, action,
-      service.rawQuery, service.hasLabels)
+      service.rawQuery, service.hasLabels, service.rawLabelId)
     if (!service.act(acted, action)) return false
     if (!leaves) return true
     // The row is going and the cursor must not go with it: a cursor on a

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1370,7 +1370,8 @@ Item {
     var before = index >= 0 ? messages[index] : previewMessages[previewIndex]
     var sourceLabelId = hasLabels ? rawLabelId : ""
     var updated = Model.applyLabelChange(before, action, sourceLabelId)
-    var survives = Model.survivesAction(mailboxKey, action, rawQuery, hasLabels)
+    var survives = Model.survivesAction(mailboxKey, action, rawQuery, hasLabels,
+      sourceLabelId)
 
     if (action === "markRead" && before.unread) inboxUnread = Math.max(0, inboxUnread - 1)
     if (action === "markUnread" && !before.unread) inboxUnread = inboxUnread + 1

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1370,7 +1370,7 @@ Item {
     var before = index >= 0 ? messages[index] : previewMessages[previewIndex]
     var sourceLabelId = hasLabels ? rawLabelId : ""
     var updated = Model.applyLabelChange(before, action, sourceLabelId)
-    var survives = Model.survivesAction(mailboxKey, action, rawQuery)
+    var survives = Model.survivesAction(mailboxKey, action, rawQuery, hasLabels)
 
     if (action === "markRead" && before.unread) inboxUnread = Math.max(0, inboxUnread - 1)
     if (action === "markUnread" && !before.unread) inboxUnread = inboxUnread + 1
@@ -1518,6 +1518,7 @@ Item {
     if (action === "unstar") return "Unstarred"
     if (action === "markRead") return "Marked read"
     if (action === "markUnread") return "Marked unread"
+    if (action === "unarchive") return "Moved to Inbox"
     if (action === "spam") return "Reported as spam"
     // Named, not "Moved": the destination was chosen a keystroke ago from a
     // list of thirty, and a note that does not say which one leaves the only

--- a/account/Model.js
+++ b/account/Model.js
@@ -142,17 +142,44 @@ function setupActionLabel(state, provider, authKind) {
 // have had to be carried, and correctly put back, by all four.
 var MOVE_PREFIX = "label:"
 
+// Gmail's own labels are upper case with no `Label_` prefix; a user's carry one
+// or are a folder name on IMAP. Only the second kind is a place a message is
+// filed under and can be taken out of, and `survivesAction` asks the same
+// question of the same fact so the two cannot disagree about a row.
+var SYSTEM_LABEL_IDS = ["INBOX", "UNREAD", "STARRED", "IMPORTANT", "SENT",
+  "DRAFT", "TRASH", "SPAM", "CHAT"]
+
+function isSystemLabelId(id) {
+  var value = String(id || "")
+  if (SYSTEM_LABEL_IDS.indexOf(value) >= 0) return true
+  return value.indexOf("CATEGORY_") === 0
+}
+
 function labelTarget(action) {
   var verb = String(action || "")
   if (verb.indexOf(MOVE_PREFIX) !== 0) return ""
   return verb.slice(MOVE_PREFIX.length)
 }
 
-function survivesAction(mailboxKey, action, rawQuery) {
+// `labels` is whether the provider files by label rather than by folder, which
+// is the one thing this cannot infer and the one thing `unarchive` turns on: a
+// folder provider answers it with a UID MOVE, so the message leaves the list
+// with a new id and a surviving row would point at nothing.
+function survivesAction(mailboxKey, action, rawQuery, labels) {
   var key = String(mailboxKey || "inbox")
   var verb = String(action || "")
   if (verb === "trash") return key === "trash"
   if (verb === "untrash") return key !== "trash"
+  if (verb === "unarchive") {
+    // Moving relocates on a folder provider: the message is given a new UID in
+    // INBOX, nothing parses COPYUID, and the row it left would point at a
+    // message that is no longer there — opening it says so, a star succeeds
+    // against nothing, and no reload corrects it.
+    if (labels !== true) return false
+    // On a label provider the row leaves a label's list, because the label
+    // came off, and stays in a mailbox or a search, which still contain it.
+    return String(rawQuery || "") === ""
+  }
   // A move takes INBOX away exactly as archive does, so it leaves exactly the
   // lists archive leaves. Said once, because two branches with the same answer
   // are two places for it to drift.
@@ -170,7 +197,16 @@ function labelChangesFor(action, sourceLabelId) {
   if (action === "star") return { add: ["STARRED"], remove: [] }
   if (action === "unstar") return { add: [], remove: ["STARRED"] }
   if (action === "archive") return { add: [], remove: ["INBOX"] }
-  if (action === "unarchive") return { add: ["INBOX"], remove: [] }
+  // Moving back to the inbox takes the message out of the label whose list it
+  // was found in, the same way a move does and for the same reason: a label
+  // somebody files things under is a queue, and one that keeps everything ever
+  // put in it only grows. `sourceLabelId` is already "" on a provider whose
+  // labels are folders, so a folder name never reaches a Gmail remove list.
+  if (action === "unarchive") {
+    var filed = String(sourceLabelId || "")
+    if (filed === "" || isSystemLabelId(filed)) return { add: ["INBOX"], remove: [] }
+    return { add: ["INBOX"], remove: [filed] }
+  }
   if (action === "spam") return { add: ["SPAM"], remove: ["INBOX"] }
   // A move is archive with somewhere to go. Where a folder is a label, putting
   // a message in one is adding that label and taking INBOX away -- the same

--- a/account/Model.js
+++ b/account/Model.js
@@ -144,8 +144,9 @@ var MOVE_PREFIX = "label:"
 
 // Gmail's own labels are upper case with no `Label_` prefix; a user's carry one
 // or are a folder name on IMAP. Only the second kind is a place a message is
-// filed under and can be taken out of, and `survivesAction` asks the same
-// question of the same fact so the two cannot disagree about a row.
+// filed under and can be taken out of. `survivesAction` does not read that
+// rule a second time — it asks `labelChangesFor` whether the label actually
+// comes off — so the two cannot disagree about a row.
 var SYSTEM_LABEL_IDS = ["INBOX", "UNREAD", "STARRED", "IMPORTANT", "SENT",
   "DRAFT", "TRASH", "SPAM", "CHAT"]
 
@@ -165,7 +166,7 @@ function labelTarget(action) {
 // is the one thing this cannot infer and the one thing `unarchive` turns on: a
 // folder provider answers it with a UID MOVE, so the message leaves the list
 // with a new id and a surviving row would point at nothing.
-function survivesAction(mailboxKey, action, rawQuery, labels) {
+function survivesAction(mailboxKey, action, rawQuery, labels, sourceLabelId) {
   var key = String(mailboxKey || "inbox")
   var verb = String(action || "")
   if (verb === "trash") return key === "trash"
@@ -176,9 +177,20 @@ function survivesAction(mailboxKey, action, rawQuery, labels) {
     // message that is no longer there — opening it says so, a star succeeds
     // against nothing, and no reload corrects it.
     if (labels !== true) return false
-    // On a label provider the row leaves a label's list, because the label
-    // came off, and stays in a mailbox or a search, which still contain it.
-    return String(rawQuery || "") === ""
+    // On a label provider the row stays in a mailbox or a search, which still
+    // contain it, and leaves a label's list because the label came off. Which
+    // of those a label view is, is `labelChangesFor`'s answer rather than a
+    // second reading of the same rule here: a system label is not a place a
+    // message is filed under, so it stays on the message and the row stays in
+    // its list.
+    if (String(rawQuery || "") === "") return true
+    var filed = String(sourceLabelId || "")
+    // A label view with nothing naming its label cannot say the label stayed,
+    // so the row goes: a row that leaves and should not have comes back on the
+    // reload `invalidatesPage` asks for, and one that stays and should not
+    // have is stale until something else reloads the list.
+    if (filed === "") return false
+    return labelChangesFor("unarchive", filed).remove.length === 0
   }
   // A move takes INBOX away exactly as archive does, so it leaves exactly the
   // lists archive leaves. Said once, because two branches with the same answer
@@ -311,6 +323,14 @@ function applyLabelChange(summary, action, sourceLabelId) {
   next.unread = labels.indexOf("UNREAD") >= 0
   next.starred = labels.indexOf("STARRED") >= 0
   next.inInbox = labels.indexOf("INBOX") >= 0
+  // Every flag that mirrors a label, rather than the three that used to be the
+  // only ones read. `spam` moves a row between two of these, and a menu asking
+  // a stale `inSpam` offers "Move to Inbox" on a message just reported as
+  // spam — which would add INBOX and keep SPAM.
+  next.inTrash = labels.indexOf("TRASH") >= 0
+  next.inSpam = labels.indexOf("SPAM") >= 0
+  next.isSent = labels.indexOf("SENT") >= 0
+  next.isDraft = labels.indexOf("DRAFT") >= 0
   return next
 }
 

--- a/cache/Cache.js
+++ b/cache/Cache.js
@@ -9,7 +9,11 @@
 // caches, which is the entire reason a cache exists. Everything here is pure:
 // CacheStore.qml owns the file.
 
-var VERSION = 1
+// Bumped for the summary fields a page is read for: rows written before
+// `inSpam` and `isSent` existed answer "not spam" to a menu that asks, and
+// offer to move a spam message to the inbox until the first load replaces
+// them. Bodies are separate files, so a bump costs one cold list load.
+var VERSION = 2
 var MAX_QUERIES = 12
 var MAX_SUMMARIES_PER_QUERY = 100
 // Bodies are the one thing worth keeping deep: a message body never changes, so

--- a/components/MessageMenu.qml
+++ b/components/MessageMenu.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls as QQC
 import qs.Commons
 import qs.Ui
 import "Menu.js" as Menu
+import "../account/Model.js" as Model
 
 // The list's right-click menu. It is a Popup rather than a child of the row
 // because the list scrolls inside a clipping Flickable, which would cut the
@@ -23,7 +24,29 @@ Item {
   property real anchorY: 0
   property int cursorIndex: -1
   readonly property var menuRows: [replyRow, replyAllRow, forwardRow, archiveRow,
+    unarchiveRow,
     trashRow, spamRow, readRow, starRow, browserRow]
+  // Whether this message is archived — out of the inbox and not somewhere
+  // that has its own verb. Read off the summary the menu was opened on rather
+  // than asked of the service, because the menu is about one message. IMAP
+  // synthesises all four of these from the folder, so one rule serves both
+  // kinds of provider.
+  readonly property bool archived: !!root.summary
+    && root.summary.inInbox === false
+    && root.summary.inTrash !== true
+    && root.summary.inSpam !== true
+    && root.summary.isSent !== true
+    && root.summary.isDraft !== true
+
+  // Whether the list it was opened from is a label's, and whether that label
+  // is one a message can be taken out of — which is the same question
+  // `labelChangesFor` asks, so the wording cannot promise a removal that does
+  // not happen.
+  readonly property bool inLabelView: !!root.service
+    && !!root.service.hasLabels
+    && String(root.service.rawLabelId || "") !== ""
+    && !Model.isSystemLabelId(String(root.service.rawLabelId || ""))
+
   readonly property bool opened: menu.opened
   readonly property var summary: {
     if (!service || messageId === "") return null
@@ -132,9 +155,24 @@ Item {
       // meant "move to a folder" would be a promise this cannot keep.
       MenuRow {
         id: archiveRow
-        visible: !root.service || root.service.canArchive
+        visible: (!root.service || root.service.canArchive) && !root.archived
         text: "Archive"
         onActivated: root.run("archive")
+      }
+      // The other direction, and only where it would be the truth.
+      //
+      // `inInbox === false` alone put this row in Spam, Trash, Drafts and
+      // Sent, where adding INBOX is not what "move to the inbox" means:
+      // `labelChangesFor` removes neither SPAM nor TRASH, so a spam message
+      // would carry INBOX *and* SPAM and stay in Spam while the row claimed
+      // otherwise, and on IMAP the same press physically relocates a draft
+      // out of the Drafts folder. Spam has its own verb and trash has its own
+      // endpoint, for exactly this reason; archived mail is what is left.
+      MenuRow {
+        id: unarchiveRow
+        visible: (!root.service || root.service.canArchive) && root.archived
+        text: root.inLabelView ? "Move to Inbox and remove label" : "Move to Inbox"
+        onActivated: root.run("unarchive")
       }
       MenuRow { id: trashRow; text: "Move to trash"; tone: root.urgentColor; onActivated: root.run("trash") }
       MenuRow {

--- a/message/Message.js
+++ b/message/Message.js
@@ -838,6 +838,8 @@ function summarize(message, now) {
     important: hasLabel(message, "IMPORTANT"),
     inInbox: hasLabel(message, "INBOX"),
     inTrash: hasLabel(message, "TRASH"),
+    inSpam: hasLabel(message, "SPAM"),
+    isSent: hasLabel(message, "SENT"),
     isDraft: hasLabel(message, "DRAFT"),
     labelIds: labelIds(message).slice(),
     sizeEstimate: Math.max(0, Math.floor(Number(message && message.sizeEstimate) || 0))

--- a/tests/qml/tst_message_menu_inbox.qml
+++ b/tests/qml/tst_message_menu_inbox.qml
@@ -1,0 +1,189 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../../components" as Omamail
+
+// "Move to Inbox", where it appears and what it says.
+//
+// The rule is the whole feature: `inInbox === false` alone put this row in
+// Spam, Trash, Drafts and Sent, where adding INBOX is not what it means —
+// `labelChangesFor` removes neither SPAM nor TRASH, so the message would carry
+// both and stay where it was while the row claimed otherwise. Nothing in the
+// suite touched either menu before this.
+Item {
+  width: 500
+  height: 500
+
+  QtObject {
+    id: fakeService
+
+    property bool canArchive: true
+    property bool canReportSpam: true
+    property bool canStar: true
+    property bool canOpenOnWeb: false
+    property bool hasLabels: true
+    property string rawLabelId: ""
+    property var messages: []
+    property var unavailableActions: []
+
+    // What was asked of it.
+    property string ranAction: ""
+    property string ranId: ""
+
+    function act(id, action) {
+      ranId = String(id || "")
+      ranAction = String(action || "")
+      return true
+    }
+    function toggleStar(_id) {}
+  }
+
+  Omamail.MessageMenu {
+    id: menu
+    anchors.fill: parent
+    service: fakeService
+    textColor: Qt.rgba(0.1, 0.1, 0.1, 1)
+    urgentColor: Qt.rgba(0.8, 0.1, 0.1, 1)
+    dimColor: Qt.rgba(0.45, 0.45, 0.45, 1)
+    popupBackgroundColor: Qt.rgba(0.95, 0.95, 0.95, 1)
+    popupBorderColor: Qt.rgba(0.6, 0.6, 0.6, 1)
+    panelFontFamily: "monospace"
+  }
+
+  SignalSpy {
+    id: actionSpy
+    target: menu
+    signalName: "actionRequested"
+  }
+
+  TestCase {
+    name: "MessageMenuInbox"
+    when: windowShown
+
+    function rowFor(name) {
+      for (var i = 0; i < menu.menuRows.length; i++) {
+        var row = menu.menuRows[i]
+        if (row && String(row.objectName || "") === name) return row
+      }
+      return null
+    }
+
+    // The rows have no objectName, so they are found by position in the array
+    // the cursor itself indexes — which is also the thing that has to contain
+    // the new row at all.
+    function unarchiveRow() { return menu.menuRows[4] }
+    function archiveRow() { return menu.menuRows[3] }
+
+    // The popup builds its rows only once opened, so nothing about their
+    // visibility is readable before that.
+    function show(summary) {
+      fakeService.messages = [summary]
+      fakeService.ranAction = ""
+      fakeService.ranId = ""
+      fakeService.rawLabelId = ""
+      menu.close()
+      actionSpy.clear()
+      menu.openAt(String(summary.id), 100, 100)
+      wait(20)
+    }
+
+    function cleanup() { menu.close() }
+
+    function archivedMessage() {
+      return { id: "m1", subject: "filed", unread: false, starred: false,
+        inInbox: false, inTrash: false, inSpam: false, isSent: false,
+        isDraft: false, labelIds: ["Label_17"] }
+    }
+
+    // ---------------------------------------------------- where it appears
+
+    function test_an_archived_message_offers_it_in_place_of_archive() {
+      show(archivedMessage())
+      compare(menu.archived, true)
+      compare(unarchiveRow().visible, true)
+      compare(archiveRow().visible, false,
+        "a message out of the inbox cannot be archived again")
+    }
+
+    function test_an_inbox_message_offers_archive_instead() {
+      var summary = archivedMessage()
+      summary.inInbox = true
+      show(summary)
+      compare(menu.archived, false)
+      compare(unarchiveRow().visible, false)
+      compare(archiveRow().visible, true)
+    }
+
+    // The four that have their own verb or their own place. Adding INBOX to any
+    // of them is not what "move to the inbox" means.
+    function test_it_is_not_offered_where_it_would_lie_data() {
+      return [
+        { tag: "spam", field: "inSpam" },
+        { tag: "trash", field: "inTrash" },
+        { tag: "sent", field: "isSent" },
+        { tag: "draft", field: "isDraft" }
+      ]
+    }
+
+    function test_it_is_not_offered_where_it_would_lie(row) {
+      var summary = archivedMessage()
+      summary[row.field] = true
+      show(summary)
+      compare(menu.archived, false, row.tag + " has its own verb or its own place")
+      compare(unarchiveRow().visible, false)
+    }
+
+    // ------------------------------------------------------- what it says
+
+    function test_from_a_label_it_says_the_label_goes_too() {
+      show(archivedMessage())
+      compare(unarchiveRow().text, "Move to Inbox")
+
+      fakeService.rawLabelId = "Label_17"
+      compare(menu.inLabelView, true)
+      compare(unarchiveRow().text, "Move to Inbox and remove label")
+    }
+
+    // The wording asks the same question `labelChangesFor` does, so it cannot
+    // promise a removal that will not happen.
+    function test_a_system_label_is_not_a_label_it_can_remove() {
+      show(archivedMessage())
+      fakeService.rawLabelId = "IMPORTANT"
+      compare(menu.inLabelView, false)
+      compare(unarchiveRow().text, "Move to Inbox")
+    }
+
+    // A folder provider's `rawLabelId` is a folder name, which is not a Gmail
+    // label id and must not be promised as one.
+    function test_a_folder_provider_promises_no_label_removal() {
+      show(archivedMessage())
+      fakeService.rawLabelId = "Archive"
+      fakeService.hasLabels = false
+      compare(menu.inLabelView, false)
+      compare(unarchiveRow().text, "Move to Inbox")
+      fakeService.hasLabels = true
+    }
+
+    // -------------------------------------------------------- the routing
+
+    function test_choosing_it_asks_for_unarchive_on_that_message() {
+      show(archivedMessage())
+      unarchiveRow().activated()
+
+      compare(actionSpy.count, 1)
+      compare(actionSpy.signalArguments[0][0], "unarchive")
+      compare(actionSpy.signalArguments[0][1], "m1",
+        "and names the message the menu was opened on")
+      compare(menu.opened, false, "choosing a row closes the menu")
+    }
+
+    // The cursor is an index into `menuRows`, so a row drawn but unlisted is
+    // mouse-only: j and k step over it and Enter can never reach it.
+    function test_the_keyboard_can_reach_it() {
+      show(archivedMessage())
+      var listed = false
+      for (var i = 0; i < menu.menuRows.length; i++)
+        if (menu.menuRows[i] === unarchiveRow()) listed = true
+      verify(listed, "the row has to be in the array the cursor indexes")
+    }
+  }
+}

--- a/tests/qml/tst_message_menu_inbox.qml
+++ b/tests/qml/tst_message_menu_inbox.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtTest 1.3
 import "../../components" as Omamail
+import "../../account/Model.js" as Model
 
 // "Move to Inbox", where it appears and what it says.
 //
@@ -23,18 +24,6 @@ Item {
     property bool hasLabels: true
     property string rawLabelId: ""
     property var messages: []
-    property var unavailableActions: []
-
-    // What was asked of it.
-    property string ranAction: ""
-    property string ranId: ""
-
-    function act(id, action) {
-      ranId = String(id || "")
-      ranAction = String(action || "")
-      return true
-    }
-    function toggleStar(_id) {}
   }
 
   Omamail.MessageMenu {
@@ -59,14 +48,6 @@ Item {
     name: "MessageMenuInbox"
     when: windowShown
 
-    function rowFor(name) {
-      for (var i = 0; i < menu.menuRows.length; i++) {
-        var row = menu.menuRows[i]
-        if (row && String(row.objectName || "") === name) return row
-      }
-      return null
-    }
-
     // The rows have no objectName, so they are found by position in the array
     // the cursor itself indexes — which is also the thing that has to contain
     // the new row at all.
@@ -77,8 +58,6 @@ Item {
     // visibility is readable before that.
     function show(summary) {
       fakeService.messages = [summary]
-      fakeService.ranAction = ""
-      fakeService.ranId = ""
       fakeService.rawLabelId = ""
       menu.close()
       actionSpy.clear()
@@ -178,12 +157,42 @@ Item {
 
     // The cursor is an index into `menuRows`, so a row drawn but unlisted is
     // mouse-only: j and k step over it and Enter can never reach it.
+    //
+    // Walked rather than looked up. Searching `menuRows` for `menuRows[4]` is
+    // true of whatever that array holds, which is how the first version of
+    // this passed with the row unlisted.
     function test_the_keyboard_can_reach_it() {
       show(archivedMessage())
-      var listed = false
-      for (var i = 0; i < menu.menuRows.length; i++)
-        if (menu.menuRows[i] === unarchiveRow()) listed = true
-      verify(listed, "the row has to be in the array the cursor indexes")
+      var steps = 0
+      while (steps < menu.menuRows.length
+        && (menu.cursorIndex < 0
+          || menu.menuRows[menu.cursorIndex].text !== "Move to Inbox")) {
+        menu.moveCursor(1)
+        steps++
+      }
+      compare(menu.menuRows[menu.cursorIndex].text, "Move to Inbox",
+        "j steps onto the row rather than over it")
+
+      menu.runCursor()
+      compare(actionSpy.count, 1)
+      compare(actionSpy.signalArguments[0][0], "unarchive",
+        "and Enter on it asks for the action")
+    }
+
+    // The two halves composed, which is where this went wrong: the row the
+    // menu reads after a press is the one `applyLabelChange` wrote, and that
+    // used to carry a stale `inSpam`. Reporting spam from the inbox left
+    // "Move to Inbox" on offer — a press that adds INBOX, keeps SPAM, and
+    // leaves the message sitting in Spam.
+    function test_a_message_just_reported_as_spam_is_not_offered_it() {
+      var summary = archivedMessage()
+      summary.inInbox = true
+      summary.labelIds = ["INBOX"]
+      show(Model.applyLabelChange(summary, "spam"))
+
+      compare(menu.summary.inSpam, true, "the row is in Spam the moment it is reported")
+      compare(menu.archived, false)
+      compare(unarchiveRow().visible, false)
     }
   }
 }

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -717,3 +717,50 @@ assert.strictEqual(model.wheelScrollTarget(4770, -NOTCH, 5000, 300, 0, 50, 70), 
 assert.strictEqual(model.wheelScrollTarget(-200, -NOTCH, 4200, 300, -200, 0, 0), -80)
 assert.strictEqual(model.wheelScrollTarget(-200, NOTCH, 4200, 300, -200, 0, 0), -200,
   "and the header stays reachable")
+// ------------------------------------------- moving back into the inbox
+
+// The same pattern a `label:` move already writes: a message filed under a
+// label and pulled back into the inbox has been dealt with, and leaving the
+// label on it means it is still waiting in a list it is no longer in.
+deepEqual(model.labelChangesFor("unarchive", "Label_17"),
+  { add: ["INBOX"], remove: ["Label_17"] })
+deepEqual(model.labelChangesFor("unarchive"), { add: ["INBOX"], remove: [] })
+deepEqual(model.labelChangesFor("unarchive", ""), { add: ["INBOX"], remove: [] })
+
+// Never a system label: INBOX would undo the move it is part of, and UNREAD,
+// STARRED or a CATEGORY_ are states rather than places a message is filed
+// under. The same fact `survivesAction` asks, so the two cannot disagree.
+deepEqual(model.labelChangesFor("unarchive", "INBOX"), { add: ["INBOX"], remove: [] })
+deepEqual(model.labelChangesFor("unarchive", "CATEGORY_PERSONAL"),
+  { add: ["INBOX"], remove: [] })
+assert.strictEqual(model.isSystemLabelId("Label_17"), false)
+assert.strictEqual(model.isSystemLabelId("IMPORTANT"), true)
+assert.strictEqual(model.isSystemLabelId("CATEGORY_UPDATES"), true)
+
+// A provider that files by folder answers this with a UID MOVE: the message is
+// given a new id in INBOX, nothing parses COPYUID, and a surviving row would
+// point at a message that is no longer there.
+assert.strictEqual(model.survivesAction("archive", "unarchive", "", false), false,
+  "a folder provider relocates, so the row cannot stay")
+assert.strictEqual(model.survivesAction("all", "unarchive", "label:TODO", false), false)
+
+// A label provider keeps the message in a mailbox or a search, and takes it
+// out of the label whose list it was found in.
+assert.strictEqual(model.survivesAction("all", "unarchive", "", true), true)
+assert.strictEqual(model.survivesAction("all", "unarchive", "label:TODO", true), false)
+
+// The third argument is still main's query string, not a boolean. Passing a
+// boolean here would have read every non-empty query as "in a label view" at
+// every existing call site.
+assert.strictEqual(model.survivesAction("inbox", "archive", ""), false,
+  "archive still leaves the inbox")
+assert.strictEqual(model.survivesAction("all", "archive", ""), true)
+
+// End to end on a summary: the label goes, INBOX arrives, the derived flags
+// follow, and the original is untouched.
+const filed = { id: "m1", labelIds: ["Label_17", "IMPORTANT"], unread: false,
+  starred: false, inInbox: false }
+const moved = model.applyLabelChange(filed, "unarchive", "Label_17")
+deepEqual(moved.labelIds, ["IMPORTANT", "INBOX"])
+assert.strictEqual(moved.inInbox, true)
+assert.strictEqual(filed.labelIds.indexOf("Label_17"), 0)

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -729,7 +729,8 @@ deepEqual(model.labelChangesFor("unarchive", ""), { add: ["INBOX"], remove: [] }
 
 // Never a system label: INBOX would undo the move it is part of, and UNREAD,
 // STARRED or a CATEGORY_ are states rather than places a message is filed
-// under. The same fact `survivesAction` asks, so the two cannot disagree.
+// under. `survivesAction` asks this function rather than reading the rule
+// again, which is asserted below rather than assumed here.
 deepEqual(model.labelChangesFor("unarchive", "INBOX"), { add: ["INBOX"], remove: [] })
 deepEqual(model.labelChangesFor("unarchive", "CATEGORY_PERSONAL"),
   { add: ["INBOX"], remove: [] })
@@ -747,7 +748,21 @@ assert.strictEqual(model.survivesAction("all", "unarchive", "label:TODO", false)
 // A label provider keeps the message in a mailbox or a search, and takes it
 // out of the label whose list it was found in.
 assert.strictEqual(model.survivesAction("all", "unarchive", "", true), true)
-assert.strictEqual(model.survivesAction("all", "unarchive", "label:TODO", true), false)
+assert.strictEqual(model.survivesAction("all", "unarchive", "label:TODO", true), false,
+  "a label view with nothing naming its label cannot say the label stayed")
+
+// The two answering together, which is the whole of it: a system label's list
+// is not a place a message is filed under, so the label stays on the message
+// and the row stays in the list. Paired against `labelChangesFor` rather than
+// against a constant, because a constant would let the two drift apart again.
+deepEqual(model.labelChangesFor("unarchive", "IMPORTANT").remove, [])
+assert.strictEqual(
+  model.survivesAction("all", "unarchive", "label:important", true, "IMPORTANT"), true,
+  "the label stays, so the row stays")
+deepEqual(model.labelChangesFor("unarchive", "Label_17").remove, ["Label_17"])
+assert.strictEqual(
+  model.survivesAction("all", "unarchive", "label:todo", true, "Label_17"), false,
+  "the label comes off, so the row goes")
 
 // The third argument is still main's query string, not a boolean. Passing a
 // boolean here would have read every non-empty query as "in a label view" at
@@ -764,3 +779,20 @@ const moved = model.applyLabelChange(filed, "unarchive", "Label_17")
 deepEqual(moved.labelIds, ["IMPORTANT", "INBOX"])
 assert.strictEqual(moved.inInbox, true)
 assert.strictEqual(filed.labelIds.indexOf("Label_17"), 0)
+
+// Every flag that mirrors a label follows the labels, not the three that used
+// to be read. Reporting spam is the press that moves a row between two of
+// them, and a menu asking a stale `inSpam` offers "Move to Inbox" on the
+// message just reported — a press that would add INBOX, keep SPAM, and leave
+// it sitting in Spam.
+const reported = model.applyLabelChange(
+  { id: "m2", labelIds: ["UNREAD", "INBOX"], inInbox: true, inSpam: false }, "spam")
+deepEqual(reported.labelIds, ["UNREAD", "SPAM"])
+assert.strictEqual(reported.inInbox, false)
+assert.strictEqual(reported.inSpam, true, "the row is in Spam the moment it is reported")
+const binned = model.applyLabelChange(
+  { id: "m3", labelIds: ["Label_17"], isSent: true, isDraft: true, inTrash: true },
+  "unarchive", "Label_17")
+assert.strictEqual(binned.isSent, false)
+assert.strictEqual(binned.isDraft, false)
+assert.strictEqual(binned.inTrash, false)

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -892,6 +892,27 @@ for file in components/AppMenu.qml components/MessageMenu.qml; do
   fi
 done
 
+# A row that is drawn but left out of `menuRows` is mouse-only: the cursor is an
+# index into that array, so j and k step over the row, Enter can never reach it,
+# and `MenuActionRow.selected` never matches. "Move to Inbox" was added to the
+# column and left out of the array.
+python3 - <<'MENUROWS'
+import re
+from pathlib import Path
+
+for name in ("components/AppMenu.qml", "components/MessageMenu.qml"):
+    source = Path(name).read_text()
+    listed = re.search(r"property var menuRows: \[(.*?)\]", source, re.S)
+    if not listed:
+        raise SystemExit("test_source.sh: %s must list its rows in menuRows" % name)
+    known = set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", listed.group(1)))
+    drawn = re.findall(r"MenuRow \{\s*id: ([A-Za-z_][A-Za-z0-9_]*)", source)
+    missing = [row for row in drawn if row not in known]
+    if missing:
+        raise SystemExit("test_source.sh: %s draws %s without listing it in menuRows"
+                         % (name, ", ".join(missing)))
+MENUROWS
+
 # Feature views receive semantic colours from App. Reading theme roles locally
 # makes the same concept drift between pages and prevents App from naming it.
 for file in components/AppMenu.qml components/MessageMenu.qml components/AccountSwitcher.qml \


### PR DESCRIPTION
`unarchive` has been in the action vocabulary all along — in `labelChangesFor`, in `actionCapability`, and `flagPlanForLabels` already turns it into a move into `INBOX`. Nothing ever offered it, so there was no way to put a message back in the inbox from inside the application.

It is a row in the message menu now, in place of Archive rather than beside it.

## The label is the point

From a label's list, moving a message to the inbox also takes it out of that label, and the row says so. A label somebody files things under — TODO, Waiting, Later — is a queue, and one that keeps everything ever put in it only grows.

This writes the same pair a `label:` move already writes, using #83's `rawLabelId` and `sourceLabelId`, so a folder name never reaches a Gmail remove list and a system label is never removed. `isSystemLabelId` is one fact asked in two places — by `labelChangesFor` before it removes anything, and by the menu before it promises a removal — so the wording cannot offer one that will not happen.

## Where the row appears

Only where it is the truth: out of the inbox, and not somewhere that has its own verb.

`inInbox === false` alone would put it in Spam, Trash, Drafts and Sent, where adding `INBOX` is not what "move to the inbox" means. `labelChangesFor` removes neither `SPAM` nor `TRASH`, so a spam message would carry `INBOX` *and* `SPAM` and stay in Spam while the row claimed otherwise; on IMAP the same press physically relocates a draft out of `\Drafts`. Spam has its own verb and trash has its own endpoint for exactly that reason.

`summarize` gained `inSpam` and `isSent` to say this. IMAP synthesises all four from the folder in `labelIdsFor`, so one rule serves both kinds of provider.

The row the menu reads is the one `applyLabelChange` wrote, and that maintained three of these flags and left the rest as they were — so reporting spam from the inbox produced a row carrying `SPAM` whose `inSpam` still said false, and the menu went on offering the press this rule exists to prevent. Every flag that mirrors a label follows the labels now. The cache version goes with it, because the page a menu reads is the page the cache paints first and rows written before `inSpam` existed answer "not spam" to a menu that asks; bodies are separate files, so the bump costs one cold list load.

## Whether the row survives

`survivesAction` keeps its `rawQuery` string third argument and gains two more: whether the provider files by label or by folder, and which label the list is. The first is the one thing it cannot infer, and `unarchive` is the action that turns on it.

The second is there so the two answers cannot disagree. `survivesAction` asks `labelChangesFor` whether the label actually comes off rather than reading the system-label rule a second time — in a system label's list the label stays on the message, and so the row stays in the list. A label view with nothing naming its label still evicts: a row that leaves and should not have comes back on the reload `invalidatesPage` asks for, and one that stays and should not have is stale until something else loads the list.

A folder provider answers with a `UID MOVE`. The message is given a new UID in `INBOX`, nothing parses `COPYUID`, and the row it left would point at a message that is no longer there — opening it says so, a star succeeds against nothing, and `invalidatesPage` would not reload to correct it. So on a folder provider the row never survives.

Scoped to `unarchive` on purpose: a `label:` move from All mail on IMAP has the same shape, and extending it there uninvited seemed worse than naming it.

## Verification

`make validate` green, 254 QML assertions.

`tests/test_model.js` covers the label arithmetic, the system-label refusal, and both providers' answers to `survivesAction`. `tests/qml/tst_message_menu_inbox.qml` covers the QML layer, which had none: the visibility rule against all four of spam, trash, sent and draft, both wordings, the system-label and folder-provider cases, and the routing.

Mutation-checked five ways: reverting the gating to `inInbox` alone fails four tests; removing the row from `menuRows` fires the `test_source.sh` guard and fails the keyboard test, which walks the cursor onto the row rather than looking it up; removing the folder-provider branch from `survivesAction` fails a node assertion; reverting `applyLabelChange` to the three flags it used to maintain fails the spam case; and reverting `survivesAction` to reading the system-label rule itself fails a pair asserted against `labelChangesFor` rather than against a constant.

## Release Notes

- A message can be moved back to the inbox from the message menu, which nothing offered before. The row appears in place of Archive, on messages that are out of the inbox.
- Done from a label's list it also takes the message out of that label, so a label used as a queue empties as things are dealt with instead of only growing.

