### PR TITLE
Stop marking the mailbox the window is showing in the settings list

### DIFF
--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -596,9 +596,12 @@ Column {
         implicitHeight: Math.max(rowText.implicitHeight, rowActions.implicitHeight)
           + Style.space(16)
         radius: Style.cornerRadius
-        color: modelData.active
-          ? Style.selectedFillFor(root.textColor, root.accentColor)
-          : Style.normalFillFor(root.textColor, root.accentColor)
+        // Which mailbox the window is showing is not a fact about this page.
+        // Nothing here acts on it — `Edit...` acts on its own row, and the
+        // signature section names the mailbox it signs — and the row answers
+        // no click, so marking it borrowed the switcher's "you are here, click
+        // another" fill for a row that switches nothing.
+        color: Style.normalFillFor(root.textColor, root.accentColor)
 
         Column {
           id: rowText
@@ -616,7 +619,6 @@ Column {
             color: root.textColor
             font.family: root.panelFontFamily
             font.pixelSize: Style.font.bodySmall
-            font.bold: row.modelData.active
             elide: Text.ElideMiddle
           }
 
@@ -627,9 +629,8 @@ Column {
                 return row.modelData.error
               if (!row.modelData.signedIn) return "Signed out"
               var count = row.modelData.unread
-              var unread = count === 0 ? "No unread mail"
+              return count === 0 ? "No unread mail"
                 : (count === 1 ? "1 unread message" : count + " unread messages")
-              return row.modelData.active ? unread + " · showing now" : unread
             }
             color: row.modelData.error !== undefined && row.modelData.error !== ""
               ? root.urgentColor : root.dimColor


### PR DESCRIPTION
The mailbox list in Settings said which mailbox the window was on three times over: a selected fill on the row, a bold address, and `· showing now` after the unread count. All three are gone. The rows are now identical — an address, what the mailbox has to say for itself, and `Edit...`.

## Why

Which mailbox the window is showing is not a fact about that page. Nothing there acts on it: `Edit...` acts on the row it sits in, and the signature section names the mailbox it signs and carries its own selector. So the mark told a reader something they could do nothing with, on a page they opened to change a setting.

The fill was borrowed, too. In `AccountSwitcher` the same `selectedFillFor` means "you are here, click another and you move" — on a row that has a tap handler, hover feedback, and the keyboard cursor resting on it when the menu opens. On an inert settings row it asks for a click that has nowhere to go. One colour with two meanings, and the second one answers nothing.

The invariant: a state that no action on the page consumes is not state the page shows.

`modelData.active` now has no reader in `SettingsPage.qml`. It stays on the account summaries for the switcher and the status line, which is where a reader can act on it.

## Verification

`make validate` passes. No test asserted the fill, the weight, or the `showing now` suffix — the string appeared once in the tree, at the line this removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
