### PR TITLE
Show the status line's address whole, and let the key hints give way to it

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -1835,11 +1835,14 @@ Item {
           anchors.leftMargin: railToggle.visible
             ? Style.space(9) - (railToggle.size - railToggle.iconSize) / 2
             : Style.space(14)
-          // An invisible sibling still holds its place, so the hints must only
-          // take room from this line while they are actually on screen.
-          anchors.right: statusBar.hasNotice
-            ? notice.left
-            : (keyHints.visible ? keyHints.left : parent.right)
+          // The address runs to the end of the line and the hints take what it
+          // leaves. Stopping at the hints instead asked a question with no
+          // answer: the slot wanted to know how much the hints had left over
+          // while the hints wanted to know whether the address had left them
+          // room. A notice is the one thing that does push the address over,
+          // because a notice is what the window most needs to say and it says
+          // it only while there is something wrong.
+          anchors.right: statusBar.hasNotice ? notice.left : parent.right
           anchors.rightMargin: Style.space(12)
           anchors.verticalCenter: parent.verticalCenter
           height: Style.space(24)
@@ -1937,10 +1940,19 @@ Item {
 
         KeyHints {
           id: keyHints
+          objectName: "status-key-hints"
           anchors.right: parent.right
           anchors.rightMargin: Style.space(14)
           anchors.verticalCenter: parent.verticalCenter
-          visible: !statusBar.hasNotice && !root.compact
+          // Only once the address has been given its room, and only whole:
+          // hints are a nicety and the address is a fact, so the run of them
+          // steps off the line rather than arriving with its last pair cut in
+          // half. `accountSlot` no longer measures itself against this, which
+          // is what keeps the two from asking each other.
+          readonly property real roomLeft: statusBar.width
+            - (accountSlot.x + accountControl.width)
+            - Style.space(12) - Style.space(14)
+          visible: !statusBar.hasNotice && !root.compact && roomLeft >= implicitWidth
           textColor: root.foreground
           dimColor: root.dimmer
           accentColor: root.accent

--- a/App.qml
+++ b/App.qml
@@ -1848,7 +1848,16 @@ Item {
             id: accountControl
             objectName: "status-account-button"
             property bool selected: accountSwitcher.opened
-            width: Math.min(parent.width, accountText.implicitWidth + Style.space(8))
+            // One inset, counted twice, rather than asked for again as its own
+            // double. `Style.space` rounds, and a theme whose spacing follows
+            // the font does not round the two the same way: at `base-size 14`
+            // the scale is 7/6, which makes `space(4)` 5 a side while
+            // `space(8)` is 9 — a box a pixel narrower than the text it holds.
+            // The text was then elided at every window width, which is what put
+            // "just n..." on the line and why it looked like a fixed width: the
+            // cut had nothing to do with how much room there was.
+            readonly property real inset: Style.space(4)
+            width: Math.min(parent.width, accountText.implicitWidth + inset * 2)
             height: parent.height
 
             Rectangle {
@@ -1866,10 +1875,11 @@ Item {
 
             Text {
               id: accountText
+              objectName: "status-account-label"
               anchors.left: parent.left
-              anchors.leftMargin: Style.space(4)
+              anchors.leftMargin: accountControl.inset
               anchors.right: parent.right
-              anchors.rightMargin: Style.space(4)
+              anchors.rightMargin: accountControl.inset
               anchors.verticalCenter: parent.verticalCenter
               // The full address lives here at every window width; the sync
               // age follows it, and the line opens the account controls.

--- a/tests/qml/imports/qs/Commons/Style.qml
+++ b/tests/qml/imports/qs/Commons/Style.qml
@@ -13,7 +13,18 @@ QtObject {
     controlHeight: 30, controlGap: 6, sm: 3, md: 6
   })
 
-  function space(value) { return Number(value) }
+  // The shell's own `space` is `round(px * scale)`, and the rounding is the
+  // point rather than an implementation detail: a theme whose spacing follows
+  // the font — `base-size 14` gives 7/6 — makes `space(4)` 5 while `space(8)`
+  // is 9, so a box that pads by one and measures itself by the other comes out
+  // a pixel short. A stub that multiplied nothing could not see that, and did
+  // not. Tests that care set `spacingScale`; the rest run at 1, where this
+  // rounds integers to themselves.
+  property real spacingScale: 1
+  function space(value) {
+    var n = Number(value) * spacingScale
+    return n <= 0 ? 0 : Math.max(1, Math.round(n))
+  }
   function hoverFillFor(_foreground, accent) { return accent }
   function selectedFillFor(_foreground, accent) { return accent }
   function selectionFillFor(_foreground, accent) { return accent }

--- a/tests/qml/tst_app_navigation.qml
+++ b/tests/qml/tst_app_navigation.qml
@@ -381,6 +381,53 @@ Item {
       switcher.close()
     }
 
+    // The address is what this line is about and the key hints are a nicety
+    // beside it, so the room goes to the address first.
+    function test_the_status_address_keeps_its_room_from_the_key_hints() {
+      // The right of the line carries a notice or the hints, never both, so a
+      // status an earlier test left standing is a line with no hints on it.
+      mailService.actionStatus = ""
+      mailService.lastError = ""
+      app.notice = ""
+      mailService.syncedLabel = "Synced just now"
+      waitForRendering(app)
+
+      var label = named(app, "status-account-label")
+      var hints = named(app, "status-key-hints")
+      verify(label && hints)
+      compare(label.text, "me@example.com \u00b7 just now")
+      verify(!label.truncated, "a short address and its age fit beside the hints")
+      verify(hints.visible, "and the hints keep the room they were left")
+
+      // Grown rather than measured: how many characters fit is a fact about
+      // the theme's font, and what is being asserted is which of the two gives
+      // way, whatever that number turns out to be.
+      var address = "a.long.standing.mailbox.address@example.org"
+      for (var i = 0; i < 20 && hints.visible; i++) {
+        address = "longer." + address
+        mailService.accountEmail = address
+        waitForRendering(app)
+      }
+      verify(!hints.visible, "the hints step off the line rather than cutting the address")
+      verify(!label.truncated, "and the address keeps every character it has room for")
+
+      mailService.accountEmail = "me@example.com"
+      waitForRendering(app)
+      verify(hints.visible, "the hints come back when the address gives the room up")
+
+      // The one thing that still pushes the address over, because a notice is
+      // what the window most needs to say.
+      var slot = label.parent.parent
+      var wide = slot.width
+      mailService.actionStatus = "Moved to Archive"
+      waitForRendering(app)
+      verify(slot.width < wide, "a notice takes the right of the line back")
+
+      mailService.actionStatus = ""
+      mailService.syncedLabel = ""
+      waitForRendering(app)
+    }
+
     // The box around the address pads it by one number and measures itself by
     // another, and `Style.space` rounds each on its own. At the shell's
     // `base-size 14` the two disagree by a pixel, and a Text a pixel short of

--- a/tests/qml/tst_app_navigation.qml
+++ b/tests/qml/tst_app_navigation.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 import QtTest 1.3
+import qs.Commons
 import "../.." as Omamail
 
 // Where the window is, is a history. Every page is an entry on it, every Back
@@ -244,6 +245,9 @@ Item {
     function kinds() { return app.navKinds.join(",") }
 
     function init() {
+      // A test that failed part way through its scales must not leave the next
+      // one measuring at somebody else's.
+      Style.spacingScale = 1
       mailService.log = []
       mailService.lastSavedDraft = null
       mailService.refuseMove = false
@@ -375,6 +379,31 @@ Item {
       tryCompare(switcher, "opened", true)
       compare(trigger.selected, true, "the trigger stays selected while its popup is open")
       switcher.close()
+    }
+
+    // The box around the address pads it by one number and measures itself by
+    // another, and `Style.space` rounds each on its own. At the shell's
+    // `base-size 14` the two disagree by a pixel, and a Text a pixel short of
+    // its own content is elided however wide the window is — which is what put
+    // "just n..." on the line and made it look like a fixed width.
+    function test_the_status_address_is_not_a_pixel_short_of_its_box() {
+      var label = named(app, "status-account-label")
+      verify(label)
+      mailService.syncedLabel = "Synced just now"
+
+      // Every scale a rounded 4 and a rounded 8 can fall out of step on, and a
+      // couple where they agree, because the assertion is the same either way.
+      var scales = [1, 0.9, 7 / 6, 1.25, 1.375, 1.4, 1.5, 1.9]
+      for (var i = 0; i < scales.length; i++) {
+        Style.spacingScale = scales[i]
+        waitForRendering(app)
+        verify(!label.truncated,
+          "the address fits its own box at spacing scale " + scales[i])
+      }
+
+      Style.spacingScale = 1
+      mailService.syncedLabel = ""
+      waitForRendering(app)
     }
 
     function test_header_creation_actions_keep_their_labels() {


### PR DESCRIPTION
The address at the foot of the window was elided at every window width, however much room stood empty beside it. `scott_s829@173.com · just now` arrived as `scott_s829@173.com · just n...`, and because the cut never moved it read as a fixed-width field rather than a truncation.

## The pixel

The box around the address measured itself as `implicitWidth + Style.space(8)` while the text inside was inset `Style.space(4)` on each side. `Style.space` is `round(px * scale)`, and a theme whose spacing follows its font does not round the two the same way: at `base-size 14` the scale is 7/6, where `space(4)` is 5 a side — 10 in total — against a `space(8)` of 9. The box was a pixel narrower than the text it held, so `Text` elided, and no window width could answer a shortfall that never depended on the window.

One inset now pads both sides and is counted twice into the box. It is the same number by construction, whatever the scale rounds it to.

The invariant this restores: a control sized to its content pads and measures with one number, never with a number and its double.

## The line

The account slot also stopped at the key hints, so a long address was shortened to leave the hints their room. That is backwards — the address is the one fact on this line and the hints repeat what the keyboard already does — and it asked a question with no answer, each side waiting to be measured against the other. The slot now runs to the end of the line and the hints measure themselves against it: one direction, no cycle. The hints step off whole rather than arriving with their last pair cut in half, because `KeyHints` is a `Row` with nothing to shrink. A notice still pushes the address over, because that is what the window most needs to say and it says it only while something is wrong.

## Verification

`make validate` passes. The QML stub for `Style` returned `space(px)` as `px`, so the rounding it models did not exist in the tests and neither did the bug; it now rounds the way the shell does and takes a `spacingScale`. Two cases in `tst_app_navigation.qml` cover the results: one walks the spacing scales where a rounded 4 and a rounded 8 fall out of step and asserts the address is never truncated, and one grows the address until the hints can no longer fit beside it and asserts it is the hints that give way. Both were confirmed to fail without the changes.

Checked in the running shell at `base-size 14`, which is where the truncation was reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
