### PR TITLE
Speed up JavaScript message rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ test-js:
 	node tests/test_html.js
 	node tests/test_direction.js
 	node tests/test_cache.js
+	node tests/test_render_cache.js
 	node tests/test_model.js
 	node tests/test_icons.js
 	node tests/test_navigation.js

--- a/Service.qml
+++ b/Service.qml
@@ -1064,6 +1064,7 @@ Item {
       // only the first one may claim it.
       mayAdoptLegacyToken: index === 0 && (!entry || entry.provider === "gmail")
       settings: root.settings
+      bodyMode: root.bodyMode
       // Every mailbox obeys the one answer: it is about what the reader is
       // willing to tell a sender, not about which account the mail came to.
       alwaysShowImages: root.alwaysShowImages

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -13,6 +13,7 @@ import "../message/Unsubscribe.js" as Unsub
 import "../message/Outbox.js" as Outbox
 import "Model.js" as Model
 import "Accounts.js" as Accounts
+import "RenderCache.js" as RenderCache
 import "../providers/Registry.js" as Provider
 import "../providers/ImapProtocol.js" as Imap
 import "../providers/OAuth.js" as OAuth
@@ -68,6 +69,9 @@ Item {
 
   // The window drives this; the unread poll keeps running while it is false.
   property bool windowOpen: false
+  // The representation currently on screen. Reader mode needs its rebuild on
+  // the first paint; the other modes let that work finish on the next turn.
+  property string bodyMode: "reader"
   // Keyed by attachmentId, holding only the saves that are in flight.
   property var savingAttachmentIds: ({})
 
@@ -219,6 +223,12 @@ Item {
   // do — those clear themselves after a few seconds, and this is the answer to
   // a question the user may look back at the message to ask.
   property string unsubscribeDone: ""
+
+  // Parsed trees are expensive and immutable after sanitize returns. Keep only
+  // the recent working set in memory; the durable cache remains the sender's
+  // source HTML so sanitizer fixes still apply after a restart.
+  property var renderCache: RenderCache.create(12)
+  onAccountIdChanged: renderCache = RenderCache.create(12)
 
   // Which of this account's own addresses this message arrived at.
   //
@@ -1096,14 +1106,22 @@ Item {
   // know about this body comes back from the same call — how heavy it is, and
   // its plain-text reading — because each of those asked separately is another
   // parse of the whole message to work out what was just worked out.
-  function renderSource(source, withPlainText) {
+  function renderSource(source, withPlainText, completeReader) {
     sourceHtml = String(source || "")
-    var ready = Html.sanitize(sourceHtml, ({
-      allowRemoteImages: remoteImagesAllowed,
-      remoteImageData: remoteImagesAllowed ? remoteImageData : null,
-      withPlainText: withPlainText === true,
-      withReader: true
-    }))
+    withPlainText = withPlainText === true
+    var eagerReader = completeReader === true || bodyMode === "reader" || remoteImagesAllowed
+    var ready = remoteImagesAllowed ? null
+      : RenderCache.get(renderCache, selectedId, sourceHtml, withPlainText)
+    if (!ready) {
+      ready = Html.sanitize(sourceHtml, ({
+        allowRemoteImages: remoteImagesAllowed,
+        remoteImageData: remoteImagesAllowed ? remoteImageData : null,
+        withPlainText: withPlainText,
+        withReader: eagerReader
+      }))
+      if (!remoteImagesAllowed && eagerReader)
+        RenderCache.put(renderCache, selectedId, sourceHtml, withPlainText, ready)
+    }
     selectedHtml = ready.html
     selectedDocument = ready.document
     selectedReaderDocument = ready.reader ? ready.reader.document : null
@@ -1118,6 +1136,16 @@ Item {
       && Object.keys(remoteImageData).length === 0
       && selectedRemoteImageSources.length > 0)
       Qt.callLater(root.prepareRemoteImages)
+    if (!ready.reader && !remoteImagesAllowed && !eagerReader) {
+      var deferredId = selectedId
+      var deferredSource = sourceHtml
+      var deferredSerial = detailSerial
+      Qt.callLater(function() {
+        if (root.detailSerial !== deferredSerial || root.selectedId !== deferredId
+          || root.sourceHtml !== deferredSource) return
+        root.renderSource(deferredSource, withPlainText, true)
+      })
+    }
     return ready
   }
 

--- a/account/RenderCache.js
+++ b/account/RenderCache.js
@@ -1,0 +1,52 @@
+.pragma library
+
+// A small process-local cache of parsed message bodies. The disk cache keeps
+// the sender's source so sanitizer fixes apply after a restart; this only
+// avoids doing the same work again while the account object is alive.
+
+function create(limit) {
+  return {
+    limit: Math.max(0, Math.floor(Number(limit) || 0)),
+    values: {},
+    order: []
+  }
+}
+
+function keyOf(id) {
+  return "$" + String(id || "")
+}
+
+function removeFromOrder(cache, key) {
+  for (var i = 0; i < cache.order.length; i++) {
+    if (cache.order[i] !== key) continue
+    cache.order.splice(i, 1)
+    return
+  }
+}
+
+function get(cache, id, source, withPlainText) {
+  if (!cache || cache.limit < 1) return null
+  var key = keyOf(id)
+  var entry = cache.values[key]
+  if (!entry || entry.source !== String(source || "")
+    || entry.withPlainText !== (withPlainText === true)) return null
+  removeFromOrder(cache, key)
+  cache.order.push(key)
+  return entry.value
+}
+
+function put(cache, id, source, withPlainText, value) {
+  if (!cache || cache.limit < 1 || String(id || "") === "" || !value) return
+  var key = keyOf(id)
+  removeFromOrder(cache, key)
+  cache.values[key] = {
+    source: String(source || ""),
+    withPlainText: withPlainText === true,
+    value: value
+  }
+  cache.order.push(key)
+  while (cache.order.length > cache.limit) {
+    var oldest = cache.order.shift()
+    delete cache.values[oldest]
+  }
+}

--- a/message/Html.js
+++ b/message/Html.js
@@ -111,6 +111,20 @@ function readTag(text, from, out) {
   var name = text.substring(nameStart, at)
   if (upper) name = name.toLowerCase()
 
+  // Closing tags carry no attributes. Nearly every one ends here, so do not
+  // allocate an empty list or enter the start-tag attribute scanner for the
+  // common half of a document's tags. Odd malformed closings still take the
+  // tolerant path below and keep its existing behaviour.
+  if (closing) {
+    var closeAt = at
+    while (closeAt < length && isSpaceCode(text.charCodeAt(closeAt))) closeAt++
+    if (text.charCodeAt(closeAt) === 62) {
+      out.end = closeAt + 1
+      out.terminated = true
+      return { type: "end", name: name }
+    }
+  }
+
   var attributes = []
   var selfClosing = false
   while (at < length) {
@@ -330,8 +344,10 @@ function parse(html) {
     var top = stack[stack.length - 1]
 
     if (token.type === "text") {
-      if (token.text !== "")
-        top.children.push({ type: "text", text: token.text, raw: token.raw === true })
+      // This token already is the tree node's exact shape and is never reused
+      // by the streaming tokenizer. Keep it instead of allocating and copying
+      // every text run in the message.
+      if (token.text !== "") top.children.push(token)
       return
     }
     // A comment or a doctype has nothing a reader needs, and Qt would lay the
@@ -735,6 +751,20 @@ function splitDeclarations(style) {
   return declarations
 }
 
+// Reader mode, image discovery and the formatted cleaner all inspect the
+// sender's original style before `clean` rewrites it. Keep that one parse on
+// the source node so style-heavy mail does not rescan the same string in every
+// walk. The cache is deliberately source-only: fitting later reads the cleaned
+// style from attrs and calls splitDeclarations directly.
+function sourceDeclarations(node) {
+  if (node._sourceDeclarationsRead === true) return node._sourceDeclarations
+  var style = attributeOf(node, "style")
+  node._sourceDeclarationsRead = true
+  node._sourceDeclarations = style !== null && style.value !== null
+    && style.value !== undefined ? splitDeclarations(style.value) : null
+  return node._sourceDeclarations
+}
+
 function joinDeclarations(declarations) {
   var parts = []
   for (var i = 0; i < declarations.length; i++) {
@@ -851,7 +881,7 @@ function isTrackingPixel(node) {
   var height = Number(attributeValue(node, "height"))
   if (isFinite(width) && attributeValue(node, "width") !== "" && width <= 2) return true
   if (isFinite(height) && attributeValue(node, "height") !== "" && height <= 2) return true
-  var declarations = splitDeclarations(attributeValue(node, "style"))
+  var declarations = sourceDeclarations(node) || []
   for (var i = 0; i < declarations.length; i++) {
     if (declarations[i].name !== "width" && declarations[i].name !== "height") continue
     if (/^[012](\.\d+)?px/i.test(declarations[i].value)) return true
@@ -964,39 +994,6 @@ var MAX_TABLE_DEPTH = 4
 // then handlers, then hrefs, then styles — rebuilt the array four times for
 // every element in the document, which on a large message is most of the work.
 var HANDLER_ATTRIBUTE = /^on[a-z]+$/
-
-// The addresses a caller may prepare before Qt receives the document. Taken
-// from the parsed tree so asking for them costs no second parse, with the same
-// tracker, host and count rules the renderer uses.
-function readerRemoteImageSources(root, limit) {
-  var out = []
-  var seen = {}
-
-  function walk(node) {
-    for (var i = 0; i < node.children.length && out.length < limit; i++) {
-      var child = node.children[i]
-      if (child.type === "text") continue
-      if (DROPPED_ELEMENTS[child.name] === true) continue
-      var style = attributeOf(child, "style")
-      var declarations = style !== null && style.value !== null && style.value !== undefined
-        ? splitDeclarations(style.value) : null
-      if (declarations !== null && VOID_ELEMENTS[child.name] !== true
-        && isHiddenBy(declarations)) continue
-      if (child.name === "img") {
-        var source = attributeValue(child, "src")
-        if (imageSourceKind(source) === "remote" && !isTrackingPixel(child)
-          && seen[source] !== true) {
-          seen[source] = true
-          out.push(source)
-        }
-      }
-      walk(child)
-    }
-  }
-
-  walk(root)
-  return out
-}
 
 // The sender centres a 600px card in the middle of a wide window. This reader
 // is a panel of left-aligned text beside a left-aligned list, and the same
@@ -1211,6 +1208,8 @@ function sanitize(html, options) {
   var blocked = 0
   var kept = 0
   var loadable = 0
+  var remoteSources = []
+  var seenRemoteSources = {}
 
   function preparedImage(source) {
     if (imageData === null || !Object.prototype.hasOwnProperty.call(imageData, source)) return ""
@@ -1267,12 +1266,22 @@ function sanitize(html, options) {
       // survives of its declarations are two questions about the same list.
       // Most elements in real mail carry one, so asking twice was most of a
       // second pass over the document.
-      var style = attributeOf(child, "style")
-      var declarations = style !== null && style.value !== null && style.value !== undefined
-        ? splitDeclarations(style.value)
-        : null
+      var declarations = sourceDeclarations(child)
       if (declarations !== null && VOID_ELEMENTS[child.name] !== true
         && isHiddenBy(declarations)) continue
+
+      // Collect fetch candidates while this walk already has the sender's
+      // unmodified attributes in hand. Keeping this before promotion and
+      // cleaning preserves the tracker and source rules without traversing
+      // the complete tree a second time.
+      if (child.name === "img" && remoteSources.length < limit) {
+        var remoteSource = attributeValue(child, "src")
+        if (imageSourceKind(remoteSource) === "remote" && !isTrackingPixel(child)
+          && seenRemoteSources[remoteSource] !== true) {
+          seenRemoteSources[remoteSource] = true
+          remoteSources.push(remoteSource)
+        }
+      }
 
       promoteImageDimensions(child, declarations)
       promoteDirection(child, declarations)
@@ -1288,7 +1297,6 @@ function sanitize(html, options) {
   }
 
   var root = parse(source)
-  var remoteSources = readerRemoteImageSources(root, limit)
 
   // Read as text before anything is dropped, and only when a caller asked: the
   // reader wants both of these for a message with no text/plain part of its
@@ -1978,7 +1986,7 @@ function readerHidden(node) {
   for (var i = 0; i < node.children.length; i++) {
     if (node.children[i].type !== "text") { leaf = false; break }
   }
-  return readerHiddenBy(splitDeclarations(style), leaf)
+  return readerHiddenBy(sourceDeclarations(node) || [], leaf)
 }
 
 // ------------------------------------------------------------- what it points at
@@ -2020,7 +2028,7 @@ function readerImageDimension(node, name) {
   var raw = attributeValue(node, name)
   var value = /^\s*\d+(?:\.\d+)?\s*$/.test(raw) ? Number(raw) : 0
   if (!(value > 0)) {
-    var declarations = splitDeclarations(attributeValue(node, "style"))
+    var declarations = sourceDeclarations(node) || []
     for (var i = 0; i < declarations.length; i++) {
       if (declarations[i].name !== name) continue
       var match = String(declarations[i].value).match(/^\s*(\d+(?:\.\d+)?)px\s*$/i)
@@ -2120,7 +2128,7 @@ function readerHeadingOf(node) {
   var style = attributeValue(node, "style")
   if (style === "") return ""
   if (style.toLowerCase().indexOf("font-size") < 0) return ""
-  var declarations = splitDeclarations(style)
+  var declarations = sourceDeclarations(node) || []
   var level = ""
   for (var i = 0; i < declarations.length; i++) {
     if (declarations[i].name !== "font-size") continue

--- a/tests/qml/tst_render_cache.qml
+++ b/tests/qml/tst_render_cache.qml
@@ -1,0 +1,70 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../../account" as Account
+import "../../account/RenderCache.js" as RenderCache
+
+Item {
+  Account.MailAccount {
+    id: account
+    pluginDir: "/tmp/omamail-render-cache-test"
+    active: false
+    windowOpen: false
+    bodyMode: "original"
+  }
+
+  TestCase {
+    name: "RenderCache"
+    when: windowShown
+
+    function init() {
+      account.clearSelection()
+      account.accountId = "account-one"
+      account.renderCache = RenderCache.create(12)
+      account.bodyMode = "original"
+    }
+
+    function test_reader_rebuild_is_deferred_then_cached() {
+      account.selectedId = "message-one"
+      var first = account.renderSource("<p>First message</p>", true)
+
+      compare(first.reader, null, "original mode does not rebuild reading mode on its paint path")
+      compare(account.selectedReaderDocument, null)
+
+      wait(0)
+      verify(account.selectedReaderDocument !== null,
+        "the next event-loop turn completes the reading document")
+
+      var cached = RenderCache.get(account.renderCache, "message-one",
+        "<p>First message</p>", true)
+      verify(cached !== null)
+      compare(account.renderSource("<p>First message</p>", true), cached,
+        "reopening returns the cached render result")
+    }
+
+    function test_a_stale_deferred_render_cannot_replace_the_new_selection() {
+      account.selectedId = "message-one"
+      account.renderSource("<p>Old message</p>", false)
+      account.detailSerial++
+      account.selectedId = "message-two"
+      // Complete the current message immediately. If the older callback is
+      // not guarded it runs afterwards and becomes the final visible state.
+      account.renderSource("<p>Current message</p>", false, true)
+
+      wait(0)
+      verify(account.selectedHtml.indexOf("Current message") >= 0)
+      verify(account.selectedHtml.indexOf("Old message") < 0)
+      verify(account.selectedReaderDocument !== null)
+    }
+
+    function test_changing_account_identity_drops_render_entries() {
+      account.selectedId = "message-one"
+      account.renderSource("<p>First message</p>", false, true)
+      verify(RenderCache.get(account.renderCache, "message-one",
+        "<p>First message</p>", false) !== null)
+
+      account.accountId = "account-two"
+      compare(RenderCache.get(account.renderCache, "message-one",
+        "<p>First message</p>", false), null)
+    }
+  }
+}

--- a/tests/test_html.js
+++ b/tests/test_html.js
@@ -43,6 +43,13 @@ const html = load("message/Html.js")
   assert.strictEqual(html.stripColors("<img src=a.png width=600>"),
     "<img src=\"a.png\" width=\"600\">")
   assert.strictEqual(html.stripColors("<input disabled>"), "<input disabled>")
+  const closing = { end: 0, terminated: false }
+  const closingToken = html.readTag("</p>", 0, closing)
+  assert.strictEqual(closingToken.type, "end")
+  assert.strictEqual(closingToken.name, "p")
+  assert.strictEqual(closingToken.attrs, undefined,
+    "an ordinary closing tag does not allocate an attribute list")
+  assert.strictEqual(closing.end, 4)
   // A single-quoted value is re-quoted, so the quote inside it has to go.
   assert.strictEqual(html.stripColors("<a title='say \"hi\"'>t</a>"),
     "<a title=\"say &quot;hi&quot;\">t</a>")
@@ -82,6 +89,19 @@ const html = load("message/Html.js")
   // A title is not body text either, and nearly every marketing mail ships one.
   assert.strictEqual(html.sanitize("<head><title>Newsletter</title></head><p>real</p>").html,
     "<head></head><p>real</p>")
+}
+
+// The sanitised and reading documents ask the same source element about its
+// style. Parsing that declaration list once per phase made style-heavy mail do
+// the same character scan repeatedly.
+{
+  const node = html.parse('<p style="color:red; padding: 4px">x</p>').children[0]
+  const first = html.sourceDeclarations(node)
+  const second = html.sourceDeclarations(node)
+  assert.strictEqual(first, second, "source declarations are cached on their node")
+  assert.strictEqual(first.length, 2)
+  assert.strictEqual(first[1].name, "padding")
+  assert.strictEqual(html.sourceDeclarations(html.parse("<p>x</p>").children[0]), null)
 }
 
 // A tree is walked by recursion everywhere downstream, so a message nested a

--- a/tests/test_render_cache.js
+++ b/tests/test_render_cache.js
@@ -1,0 +1,39 @@
+const assert = require("assert")
+const { load } = require("./load")
+
+const cache = load("account/RenderCache.js")
+
+let entries = cache.create(2)
+const one = { html: "one" }
+const two = { html: "two" }
+const three = { html: "three" }
+
+cache.put(entries, "m1", "<p>one</p>", true, one)
+cache.put(entries, "m2", "<p>two</p>", false, two)
+
+assert.strictEqual(cache.get(entries, "m1", "<p>one</p>", true), one,
+  "the same message, source and plain-text mode hit")
+assert.strictEqual(cache.get(entries, "m1", "<p>changed</p>", true), null,
+  "changed source misses")
+assert.strictEqual(cache.get(entries, "m1", "<p>one</p>", false), null,
+  "a different plain-text request misses")
+
+// Reading m1 made it newest, so inserting m3 evicts m2.
+cache.put(entries, "m3", "<p>three</p>", true, three)
+assert.strictEqual(cache.get(entries, "m2", "<p>two</p>", false), null)
+assert.strictEqual(cache.get(entries, "m1", "<p>one</p>", true), one)
+assert.strictEqual(cache.get(entries, "m3", "<p>three</p>", true), three)
+
+// Replacing an id does not consume another slot and the old source stops
+// matching immediately.
+const replaced = { html: "new one" }
+cache.put(entries, "m1", "<p>new one</p>", true, replaced)
+assert.strictEqual(cache.get(entries, "m1", "<p>one</p>", true), null)
+assert.strictEqual(cache.get(entries, "m1", "<p>new one</p>", true), replaced)
+
+entries = cache.create(0)
+cache.put(entries, "m1", "x", false, one)
+assert.strictEqual(cache.get(entries, "m1", "x", false), null,
+  "a disabled cache retains nothing")
+
+console.log("render cache tests passed")

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -111,14 +111,24 @@ grep -q 'out.push(escapeMarkup(node.text))' message/Html.js \
 if grep -nE 'Html\.(sanitize|readerTree)\(' components/MessageReader.qml; then
   fail "the reader view must not sanitise a body; the account renders it once"
 fi
-grep -q 'withReader: true' account/MailAccount.qml \
-  || fail "the reading document must come off the same parse as the formatted one"
+grep -q 'withReader: eagerReader' account/MailAccount.qml \
+  || fail "the current reading mode must decide whether reader rebuilding is on the paint path"
+grep -q 'Qt.callLater(function()' account/MailAccount.qml \
+  || fail "a deferred reading document must be completed outside the first paint"
+grep -q 'RenderCache.get(renderCache, selectedId, sourceHtml, withPlainText)' account/MailAccount.qml \
+  || fail "reopening a cached body must reuse its process-local parsed documents"
+grep -q 'RenderCache.put(renderCache, selectedId, sourceHtml, withPlainText, ready)' account/MailAccount.qml \
+  || fail "a parsed body must enter the bounded process-local render cache"
+grep -q 'onAccountIdChanged: renderCache = RenderCache.create(12)' account/MailAccount.qml \
+  || fail "the render cache must not cross account identities"
 grep -q 'remoteImageData: remoteImagesAllowed ? remoteImageData : null' account/MailAccount.qml \
   || fail "Qt must receive prepared image bytes rather than a pending remote source"
 grep -q 'max-redirs = 0' scripts/image-fetch.sh \
   || fail "the image fetcher must not follow an unchecked redirect"
 grep -q 'property string bodyMode: "reader"' Service.qml \
   || fail "a message opens in reading mode"
+grep -q 'bodyMode: root.bodyMode' Service.qml \
+  || fail "each account must know which body representation is on the paint path"
 # Choosing between three readings that were all built when the body arrived is a
 # preference and nothing else. A mode switch that re-rendered would re-run the
 # image policy, and one that re-fetched would tell the sender the mail was


### PR DESCRIPTION
## Summary
- add a bounded per-account LRU cache for sanitized message render results
- reduce sanitizer tree walks, CSS parsing, and tokenizer/tag allocations
- defer reader-document rebuilding when another body mode is initially visible
- cover cache reuse, invalidation, and deferred-render races with JS and QML tests

## Performance
On the 311 KB QML benchmark fixture, first rendering improved from about 114.67 ms to 109 ms. Reopening a recent message now skips sanitization through the render cache.

## Validation
- QT_QPA_PLATFORMTHEME= make validate
- 220 QML checks passed, 0 failed
- omarchy plugin validate .
- git diff --check