### PR TITLE
calendar: Unwrap XML CDATA in CalDAV responses

### DIFF
--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -78,7 +78,11 @@ function tagText(block, localName) {
   var pattern = new RegExp("<(?:[A-Za-z0-9_-]+:)?" + name
     + "(?:\\s[^>]*)?>([\\s\\S]*?)</(?:[A-Za-z0-9_-]+:)?" + name + ">", "i")
   var match = pattern.exec(String(block || ""))
-  return match ? decodeXml(match[1]) : ""
+  if (!match) return ""
+  var text = match[1]
+  if (/<!\[CDATA\[/i.test(text))
+    return text.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/gi, "$1")
+  return decodeXml(text)
 }
 
 function caldavResponses(xml) {

--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -72,17 +72,41 @@ function decodeXml(value) {
     .replace(/&amp;/g, "&")
 }
 
+// An element's text, with both of the encodings a server is allowed to use.
+// RFC 4791 section 9.6 lets a calendar object arrive entity-escaped or inside a
+// CDATA section, and servers send the second: DAViCal wraps every object, and
+// this reached the project from an iCloud account whose calendars read empty.
+// Unwrapped, the payload begins `<![CDATA[BEGIN:VCALENDAR`, which is not a
+// property line, so the parse finds no VCALENDAR root and there are no events.
+//
+// The two encodings cannot be undone in one pass. A CDATA section's content is
+// already literal — `&amp;` inside one is those five characters, and a summary
+// of "Q&amp;A" would come out "Q&A" if the entity pass ran over it. So the
+// markers are cut and the entity pass runs only on the text between sections,
+// which is where the entities an escaping server wrote actually are.
+function decodeXmlText(value) {
+  var text = String(value || "")
+  var out = ""
+  var index = 0
+  while (true) {
+    // Case-sensitive: `<![cdata[` is ordinary text in XML, not a section.
+    var start = text.indexOf("<![CDATA[", index)
+    if (start < 0) break
+    var end = text.indexOf("]]>", start + 9)
+    if (end < 0) break
+    out += decodeXml(text.substring(index, start)) + text.substring(start + 9, end)
+    index = end + 3
+  }
+  return out + decodeXml(text.substring(index))
+}
+
 function tagText(block, localName) {
   var name = String(localName || "").replace(/[^A-Za-z0-9_-]/g, "")
   if (name === "") return ""
   var pattern = new RegExp("<(?:[A-Za-z0-9_-]+:)?" + name
     + "(?:\\s[^>]*)?>([\\s\\S]*?)</(?:[A-Za-z0-9_-]+:)?" + name + ">", "i")
   var match = pattern.exec(String(block || ""))
-  if (!match) return ""
-  var text = match[1]
-  if (/<!\[CDATA\[/i.test(text))
-    return text.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/gi, "$1")
-  return decodeXml(text)
+  return match ? decodeXmlText(match[1]) : ""
 }
 
 function caldavResponses(xml) {

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -156,13 +156,29 @@ assert.strictEqual(parsed[0].sourceId, "work")
 assert.strictEqual(parsed[0].href, "/cal/a.ics")
 assert.strictEqual(parsed[1].start.allDay, true)
 
-const cdataXml = '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">'
-  + '<d:response><d:href>/cal/cdata.ics</d:href><d:propstat><d:prop>'
-  + '<c:calendar-data><![CDATA[BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:cdata\r\nSUMMARY:iCloud Event\r\nDTSTART:20260824T080000Z\r\nDTEND:20260824T083000Z\r\nEND:VEVENT\r\nEND:VCALENDAR]]></c:calendar-data>'
-  + '</d:prop></d:propstat></d:response></d:multistatus>'
+// A server may send the calendar object in a CDATA section instead of escaping
+// it, which RFC 4791 allows and DAViCal and iCloud do. Unwrapped, its first
+// line reads `<![CDATA[BEGIN:VCALENDAR` and the collection parses to nothing.
+const cdataXml = '<?xml version="1.0" encoding="UTF-8"?>'
+  + '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">'
+  + '<d:response><d:href>/cal/cdata.ics</d:href><d:propstat>'
+  + '<d:prop><d:getetag>"C=1@U=cdata"</d:getetag>'
+  + '<c:calendar-data><![CDATA[BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:cdata\r\nSUMMARY:R&D sync &amp; Q&A\r\nDTSTART:20260824T080000Z\r\nDTEND:20260824T083000Z\r\nEND:VEVENT\r\nEND:VCALENDAR]]></c:calendar-data>'
+  + '</d:prop><d:status>HTTP/1.1 200 OK</d:status>'
+  + '</d:propstat></d:response></d:multistatus>'
 const cdataParsed = feed.eventsFromCaldav(cdataXml, "work")
 assert.strictEqual(cdataParsed.length, 1)
-assert.strictEqual(cdataParsed[0].summary, "iCloud Event")
+assert.strictEqual(cdataParsed[0].href, "/cal/cdata.ics")
+// Nothing inside a CDATA section is escaped, so the entity pass must not touch
+// it: "&amp;" there is those five characters and a summary keeps them.
+assert.strictEqual(cdataParsed[0].summary, "R&D sync &amp; Q&A")
+
+// Both encodings can appear in one element. The entities outside the section
+// are decoded; the section's own content is handed over exactly as it arrived.
+assert.strictEqual(
+  feed.tagText('<c:calendar-data>A &amp; B&#13;<![CDATA[C &amp; D]]>'
+    + ' &lt;end&gt;</c:calendar-data>', "calendar-data"),
+  "A & B\rC &amp; D <end>")
 
 const recurringXml = [
   '<?xml version="1.0"?>',

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -156,6 +156,14 @@ assert.strictEqual(parsed[0].sourceId, "work")
 assert.strictEqual(parsed[0].href, "/cal/a.ics")
 assert.strictEqual(parsed[1].start.allDay, true)
 
+const cdataXml = '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">'
+  + '<d:response><d:href>/cal/cdata.ics</d:href><d:propstat><d:prop>'
+  + '<c:calendar-data><![CDATA[BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:cdata\r\nSUMMARY:iCloud Event\r\nDTSTART:20260824T080000Z\r\nDTEND:20260824T083000Z\r\nEND:VEVENT\r\nEND:VCALENDAR]]></c:calendar-data>'
+  + '</d:prop></d:propstat></d:response></d:multistatus>'
+const cdataParsed = feed.eventsFromCaldav(cdataXml, "work")
+assert.strictEqual(cdataParsed.length, 1)
+assert.strictEqual(cdataParsed[0].summary, "iCloud Event")
+
 const recurringXml = [
   '<?xml version="1.0"?>',
   '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">',


### PR DESCRIPTION
Apple iCloud (and some other CalDAV servers) wrap `<c:calendar-data>` XML responses in `<![CDATA[ ... ]]>`.

Currently, `tagText()` in `calendar/Calendar.js` passes the inner text directly to `decodeXml()` without stripping CDATA markers. As a result, the parsed iCalendar payload starts with `<![CDATA[BEGIN:VCALENDAR...`, causing `Ics.eventsFrom()` to fail to detect the `VCALENDAR` root and return zero events.

This change:
- Unwraps `<![CDATA[ ... ]]>` in `tagText()` before decoding XML entities.
- Adds regression test coverage in `tests/test_calendar_feed.js`.
- Verified against live Apple iCloud CalDAV endpoints.