### PR TITLE
Say which version is running in the empty reader

### DIFF
--- a/Service.qml
+++ b/Service.qml
@@ -44,6 +44,15 @@ Item {
     ? String(manifest.id) : "omamail"
   readonly property string pluginDir: manifest && manifest.__sourceDir
     ? String(manifest.__sourceDir) : ""
+  // Shown in the empty reader, so a screenshot in a bug report says which build
+  // it came from. The shell's manifest validation requires both fields, so a
+  // loaded plugin always has them; the fallbacks are for a harness that
+  // constructs the service with a stub manifest, and an empty version makes the
+  // interface say nothing rather than guess a number.
+  readonly property string pluginName: manifest && manifest.name
+    ? String(manifest.name) : "Omamail"
+  readonly property string version: manifest && manifest.version
+    ? String(manifest.version) : ""
 
   readonly property var defaultSettingValues: ({
     refreshIntervalSec: 120,

--- a/components/ReaderBlankSlate.qml
+++ b/components/ReaderBlankSlate.qml
@@ -30,6 +30,17 @@ Item {
   // above it is the part that carries information.
   readonly property bool showLegend: height > Style.space(300) && width > Style.space(320)
 
+  readonly property string versionText: !!service && service.version
+    ? String(service.pluginName || "Omamail") + " " + String(service.version)
+    : ""
+  // The column above is centred, so what is left under it is half the leftover
+  // height — and that has to hold the label, its margin, and a gap wide enough
+  // that the two do not read as one block. A constant threshold cannot do this:
+  // the column is more than twice as tall with the shortcut legend as without.
+  readonly property bool showVersion: versionText !== ""
+    && (height - centeredColumn.height) / 2
+       >= versionLabel.implicitHeight + Style.space(12) + Style.space(12)
+
   readonly property var keys: [
     { key: "j / k", action: "Move through the list" },
     { key: "Enter or o", action: "Open the selected message" },
@@ -40,6 +51,7 @@ Item {
   ]
 
   Column {
+    id: centeredColumn
     anchors.centerIn: parent
     width: Math.min(parent.width - Style.space(48), Style.space(340))
     spacing: Style.space(10)
@@ -144,5 +156,24 @@ Item {
         font.pixelSize: Style.font.caption
       }
     }
+  }
+
+  // Not part of the column above: the legend hides itself on a narrow pane and
+  // the version has no reason to move when it does. Quietest thing on screen —
+  // it is there to be found, not read.
+  Text {
+    id: versionLabel
+    objectName: "reader-version"
+    anchors.bottom: parent.bottom
+    anchors.bottomMargin: Style.space(12)
+    anchors.horizontalCenter: parent.horizontalCenter
+    width: Math.min(parent.width - Style.space(48), Style.space(340))
+    horizontalAlignment: Text.AlignHCenter
+    visible: root.showVersion
+    text: root.versionText
+    color: root.dimmerColor
+    font.family: root.panelFontFamily
+    font.pixelSize: Style.font.caption
+    elide: Text.ElideRight
   }
 }

--- a/tests/qml/tst_reader_blank_slate.qml
+++ b/tests/qml/tst_reader_blank_slate.qml
@@ -1,0 +1,150 @@
+import QtQuick 2.15
+import QtTest 1.3
+
+// The version number belongs where somebody reporting a bug will already be
+// looking: the empty reader. The pane it sits in is resized by the window and
+// by the three-column-to-one collapse, so the interesting cases are geometric —
+// it must not land on top of the centred block at any height, and the shortcut
+// legend disappearing must not take it along.
+Item {
+  width: 400
+  height: 400
+
+  QtObject {
+    id: mailService
+    property string providerId: "gmail"
+    property string mailboxKey: "inbox"
+    property string searchQuery: ""
+    property bool listLoaded: true
+    property bool listLoading: false
+    property var messages: [({ id: "m1" })]
+    property string pluginName: "Omamail"
+    property string version: "0.7.0"
+  }
+
+  Loader {
+    id: blankSlateLoader
+    width: 400
+    height: 400
+    Component.onCompleted: setSource("../../components/ReaderBlankSlate.qml", ({
+      service: mailService,
+      textColor: Qt.rgba(1, 1, 1, 1),
+      accentColor: Qt.rgba(0.4, 0.6, 1, 1),
+      dimColor: Qt.rgba(0.67, 0.67, 0.67, 1),
+      dimmerColor: Qt.rgba(0.47, 0.47, 0.47, 1),
+      panelFontFamily: "monospace"
+    }))
+  }
+
+  // Nothing signed in yet, and the reader is handed no service at all.
+  Loader {
+    id: serviceless
+    width: 400
+    height: 400
+    Component.onCompleted: setSource("../../components/ReaderBlankSlate.qml", ({
+      service: null,
+      textColor: Qt.rgba(1, 1, 1, 1),
+      accentColor: Qt.rgba(0.4, 0.6, 1, 1),
+      dimColor: Qt.rgba(0.67, 0.67, 0.67, 1),
+      dimmerColor: Qt.rgba(0.47, 0.47, 0.47, 1),
+      panelFontFamily: "monospace"
+    }))
+  }
+
+  TestCase {
+    name: "ReaderBlankSlate"
+    when: windowShown
+
+    function named(item, objectName) {
+      if (!item) return null
+      if (item.objectName === objectName) return item
+      var values = item.children || []
+      for (var i = 0; i < values.length; i++) {
+        var found = named(values[i], objectName)
+        if (found) return found
+      }
+      return null
+    }
+
+    function slate() {
+      tryCompare(blankSlateLoader, "status", Loader.Ready)
+      return blankSlateLoader.item
+    }
+
+    function version() {
+      var label = named(slate(), "reader-version")
+      verify(label, "the blank slate must carry an identifiable version label")
+      return label
+    }
+
+    // A Column repositions on the next polish, so a size assigned and read back
+    // in the same frame reports the previous layout — and the stale answer is
+    // the conservative one, which is how a broken guard passes unnoticed.
+    // forceLayout settles it now rather than waiting on a frame, so the sweep
+    // below stays a few milliseconds instead of a few seconds.
+    function resize(width, height) {
+      blankSlateLoader.width = width
+      blankSlateLoader.height = height
+      slate().children[0].forceLayout()
+    }
+
+    // The centred block and the bottom label are laid out by different anchors,
+    // so only their coordinates can say whether they are printing on each other.
+    function overlapping(label) {
+      var column = label.parent.children[0]
+      var columnBottom = column.y + column.height
+      return label.visible && columnBottom > label.y
+    }
+
+    function init() {
+      mailService.pluginName = "Omamail"
+      mailService.version = "0.7.0"
+      blankSlateLoader.width = 400
+      blankSlateLoader.height = 400
+    }
+
+    function test_names_the_running_version() {
+      var label = version()
+      compare(label.text, "Omamail 0.7.0")
+      verify(label.visible)
+    }
+
+    function test_follows_the_name_the_manifest_gives() {
+      mailService.pluginName = "Forkmail"
+      compare(version().text, "Forkmail 0.7.0")
+    }
+
+    function test_outlasts_the_shortcut_legend() {
+      var label = version()
+      resize(200, 240)
+      verify(!slate().showLegend,
+        "this pane must be too small for the legend, or the test proves nothing")
+      verify(label.visible, "the version outlives the legend it is not part of")
+    }
+
+    // The heights either side of every threshold, one pixel at a time: a guard
+    // derived against the short column silently fails once the legend doubles it.
+    function test_never_prints_over_the_centred_block() {
+      var label = version()
+      for (var h = 120; h <= 520; h++) {
+        resize(400, h)
+        verify(!overlapping(label),
+          "version label overlaps the centred column at height " + h
+            + (slate().showLegend ? " (legend shown)" : ""))
+      }
+    }
+
+    function test_says_nothing_without_a_version() {
+      var label = version()
+      mailService.version = ""
+      verify(!label.visible)
+    }
+
+    function test_says_nothing_without_a_service() {
+      tryCompare(serviceless, "status", Loader.Ready)
+      var label = named(serviceless.item, "reader-version")
+      verify(label, "the label exists even with no service behind it")
+      verify(!label.visible)
+    }
+  }
+}


### PR DESCRIPTION
A bug report arrives as a screenshot of the window, and until now the
window did not say which build it was. The empty reader is where that
belongs: it is the pane somebody is looking at before they pick a
message, it already exists to say what is going on rather than to
decorate, and one quiet line at the floor costs it nothing.

`version` and `name` are required fields the shell already validates and
hands over in the manifest, so `Service` only has to expose them. The
label is deliberately outside the centred column: the shortcut legend
hides itself once the pane is narrow, and the version has no reason to
move when it does.

That independence is also the trap. The centred column is more than
twice as tall with the legend as without, so a constant height threshold
cannot tell when the two collide — one derived against the short column
lets the label print on top of "? for every shortcut" through a band of
perfectly ordinary reader heights. The guard measures the column instead
and asks whether what is left under it holds the label, its margin and a
gap.

## Verification

`make validate` green on this commit: 228 QML checks passed, 0 failed,
`omarchy plugin validate .` and `git diff --check` clean.

`tests/qml/tst_reader_blank_slate.qml` sweeps every height from 120 to
520 and fails on the first one where the label's box crosses the
column's. Watched it fail against a constant threshold — "version label
overlaps the centred column at height 161" — and pass with the measured
one. It also covers the label outliving the legend, the name coming from
the manifest rather than a literal, and the two states that hide it: no
version, and no service at all.

By hand, offscreen: Tokyo Night and Rose Pine, at 460x520 with the
legend and 280x320 without, plus 420x320 — the size that overlapped
before, where the label now stays away. Unmodified `dimmerColor` reads
as the quietest thing on screen in both themes; an earlier alpha on top
of it did not survive the light one.

A fresh agent reviewed the diff and found the overlap, that the test
missed the legend-visible geometry, the alpha, the hard-coded product
name, and a missing elide. All five are fixed here.

## Release Notes

- The empty reader now shows which version of Omamail is running, so a
  screenshot in a bug report says what it was taken on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjBFdyje8tBGpCu5KJjGcY