### PR TITLE
Keep the libcurl-dependent IMAP check off the release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,16 +42,18 @@ jobs:
       # The parsing, formatting and decision rules are plain JS and the source
       # checks are shell, so those need nothing at all and run here.
       #
-      # Two gates stay local. qmllint needs the Omarchy shell on the import
-      # path, which a runner does not have. The QML tests need the Qt the
-      # plugin actually runs on: Ubuntu ships 6.4 and Omarchy is current, and
-      # they exercise exactly the engine behaviour that differs between them —
-      # shortcut objects rebuilt when a context changes fire on one and not the
-      # other. Running them here would report on an engine nobody uses.
+      # Three gates stay local, and for one reason: each reports on a version of
+      # something the plugin does not run on. qmllint needs the Omarchy shell on
+      # the import path, which a runner does not have. The QML tests need the Qt
+      # the plugin actually runs on — Ubuntu ships 6.4 and Omarchy is current,
+      # and they exercise exactly the engine behaviour that differs between
+      # them: shortcut objects rebuilt when a context changes fire on one and
+      # not the other. `test-shell-libcurl` asserts which of libcurl's two
+      # output channels carries a fetched message, which its version decides.
       #
-      # `make test` includes them, so it is not what runs here.
+      # `make test` includes all three, so it is not what runs here.
       - name: Test
-        run: make test-js test-shell
+        run: make test-js test-shell-portable
 
       - name: Publish the release
         env:

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/WeekCalendarView.qml \
 	bar/BarPreview.qml
 
-.PHONY: test test-js test-shell test-qml qml-check validate bench install
+.PHONY: test test-js test-shell test-shell-portable test-shell-libcurl \
+	test-qml qml-check validate bench install
 
 test: test-js test-shell test-qml
 
@@ -95,7 +96,11 @@ test-js:
 	node tests/test_imap.js
 	node tests/test_hey.js
 
-test-shell:
+test-shell: test-shell-portable test-shell-libcurl
+
+# Everything here drives one of our own scripts against a fake server and
+# asserts what the script did with the answer, so any libcurl can run it.
+test-shell-portable:
 	python3 tests/test_contacts.py
 	python3 tests/test_qml_names.py
 	python3 tests/test_qml_text_format.py
@@ -105,7 +110,6 @@ test-shell:
 	bash tests/test_link_plugin.sh
 	bash tests/test_mailto.sh
 	bash tests/test_transport.sh
-	bash tests/test_imap_ordering.sh
 	bash tests/test_unsubscribe_transport.sh
 	bash tests/test_image_fetch.sh
 	bash tests/test_attachment_open.sh
@@ -115,6 +119,16 @@ test-shell:
 	bash tests/test_calendar_write.sh
 	bash tests/test_calendar_delete.sh
 	bash tests/test_release_notes.sh
+
+# This one asserts libcurl's own behaviour rather than ours: which of its two
+# output channels a single-UID BODY.PEEK fetch arrives on. That is a property
+# of the installed libcurl and it differs by version — Omarchy's 8.21 puts the
+# message on stdout, and the libcurl on a GitHub runner delivers neither the
+# body there nor a complete one through the header callback. Running it on a
+# runner reports on a library nobody here runs, which is why the release
+# workflow does not, and why `make test` still does.
+test-shell-libcurl:
+	bash tests/test_imap_ordering.sh
 
 # Focus ownership and key routing cannot be tested without a focus scope, and a
 # focus scope needs the QML engine. Offscreen, so it needs no compositor: the


### PR DESCRIPTION
`tests/test_imap_ordering.sh` arrived with #82, after v0.7.0 was cut, so
v0.8.0 was the first tag whose release workflow ran it — and it failed
there twice in a row while passing on every machine that develops this.

What it asserts is not ours. libcurl decides which of its two output
channels carries the answer to a single-UID `BODY.PEEK[]` fetch: 8.21
puts the message on stdout, and the libcurl on a GitHub runner puts
neither the body there nor a complete one through the header callback,
so the reply is the literal announcement and nothing after it. The test
is right about the library Omarchy ships and cannot be right about both.

That is the same reason qmllint and the QML tests already stay local —
each of the three reports on a version of something the plugin does not
run on — so this joins them rather than inventing a new exception.
`test-shell` still runs everything it ran before, and so `make test` and
`make validate` are unchanged; the runner gets `test-shell-portable`,
which is every shell check that asserts what one of our own scripts did
with an answer rather than how curl delivered it.

## Verification

`make validate` green on this commit: 228 QML checks passed, 0 failed,
`omarchy plugin validate .` and `git diff --check` clean.

`make test-js test-shell-portable` — exactly what the runner now runs —
exits 0 locally, and `make test-shell-libcurl` runs the moved test on its
own and passes on curl 8.21.0.

Checked that the split drops nothing: the set of `tests/` files named by
`test-shell-portable` and `test-shell-libcurl` together is identical to
the set the old `test-shell` named, and no `tests/*.sh` or `tests/*.py`
is unreferenced by the Makefile.

The failure itself was read from the two red runs of workflow 33893162536
on tag v0.8.0, both stopping at the same assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjBFdyje8tBGpCu5KJjGcY