### PR TITLE
Name the open mailbox and act on selected messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,8 +207,9 @@ key. What matters while working:
   place the rule above inverts. It takes the key before the shortcut map sees
   it — `focus` true or false, bare or modified — so inside a popup a `KeyRouter`
   binding is what looks live and never runs, and a `Keys` handler on the
-  popup's `contentItem` is the only thing that works. The account switcher is
-  the one component that answers keys itself, for this reason.
+  popup's `contentItem` is the only thing that works. The account switcher and
+  the mailbox switcher are the two components that answer keys themselves, for
+  this reason.
   `tests/qml/tst_popup_keys.qml` asserts both halves, so the exception cannot
   be tidied back into the rule by someone who only read the rule.
 - The mouse does not move the keyboard's cursor. Qt re-reports hover when

--- a/App.qml
+++ b/App.qml
@@ -1987,12 +1987,17 @@ Item {
             // from a member the action lands on the row the conversation was
             // opened from, which is where the reader came from. Which members
             // an action reaches from there is "Actions on a conversation row".
-            // The toolbar emits archive and trash and nothing else; the star
-            // is a button of its own, through `toggleStar`, which acts on the
-            // open message. Unless the open message is one of the ticked rows,
-            // in which case the buttons mean all of them, by the same rule as
-            // a row's buttons.
             var outside = root.checkedIds.indexOf(root.service.selectedId) < 0
+            // A star stays on the open member unless it belongs to the visible
+            // selection. It never moves the list's independent cursor.
+            if (action === "star") {
+              if (root.selectionActive && !outside)
+                root.actOnChecked(Model.starActionFor(Model.summariesById(
+                    root.service.messages, root.checkedIds)))
+              else
+                root.service.toggleStar(root.service.selectedId)
+              return
+            }
             if (!Conversation.holdsMember(root.service.selectedThread,
                 root.service.selectedId) || root.cursorId === "")
               root.cursorId = root.service.selectedId

--- a/App.qml
+++ b/App.qml
@@ -12,6 +12,7 @@ import "account/Accounts.js" as Accounts
 import "account/Navigation.js" as Nav
 import "compose/Recovery.js" as Recovery
 import "keys/Keymap.js" as Keymap
+import "providers/Registry.js" as Provider
 import "message/Mailto.js" as Mailto
 import "message/Message.js" as Message
 import "components"
@@ -206,6 +207,100 @@ Item {
   readonly property bool compact: window.width < Style.space(760)
 
   property string cursorId: ""
+  // The rows ticked for a bulk action, by id. Like the cursor, a fact about
+  // this window rather than about the mailbox, and pruned the same way when
+  // the list under it changes. Only the list acts on it: in the reader there
+  // is one message and it is the one open.
+  property var checkedIds: []
+  // The mailbox the ticks belong to. An IMAP id is a UID and a folder, unique
+  // only inside one account, so a tick carried across an account switch
+  // would name whatever the other mailbox keeps under the same id — and a
+  // batch dispatched through it would act on that. The ticks are bound to
+  // the account they were made in and dropped the moment it changes, from
+  // any path, before a batch can run.
+  property string checkedAccountId: ""
+  // Ticked rows mean the selection whenever the list is on screen: alone, or
+  // beside the reader in a wide window. A plain click opens a message and
+  // puts the window in the reader view, so a click, a Shift+click and `d`
+  // would otherwise trash only the open message with the ticks ignored.
+  readonly property bool listOnScreen: currentView === "list"
+    || (currentView === "reader" && !compact)
+  readonly property bool selectionActive: checkedIds.length > 0 && listOnScreen
+
+  function toggleCheck(id) {
+    var key = String(id || "")
+    if (key === "") return false
+    claimChecks()
+    checkedIds = Model.toggleId(checkedIds, key)
+    return true
+  }
+
+  // Ticks made in another mailbox are not this one's: start over.
+  function claimChecks() {
+    var owner = service ? String(service.activeAccountId || "") : ""
+    if (checkedAccountId !== owner) checkedIds = []
+    checkedAccountId = owner
+  }
+
+  function clearChecksIfForeign() {
+    var owner = service ? String(service.activeAccountId || "") : ""
+    if (checkedIds.length > 0 && checkedAccountId !== owner) checkedIds = []
+    checkedAccountId = owner
+  }
+
+  // Shift+click: everything from the cursor to here joins the selection, and
+  // the cursor moves here so the next stretch starts where this one ended.
+  function checkRange(id) {
+    if (!service) return false
+    var key = String(id || "")
+    if (key === "") return false
+    claimChecks()
+    checkedIds = Model.unionIds(checkedIds, Model.idsBetween(service.messages, cursorId, key))
+    cursorId = key
+    return true
+  }
+
+  // Every loaded row, or none when every one is already ticked: one key that
+  // means "all of these" has to be able to mean "none of them" as well.
+  function checkAll() {
+    if (!service) return false
+    claimChecks()
+    var all = Model.allIds(service.messages)
+    checkedIds = Model.retainIds(checkedIds, service.messages).length === all.length ? [] : all
+    return true
+  }
+
+  // Acting on the selection acts on every ticked row at once, then drops the
+  // selection: the rows it named have moved or changed, and a selection that
+  // outlived the action would be one keystroke from repeating it.
+  function actOnChecked(action) {
+    if (!service || checkedIds.length === 0) return false
+    // Never through another mailbox: a switch that reached the service by
+    // any road drops the ticks before a batch can be built from them.
+    if (checkedAccountId !== String(service.activeAccountId || "")) {
+      checkedIds = []
+      return false
+    }
+    var ids = checkedIds.slice()
+    var leaves = !Model.survivesAction(service.mailboxKey, action,
+      service.rawQuery, service.hasLabels, service.rawLabelId)
+    var next = leaves ? Model.cursorAfterRemovals(service.messages, ids, cursorId) : cursorId
+    // The open message going with the selection closes the reader, the way
+    // acting on it alone does: it is about to leave this list.
+    var wasOpen = currentView === "reader" && ids.indexOf(service.selectedId) >= 0
+    if (!service.actMany(ids, action)) return false
+    checkedIds = []
+    if (!leaves) return true
+    if (wasOpen) {
+      if (next !== "") openMessage(next)
+      else backToList()
+      return true
+    }
+    cursorId = next
+    revealCursorRow()
+    return true
+  }
+
   // Kept across messages, and across the window being closed: how somebody
   // reads their mail is a fact about them, not about the message that made them
   // reach for it. The service holds it because that is what writes it to disk.
@@ -852,7 +947,7 @@ Item {
   // move before asking for a destination, through the same provider guard that
   // checks the final action before its optimistic update.
   function openLabelPicker() {
-    if (!service || cursorId === "") return false
+    if (!service || (cursorId === "" && !selectionActive)) return false
     // A merged list draws no labels, so there is nothing to offer and the
     // picker would open empty on a destination list it cannot fill — and a
     // chosen id would belong to whichever mailbox happened to be active
@@ -870,9 +965,32 @@ Item {
     return true
   }
 
+  // A row's own button: the selection when the row is ticked, that row alone
+  // when it is not — the rule the row menu follows, so a click and a key on
+  // the same row cannot mean different sets of messages.
+  function actFromRow(id, action) {
+    if (!service) return false
+    var outside = checkedIds.indexOf(id) < 0
+    cursorId = id
+    if (action === "star") {
+      if (selectionActive && !outside)
+        return actOnChecked(Model.starActionFor(Model.summariesById(service.messages, checkedIds)))
+      service.toggleStar(id)
+      return true
+    }
+    return actOnCursor(action, outside)
+  }
+
   // Acting on the open message closes it: it is about to leave this list.
-  function actOnCursor(action) {
-    if (!service || cursorId === "") return false
+  //
+  // With rows ticked, the key means all of them rather than the one under the
+  // cursor — the same key, the same guard in `MailAccount`, one more row in
+  // the request. `onlyCursor` is for the row menu opened on a row outside the
+  // selection, which means that row and nothing else.
+  function actOnCursor(action, onlyCursor) {
+    if (!service) return false
+    if (selectionActive && onlyCursor !== true) return actOnChecked(action)
+    if (cursorId === "") return false
     var acted = cursorId
     var row = service.messages[Model.indexById(service.messages, acted)]
     // "Was open" is the conversation's: with the rail up the reader can be
@@ -946,6 +1064,17 @@ Item {
   readonly property var sidebarSlots: service
     ? Model.sidebarSlots(service.mailboxes, service.labels, 10) : []
 
+  // What the header names: the mailbox open, or the label. Derived from the
+  // same facts the rail draws its selected row from.
+  readonly property var scope: service
+    ? Model.currentScope(service.mailboxKey, service.mailboxes, service.labels,
+        service.rawQuery, service.rawLabelId,
+        function(name) { return Provider.labelQuery(service.providerId, name) })
+    : Model.currentScope("inbox", [], [], "", "", null)
+
+  readonly property var switcherRows: service
+    ? Model.switcherRows(sidebarSlots, service.labels, scope) : []
+
   function goSlot(index) {
     if (!service || index < 0 || index >= sidebarSlots.length) return
     var slot = sidebarSlots[index]
@@ -984,11 +1113,15 @@ Item {
     // on the row while `n` and `p` walk the rail, so `s` would otherwise star
     // the representative rather than the message on screen.
     if (id === "star") {
+      if (selectionActive)
+        return actOnChecked(Model.starActionFor(Model.summariesById(service.messages, checkedIds)))
       var starred = currentView === "reader" && service && service.selectedId !== ""
         ? service.selectedId : cursorId
       if (service && starred !== "") service.toggleStar(starred)
       return
     }
+    if (id === "toggleCheck") return toggleCheck(cursorId)
+    if (id === "checkAll") return checkAll()
     if (id === "moveToLabel") return openLabelPicker()
     if (id === "markRead") return actOnCursor("markRead")
     if (id === "markUnread") return actOnCursor("markUnread")
@@ -1019,6 +1152,7 @@ Item {
       return
     }
     if (id === "switchAccount") return accountSwitcher.openCentered()
+    if (id === "switchMailbox") return mailboxSwitcher.openCentered()
     if (id === "calendar") {
       if (calendarVisible) backToList()
       else {
@@ -1060,6 +1194,12 @@ Item {
     if (searchBar.fieldFocused) {
       if (searchBar.queryText !== "") searchBar.clear()
       focusScope.parkKeyboard()
+      return
+    }
+    // A selection is the next nearest thing: Escape with rows ticked unticks
+    // them and goes nowhere, which is what every file manager does with it.
+    if (selectionActive) {
+      checkedIds = []
       return
     }
     back()
@@ -1107,9 +1247,19 @@ Item {
       root.resumeHeldDraft()
     }) }
 
+    // The cursor is an id too, and an IMAP id names a different message in
+    // another mailbox: it is dropped with the ticks, so the next `d` after
+    // a switch acts on nothing rather than on whatever shares the id.
+    function onActiveAccountIdChanged() {
+      root.clearChecksIfForeign()
+      root.cursorId = ""
+    }
     function onMessagesChanged() {
+      root.clearChecksIfForeign()
       root.cursorId = Model.cursorAfterReload(
         root.service ? root.service.messages : [], root.cursorId)
+      root.checkedIds = Model.retainIds(root.checkedIds,
+        root.service ? root.service.messages : [])
     }
     function onDuplicateAccount(email) {
       root.notice = email + " is already added"
@@ -1429,13 +1579,61 @@ Item {
             brand: true
           }
 
+          // What this window is looking at, said where the eye lands first:
+          // the account, then the mailbox or label open in it. Each half is
+          // the control that changes it, so the line is the switcher as much
+          // as the title. The rail says the same thing further down and only
+          // when it is expanded; the status line carries the address.
+          ScopeButton {
+            id: accountScope
+            objectName: "scope-account"
+            anchors.verticalCenter: parent.verticalCenter
+            visible: !root.showPage && !root.composing
+            text: root.ready ? root.service.accountLabel : "No account"
+            tooltipText: "Switch account · Alt+A"
+            foreground: root.foreground
+            hoverColor: root.foreground
+            accent: root.accent
+            fontFamily: root.fontFamily
+            fontSize: Style.font.body
+            maxTextWidth: root.compact ? Style.space(110) : Style.space(180)
+            selected: accountSwitcher.opened
+            enabled: root.ready
+            onClicked: {
+              var scene = mapToGlobal(0, height)
+              accountSwitcher.openAt(scene.x, scene.y)
+            }
+          }
+
           Text {
             anchors.verticalCenter: parent.verticalCenter
-            visible: !root.compact
-            text: "Omamail"
-            color: root.foreground
+            visible: accountScope.visible && mailboxScope.visible
+            text: "\u203A"
+            color: root.dim
             font.family: root.fontFamily
-            font.pixelSize: Style.font.title
+            font.pixelSize: Style.font.body
+          }
+
+          ScopeButton {
+            id: mailboxScope
+            objectName: "scope-mailbox"
+            anchors.verticalCenter: parent.verticalCenter
+            visible: !root.showPage && !root.composing && !root.calendarVisible
+            iconName: root.scope.icon
+            text: root.scope.name
+            tooltipText: "Go to a mailbox · Alt+M"
+            foreground: root.foreground
+            hoverColor: root.foreground
+            accent: root.accent
+            fontFamily: root.fontFamily
+            fontSize: Style.font.body
+            maxTextWidth: root.compact ? Style.space(110) : Style.space(180)
+            selected: mailboxSwitcher.opened
+            enabled: root.ready
+            onClicked: {
+              var scene = mapToGlobal(0, height)
+              mailboxSwitcher.openAt(scene.x, scene.y)
+            }
           }
 
           // Next to the mark: this is the window's own menu, not an action on
@@ -1684,7 +1882,11 @@ Item {
               dimColor: root.dim
               panelFontFamily: root.fontFamily
               cursorId: root.cursorId
+              checkedIds: root.checkedIds
               onMessageActivated: function(id) { root.openMessage(id) }
+              onCheckToggled: function(id) { root.toggleCheck(id) }
+              onCheckRangeRequested: function(id) { root.checkRange(id) }
+              onRowActionRequested: function(id, action) { root.actFromRow(id, action) }
               onMenuRequested: function(id, sceneX, sceneY) {
                 root.cursorId = id
                 rowMenu.openAt(id, sceneX, sceneY)
@@ -1787,11 +1989,14 @@ Item {
             // an action reaches from there is "Actions on a conversation row".
             // The toolbar emits archive and trash and nothing else; the star
             // is a button of its own, through `toggleStar`, which acts on the
-            // open message.
+            // open message. Unless the open message is one of the ticked rows,
+            // in which case the buttons mean all of them, by the same rule as
+            // a row's buttons.
+            var outside = root.checkedIds.indexOf(root.service.selectedId) < 0
             if (!Conversation.holdsMember(root.service.selectedThread,
                 root.service.selectedId) || root.cursorId === "")
               root.cursorId = root.service.selectedId
-            root.actOnCursor(action)
+            root.actOnCursor(action, outside)
           }
         }
 
@@ -2135,9 +2340,27 @@ Item {
           onClicked: root.toggleSidebar()
         }
 
+        // How many rows are ticked, beside the rail toggle. Said here rather
+        // than in the list because the list is where the ticks already are;
+        // this is the count, for a selection longer than the window.
+        Text {
+          id: selectionLabel
+          objectName: "status-selection"
+          anchors.left: railToggle.visible ? railToggle.right : parent.left
+          anchors.leftMargin: Style.space(8)
+          anchors.verticalCenter: parent.verticalCenter
+          visible: root.selectionActive && !root.showPage && !root.composing
+          text: Model.selectionStatus(root.checkedIds.length)
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          font.bold: true
+        }
+
         Item {
           id: accountSlot
-          anchors.left: railToggle.visible ? railToggle.right : parent.left
+          anchors.left: selectionLabel.visible ? selectionLabel.right
+            : (railToggle.visible ? railToggle.right : parent.left)
           // The rail's labels sit 9 after their glyph; the toggle's box runs
           // past its glyph by half its slack, so the text starts that much
           // less after the box.
@@ -2329,6 +2552,20 @@ Item {
         }
       }
 
+      MailboxSwitcher {
+        id: mailboxSwitcher
+        objectName: "mailbox-switcher"
+        anchors.fill: parent
+        textColor: root.foreground
+        accentColor: root.accent
+        dimColor: root.dim
+        popupBackgroundColor: root.popupBackground
+        popupBorderColor: root.popupBorder
+        panelFontFamily: root.fontFamily
+        rows: root.switcherRows
+        onRowChosen: function(index) { root.goSlot(index) }
+      }
+
       LabelPicker {
         id: labelPicker
         objectName: "label-picker"
@@ -2386,8 +2623,13 @@ Item {
           root.startCompose(mode)
         }
         onActionRequested: function(action, id) {
+          // On a ticked row the menu means the selection; on any other row it
+          // means that row alone, whatever else is ticked.
+          var outside = root.checkedIds.indexOf(id) < 0
           root.cursorId = id
-          root.actOnCursor(action)
+          if ((action === "star" || action === "unstar") && root.selectionActive && !outside)
+            return root.actOnChecked(Model.starActionFor(Model.summariesById(root.service.messages, root.checkedIds)))
+          root.actOnCursor(action, outside)
         }
         // From a stop on the rail. A member is not a row, so the cursor stays
         // where the list has it and the action reaches the one message.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 QMLLINT := /usr/lib/qt6/bin/qmllint
 QML_FILES := Service.qml BarWidget.qml App.qml \
-	account/MailAccount.qml account/NewMailNotification.qml \
+	account/MailAccount.qml account/BatchAction.qml account/Rsvp.qml account/NewMailNotification.qml \
 	cache/CacheStore.qml cache/BodyCache.qml \
 	providers/AuthManager.qml providers/GmailApiClient.qml \
 	providers/OutlookAuth.qml \
@@ -46,6 +46,8 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/SearchBar.qml \
 	components/AppMenu.qml \
 	components/AccountSwitcher.qml \
+	components/MailboxSwitcher.qml \
+	components/ScopeButton.qml \
 	components/AccountRemovalDialog.qml \
 	components/BackBar.qml \
 	components/SettingsPage.qml \

--- a/README.md
+++ b/README.md
@@ -238,6 +238,9 @@ and the client itself are console-only; there is no CLI for them.
 | `/` | Search |
 | `Alt+1` … `Alt+0` | The mailbox with that number on the rail |
 | `Alt+A` | Switch account |
+| `Alt+M` | Go to a mailbox or label from a list |
+| `x` | Select the message; `e`, `d`, `s`, `v`, `Shift+I`, `Shift+U` then act on every selected one |
+| `Ctrl+A` | Select every message loaded, or none |
 | `Ctrl+=` / `Ctrl+-` / `Ctrl+0` | Zoom the message body, or reset it |
 | `F5` / `Ctrl+R` | Check for mail |
 | `?` | Every shortcut |

--- a/Service.qml
+++ b/Service.qml
@@ -1322,6 +1322,16 @@ Item {
     }
     eachHost(function(host) { host.markAllRead() })
   }
+  // Several ticked rows at once. A merged list draws rows from several
+  // mailboxes, and a batch is one mailbox's request, so it is refused there
+  // the way a move is: the rule every unavailable action follows.
+  function actMany(ids, action) {
+    if (unified) {
+      fail("Acting on several messages needs one mailbox on screen")
+      return false
+    }
+    return current ? current.actMany(ids, action) : false
+  }
   // The mailbox the From address belongs to, which compose already names:
   // `sendIdentities` spans every account and carries the id, so a unified
   // view needed the routing rather than a new question.

--- a/account/BatchAction.qml
+++ b/account/BatchAction.qml
@@ -1,0 +1,291 @@
+import QtQuick
+import "Model.js" as Model
+import "../providers/Registry.js" as Provider
+
+// Several rows at once: the ticked ones. One optimistic edit for the lot,
+// one request where the client takes a list and one per row where it
+// answers per message. Each row expands to its counted members the way a
+// single action does, so a conversation row marked read reads as one
+// across the rail as well as in the list. A second caller of the account's
+// optimistic and restore machinery, kept beside it rather than in it: the
+// account file is at its size ceiling.
+QtObject {
+  id: batch
+
+  required property var account
+
+  function run(ids, action) {
+    var wanted = []
+    var given = Array.isArray(ids) ? ids : []
+    for (var g = 0; g < given.length; g++) wanted.push(String(given[g]))
+    if (!account.ready || wanted.length === 0) return false
+    if (account.refuseUnavailableAction(action)) return false
+    // One mutation in flight at a time, for the same reason `act` waits: the
+    // rows go back by the index they held. The line is per row, so a batch
+    // asked for while another action finishes joins it one row at a time.
+    if (account.pendingAction !== "") {
+      for (var q = 0; q < wanted.length; q++) account.queueAction(wanted[q], action, account.cacheKey, false, false)
+      return true
+    }
+    var sourceLabelId = account.hasLabels ? account.rawLabelId : ""
+    var change = action === "trash" || action === "untrash"
+      ? { add: [], remove: [] } : Model.labelChangesFor(action, sourceLabelId)
+    if (!change) return false
+    var rows = []
+    var listed = []
+    for (var l = 0; l < account.messages.length; l++) {
+      if (wanted.indexOf(String(account.messages[l].id)) < 0) continue
+      rows.push(account.messages[l])
+      listed.push(String(account.messages[l].id))
+    }
+    if (listed.length === 0) return false
+
+    // The account.messages this action is sent for: every row's counted members, as
+    // for a single action, so no client expands anything.
+    var conversationAction = Model.actionScope(action) === "conversation"
+    var targets = []
+    var targetsOf = ({})
+    for (var r = 0; r < rows.length; r++) {
+      var own = Model.actionTargets(rows[r], action)
+      targetsOf[String(rows[r].id)] = own
+      for (var o = 0; o < own.length; o++) {
+        if (targets.indexOf(own[o]) < 0) targets.push(own[o])
+      }
+    }
+    if (targets.length === 0) return false
+
+    var actionQuery = account.cacheKey
+    var actionEstimate = account.resultEstimate
+    var actionToken = account.nextPageToken
+    var before = account.messages.slice()
+    var beforePreview = account.previewMessages.slice()
+    var beforeSelected = account.selectedMessage
+    var selectedWas = account.selectedId
+    var interrupted = account.listLoading
+    if (interrupted) {
+      account.listSerial++
+      account.abortRequest(account.listHandle)
+      account.listHandle = null
+      account.listLoading = false
+      account.nextPageToken = ""
+      actionToken = ""
+    }
+
+    // Every member summary the rail holds for a target takes the change; a
+    // representative takes its row's, block and all. What each was is kept
+    // so a refusal can put it back.
+    var memberBefore = ({})
+    var memberAfter = ({})
+    var changedMembers = []
+    function rememberBefore(id, summary) {
+      if (changedMembers.indexOf(id) < 0) {
+        changedMembers.push(id)
+        memberBefore[id] = summary
+      }
+    }
+    for (var t = 0; t < targets.length; t++) {
+      var known = account.memberSummaries[targets[t]]
+      if (!known) continue
+      var after = Model.applyLabelChange(known, action, sourceLabelId)
+      if (!after || after === known) continue
+      rememberBefore(targets[t], known)
+      memberAfter[targets[t]] = after
+    }
+
+    var next = []
+    var nextPreview = account.previewMessages.slice()
+    var unreadDelta = 0
+    var selectedGone = false
+    var removedIds = []
+    for (var j = 0; j < account.messages.length; j++) {
+      var row = account.messages[j]
+      var rowId = String(row.id)
+      if (listed.indexOf(rowId) < 0) {
+        next.push(row)
+        continue
+      }
+      var updated
+      if (conversationAction) {
+        // Every counted member was sent the same patch, so the row says so
+        // at once rather than waiting for the next read to agree.
+        updated = Model.applyLabelChange(row, action, sourceLabelId,
+          Model.threadAfterAction(row, action))
+      } else {
+        var ownLabels = Model.applyLabelChange(row, action, sourceLabelId)
+        var nextMembers = ({})
+        for (var held in account.memberSummaries) nextMembers[held] = account.memberSummaries[held]
+        for (var changed in memberAfter) nextMembers[changed] = memberAfter[changed]
+        nextMembers[rowId] = ownLabels
+        updated = Model.rowWithThread(ownLabels,
+          Model.threadAfterMemberChange(row, nextMembers))
+      }
+      if (account.memberSummaries[rowId]) {
+        rememberBefore(rowId, account.memberSummaries[rowId])
+        memberAfter[rowId] = updated
+      }
+      if (action === "markRead" && row.unread && !updated.unread) unreadDelta--
+      if (action === "markUnread" && !row.unread && updated.unread) unreadDelta++
+      var survives = Model.survivesAction(account.mailboxKey, action, account.rawQuery, account.hasLabels,
+        sourceLabelId, updated)
+      if (survives) next.push(updated)
+      else removedIds.push(rowId)
+      if (Model.indexById(nextPreview, rowId) >= 0) {
+        nextPreview = updated.unread
+          ? Model.replaceById(nextPreview, updated)
+          : Model.removeById(nextPreview, rowId)
+      }
+      if (Model.rowHoldsMember(row, account.selectedId)) {
+        if (!survives) selectedGone = true
+        else if (account.selectedId === rowId) account.selectedMessage = updated
+        else if (memberAfter[account.selectedId]) account.selectedMessage = memberAfter[account.selectedId]
+        else if (targets.indexOf(account.selectedId) >= 0 && account.selectedMessage)
+          account.selectedMessage = Model.applyLabelChange(account.selectedMessage, action, sourceLabelId)
+      }
+    }
+    if (changedMembers.length > 0) account.mergeMembers(memberAfter)
+    account.inboxUnread = Math.max(0, account.inboxUnread + unreadDelta)
+    var opaqueQuery = account.effectiveQuery
+      !== Provider.query(account.providerId, account.mailboxKey, "", "")
+    var invalidatesPage = removedIds.length > 0 || opaqueQuery
+    account.messages = next
+    account.previewMessages = nextPreview
+    if (selectedGone) account.clearSelection()
+    if (invalidatesPage) account.nextPageToken = ""
+    var optimistic = account.messages.slice()
+    var optimisticToken = account.nextPageToken
+    if (!interrupted) account.rememberList()
+    account.pendingActionQuery = actionQuery
+    account.pendingAction = action
+
+    // The member summaries behind a set of rows go back with them.
+    function restoreMembersOf(rowIds) {
+      for (var f = 0; f < rowIds.length; f++) {
+        var owned = targetsOf[rowIds[f]] || []
+        for (var m = 0; m < owned.length; m++) {
+          if (memberBefore[owned[m]] !== undefined) account.rememberMember(memberBefore[owned[m]])
+        }
+        if (memberBefore[rowIds[f]] !== undefined) account.rememberMember(memberBefore[rowIds[f]])
+      }
+    }
+
+    // A failure is not proof that nothing changed. One request per row
+    // reports each on its own, and only the rows whose request failed go
+    // back where they were. A provider that answers a whole batch with one
+    // word — Gmail's batchModify, IMAP's plan across folders — may have done
+    // part of it, so its failure is answered by reading the list again from
+    // the server rather than by restoring rows the server may no longer have.
+    var done = function(payload, error, failedIds) {
+      account.pendingAction = ""
+      account.pendingActionQuery = ""
+      if (error) {
+        var partial = Array.isArray(failedIds)
+        if (partial && account.cacheKey === actionQuery
+            && !account.deferredLoadCleared(actionQuery)) {
+          account.messages = Model.restoreRows(account.messages, before, failedIds)
+          account.previewMessages = Model.restoreRows(account.previewMessages, beforePreview, failedIds)
+          restoreMembersOf(failedIds)
+          if (!selectedGone && beforeSelected && beforeSelected.id === account.selectedId)
+            account.selectedMessage = beforeSelected
+          if (!interrupted) account.rememberList()
+          account.refreshCounts()
+          var note = Model.batchFailureNote(listed.length, failedIds.length, account.actionLabel(action), error)
+          account.fail(note)
+          // The refused rows are back, but the page is not whole: a refresh
+          // that waited on this action still has to run, and a page token
+          // the optimistic update cleared is read again from the server
+          // rather than put back, because the rows that did go are gone and
+          // the old token names a page that no longer starts where it did.
+          if (account.resumeDeferredListLoad(actionQuery, note)) return
+          if (invalidatesPage) account.loadMessages(false, true, note)
+          return
+        }
+        if (partial) {
+          // The view moved on while the batch ran — to another query, or
+          // cleared for a reload of this one — so the pre-action page must
+          // not come back, on screen or in the cache: the rows that did go
+          // are gone from the server. Only the refused rows are put back,
+          // into the cache that the next look at this query paints from
+          // before it reads the server, and the page token is left empty
+          // so that read starts from the top.
+          restoreMembersOf(failedIds)
+          var partNote = Model.batchFailureNote(listed.length, failedIds.length, account.actionLabel(action), error)
+          account.fail(partNote)
+          if (account.cache.loaded) {
+            account.cache.putQuery(actionQuery, ({
+              summaries: Model.restoreRows(optimistic, before, failedIds),
+              estimate: actionEstimate, nextPageToken: ""
+            }))
+          }
+          if (account.resumeDeferredListLoad(actionQuery, partNote)) return
+          if (account.cacheKey === actionQuery) account.loadMessages(false, true, partNote)
+          return
+        }
+        restoreMembersOf(listed)
+        if (selectedWas !== "" && account.selectedId === selectedWas) account.selectedMessage = beforeSelected
+        account.fail(error)
+        if (account.resumeDeferredListLoad(actionQuery, error)) return
+        if (account.cacheKey === actionQuery) account.loadMessages(false, true, error)
+        else if (account.cache.loaded) {
+          // Not on screen: the old page goes back into the cache so the next
+          // visit reads the server rather than the optimistic guess.
+          account.cache.putQuery(actionQuery, ({
+            summaries: before, estimate: actionEstimate, nextPageToken: actionToken
+          }))
+        }
+        return
+      }
+      account.note(Model.batchNote(listed.length, account.actionLabel(action)))
+      account.refreshCounts()
+      if (interrupted && account.deferredLoadCleared(actionQuery)
+          && account.cache.loaded) {
+        account.cache.putQuery(actionQuery, ({
+          summaries: optimistic,
+          estimate: actionEstimate,
+          nextPageToken: optimisticToken
+        }))
+      }
+      if (account.resumeDeferredListLoad(actionQuery, "")) return
+      if (interrupted && account.cacheKey === actionQuery) {
+        account.rememberList()
+        account.loadMessages(false, true, "")
+      } else if (interrupted && account.cache.loaded) {
+        account.cache.putQuery(actionQuery, ({
+          summaries: optimistic,
+          estimate: actionEstimate,
+          nextPageToken: optimisticToken
+        }))
+      } else if (invalidatesPage && account.cacheKey === actionQuery) {
+        account.loadMessages(false, true, "")
+      }
+      if (account.active && account.cacheKey !== actionQuery)
+        account.loadMessages(false, true, "")
+    }
+
+    if (action === "trash" || action === "untrash") {
+      // One request per row, so each answers for itself: `trashMessage` and
+      // `untrashMessage` take a row's whole list of members on every client.
+      var remaining = listed.length
+      var firstError = ""
+      var failed = []
+      var each = function(rowId) {
+        return function(payload, error) {
+          if (error) {
+            if (firstError === "") firstError = String(error)
+            failed.push(rowId)
+          }
+          remaining--
+          if (remaining === 0) done(null, firstError, failed)
+        }
+      }
+      for (var d = 0; d < listed.length; d++) {
+        var owned = targetsOf[listed[d]]
+        var sent = owned.length > 1 ? owned : owned[0]
+        if (action === "trash") account.api.trashMessage(sent, each(listed[d]))
+        else account.api.untrashMessage(sent, each(listed[d]))
+      }
+    } else {
+      account.api.batchModify(targets, change.add, change.remove, done)
+    }
+    return true
+  }
+}

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -2023,6 +2023,14 @@ Item {
     return true
   }
 
+  // The batch — several ticked rows at once — lives in `BatchAction.qml`.
+  function actMany(ids, action) { return batchAction.run(ids, action) }
+
+  BatchAction {
+    id: batchAction
+    account: root
+  }
+
   // ---------------------------------------------------------------- reply
 
   // Loads the original bytes before a forward can claim it includes them.
@@ -2356,85 +2364,13 @@ Item {
 
   // ------------------------------------------------------------------ RSVP
 
-  // Answering an invitation is sending a mail, which is the whole reason this
-  // needs no calendar API, no second OAuth scope, and works the same on IMAP
-  // as on Gmail: an RFC 5546 REPLY addressed to the organiser is what every
-  // calendar server is already listening for.
-  //
-  // Not routed through `send`: that one is the compose window's, and finishing
-  // emits `replySent`, which closes it. This finishes with a card that has
-  // changed its mind.
-  function rsvp(response) {
-    if (!ready || rsvpSending || !canRespondToInvite) return
-    var answer = String(response || "")
-    // The alias the invitation was addressed to, not the account's primary
-    // address: the ATTENDEE line has to name the person who was invited.
-    var answeringAs = receivedAsAddress
-    var answeringName = receivedAsName
-    var fields = Calendar.replyFields(selectedInvite,
-      ({ email: answeringAs, name: answeringName }), answer)
-    if (!fields) {
-      fail("This invitation names no organiser to answer")
-      return
-    }
+  // See `Rsvp.qml`: the account file is at its size ceiling.
+  function rsvp(response) { rsvpAction.run(response) }
+  readonly property alias bodies: bodyCache
 
-    // The message the answer belongs to, held so a reply that lands after the
-    // reader has moved on does not mark a different message answered.
-    var messageId = selectedId
-    var invited = selectedInvite
-    var summary = selectedMessage
-    rsvpSending = true
-    clearNotice()
-
-    api.sendMessage(Mail.buildSendPayload({
-      // The ATTENDEE line claims this address; the envelope has to agree, or a
-      // strict organiser drops the reply as somebody answering for a third
-      // party. Gmail fills a From in for itself, and the IMAP client puts the
-      // account on the envelope rather than in the headers — so neither of
-      // them would have written this one.
-      from: answeringAs,
-      fromName: answeringName,
-      accountAddress: ownAddress,
-      to: fields.to,
-      subject: fields.subject,
-      body: fields.body,
-      calendar: fields.calendar,
-      // Threaded with the invitation it answers, the way a calendar's own
-      // reply is. An answer that starts a conversation of its own is one the
-      // organiser reads as a second, unrelated mail.
-      inReplyTo: summary ? summary.messageId : "",
-      threadId: summary ? summary.threadId : ""
-    }), function(payload, error) {
-      root.rsvpSending = false
-      if (error) {
-        root.fail(error)
-        return
-      }
-      root.note("Answer sent to " + fields.to)
-      if (root.selectedId !== messageId) return
-      root.rememberResponse(messageId, invited, answeringAs, answer)
-    })
-  }
-
-  // The answer, written back into the copy of the invitation on disk.
-  //
-  // The `text/calendar` part is the organiser's document and this does not
-  // rewrite it — but a message reopened tomorrow reading its own file would
-  // otherwise show its buttons unanswered, after the answer had been sent and
-  // had worked. Everything else in the row is what is already on screen, which
-  // is what was cached a moment ago.
-  function rememberResponse(messageId, invited, answeringAs, answer) {
-    var updated = Calendar.withResponse(invited, answeringAs, answer)
-    selectedInvite = updated
-    bodyCache.put(messageId, ({
-      text: selectedBody.text,
-      source: selectedBody.source,
-      html: sourceHtml,
-      attachments: selectedAttachments,
-      images: selectedImages,
-      invite: updated,
-      unsubscribe: selectedUnsubscribe
-    }))
+  Rsvp {
+    id: rsvpAction
+    account: root
   }
 
   // ----------------------------------------------------------- unsubscribe
@@ -2880,13 +2816,19 @@ Item {
 
   // The client takes the manager as a required property, so it cannot be built
   // until there is one.
+  // A test's stand-in for the provider: a component the loader prefers when
+  // set, so the account can be driven against a controlled client without a
+  // server or a credential. Never set outside a test.
+  property Component clientOverride: null
+
   Loader {
     id: apiLoader
     active: !!authLoader.item
-    sourceComponent: root.providerId === "imap" || root.providerId === "outlook"
-      ? imapClientComponent
-      : (root.providerId === "jmap" ? jmapClientComponent
-        : (root.providerId === "hey" ? heyClientComponent : gmailClientComponent))
+    sourceComponent: root.clientOverride ? root.clientOverride
+      : (root.providerId === "imap" || root.providerId === "outlook"
+        ? imapClientComponent
+        : (root.providerId === "jmap" ? jmapClientComponent
+          : (root.providerId === "hey" ? heyClientComponent : gmailClientComponent)))
   }
 
   Component {

--- a/account/Model.js
+++ b/account/Model.js
@@ -781,7 +781,8 @@ function sidebarSlots(mailboxes, labels, limit) {
   var boxes = Array.isArray(mailboxes) ? mailboxes : []
   for (var i = 0; i < boxes.length && out.length < max; i++) {
     if (!boxes[i] || !boxes[i].key) continue
-    out.push({ kind: "mailbox", key: String(boxes[i].key), name: String(boxes[i].label || "") })
+    out.push({ kind: "mailbox", key: String(boxes[i].key), name: String(boxes[i].label || ""),
+      icon: String(boxes[i].icon || "mail") })
   }
   var all = railLabels(labels)
   for (var j = 0; j < all.length && out.length < max; j++) {
@@ -1320,4 +1321,231 @@ function previewReadable(messages, id) {
 // the message, or asking for them in the reader, loads them.
 function showsRemoteImages(alwaysShow, isPreview) {
   return alwaysShow === true && isPreview !== true
+}
+
+// ------------------------------------------------------------ the scope
+
+// What the window is looking at, named the way the rail names it: the mailbox
+// whose key is open, or the label or folder whose query is. A label is matched
+// by the id the rail selected it with first, and by its query second, because
+// a folder restored from the store carries the query and nothing else.
+//
+// The answer is never empty. A key the provider does not list — a cache from an
+// older version, a mailbox removed from the provider's table — still names
+// itself, capitalised, rather than leaving the header with nothing to say.
+function currentScope(mailboxKey, mailboxes, labels, rawQuery, rawLabelId, labelQueryOf) {
+  var query = String(rawQuery || "")
+  var labelId = String(rawLabelId || "")
+  var all = Array.isArray(labels) ? labels : []
+  if (query !== "") {
+    var i
+    for (i = 0; i < all.length; i++) {
+      if (!all[i] || all[i].system) continue
+      if (labelId !== "" && String(all[i].id || "") === labelId)
+        return { kind: "label", id: String(all[i].id || ""),
+          name: String(all[i].name || all[i].rawName || ""), icon: "label" }
+    }
+    for (i = 0; i < all.length; i++) {
+      if (!all[i] || all[i].system) continue
+      var name = String(all[i].rawName || all[i].name || "")
+      if (typeof labelQueryOf === "function" && labelQueryOf(name) === query)
+        return { kind: "label", id: String(all[i].id || ""),
+          name: String(all[i].name || name), icon: "label" }
+    }
+    return { kind: "label", id: labelId, name: query, icon: "label" }
+  }
+  var key = String(mailboxKey || "inbox")
+  var boxes = Array.isArray(mailboxes) ? mailboxes : []
+  for (var j = 0; j < boxes.length; j++) {
+    if (boxes[j] && String(boxes[j].key) === key)
+      return { kind: "mailbox", key: key, name: String(boxes[j].label || key),
+        icon: String(boxes[j].icon || "mail") }
+  }
+  return { kind: "mailbox", key: key,
+    name: key.charAt(0).toUpperCase() + key.slice(1), icon: "mail" }
+}
+
+// The rows the mailbox switcher draws: the rail's own numbered list, each row
+// told whether it is the scope on screen. Same slots as the badges and the
+// Ctrl digits, so the number a row shows here is the key that opens it from
+// the list too.
+function switcherRows(slots, labels, scope) {
+  var list = Array.isArray(slots) ? slots : []
+  var all = Array.isArray(labels) ? labels : []
+  var current = scope || {}
+  var out = []
+  for (var i = 0; i < list.length; i++) {
+    var slot = list[i]
+    if (!slot) continue
+    var row = { kind: slot.kind, name: String(slot.name || ""), number: i + 1,
+      count: 0, icon: "mail", selected: false }
+    if (slot.kind === "mailbox") {
+      row.key = String(slot.key || "")
+      row.icon = String(slot.icon || "mail")
+      row.selected = current.kind === "mailbox" && current.key === row.key
+    } else {
+      row.id = String(slot.id || "")
+      row.icon = "label"
+      row.selected = current.kind === "label" && current.id !== "" && current.id === row.id
+      for (var j = 0; j < all.length; j++) {
+        if (all[j] && String(all[j].id || "") === row.id) {
+          row.count = Math.max(0, Math.floor(Number(all[j].unread) || 0))
+          if (!row.selected && current.kind === "label" && current.id === "")
+            row.selected = String(all[j].rawName || all[j].name || "") === current.name
+          break
+        }
+      }
+    }
+    out.push(row)
+  }
+  return out
+}
+
+// ------------------------------------------------------------ selection
+
+// The rows checked for a bulk action. A list of ids rather than a flag on the
+// summaries, because a summary is what the provider said about a message and
+// which rows the user has ticked is not that.
+function toggleId(ids, id) {
+  var list = Array.isArray(ids) ? ids.slice() : []
+  var key = String(id || "")
+  if (key === "") return list
+  var at = list.indexOf(key)
+  if (at >= 0) list.splice(at, 1)
+  else list.push(key)
+  return list
+}
+
+// Every id from one row to another, inclusive, in list order — what a
+// Shift+click means. Either end unknown to the list means just the other.
+function idsBetween(list, fromId, toId) {
+  var source = Array.isArray(list) ? list : []
+  var a = indexById(source, fromId)
+  var b = indexById(source, toId)
+  if (a < 0 && b < 0) return []
+  if (a < 0) a = b
+  if (b < 0) b = a
+  var lo = Math.min(a, b)
+  var hi = Math.max(a, b)
+  var out = []
+  for (var i = lo; i <= hi; i++) out.push(source[i].id)
+  return out
+}
+
+function unionIds(ids, more) {
+  var out = Array.isArray(ids) ? ids.slice() : []
+  var extra = Array.isArray(more) ? more : []
+  for (var i = 0; i < extra.length; i++) {
+    if (out.indexOf(extra[i]) < 0) out.push(extra[i])
+  }
+  return out
+}
+
+// The checked ids that are still listed. A reload, a search or an action can
+// take rows away, and a selection that kept naming them would act on messages
+// the user can no longer see.
+function retainIds(ids, list) {
+  var source = Array.isArray(list) ? list : []
+  var checked = Array.isArray(ids) ? ids : []
+  var out = []
+  for (var i = 0; i < checked.length; i++) {
+    if (indexById(source, checked[i]) >= 0) out.push(checked[i])
+  }
+  return out
+}
+
+function allIds(list) {
+  var source = Array.isArray(list) ? list : []
+  var out = []
+  for (var i = 0; i < source.length; i++) out.push(source[i].id)
+  return out
+}
+
+function summariesById(list, ids) {
+  var source = Array.isArray(list) ? list : []
+  var checked = Array.isArray(ids) ? ids : []
+  var out = []
+  for (var i = 0; i < checked.length; i++) {
+    var index = indexById(source, checked[i])
+    if (index >= 0) out.push(source[index])
+  }
+  return out
+}
+
+// Where the cursor goes when several rows leave at once: the first survivor
+// after it, or the last one before it. Worked out on the list as it still is,
+// like cursorAfterRemoval, and for the same reason.
+function cursorAfterRemovals(list, removedIds, cursorId) {
+  var source = Array.isArray(list) ? list : []
+  var gone = Array.isArray(removedIds) ? removedIds : []
+  var index = indexById(source, cursorId)
+  if (index < 0) return ""
+  var i
+  for (i = index; i < source.length; i++) {
+    if (gone.indexOf(source[i].id) < 0) return source[i].id
+  }
+  for (i = index - 1; i >= 0; i--) {
+    if (gone.indexOf(source[i].id) < 0) return source[i].id
+  }
+  return ""
+}
+
+// One star key over several rows: they all go the way the majority has not
+// gone yet. All starred means unstar; anything else means star, so a mixed
+// selection lands in one state rather than swapping every row.
+function starActionFor(summaries) {
+  var rows = Array.isArray(summaries) ? summaries : []
+  if (rows.length === 0) return "star"
+  for (var i = 0; i < rows.length; i++) {
+    if (!rows[i] || !rows[i].starred) return "star"
+  }
+  return "unstar"
+}
+
+// "3 messages archived": the count, then the single-message note with its
+// capital taken off. One rule for every action, so a new action's note only
+// has to be written once.
+function batchNote(count, actionLabel) {
+  var label = String(actionLabel || "")
+  if (label === "") return pluralize(count, "message")
+  return pluralize(count, "message") + " " + label.charAt(0).toLowerCase() + label.slice(1)
+}
+
+function selectionStatus(count) {
+  var n = Math.max(0, Math.floor(Number(count) || 0))
+  return n === 0 ? "" : n + " selected"
+}
+
+// The rows whose request failed, put back where they were: each is taken
+// from the list as it stood before the action and inserted at its old
+// place, or as near as the rows still around it allow. Rows whose request
+// succeeded are left as the action left them.
+function restoreRows(current, before, failedIds) {
+  var now = Array.isArray(current) ? current.slice() : []
+  var was = Array.isArray(before) ? before : []
+  var ids = Array.isArray(failedIds) ? failedIds : []
+  for (var i = 0; i < was.length; i++) {
+    var row = was[i]
+    if (!row || ids.indexOf(String(row.id)) < 0) continue
+    var at = indexById(now, row.id)
+    if (at >= 0) { now[at] = row; continue }
+    // The first later row of the old order that is still present decides
+    // where this one goes back; none means the end.
+    var insertAt = now.length
+    for (var j = i + 1; j < was.length; j++) {
+      var later = indexById(now, was[j].id)
+      if (later >= 0) { insertAt = later; break }
+    }
+    now.splice(insertAt, 0, row)
+  }
+  return now
+}
+
+// "2 of 5 could not be moved to trash: <reason>" — the count that failed,
+// the count asked, the action in the words its note uses, and why.
+function batchFailureNote(asked, failed, actionLabel, error) {
+  var label = String(actionLabel || "")
+  var verb = label === "" ? "acted on" : label.charAt(0).toLowerCase() + label.slice(1)
+  var reason = String(error || "").trim()
+  return failed + " of " + asked + " could not be " + verb + (reason === "" ? "" : ": " + reason)
 }

--- a/account/Rsvp.qml
+++ b/account/Rsvp.qml
@@ -1,0 +1,99 @@
+import QtQuick
+import "../message/Message.js" as Mail
+import "../message/Calendar.js" as Calendar
+
+// Answering an invitation is sending a mail, which is the whole reason this
+// needs no calendar API, no second OAuth scope, and works the same on IMAP
+// as on Gmail: an RFC 5546 REPLY addressed to the organiser is what every
+// calendar server is already listening for. Not routed through the account's
+// `send`: that one is the compose window's, and finishing emits `replySent`,
+// which closes it. This finishes with a card that has changed its mind.
+// Beside the account rather than in it, which is at its size ceiling; the
+// state the reader draws (`rsvpSending`, `selectedResponse`) stays there.
+QtObject {
+  id: rsvpAction
+
+  required property var account
+
+
+  // Answering an invitation is sending a mail, which is the whole reason this
+  // needs no calendar API, no second OAuth scope, and works the same on IMAP
+  // as on Gmail: an RFC 5546 REPLY addressed to the organiser is what every
+  // calendar server is already listening for.
+  //
+  // Not routed through `send`: that one is the compose window's, and finishing
+  // emits `replySent`, which closes it. This finishes with a card that has
+  // changed its mind.
+  function run(response) {
+    if (!account.ready || account.rsvpSending || !account.canRespondToInvite) return
+    var answer = String(response || "")
+    // The alias the invitation was addressed to, not the account's primary
+    // address: the ATTENDEE line has to name the person who was invited.
+    var answeringAs = account.receivedAsAddress
+    var answeringName = account.receivedAsName
+    var fields = Calendar.replyFields(account.selectedInvite,
+      ({ email: answeringAs, name: answeringName }), answer)
+    if (!fields) {
+      account.fail("This invitation names no organiser to answer")
+      return
+    }
+
+    // The message the answer belongs to, held so a reply that lands after the
+    // reader has moved on does not mark a different message answered.
+    var messageId = account.selectedId
+    var invited = account.selectedInvite
+    var summary = account.selectedMessage
+    account.rsvpSending = true
+    account.clearNotice()
+
+    account.api.sendMessage(Mail.buildSendPayload({
+      // The ATTENDEE line claims this address; the envelope has to agree, or a
+      // strict organiser drops the reply as somebody answering for a third
+      // party. Gmail fills a From in for itself, and the IMAP client puts the
+      // account on the envelope rather than in the headers — so neither of
+      // them would have written this one.
+      from: answeringAs,
+      fromName: answeringName,
+      accountAddress: account.ownAddress,
+      to: fields.to,
+      subject: fields.subject,
+      body: fields.body,
+      calendar: fields.calendar,
+      // Threaded with the invitation it answers, the way a calendar's own
+      // reply is. An answer that starts a conversation of its own is one the
+      // organiser reads as a second, unrelated mail.
+      inReplyTo: summary ? summary.messageId : "",
+      threadId: summary ? summary.threadId : ""
+    }), function(payload, error) {
+      account.rsvpSending = false
+      if (error) {
+        account.fail(error)
+        return
+      }
+      account.note("Answer sent to " + fields.to)
+      if (account.selectedId !== messageId) return
+      rememberResponse(messageId, invited, answeringAs, answer)
+    })
+  }
+
+  // The answer, written back into the copy of the invitation on disk.
+  //
+  // The `text/calendar` part is the organiser's document and this does not
+  // rewrite it — but a message reopened tomorrow reading its own file would
+  // otherwise show its buttons unanswered, after the answer had been sent and
+  // had worked. Everything else in the row is what is already on screen, which
+  // is what was cached a moment ago.
+  function rememberResponse(messageId, invited, answeringAs, answer) {
+    var updated = Calendar.withResponse(invited, answeringAs, answer)
+    account.selectedInvite = updated
+    account.bodies.put(messageId, ({
+      text: account.selectedBody.text,
+      source: account.selectedBody.source,
+      html: account.sourceHtml,
+      attachments: account.selectedAttachments,
+      images: account.selectedImages,
+      invite: updated,
+      unsubscribe: account.selectedUnsubscribe
+    }))
+  }
+}

--- a/components/AccountSwitcher.qml
+++ b/components/AccountSwitcher.qml
@@ -378,6 +378,7 @@ Item {
 
           HoverHandler { id: rowHover }
           TapHandler {
+            gesturePolicy: TapHandler.ReleaseWithinBounds
             onTapped: {
               menu.close()
               root.accountChosen(row.index)
@@ -441,6 +442,6 @@ Item {
     }
 
     HoverHandler { id: plainHover }
-    TapHandler { onTapped: plainRow.activated() }
+    TapHandler { gesturePolicy: TapHandler.ReleaseWithinBounds; onTapped: plainRow.activated() }
   }
 }

--- a/components/ContactsPicker.qml
+++ b/components/ContactsPicker.qml
@@ -255,6 +255,7 @@ Item {
 
           HoverHandler { id: contactHover }
           TapHandler {
+            gesturePolicy: TapHandler.ReleaseWithinBounds
             onTapped: {
               root.contactChosen(contactRow.modelData, "to")
               menu.close()

--- a/components/LabelPicker.qml
+++ b/components/LabelPicker.qml
@@ -201,6 +201,7 @@ Item {
           HoverHandler { id: rowHover }
 
           TapHandler {
+            gesturePolicy: TapHandler.ReleaseWithinBounds
             onTapped: {
               root.cursorIndex = labelRow.index
               root.chooseCursor()

--- a/components/MailboxSwitcher.qml
+++ b/components/MailboxSwitcher.qml
@@ -1,0 +1,226 @@
+import QtQuick
+import QtQuick.Controls as QQC
+import qs.Commons
+import qs.Ui
+import "../account/Model.js" as Model
+import "Menu.js" as Menu
+
+// The rail as a menu: every mailbox and label the sidebar draws, opened from
+// the header's scope line or from `Alt+M`, for a window whose rail is
+// collapsed to icons, folded into tabs, or simply further from the pointer
+// than the header is.
+//
+// The rows are `Model.switcherRows` over the same slots the rail numbers, so
+// the digit a row shows here is the Ctrl key that opens it from the list, and
+// a bare digit while this is up opens it too.
+Item {
+  id: root
+
+  required property color textColor
+  required property color accentColor
+  required property color dimColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
+  required property string panelFontFamily
+
+  // [{ kind, key|id, name, icon, count, selected, number }]
+  property var rows: []
+
+  readonly property bool opened: menu.opened
+  readonly property alias menuRows: list
+
+  // Where the keyboard is standing, and never where the mouse is: a row draws
+  // its own hover, for the reason the account switcher gives.
+  property int cursorIndex: 0
+
+  signal rowChosen(int index)
+
+  anchors.fill: parent
+  z: 45
+
+  property real anchorX: 0
+  property real anchorY: 0
+
+  function openAt(sceneX, sceneY) {
+    var local = root.mapFromGlobal(sceneX, sceneY)
+    anchorX = local.x
+    anchorY = local.y
+    menu.open()
+    place()
+  }
+
+  // Placed after it opens and again whenever its height changes: a Popup has
+  // no height until its first open, and this list changes length with the
+  // account's labels.
+  function place() {
+    if (!menu.visible) return
+    var tall = menu.height > 0 ? menu.height : menu.implicitHeight
+    var placed = Menu.position(anchorX, anchorY, menu.width, tall, root.width, root.height)
+    menu.x = placed.x
+    menu.y = placed.y
+  }
+
+  function openCentered() {
+    anchorX = Math.max(0, (root.width - menu.width) / 2)
+    anchorY = Math.max(0, (root.height - menu.implicitHeight) / 2)
+    menu.open()
+    place()
+  }
+
+  function close() { menu.close() }
+
+  function moveCursor(delta) {
+    var count = root.rows ? root.rows.length : 0
+    if (count === 0) return
+    cursorIndex = Model.wrappedIndex(cursorIndex, delta, count)
+  }
+
+  function choose(index) {
+    var count = root.rows ? root.rows.length : 0
+    if (index < 0 || index >= count) return
+    menu.close()
+    root.rowChosen(index)
+  }
+
+  function chooseCursor() { choose(cursorIndex) }
+
+  // Opening puts the keyboard on the scope already open, so the first `j` is
+  // one step from it rather than back at the top.
+  function restCursorOnActive() {
+    var all = root.rows || []
+    for (var i = 0; i < all.length; i++) {
+      if (all[i].selected) { cursorIndex = i; return }
+    }
+    cursorIndex = 0
+  }
+
+  QQC.Popup {
+    id: menu
+    width: Style.space(230)
+    implicitHeight: list.implicitHeight + Style.space(8)
+    padding: Style.space(4)
+    modal: false
+    focus: true
+    closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
+    onHeightChanged: root.place()
+    onOpened: {
+      root.restCursorOnActive()
+      root.place()
+    }
+    background: Rectangle {
+      radius: Style.cornerRadius
+      color: root.popupBackgroundColor
+      border.width: 1
+      border.color: root.popupBorderColor
+    }
+
+    // Keys answered here rather than in `KeyRouter`, because an open popup
+    // takes every key before the shortcut map sees it. AGENTS.md, "Keys and
+    // focus", and `tests/qml/tst_popup_keys.qml` hold the reason.
+    contentItem: Column {
+      id: list
+      focus: true
+      spacing: Style.space(2)
+
+      Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_J || event.key === Qt.Key_Down) {
+          root.moveCursor(1)
+          event.accepted = true
+        } else if (event.key === Qt.Key_K || event.key === Qt.Key_Up) {
+          root.moveCursor(-1)
+          event.accepted = true
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter
+            || event.key === Qt.Key_O) {
+          root.chooseCursor()
+          event.accepted = true
+        } else if (event.key >= Qt.Key_0 && event.key <= Qt.Key_9) {
+          // The digit on the row, which is the Ctrl digit from the list: `0`
+          // is the tenth row, as it is on the rail.
+          var number = event.key === Qt.Key_0 ? 10 : event.key - Qt.Key_0
+          root.choose(number - 1)
+          event.accepted = true
+        }
+      }
+
+      Repeater {
+        model: root.rows
+
+        Rectangle {
+          id: row
+          objectName: "mailbox-row"
+          required property var modelData
+          required property int index
+
+          readonly property bool hasCursor: root.cursorIndex === row.index
+
+          width: menu.width - menu.leftPadding - menu.rightPadding
+          implicitHeight: Style.spacing.popupRowHeight
+          radius: Style.cornerRadius
+          color: modelData.selected
+            ? Style.selectedFillFor(root.textColor, root.accentColor)
+            : (rowHover.hovered || hasCursor
+              ? Style.hoverFillFor(root.textColor, root.accentColor) : "transparent")
+          border.width: hasCursor ? Style.normalBorderWidth : 0
+          border.color: Style.hoverBorderFor(root.textColor, root.accentColor)
+
+          ActionIcon {
+            id: rowIcon
+            anchors.left: parent.left
+            anchors.leftMargin: Style.space(8)
+            anchors.verticalCenter: parent.verticalCenter
+            name: row.modelData.icon
+            iconSize: Style.font.iconSmall
+            color: root.textColor
+          }
+
+          Text {
+            anchors.left: rowIcon.right
+            anchors.leftMargin: Style.space(8)
+            anchors.right: suffix.left
+            anchors.rightMargin: Style.space(8)
+            anchors.verticalCenter: parent.verticalCenter
+            // A label's name was typed by the account's owner.
+            textFormat: Text.PlainText
+            text: row.modelData.name
+            color: root.textColor
+            font.family: root.panelFontFamily
+            font.pixelSize: Style.font.bodySmall
+            font.bold: row.modelData.selected
+            elide: Text.ElideRight
+          }
+
+          // The count where a label has one, then the key that opens the row.
+          Row {
+            id: suffix
+            anchors.right: parent.right
+            anchors.rightMargin: Style.space(9)
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: Style.space(6)
+
+            Text {
+              anchors.verticalCenter: parent.verticalCenter
+              visible: row.modelData.count > 0
+              text: row.modelData.count > 999 ? "999+" : String(row.modelData.count)
+              color: root.textColor
+              font.family: root.panelFontFamily
+              font.pixelSize: Style.font.caption
+              font.bold: true
+            }
+
+            Text {
+              anchors.verticalCenter: parent.verticalCenter
+              visible: row.modelData.number >= 1 && row.modelData.number <= 10
+              text: row.modelData.number === 10 ? "0" : String(row.modelData.number)
+              color: root.dimColor
+              font.family: root.panelFontFamily
+              font.pixelSize: Style.font.caption
+            }
+          }
+
+          HoverHandler { id: rowHover }
+          TapHandler { gesturePolicy: TapHandler.ReleaseWithinBounds; onTapped: root.choose(row.index) }
+        }
+      }
+    }
+  }
+}

--- a/components/MenuActionRow.qml
+++ b/components/MenuActionRow.qml
@@ -37,5 +37,12 @@ Rectangle {
   }
 
   HoverHandler { id: hover }
-  TapHandler { onTapped: root.activated() }
+  // The exclusive grab on press, not a passive one: a menu can sit over a
+  // message row, whose MouseArea takes the exclusive grab if this does not,
+  // and the release then opens the message under the menu instead of
+  // running the row that was clicked.
+  TapHandler {
+    gesturePolicy: TapHandler.ReleaseWithinBounds
+    onTapped: root.activated()
+  }
 }

--- a/components/MessageList.qml
+++ b/components/MessageList.qml
@@ -23,8 +23,16 @@ Column {
   required property color dimColor
   required property string panelFontFamily
   property string cursorId: ""
+  // The rows ticked for a bulk action, by id. Held above the list, like the
+  // cursor, because a reload rebuilds every row.
+  property var checkedIds: []
 
   signal messageActivated(string id)
+  signal checkToggled(string id)
+  signal checkRangeRequested(string id)
+  // A row's own star, archive and trash buttons. Routed up rather than
+  // straight to the service so a ticked row's button means the selection.
+  signal rowActionRequested(string id, string action)
   signal menuRequested(string id, real sceneX, real sceneY)
 
   width: parent ? parent.width : 0
@@ -56,13 +64,17 @@ Column {
       panelFontFamily: root.panelFontFamily
       hasCursor: root.cursorId === modelData.id
       selected: root.service.selectedId === modelData.id
+      checked: root.checkedIds.indexOf(modelData.id) >= 0
+      selectionActive: root.checkedIds.length > 0
       canArchive: root.service.canArchive
       conversations: Unified.rowIsConversation(modelData)
       contentDirection: root.service.contentDirection
       onActivated: root.messageActivated(modelData.id)
-      onStarToggled: root.service.toggleStar(modelData.id)
-      onArchiveRequested: root.service.act(modelData.id, "archive")
-      onTrashRequested: root.service.act(modelData.id, "trash")
+      onCheckToggled: root.checkToggled(modelData.id)
+      onCheckRangeRequested: root.checkRangeRequested(modelData.id)
+      onStarToggled: root.rowActionRequested(modelData.id, "star")
+      onArchiveRequested: root.rowActionRequested(modelData.id, "archive")
+      onTrashRequested: root.rowActionRequested(modelData.id, "trash")
       onMenuRequested: function(sceneX, sceneY) {
         root.menuRequested(modelData.id, sceneX, sceneY)
       }

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -310,7 +310,7 @@ Item {
       foreground: root.summary && root.summary.starred ? root.accentColor : root.dimColor
       hoverColor: root.accentColor
       fontFamily: root.panelFontFamily
-      onClicked: if (root.service && root.summary) root.service.toggleStar(root.selectedId)
+      onClicked: if (root.service && root.summary) root.actionRequested("star")
     }
 
     Column {

--- a/components/MessageRow.qml
+++ b/components/MessageRow.qml
@@ -28,17 +28,33 @@ Rectangle {
   property bool conversations: false
   property bool hasCursor: false
   property bool selected: false
+  // Ticked for a bulk action. Not `selected`: that is the message the reader
+  // shows, and the two are different things for the same reason the cursor is.
+  property bool checked: false
+  // Whether any row in the list is ticked. While one is, every row shows its
+  // box, so the lane the boxes sit in is the same on every row being compared.
+  property bool selectionActive: false
   // How the direction of this message's own text is arrived at. Passed down
   // like every other fact a row draws, because a row decides nothing.
   property string contentDirection: Direction.MODE_DEFAULT
 
   signal activated()
+  signal checkToggled()
+  signal checkRangeRequested()
   signal starToggled()
   signal archiveRequested()
   signal trashRequested()
   signal menuRequested(real sceneX, real sceneY)
 
-  readonly property bool hot: mouse.containsMouse || hasCursor
+  // Hovered by a handler rather than by the MouseArea's `containsMouse`: a
+  // button on the row has a MouseArea of its own, and the pointer moving onto
+  // one took the row's hover away — the extra buttons hid, the lane closed,
+  // the button slid out from under the pointer, the row was hovered again,
+  // and the lane flickered open and shut. A HoverHandler is passive and stays
+  // hovered whatever the pointer is over inside the row.
+  readonly property bool hot: rowHover.hovered || hasCursor
+
+  HoverHandler { id: rowHover }
 
   // How many messages the conversation holds, for the badge — and zero for a
   // row that draws none, which `Model.badgeCount` decides: a provider that does
@@ -69,9 +85,13 @@ Rectangle {
   width: parent ? parent.width : 0
   implicitHeight: body.implicitHeight + Style.space(14)
   radius: Style.cornerRadius
+  // A ticked row is filled from the accent, but the tick is what says it is
+  // ticked: some themes put the accent close to the foreground.
   color: selected
     ? Style.selectedFillFor(textColor, accentColor)
-    : (hot ? Style.hoverFillFor(textColor, accentColor) : "transparent")
+    : (checked
+      ? Qt.rgba(accentColor.r, accentColor.g, accentColor.b, hot ? 0.22 : 0.14)
+      : (hot ? Style.hoverFillFor(textColor, accentColor) : "transparent"))
 
   MouseArea {
     id: mouse
@@ -87,6 +107,12 @@ Rectangle {
         // Middle-click archives: the one triage action worth having without
         // moving the pointer to a button.
         root.archiveRequested()
+      } else if (event.modifiers & Qt.ShiftModifier) {
+        // Shift extends the selection from the cursor to here; Ctrl ticks
+        // this row on its own. Both are the file manager's meaning of them.
+        root.checkRangeRequested()
+      } else if (event.modifiers & Qt.ControlModifier) {
+        root.checkToggled()
       } else {
         root.activated()
       }
@@ -101,8 +127,55 @@ Rectangle {
     width: Style.space(5)
     height: width
     radius: width / 2
-    visible: root.summary.unread
+    // The box takes the dot's place while it is shown; unread is still
+    // carried by the weight and the brighter subject.
+    visible: root.summary.unread && !checkBox.visible
     color: root.accentColor
+  }
+
+  // The tick, in the lane the unread dot lives in so the text never moves.
+  // Shown under the pointer or the cursor, and on every row while any row is
+  // ticked, so a selection being built can be read down the column.
+  Rectangle {
+    id: checkBox
+    objectName: "message-check"
+    anchors.left: parent.left
+    anchors.leftMargin: Style.space(1)
+    anchors.top: parent.top
+    anchors.topMargin: Style.space(10)
+    width: Style.space(10)
+    height: width
+    radius: Style.space(2)
+    visible: root.hot || root.checked || root.selectionActive
+    color: root.checked ? Style.selectedFillFor(root.textColor, root.accentColor) : "transparent"
+    border.width: Style.normalBorderWidth
+    border.color: root.checked ? root.accentColor
+      : (checkMouse.containsMouse ? root.textColor : root.dimColor)
+
+    ActionIcon {
+      anchors.centerIn: parent
+      visible: root.checked
+      name: "check"
+      iconSize: Style.space(8)
+      color: root.textColor
+    }
+
+    MouseArea {
+      id: checkMouse
+      anchors.fill: parent
+      anchors.margins: -Style.space(3)
+      hoverEnabled: true
+      onClicked: function(event) {
+        if (event.modifiers & Qt.ShiftModifier) root.checkRangeRequested()
+        else root.checkToggled()
+      }
+    }
+
+    PanelToolTip {
+      visible: checkMouse.containsMouse
+      text: (root.checked ? "Deselect" : "Select") + " · x (Shift+click a range, Ctrl+A all)"
+      fontFamily: root.panelFontFamily
+    }
   }
 
   Column {

--- a/components/ReaderBlankSlate.qml
+++ b/components/ReaderBlankSlate.qml
@@ -46,6 +46,7 @@ Item {
     { key: "Enter or o", action: "Open the selected message" },
     { key: "e", action: "Archive" },
     { key: "d", action: "Move to trash" },
+    { key: "x", action: "Select; the keys above then act on every selected message" },
     { key: "r", action: "Reply" },
     { key: "c", action: "Compose" }
   ]

--- a/components/ScopeButton.qml
+++ b/components/ScopeButton.qml
@@ -1,0 +1,90 @@
+import QtQuick
+import qs.Commons
+import qs.Ui
+
+// One segment of the header's scope line: the account, or the mailbox open in
+// it. A ghost control — the text is the state and the fill only appears under
+// the pointer or while the popup it opens is up — with a small chevron after
+// the name to say it is a list, not a title.
+Rectangle {
+  id: root
+
+  property string iconName: ""
+  property string text: ""
+  property string tooltipText: ""
+  required property color foreground
+  required property color hoverColor
+  required property color accent
+  property string fontFamily: Style.font.family
+  property real fontSize: Style.font.bodySmall
+  property real iconSize: Style.font.iconSmall
+  // Held for as long as the popup this opens is on screen, so the segment
+  // that opened it stays lit — see "Popups and their triggers" in AGENTS.md.
+  property bool selected: false
+  // The name is elided rather than the header, which has a search field and
+  // two buttons to keep on it.
+  property real maxTextWidth: Style.space(180)
+
+  signal clicked()
+
+  readonly property bool hot: mouse.containsMouse && enabled
+  readonly property color inkColor: hot || selected ? hoverColor : foreground
+
+  implicitWidth: row.implicitWidth + Style.spacing.controlPaddingX * 2
+  implicitHeight: Math.max(Style.space(24), iconSize + Style.spacing.sm * 2)
+  radius: Style.cornerRadius
+  color: mouse.pressed ? Style.pressedFillFor(root.foreground, root.accent)
+    : (root.selected ? Style.selectedFillFor(root.foreground, root.accent)
+      : (hot ? Style.hoverFillFor(root.foreground, root.accent) : "transparent"))
+  border.width: root.selected ? Style.normalBorderWidth : 0
+  border.color: Style.hoverBorderFor(root.foreground, root.accent)
+
+  Row {
+    id: row
+    anchors.centerIn: parent
+    spacing: Style.spacing.sm
+
+    ActionIcon {
+      anchors.verticalCenter: parent.verticalCenter
+      visible: root.iconName !== ""
+      name: root.iconName
+      iconSize: root.iconSize
+      color: root.inkColor
+    }
+
+    Text {
+      id: label
+      anchors.verticalCenter: parent.verticalCenter
+      visible: root.text !== ""
+      // An account's name and a folder's name are both written by somebody.
+      textFormat: Text.PlainText
+      text: root.text
+      width: Math.min(implicitWidth, root.maxTextWidth)
+      elide: Text.ElideRight
+      color: root.inkColor
+      font.family: root.fontFamily
+      font.pixelSize: root.fontSize
+    }
+
+    ActionIcon {
+      anchors.verticalCenter: parent.verticalCenter
+      name: "chevronDown"
+      iconSize: Style.font.iconSmall
+      color: root.inkColor
+      opacity: root.hot || root.selected ? 1.0 : 0.6
+    }
+  }
+
+  MouseArea {
+    id: mouse
+    anchors.fill: parent
+    hoverEnabled: true
+    onClicked: root.clicked()
+  }
+
+  PanelToolTip {
+    visible: root.tooltipText !== "" && mouse.containsMouse
+    text: root.tooltipText
+    fontFamily: root.fontFamily
+  }
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -51,7 +51,7 @@ QML components should express those contracts in QML terms: properties, signals,
 
 The window has a fixed hierarchy:
 
-1. Header: identity, global search, refresh, and compose.
+1. Header: identity, global search, refresh, and compose. Identity is the scope line — the account, then the mailbox or label open in it — and each half is the control that changes it, so the window says what it is looking at whether or not the sidebar is expanded.
 2. Body: navigation, collection, and content.
 3. Status bar: sidebar control, synchronization/account state, notice, and contextual key hints.
 4. Overlay layer: menus, account switcher, shortcut sheet, and other transient surfaces.

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -97,6 +97,8 @@ used to exist, and they had.
 | `moveToLabel` | `v` | mail | Move to |
 | `markRead` | `Shift+I` | mail | Mark read |
 | `markUnread` | `Shift+U` | mail | Mark unread |
+| `toggleCheck` | `x` | list | Select or deselect the message |
+| `checkAll` | `Ctrl+A` | list | Select every message loaded, or none |
 | `reply` | `r` | mail | Reply |
 | `replyAll` | `a` | mail | Reply to all |
 | `forward` | `f` | mail | Forward |
@@ -116,6 +118,7 @@ used to exist, and they had.
 | `goMailbox` | `Ctrl+1`, `Ctrl+2`, `Ctrl+3`, `Ctrl+4`, `Ctrl+5`, `Ctrl+6`, `Ctrl+7`, `Ctrl+8`, `Ctrl+9`, `Ctrl+0` | mail | Go to that mailbox |
 | `goAccount` | `Alt+1`, `Alt+2`, `Alt+3`, `Alt+4`, `Alt+5`, `Alt+6`, `Alt+7`, `Alt+8`, `Alt+9`, `Alt+0` | mail+calendar | Go to that email account |
 | `switchAccount` | `Alt+A` | mail | Switch account |
+| `switchMailbox` | `Alt+M` | mail | Go to a mailbox |
 | `calendar` | `Alt+C` | mail+calendar | Switch between mail and calendar |
 | `mailView` | `Ctrl+Shift+M` | mail+calendar | Go to mail |
 | `calendarView` | `Ctrl+Shift+C` | mail+calendar | Go to calendar |
@@ -167,7 +170,9 @@ no event, so what follows Ctrl still goes where it always went. It clears on
 waiting for one that is not coming would paint the numbers on permanently.
 
 `Escape` is the only bare key bound everywhere, because it is the way out of
-everywhere. Where it goes is not decided by the key: the window keeps a history
+everywhere. With rows ticked and the list on screen — alone, or beside the
+reader in a wide window — it unticks them first and goes nowhere; the next
+press goes back. Where it goes is not decided by the key: the window keeps a history
 of the places it has been — a stack in `App.qml`, ruled by
 `account/Navigation.js` — and `Escape`, like every Back bar, calls `back()`,
 which pops one entry. A draft, the event form and the shortcut sheet are
@@ -192,7 +197,9 @@ read with a mouse would be the one screen here that contradicts the rest.
 `focus` true or false, bare key or modified. So `Alt+A` opens it through the
 table like any other key, and from there `j`, `k`, `Enter` and `o` come from a
 `Keys` handler on the popup's own `contentItem`: the one place in this window
-where the rule at the top of this document runs backwards.
+where the rule at the top of this document runs backwards. The mailbox switcher
+(`Alt+M`) is the same popup over the rail's rows, and inside it a bare digit is
+the Ctrl digit: `4` opens the fourth row, `0` the tenth.
 `tests/qml/tst_popup_keys.qml` holds the Qt behaviour that makes it so, and
 `Model.wrappedIndex` holds the only decision in it — the cursor wraps, where the
 message list clamps.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -91,7 +91,7 @@ render or are checked against it, so no second list is maintained by hand.
 
 `j`/`k` move · `Enter` or `o` open · `u` back to list · `e` archive · `d` trash ·
 `s` star · `r`/`a`/`f` reply, reply all, forward · `c` compose · `/`
-search · `Alt+1`…`0` the mailboxes · `Alt+A` switch account · `?` the reference sheet ·
+search · `Alt+1`…`0` the mailboxes · `Alt+A` switch account · `Alt+M` go to a mailbox · `?` the reference sheet ·
 `Esc` back or close.
 
 **See `docs/KEYS.md`** for the model, the contexts, the full table, and the four

--- a/keys/Keymap.js
+++ b/keys/Keymap.js
@@ -67,7 +67,7 @@ var BINDINGS = [
     hint: { list: "archive", reader: "archive" } },
   { id: "trash", keys: ["d"], contexts: MAIL,
     group: "Acting", label: "Move to trash",
-    hint: { reader: "trash" } },
+    hint: { list: "trash", reader: "trash" } },
   { id: "star", keys: ["s"], contexts: MAIL,
     group: "Acting", label: "Star or unstar" },
   // `v` because that is the key Gmail moves a message with, and issue #58 asks
@@ -83,6 +83,14 @@ var BINDINGS = [
     group: "Acting", label: "Mark read" },
   { id: "markUnread", keys: ["Shift+U"], contexts: MAIL,
     group: "Acting", label: "Mark unread" },
+  // Gmail's `x`: tick the row under the cursor, and the acting keys above
+  // then mean every ticked row rather than the one the cursor is on. List
+  // only — in the reader there is one message and it is the one open.
+  { id: "toggleCheck", keys: ["x"], contexts: ["list"],
+    group: "Acting", label: "Select or deselect the message",
+    hint: { list: "select" } },
+  { id: "checkAll", keys: ["Ctrl+A"], contexts: ["list"],
+    group: "Acting", label: "Select every message loaded, or none" },
 
   // Answering works from the list too, the way the row's own menu does: the
   // message is opened first and the draft waits for it. Binding these to the
@@ -155,6 +163,10 @@ var BINDINGS = [
   // then walks: `j`/`k` to move, `Enter` or `o` to take one.
   { id: "switchAccount", keys: ["Alt+A"], contexts: MAIL,
     group: "Going", label: "Switch account" },
+  // The rail as a list, for a window whose rail is collapsed or folded into
+  // tabs. Same rows, same digits: a bare digit inside it is the Ctrl digit.
+  { id: "switchMailbox", keys: ["Alt+M"], contexts: MAIL,
+    group: "Going", label: "Go to a mailbox" },
 
   { id: "calendar", keys: ["Alt+C"], contexts: ["list", "reader", "calendar"],
     group: "Going", label: "Switch between mail and calendar" },

--- a/tests/qml/tst_batch_actions.qml
+++ b/tests/qml/tst_batch_actions.qml
@@ -1,0 +1,272 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../.." as Omamail
+import "../../account/Accounts.js" as Accounts
+
+// The batch's two boundaries, driven against a client the test controls.
+//
+// Ownership: an IMAP id is a UID and a folder, unique only inside one
+// account, so ticks made in one mailbox must never be dispatched through
+// another — however the switch reached the service. Reconciliation: one
+// request per message answers per message, so a refusal on one row must
+// put back that row and no other, and a whole-batch refusal must read the
+// list again rather than restore rows the server may have changed.
+Item {
+  width: 900
+  height: 600
+
+  QtObject {
+    id: shellStore
+    function updateEntryInline(_id, _entry) {}
+    function hide(_id) {}
+  }
+
+  // Every call the account makes, recorded by the account's address. Trash
+  // and untrash answer per id, one refused; batchModify answers as a whole.
+  QtObject {
+    id: record
+    property var trashed: []
+    property var untrashed: []
+    property var batches: []
+    property int lists: 0
+    property string refuse: ""
+    property bool refuseBatch: false
+    function reset() { trashed = []; untrashed = []; batches = []; lists = 0; refuse = ""; refuseBatch = false }
+  }
+
+  Component {
+    id: controlledClient
+    QtObject {
+      property var auth: null
+      property string email: ""
+      function handle() { return ({ aborted: false }) }
+      function later(fn) { Qt.callLater(fn); return handle() }
+      function trashMessage(id, callback) {
+        var mine = record.trashed.slice(); mine.push(String(id)); record.trashed = mine
+        var refused = String(id) === record.refuse
+        return later(function() { callback(null, refused ? "the server refused this one" : "") })
+      }
+      function untrashMessage(id, callback) {
+        var mine = record.untrashed.slice(); mine.push(String(id)); record.untrashed = mine
+        var refused = String(id) === record.refuse
+        return later(function() { callback(null, refused ? "the server refused this one" : "") })
+      }
+      function batchModify(ids, add, remove, callback) {
+        var mine = record.batches.slice(); mine.push(ids.join(",")); record.batches = mine
+        var refused = record.refuseBatch
+        return later(function() { callback(null, refused ? "the batch was refused" : "") })
+      }
+      function modifyMessage(id, add, remove, callback) { return batchModify([id], add, remove, callback) }
+      function listMessages() { record.lists = record.lists + 1; return handle() }
+      function getMessages() { return handle() }
+      function getMessage() { return handle() }
+      function getLabels(callback) { return later(function() { callback([], "") }) }
+      function getLabelCounts(id, callback) { return later(function() { callback({ id: id, unread: 0, total: 0, threadsUnread: 0 }, "") }) }
+      function getProfile(callback) { return later(function() { callback({ email: email }, "") }) }
+      function getSendAs(callback) { return later(function() { callback([], "") }) }
+      function getAttachment() { return handle() }
+      function saveDraft() { return handle() }
+      function deleteDraft() { return handle() }
+      function sendMessage() { return handle() }
+      function createLabel() { return handle() }
+      function renameLabel() { return handle() }
+      function deleteLabel() { return handle() }
+      function abortRequest(h) { if (h) h.aborted = true }
+    }
+  }
+
+  Omamail.Service {
+    id: mailService
+    shell: shellStore
+    manifest: ({ id: "omamail", __sourceDir: "/tmp/omamail-test" })
+  }
+
+  Omamail.App { id: app; service: mailService }
+
+  TestCase {
+    name: "BatchActions"
+    when: windowShown
+
+    readonly property string ada: "ada@example.com"
+    readonly property string bob: "bob@example.com"
+
+    function entry(email) {
+      return {
+        email: email, provider: "imap", clientId: "", clientSecret: "",
+        imap: { imapHost: "imap.example.com", imapPort: 993, smtpHost: "smtp.example.com", smtpPort: 465,
+          username: email, aliases: [], insecure: false },
+        label: "", signature: ""
+      }
+    }
+
+    function row(id) {
+      return ({ id: id, threadId: "", from: { email: "x@example.com", display: "X" }, subject: id,
+        snippet: "", time: "", date: "", unread: false, starred: false, inInbox: true, labelIds: ["INBOX"] })
+    }
+
+    function seed(entries, activeId) {
+      var list = Accounts.emptyList()
+      for (var i = 0; i < entries.length; i++) list = Accounts.add(list, entries[i])
+      list = Accounts.setActive(list, activeId)
+      mailService.activeIndex = -1
+      mailService.accountList = list
+      mailService.accountsLoaded = true
+      wait(0)
+      mailService.refreshCurrent()
+      for (var h = 0; h < entries.length; h++) {
+        var account = mailService.accountAt(h)
+        verify(account !== null)
+        account.clientOverride = controlledClient
+        account.auth.toolsChecked = true
+        account.auth.missingTools = []
+        account.auth.passwordChecked = true
+        account.auth.password = "test-password"
+        tryCompare(account, "ready", true)
+        account.listLoaded = true
+      }
+    }
+
+    function init() {
+      record.reset()
+      app.checkedIds = []
+      app.checkedAccountId = ""
+      app.resetNavigation()
+    }
+
+    // Ada and Bob both hold 42:INBOX. Ticked in Ada's list, the id must not
+    // become a trash request through Bob's client, whether the switch came
+    // through the window or straight to the service.
+    function test_ticks_do_not_cross_an_account_switch() {
+      seed([entry(ada), entry(bob)], "imap:" + ada)
+      mailService.accountAt(0).messages = [row("42:INBOX"), row("43:INBOX")]
+      mailService.accountAt(1).messages = [row("42:INBOX")]
+      app.cursorId = "42:INBOX"
+      verify(app.toggleCheck("42:INBOX"))
+      compare(app.checkedIds.length, 1)
+
+      verify(app.switchAccount(1))
+      compare(mailService.activeAccountId, "imap:" + bob)
+      compare(app.checkedIds.length, 0, "the switch dropped the ticks")
+      compare(app.cursorId, "", "and the cursor, which is an id of Ada's too")
+      app.runShortcut("trash", "d")
+      wait(30)
+      compare(record.trashed.length, 0, "nothing was trashed through Bob")
+
+      // And a switch the window did not make.
+      verify(mailService.switchToIndex(0))
+      app.cursorId = "42:INBOX"
+      verify(app.toggleCheck("42:INBOX"))
+      verify(mailService.switchToIndex(1))
+      wait(30)
+      compare(app.checkedIds.length, 0, "a switch at the service drops them too")
+      app.checkedIds = ["42:INBOX"]
+      app.checkedAccountId = "imap:" + ada
+      compare(app.actOnChecked("trash"), false, "ticks owned by another mailbox build no batch")
+      compare(record.trashed.length, 0)
+    }
+
+    // One request per message: the refused row comes back where it was; the
+    // accepted one stays gone; the note says which.
+    function test_a_partly_refused_trash_restores_only_the_refused_rows() {
+      seed([entry(ada)], "imap:" + ada)
+      var account = mailService.accountAt(0)
+      account.messages = [row("1:INBOX"), row("2:INBOX"), row("3:INBOX")]
+      record.refuse = "2:INBOX"
+      app.cursorId = "1:INBOX"
+      verify(app.toggleCheck("1:INBOX"))
+      verify(app.toggleCheck("2:INBOX"))
+      app.runShortcut("trash", "d")
+      compare(account.messages.length, 1, "both rows left optimistically")
+      tryCompare(record, "trashed", ["1:INBOX", "2:INBOX"])
+      tryVerify(function() { return account.messages.length === 2 }, 1000)
+      compare(account.messages.map(function(m) { return m.id }), ["2:INBOX", "3:INBOX"],
+        "the refused row is back in its place; the accepted one is gone")
+      verify(account.lastError.indexOf("1 of 2") >= 0, "the note counts the refusal: " + account.lastError)
+    }
+
+    // The refused row is back, but the accepted one is gone, so the page
+    // token the optimistic update cleared cannot simply come back: the page
+    // is read again from the server, which is what makes older mail
+    // reachable after a partial refusal.
+    function test_a_partly_refused_trash_reads_the_page_again() {
+      seed([entry(ada)], "imap:" + ada)
+      var account = mailService.accountAt(0)
+      account.messages = [row("1:INBOX"), row("2:INBOX"), row("3:INBOX")]
+      account.nextPageToken = "older-page"
+      record.refuse = "2:INBOX"
+      app.cursorId = "1:INBOX"
+      verify(app.toggleCheck("1:INBOX"))
+      verify(app.toggleCheck("2:INBOX"))
+      var listsBefore = record.lists
+      app.runShortcut("trash", "d")
+      compare(account.hasMore, false, "the optimistic page has no token")
+      tryCompare(record, "trashed", ["1:INBOX", "2:INBOX"])
+      tryVerify(function() { return account.messages.length === 2 }, 1000)
+      tryVerify(function() { return record.lists > listsBefore }, 1000)
+      compare(account.messages.map(function(m) { return m.id }), ["2:INBOX", "3:INBOX"],
+        "the restored rows stay on screen while the server answers")
+      verify(account.listLoading, "the page is being read again")
+      verify(account.lastError.indexOf("1 of 2") >= 0, "the note is up while the page is read: " + account.lastError)
+    }
+
+    // A refresh asked for while the batch is in flight waits for it, and
+    // runs once the refused rows are back rather than being forgotten —
+    // the partial refusal, which has its own completion path, included.
+    function test_a_refresh_waiting_on_a_partly_refused_batch_runs_after_it() {
+      seed([entry(ada)], "imap:" + ada)
+      var account = mailService.accountAt(0)
+      account.messages = [row("1:INBOX"), row("2:INBOX"), row("3:INBOX")]
+      record.refuse = "2:INBOX"
+      app.cursorId = "1:INBOX"
+      verify(app.toggleCheck("1:INBOX"))
+      verify(app.toggleCheck("2:INBOX"))
+      var listsBefore = record.lists
+      app.runShortcut("trash", "d")
+      compare(account.pendingAction, "trash")
+      account.loadMessages(false, true, "")
+      compare(record.lists, listsBefore, "the refresh waits on the action")
+      verify(account.deferredListLoad !== null, "and is remembered")
+      tryCompare(record, "trashed", ["1:INBOX", "2:INBOX"])
+      tryVerify(function() { return account.pendingAction === "" }, 1000)
+      tryVerify(function() { return record.lists > listsBefore }, 1000)
+      compare(account.deferredListLoad, null, "the waiting refresh ran")
+      compare(account.messages.map(function(m) { return m.id }), ["2:INBOX", "3:INBOX"],
+        "with the refused row back and the accepted one gone")
+      verify(account.lastError.indexOf("1 of 2") >= 0, account.lastError)
+    }
+
+    // The same, for a batch that finishes as a whole: the refresh waits and runs.
+    function test_a_refresh_waiting_on_a_batch_runs_after_it() {
+      seed([entry(ada)], "imap:" + ada)
+      var account = mailService.accountAt(0)
+      account.messages = [row("1:INBOX"), row("2:INBOX")]
+      app.cursorId = "1:INBOX"
+      verify(app.toggleCheck("1:INBOX"))
+      verify(app.toggleCheck("2:INBOX"))
+      var listsBefore = record.lists
+      app.runShortcut("markRead", "I")
+      compare(account.pendingAction, "markRead")
+      account.loadMessages(false, true, "")
+      compare(record.lists, listsBefore, "the refresh waits on the action")
+      tryVerify(function() { return account.pendingAction === "" }, 1000)
+      tryVerify(function() { return record.lists > listsBefore }, 1000)
+      compare(account.deferredListLoad, null, "the waiting refresh ran")
+    }
+
+    // A whole-batch refusal from a client that answers with one word is not
+    // proof that nothing changed: the list is read again from the server.
+    function test_a_refused_batch_reads_the_list_again() {
+      seed([entry(ada)], "imap:" + ada)
+      var account = mailService.accountAt(0)
+      account.messages = [row("1:INBOX"), row("2:INBOX")]
+      record.refuseBatch = true
+      app.cursorId = "1:INBOX"
+      verify(app.toggleCheck("1:INBOX"))
+      verify(app.toggleCheck("2:INBOX"))
+      var listsBefore = record.lists
+      app.runShortcut("archive", "e")
+      tryCompare(record, "batches", ["1:INBOX,2:INBOX"])
+      tryVerify(function() { return record.lists > listsBefore }, 1000)
+    }
+  }
+}

--- a/tests/qml/tst_batch_actions.qml
+++ b/tests/qml/tst_batch_actions.qml
@@ -133,6 +133,62 @@ Item {
       app.resetNavigation()
     }
 
+    function having(item, accept) {
+      if (accept(item)) return item
+      var children = item.children || []
+      for (var i = 0; i < children.length; i++) {
+        var found = having(children[i], accept)
+        if (found) return found
+      }
+      return null
+    }
+
+    function test_reader_star_uses_the_visible_selection_data() {
+      return [
+        { tag: "checked-open-message", checked: true, outside: false, compact: false, starred: false, expected: "1:INBOX,2:INBOX" },
+        { tag: "unstar-checked-messages", checked: true, outside: false, compact: false, starred: true, expected: "1:INBOX,2:INBOX" },
+        { tag: "open-message-outside-selection", checked: true, outside: true, compact: false, starred: false, expected: "3:INBOX" },
+        { tag: "compact-reader-hides-selection", checked: true, outside: false, compact: true, starred: false, expected: "1:INBOX" },
+        { tag: "no-selection", checked: false, outside: false, compact: false, starred: false, expected: "1:INBOX" }
+      ]
+    }
+
+    function test_reader_star_uses_the_visible_selection(data) {
+      seed([entry(ada)], "imap:" + ada)
+      var account = mailService.accountAt(0)
+      var messages = [row("1:INBOX"), row("2:INBOX"), row("3:INBOX")]
+      for (var i = 0; i < messages.length; i++) messages[i].starred = data.starred
+      account.messages = messages
+      account.selectedId = data.outside ? "3:INBOX" : "1:INBOX"
+      account.selectedMessage = messages[data.outside ? 2 : 0]
+      app.open()
+      var window = having(app, function(item) { return item.title === "Omamail" })
+      verify(window !== null)
+      window.width = data.compact ? 600 : 980
+      app.pushEntry("reader", { id: account.selectedId })
+      if (data.checked) {
+        verify(app.toggleCheck("1:INBOX"))
+        verify(app.toggleCheck("2:INBOX"))
+      }
+      compare(app.selectionActive, data.checked && !data.compact)
+      var cursorBefore = app.cursorId
+      var reader = having(app, function(item) { return item.forceRichAnyway !== undefined })
+      verify(reader !== null)
+      var star = having(reader, function(item) { return item.iconName === "star" })
+      verify(star !== null)
+      wait(0)
+      mouseClick(star, star.width / 2, star.height / 2)
+      tryCompare(record, "batches", [data.expected])
+      compare(app.cursorId, cursorBefore, "starring does not move the list cursor")
+      var acted = data.expected.split(",")
+      for (var j = 0; j < messages.length; j++) {
+        var changed = acted.indexOf(messages[j].id) >= 0
+        compare(account.messages[j].starred, changed ? !data.starred : data.starred)
+      }
+      app.close()
+      window.width = 980
+    }
+
     // Ada and Bob both hold 42:INBOX. Ticked in Ada's list, the id must not
     // become a trash request through Bob's client, whether the switch came
     // through the window or straight to the service.

--- a/tests/test_keymap.js
+++ b/tests/test_keymap.js
@@ -242,7 +242,7 @@ assert.strictEqual(keymap.hintKeyFor(byId("archive")), "e",
 
 const listHints = keymap.hintsFor("list")
 deepEqual(listHints.map(function (h) { return h.key + " " + h.label }),
-  ["j / k move", "o open", "e archive", "c compose"],
+  ["j / k move", "o open", "e archive", "d trash", "x select", "c compose"],
   "the status bar offers what the list can do, in its short form")
 const composeHints = keymap.hintsFor("compose")
 deepEqual(composeHints.map(function (h) { return h.label }),

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -1106,3 +1106,121 @@ assert.strictEqual(model.previewReadable(dwelt, "gone"), false,
   "a search or a mailbox switch takes the row out from under the dwell")
 assert.strictEqual(model.previewReadable([], "m1"), false)
 assert.strictEqual(model.previewReadable(dwelt, ""), false)
+
+// ------------------------------------------------------------ the scope
+//
+// The header names what the window is looking at from the same facts the rail
+// draws: the open mailbox key, or the label whose query is open.
+{
+  const boxes = [
+    { key: "inbox", label: "Inbox", icon: "inbox" },
+    { key: "sent", label: "Sent", icon: "sent" }]
+  const labels = [
+    { id: "INBOX", name: "INBOX", system: true },
+    { id: "Label_17", name: "Todo", rawName: "todo", unread: 3 },
+    { id: "Label_9", name: "Receipts", rawName: "Receipts", unread: 0 }]
+  const gmailQuery = function (name) { return "label:" + name }
+
+  deepEqual(model.currentScope("sent", boxes, labels, "", "", gmailQuery),
+    { kind: "mailbox", key: "sent", name: "Sent", icon: "sent" })
+  deepEqual(model.currentScope("", boxes, labels, "", "", gmailQuery),
+    { kind: "mailbox", key: "inbox", name: "Inbox", icon: "inbox" },
+    "an empty key is the inbox, as it is everywhere else")
+  deepEqual(model.currentScope("drafts", boxes, labels, "", "", gmailQuery),
+    { kind: "mailbox", key: "drafts", name: "Drafts", icon: "mail" },
+    "a key the provider does not list still names itself")
+
+  // A label selected from the rail carries its id; one carried by a query
+  // alone is found through the provider's own query rule.
+  deepEqual(model.currentScope("inbox", boxes, labels, "label:todo", "Label_17", gmailQuery),
+    { kind: "label", id: "Label_17", name: "Todo", icon: "label" })
+  deepEqual(model.currentScope("inbox", boxes, labels, "label:todo", "", gmailQuery),
+    { kind: "label", id: "Label_17", name: "Todo", icon: "label" },
+    "the query alone still names the label")
+  deepEqual(model.currentScope("inbox", boxes, labels, "label:gone", "", gmailQuery),
+    { kind: "label", id: "", name: "label:gone", icon: "label" },
+    "a query no label answers to is shown as it is rather than as nothing")
+  deepEqual(model.currentScope("inbox", boxes, labels, "label:todo", "Label_17", null).name,
+    "Todo", "matching by id needs no query rule")
+
+  // The switcher's rows are the rail's slots, numbered the way the Ctrl keys
+  // are, with the open scope marked.
+  const slots = model.sidebarSlots(boxes, labels, 10)
+  const rows = model.switcherRows(slots, labels,
+    model.currentScope("inbox", boxes, labels, "label:todo", "Label_17", gmailQuery))
+  assert.strictEqual(rows.length, 4)
+  deepEqual(rows[0], { kind: "mailbox", key: "inbox", name: "Inbox", icon: "inbox",
+    number: 1, count: 0, selected: false })
+  // The rail draws labels A to Z, so Receipts sits above todo whatever
+  // order the provider listed them in, and the switcher follows the rail.
+  deepEqual(rows[2], { kind: "label", id: "Label_9", name: "Receipts", icon: "label",
+    number: 3, count: 0, selected: false })
+  deepEqual(rows[3], { kind: "label", id: "Label_17", name: "todo", icon: "label",
+    number: 4, count: 3, selected: true })
+  assert.strictEqual(rows[2].selected, false)
+  assert.strictEqual(rows[2].number, 3)
+
+  const inInbox = model.switcherRows(slots, labels,
+    model.currentScope("inbox", boxes, labels, "", "", gmailQuery))
+  assert.strictEqual(inInbox[0].selected, true)
+  assert.strictEqual(inInbox[3].selected, false)
+
+  // A folder known only by name — an IMAP label whose id the store did not
+  // keep — is still found on the row that shares the name.
+  const byName = model.switcherRows(slots, labels,
+    { kind: "label", id: "", name: "Receipts", icon: "label" })
+  assert.strictEqual(byName[2].selected, true)
+  assert.strictEqual(byName[3].selected, false)
+
+  assert.strictEqual(model.switcherRows(null, null, null).length, 0)
+}
+
+// ------------------------------------------------------------ selection
+{
+  const list = [{ id: "a", starred: true }, { id: "b" }, { id: "c", starred: true }, { id: "d" }]
+
+  deepEqual(model.toggleId([], "b"), ["b"])
+  deepEqual(model.toggleId(["b", "c"], "b"), ["c"])
+  deepEqual(model.toggleId(["b"], ""), ["b"], "an empty id toggles nothing")
+
+  deepEqual(model.idsBetween(list, "b", "d"), ["b", "c", "d"])
+  deepEqual(model.idsBetween(list, "d", "b"), ["b", "c", "d"], "either direction")
+  deepEqual(model.idsBetween(list, "", "c"), ["c"], "no anchor means the row itself")
+  deepEqual(model.idsBetween(list, "zz", "yy"), [])
+  deepEqual(model.unionIds(["a"], ["a", "c"]), ["a", "c"])
+
+  deepEqual(model.retainIds(["a", "gone", "c"], list), ["a", "c"])
+  deepEqual(model.allIds(list), ["a", "b", "c", "d"])
+  deepEqual(model.summariesById(list, ["c", "nope", "a"]), [list[2], list[0]])
+
+  // The cursor steps over every departing row to the first that stays, and
+  // back up the list only when nothing below survives.
+  assert.strictEqual(model.cursorAfterRemovals(list, ["b", "c"], "b"), "d")
+  assert.strictEqual(model.cursorAfterRemovals(list, ["c", "d"], "c"), "b")
+  assert.strictEqual(model.cursorAfterRemovals(list, ["a", "b", "c", "d"], "b"), "")
+  assert.strictEqual(model.cursorAfterRemovals(list, ["a"], "b"), "b", "a cursor off the selection stays")
+  assert.strictEqual(model.cursorAfterRemovals(list, ["a"], "nope"), "")
+
+  assert.strictEqual(model.starActionFor([list[0], list[2]]), "unstar")
+  assert.strictEqual(model.starActionFor([list[0], list[1]]), "star", "a mixed selection stars")
+  assert.strictEqual(model.starActionFor([]), "star")
+
+  assert.strictEqual(model.batchNote(3, "Archived"), "3 messages archived")
+  assert.strictEqual(model.batchNote(1, "Moved to Todo"), "1 message moved to Todo")
+  assert.strictEqual(model.selectionStatus(0), "")
+  assert.strictEqual(model.selectionStatus(2), "2 selected")
+}
+
+// A partly failed batch puts back only the rows that failed, in their old places.
+{
+  const before = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }]
+  const afterAction = [{ id: "a" }, { id: "d" }]
+  deepEqual(model.restoreRows(afterAction, before, ["c"]).map(function (r) { return r.id }), ["a", "c", "d"])
+  deepEqual(model.restoreRows(afterAction, before, ["b", "c"]).map(function (r) { return r.id }), ["a", "b", "c", "d"])
+  deepEqual(model.restoreRows([{ id: "a" }], before, ["d"]).map(function (r) { return r.id }), ["a", "d"], "no later row left means the end")
+  deepEqual(model.restoreRows([{ id: "a", unread: false }], [{ id: "a", unread: true }], ["a"]), [{ id: "a", unread: true }],
+    "a row still listed is put back as it was")
+  deepEqual(model.restoreRows(afterAction, before, []).map(function (r) { return r.id }), ["a", "d"])
+  assert.strictEqual(model.batchFailureNote(5, 2, "Moved to trash", "server said no"), "2 of 5 could not be moved to trash: server said no")
+  assert.strictEqual(model.batchFailureNote(3, 1, "Archived", ""), "1 of 3 could not be archived")
+}

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -757,13 +757,15 @@ awk '
 test "$(grep -c 'root.active && root.cacheKey !== actionQuery' account/MailAccount.qml)" -ge 2 \
   || fail "successful actions must revalidate a mailbox opened while they were pending"
 awk '
-  /function markAllRead\(\)/ { in_mark_all = 1 }
-  in_mark_all && /if \(interrupted\)/ { saw_interrupt = 1 }
-  in_mark_all && /root\.loadMessages\(false, true, error\)/ { saw_retry = 1 }
-  in_mark_all && /^  }/ { exit !(saw_interrupt && saw_retry) }
+  /function run\(/ { in_bulk = 1 }
+  in_bulk && /if \(interrupted\)/ { saw_interrupt = 1 }
+  in_bulk && /account\.loadMessages\(false, true, error\)/ { saw_retry = 1 }
+  in_bulk && /^  }/ { exit !(saw_interrupt && saw_retry) }
   END { exit !(saw_interrupt && saw_retry) }
-' account/MailAccount.qml \
-  || fail "mark-all must stop and revalidate a live list too"
+' account/BatchAction.qml \
+  || fail "a bulk action must stop and revalidate a live list too"
+grep -q 'return batchAction.run(ids, action)' account/MailAccount.qml \
+  || fail "the account must hand its batch to BatchAction"
 grep -q 'root\.loadMessages(false, true, error)' account/MailAccount.qml \
   || fail "a failed action must resume the list without losing its error"
 grep -q 'root\.loadMessages(false, true, "")' account/MailAccount.qml \


### PR DESCRIPTION
## What changes

**The header says what the window is looking at, and switches it.** The "Omamail" title becomes a scope line: the account, then the mailbox or label open in it — `iCloud › Inbox`, `Work › Receipts`. Each half is a control. The account half opens the existing account switcher; the mailbox half opens a new `MailboxSwitcher` popup over the rail's own numbered slots, also bound to `Alt+M`. Inside it `j`/`k`/`Enter`/`o` walk the rows and a bare digit is the Ctrl digit from the list. This is the answer for a window whose rail is collapsed to icons or folded into tabs, where nothing on screen said which account or folder was open.

**Several messages can be selected and acted on with the keys they already have.** A row gains a tick in the lane the unread dot lives in: under the pointer or cursor, and on every row while any is ticked, so the text never moves. `x` ticks the cursor row, `Ctrl+A` ticks every loaded row or none, Ctrl+click and Shift+click do the same with the mouse, and Escape unticks. While rows are ticked — the list alone, or beside the reader in a wide window — `e`, `d`, `s`, `v`, `Shift+I` and `Shift+U` act on all of them; a row's own buttons, the reader's archive, trash and star buttons and the row menu mean the selection on a ticked row and that row alone on any other. The status line counts the selection; the list's hints and the reader's blank slate name `x`.

## How

- `Model.currentScope` names what is open from the same facts the rail's selected row is drawn from: the mailbox key, or the label matched by the id it was selected with and then by the provider's own query rule. `Model.switcherRows` turns `sidebarSlots` into the popup's rows with the open one marked — the same list as the badges and the Ctrl digits.
- The selection is a list of ids held in `App.qml` beside the cursor, pruned by the same `onMessagesChanged` path when the list under it changes. Every acting key goes through the existing `actOnCursor`, which routes to `actOnChecked` when rows are ticked, so the provider guard in `MailAccount.act` still refuses what the mailbox cannot do before any optimistic update. Star over a mixed selection stars everything; only an all-starred selection unstars.
- `MailAccount.actMany(ids, action)` is the batch: one `batchModify` where the client takes a list, one `trashMessage` call per message where it does not, with the same optimistic update, restore-on-failure, live-list interruption and cache repair as `act`. `markAllRead` now goes through it, and the source regression that guarded mark-all follows it there.
- Two fixes that the scope line surfaced: a row hovers through a passive `HoverHandler`, so a button's own MouseArea no longer takes the hover and flickers the action lane; and every popup row takes the exclusive grab on press (`TapHandler.ReleaseWithinBounds`), because the app menu now drops over the message list and a passive grab let the row underneath receive the release.

## Verification

Reviewer validation on `a502077e74ed04c5656645f8a9be7144cced836d`: `QT_QPA_PLATFORMTHEME= make validate` passed, including JavaScript/shell, QML, native HTTP and sidebar text checks, qmllint and plugin validation. The reader star button now applies to the visible checked selection when it contains the open message. Five added runtime cases cover star/unstar, an open message outside the selection, compact mode and no selection; the two selection cases failed before the fix. The focused suite passed 13 cases. A fresh independent agent reviewed the repair and found no defects; Security: PASS for the affected scope.

Manual light/dark and wide/compact on-screen validation remains outstanding, so this revision is not yet approved.

The author previously reported live IMAP exercises on Office 365 via XOAUTH2 and iCloud, plus a Gmail-shaped label set: header scope, mailbox switching, selection keys and modifiers, and two-row read/unread actions. HEY was not exercised live. These are author-reported checks, not new reviewer live-mailbox tests.

## Release Notes

- The header now names the open account and mailbox, and each half opens a switcher; `Alt+M` opens the mailbox list from the keyboard.
- Select several messages with `x`, `Ctrl+A`, Ctrl+click or Shift+click, then archive, trash, star, move or mark them read or unread together with the usual keys and buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8PEgfKnNP3iPhiDZGSbx6
