### PR TITLE
Queue a row action taken while another is still finishing

### DIFF
--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -320,15 +320,15 @@ Item {
   property string pendingAction: ""
   property string pendingActionQuery: ""
   property var deferredListLoad: null
-  property var queuedQuietActions: []
+  property var queuedActions: []
   property bool sending: false
   property var pendingSend: null
   property int sendSecondsRemaining: 0
   readonly property bool sendPending: pendingSend !== null
 
   onPendingActionChanged: {
-    if (pendingAction === "" && queuedQuietActions.length > 0)
-      Qt.callLater(root.runQueuedQuietAction)
+    if (pendingAction === "" && queuedActions.length > 0)
+      Qt.callLater(root.runQueuedAction)
   }
 
   // Notifications only start once the first successful load has established
@@ -1246,20 +1246,24 @@ Item {
 
   // -------------------------------------------------------------- actions
 
-  function queueQuietAction(messageId, action, actionQuery) {
-    var queued = queuedQuietActions.slice()
+  // `quiet` rides along because it decides whether the row may be evicted from
+  // under an open reader. A queued explicit trash that ran as if it were quiet
+  // would leave the message the user deleted still on screen.
+  function queueAction(messageId, action, actionQuery, quiet) {
+    var queued = queuedActions.slice()
     for (var i = 0; i < queued.length; i++) {
       if (queued[i].id === messageId && queued[i].action === action) return
     }
-    queued.push({ id: messageId, action: action, cacheKey: actionQuery })
-    queuedQuietActions = queued
+    queued.push({ id: messageId, action: action, cacheKey: actionQuery,
+      quiet: quiet === true })
+    queuedActions = queued
   }
 
-  function runQueuedQuietAction() {
-    if (pendingAction !== "" || queuedQuietActions.length === 0) return
-    var queued = queuedQuietActions.slice()
+  function runQueuedAction() {
+    if (pendingAction !== "" || queuedActions.length === 0) return
+    var queued = queuedActions.slice()
     var request = queued.shift()
-    queuedQuietActions = queued
+    queuedActions = queued
 
     // Prefer the normal optimistic path while the row is still in either
     // account view. Navigation may have removed it meanwhile; marking a
@@ -1267,13 +1271,13 @@ Item {
     if (cacheKey === request.cacheKey
         && (Model.indexById(messages, request.id) >= 0
         || Model.indexById(previewMessages, request.id) >= 0)) {
-      act(request.id, request.action, true)
+      act(request.id, request.action, request.quiet)
       return
     }
 
     var change = Model.labelChangesFor(request.action)
     if (request.action !== "trash" && request.action !== "untrash" && !change) {
-      if (queuedQuietActions.length > 0) Qt.callLater(root.runQueuedQuietAction)
+      if (queuedActions.length > 0) Qt.callLater(root.runQueuedAction)
       return
     }
     // The prior action may just have resumed this query's deferred list before
@@ -1335,13 +1339,16 @@ Item {
     // row would be moved, and the note would say "Archived", for a request no
     // server ever saw.
     if (refuseUnavailableAction(action)) return false
+    // One mutation is in flight at a time, because the rollback below restores
+    // a row by the index it held when the action was taken. That is a reason to
+    // make the next action wait, not a reason to drop it: a mailbox is cleared
+    // by pressing the same key down a list faster than any server answers, and
+    // refusing the second press lost the keystroke, left the note explaining a
+    // failure the user had not caused, and — because `act` answered false —
+    // stopped the cursor moving on. Queue it and run it when the slot frees.
     if (pendingAction !== "") {
-      if (quiet === true) {
-        queueQuietAction(messageId, action, cacheKey)
-        return true
-      }
-      note("Another action is still finishing")
-      return false
+      queueAction(messageId, action, cacheKey, quiet === true)
+      return true
     }
     var index = Model.indexById(messages, messageId)
     var previewIndex = Model.indexById(previewMessages, messageId)

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1250,13 +1250,10 @@ Item {
   // under an open reader. A queued explicit trash that ran as if it were quiet
   // would leave the message the user deleted still on screen.
   function queueAction(messageId, action, actionQuery, quiet) {
-    var queued = queuedActions.slice()
-    for (var i = 0; i < queued.length; i++) {
-      if (queued[i].id === messageId && queued[i].action === action) return
-    }
-    queued.push({ id: messageId, action: action, cacheKey: actionQuery,
-      quiet: quiet === true })
-    queuedActions = queued
+    queuedActions = Model.enqueueAction(queuedActions, {
+      id: messageId, action: action, cacheKey: actionQuery,
+      sourceLabelId: hasLabels ? rawLabelId : "", quiet: quiet === true
+    })
   }
 
   function runQueuedAction() {
@@ -1266,16 +1263,18 @@ Item {
     queuedActions = queued
 
     // Prefer the normal optimistic path while the row is still in either
-    // account view. Navigation may have removed it meanwhile; marking a
-    // message read because it was opened is still owed to the server then.
+    // account view with the same label context. A typed search may have the
+    // same cache key as a label view but no source label to remove. Navigation
+    // does not change the operation already accepted for the original view.
     if (cacheKey === request.cacheKey
+        && (hasLabels ? rawLabelId : "") === request.sourceLabelId
         && (Model.indexById(messages, request.id) >= 0
         || Model.indexById(previewMessages, request.id) >= 0)) {
       act(request.id, request.action, request.quiet)
       return
     }
 
-    var change = Model.labelChangesFor(request.action)
+    var change = Model.labelChangesFor(request.action, request.sourceLabelId)
     if (request.action !== "trash" && request.action !== "untrash" && !change) {
       if (queuedActions.length > 0) Qt.callLater(root.runQueuedAction)
       return

--- a/account/Model.js
+++ b/account/Model.js
@@ -203,6 +203,29 @@ function survivesAction(mailboxKey, action, rawQuery, labels, sourceLabelId) {
   return true
 }
 
+// Only the most recent intent for a message may be coalesced. Searching past
+// an opposite action would turn read/unread/read into read/unread. Explicit
+// intent wins over an automatic read because it may evict the open row.
+function enqueueAction(requests, request) {
+  var queued = requests.slice()
+  for (var i = queued.length - 1; i >= 0; i--) {
+    var previous = queued[i]
+    if (previous.id !== request.id) continue
+    if (previous.action === request.action && previous.cacheKey === request.cacheKey
+        && previous.sourceLabelId === request.sourceLabelId) {
+      queued[i] = {
+        id: request.id, action: request.action, cacheKey: request.cacheKey,
+        sourceLabelId: request.sourceLabelId,
+        quiet: previous.quiet === true && request.quiet === true
+      }
+      return queued
+    }
+    break
+  }
+  queued.push(request)
+  return queued
+}
+
 function labelChangesFor(action, sourceLabelId) {
   if (action === "markRead") return { add: [], remove: ["UNREAD"] }
   if (action === "markUnread") return { add: ["UNREAD"], remove: [] }

--- a/tests/qml/tst_queued_actions.qml
+++ b/tests/qml/tst_queued_actions.qml
@@ -1,0 +1,157 @@
+import QtQuick
+import QtTest
+import "../../account" as Account
+
+Item {
+  Component {
+    id: accountFactory
+    Account.MailAccount {
+      pluginDir: "/unused-queue-fixture"
+      accountId: "synthetic@example.com"
+      configuredEmail: accountId
+      function refreshCounts() {}
+      function loadMessages() {}
+      function rememberList() {}
+      function loadProfile() {}
+      function loadSendAs() {}
+    }
+  }
+  // Replace only the provider through its existing Loader. Queueing, optimistic
+  // edits, completion and rollback all belong to the real MailAccount.
+  Component {
+    id: apiFactory
+    QtObject {
+      property var calls: []
+      property var completion: null
+      function modifyMessage(id, add, remove, callback) {
+        calls = calls.concat([{ id: id, add: add, remove: remove }])
+        completion = callback
+      }
+      function trashMessage(id, callback) {
+        calls = calls.concat([{ id: id, action: "trash" }])
+        completion = callback
+      }
+      function finish(error) {
+        var callback = completion
+        completion = null
+        callback({}, error || "")
+      }
+    }
+  }
+  TestCase {
+    name: "QueuedActions"
+    function ready() {
+      var account = createTemporaryObject(accountFactory, parent)
+      verify(account !== null)
+      wait(1)
+      var original = account.api
+      var installed = false
+      for (var i = 0; i < account.children.length; i++) {
+        var child = account.children[i]
+        if (child.item === original) {
+          child.sourceComponent = apiFactory
+          installed = true
+          break
+        }
+      }
+      verify(installed)
+      account.auth.credentials = ({ clientId: "123-test.apps.googleusercontent.com",
+        clientSecret: "synthetic", projectId: "test" })
+      account.auth.toolsChecked = true
+      account.auth.missingTools = []
+      account.auth.loggedIn = true
+      account.auth.refreshBusy = true
+      tryCompare(account, "ready", true)
+      account.messages = [
+        { id: "one", labelIds: ["INBOX", "Label_A"], unread: true, inInbox: true },
+        { id: "two", labelIds: ["INBOX", "Label_A"], unread: true, inInbox: true }
+      ]
+      return account
+    }
+    function test_move_keeps_source_label_after_navigation() {
+      var account = ready()
+      account.rawQuery = "label:A"
+      account.rawLabelId = "Label_A"
+      verify(account.act("one", "star"))
+      verify(account.act("two", "label:Label_B"))
+      account.rawQuery = "label:C"
+      account.rawLabelId = "Label_C"
+      account.messages = []
+      account.api.finish()
+      tryCompare(account.api, "calls", [
+        { id: "one", add: ["STARRED"], remove: [] },
+        { id: "two", add: ["Label_B"], remove: ["INBOX", "Label_A"] }
+      ])
+    }
+    function test_read_unread_read_keeps_final_intent() {
+      var account = ready()
+      verify(account.act("one", "star"))
+      verify(account.act("two", "markRead"))
+      verify(account.act("two", "markUnread"))
+      verify(account.act("two", "markRead"))
+      account.api.finish()
+      tryVerify(function() { return account.api.calls.length === 2 })
+      account.api.finish()
+      tryVerify(function() { return account.api.calls.length === 3 })
+      account.api.finish()
+      tryVerify(function() { return account.api.calls.length === 4 })
+      compare(account.api.calls[3].remove, ["UNREAD"])
+      account.api.finish()
+      compare(account.messages[1].unread, false)
+    }
+    function test_same_query_search_keeps_original_label_context() {
+      var account = ready()
+      account.selectLabel("A", "Label_A")
+      account.messages = [
+        { id: "one", labelIds: ["Label_A"], unread: false },
+        { id: "two", labelIds: ["Label_A"], unread: false }
+      ]
+      verify(account.act("one", "star"))
+      verify(account.act("two", "label:Label_B"))
+      var query = account.cacheKey
+      account.search("label:A")
+      compare(account.cacheKey, query)
+      account.messages = [{ id: "two", labelIds: ["Label_A"], unread: false }]
+      account.api.finish()
+      tryVerify(function() { return account.api.calls.length === 2 })
+      compare(account.api.calls[1].remove, ["INBOX", "Label_A"])
+    }
+    function test_repeated_trash_waits_and_runs_once() {
+      var account = ready()
+      verify(account.act("one", "trash"))
+      verify(account.act("two", "trash"))
+      verify(account.act("two", "trash"))
+      compare(account.api.calls.length, 1)
+      account.api.finish()
+      tryVerify(function() { return account.api.calls.length === 2 })
+      compare(account.api.calls[1], { id: "two", action: "trash" })
+      account.api.finish()
+      wait(1)
+      compare(account.api.calls.length, 2)
+      compare(account.messages.length, 0)
+    }
+    function test_explicit_read_overrides_queued_quiet_read() {
+      var account = ready()
+      account.mailboxKey = "unread"
+      account.selectedId = "two"
+      verify(account.act("one", "star"))
+      verify(account.act("two", "markRead", true))
+      verify(account.act("two", "markRead", false))
+      account.api.finish()
+      tryVerify(function() { return account.api.calls.length === 2 })
+      compare(account.messages.length, 1, "An explicit action must remove the unread row")
+      compare(account.selectedId, "")
+    }
+    function test_failure_restores_first_row_before_next_action() {
+      var account = ready()
+      verify(account.act("one", "trash"))
+      verify(account.act("two", "trash"))
+      account.api.finish("Synthetic failure")
+      tryVerify(function() { return account.api.calls.length === 2 })
+      compare(account.messages.length, 1)
+      compare(account.messages[0].id, "one")
+      account.api.finish()
+      compare(account.pendingAction, "")
+    }
+  }
+}

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -683,10 +683,42 @@ grep -q 'var invalidatesPage = !survives || opaqueQuery' account/MailAccount.qml
   || fail "paging membership must not follow the reader's keep-open decision"
 grep -q 'if (!service.act(acted, action)) return false' App.qml \
   || fail "a refused action must not move the keyboard cursor"
-grep -q 'queueQuietAction(messageId, action, cacheKey)' account/MailAccount.qml \
+grep -q 'queueAction(messageId, action, cacheKey, quiet === true)' account/MailAccount.qml \
   || fail "automatic mark-read must wait rather than disappear behind another action"
+# Clearing a mailbox means pressing the same key down a list faster than any
+# server answers. Refusing the second press dropped it: the message stayed, the
+# note blamed the user for a failure they had not caused, and the false return
+# held the keyboard cursor on a row the user had already left behind.
 awk '
-  /function runQueuedQuietAction\(\)/ { in_quiet = 1 }
+  /function act\(/ { in_act = 1 }
+  in_act && /if \(pendingAction !== ""\)/ { in_guard = 1 }
+  in_guard && /queueAction\(messageId, action, cacheKey, quiet === true\)/ { queues = 1 }
+  in_guard && /return true/ { exit !queues }
+  END { exit !queues }
+' account/MailAccount.qml \
+  || fail "an action taken while one is pending must queue rather than be refused"
+# Scoped to `act`. `markAllRead` still refuses on purpose: it reads the unread
+# set at the moment it runs, so one queued behind a mutation would send a list
+# the mailbox had already moved past.
+awk '
+  /function act\(/ { in_act = 1 }
+  in_act && /Another action is still finishing/ { refuses = 1 }
+  in_act && /var index = Model\.indexById\(messages, messageId\)/ { exit refuses }
+  END { exit refuses }
+' account/MailAccount.qml \
+  || fail "a queued action must not report a failure the user did not cause"
+# The reader keeps a quiet row that the same explicit action would evict, so the
+# flag has to survive the wait. Draining every request as quiet would leave a
+# trashed message on screen under the reader that deleted it.
+awk '
+  /function runQueuedAction\(\)/ { in_queued = 1 }
+  in_queued && /act\(request\.id, request\.action, request\.quiet\)/ { forwards = 1 }
+  /function refuseUnavailableAction\(/ { exit !forwards }
+  END { exit !forwards }
+' account/MailAccount.qml \
+  || fail "a queued action must run with the quietness it was taken with"
+awk '
+  /function runQueuedAction\(\)/ { in_quiet = 1 }
   in_quiet && /listSerial\+\+/ { interrupts = 1 }
   in_quiet && /root\.loadMessages\(false, true/ { reloads = 1 }
   /function act\(/ { exit !(interrupts && reloads) }


### PR DESCRIPTION
Deleting several messages in a row only works as fast as the server answers.

## Reproduction

1. Open a mailbox on an IMAP account with a few unread messages.
2. Press `d` on the first row.
3. Before the request completes, move to the next message and press `d` again.

The second press does nothing. The status note reads "Another action is still
finishing", the message stays where it was, and the keyboard cursor does not
move on — `App.qml` holds it deliberately when `act` answers false, so a
refused action strands the cursor on a row the reader has already left.

Reproduced against a self-hosted IMAP mailbox where a round trip takes a few
hundred milliseconds, which is long enough that triaging a morning's mail hits
it on nearly every message. It is not a caching problem: the optimistic edit
and the body cache both behave. The refusal is in `act` itself.

## Why it happens

`act` allows one mutation at a time, which is right — `restore` puts a row back
at the index it held when the action was taken, so overlapping optimistic edits
would restore into a list that had moved underneath them.

But a pending slot is a reason to make the next action **wait**, not a reason to
drop it. `queueQuietAction` and `runQueuedQuietAction` already implement exactly
that waiting, and automatic mark-read already uses them. Only the explicit path
was refused.

## The change

The queue takes every action rather than only the quiet ones, and carries the
quietness it was taken with. That last part matters: `keepOpen` is
`quiet === true && selectedId === messageId`, so draining an explicit trash as
if it were quiet would leave the deleted message on screen under the reader
that deleted it. `runQueuedAction` now forwards `request.quiet` instead of a
hardcoded `true`.

`markAllRead` still refuses on purpose, and the test says why: it reads the
unread set at the moment it runs, so one queued behind a mutation would send a
list the mailbox had already moved past.

The names lost their `Quiet` now that the queue holds both kinds.

## Verification

`make validate` — `test-js`, `test-shell-portable`, `test-shell-libcurl`,
`test-qml` and `qml-check` all pass. QML: 269 passed, 0 failed. `qmllint`
reports 2146 warnings both before and after the change, so this adds none.
`git diff --check` is clean.

Four assertions were added to `tests/test_source.sh`, the file that already
guards this area:

- an action taken while one is pending must queue rather than be refused
- a queued action must not report a failure the user did not cause (scoped to
  `act`, so `markAllRead` keeps its deliberate refusal)
- a queued action must run with the quietness it was taken with
- the existing mark-read and detached-action assertions, updated for the names

Each was checked to fail without the fix. Reverting only the guard, leaving the
renames and the call text identical, fails on
"a queued action must not report a failure the user did not cause" — so the new
assertions catch the behaviour rather than the rename.

Manually: pressing `d` down a list now clears every message pressed, in order,
with the cursor moving on at each press. No note appears. Held `d` dedupes on
`(id, action)` as before.

## Release Notes

- Deleting, archiving or starring several messages quickly no longer drops the
  presses that land while the previous one is still finishing. They queue and
  run in order, and the cursor moves on with each press instead of stopping on
  a row you have already left.
