### PR TITLE
Add Outlook OAuth authentication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ three directories away from the client that calls it.
   tests can reach it without a compositor. QML holds no logic worth testing.
 - One JS resource may build on others with QML's `.import "Other.js" as Other`,
   which is how `providers/Registry.js` is assembled out of `Gmail.js`,
-  `Hey.js` and `Imap.js` — and those out of `GmailApi.js` and `HeyCli.js` in
+  `Outlook.js`, `Hey.js` and `Imap.js` — and those out of `GmailApi.js` and `HeyCli.js` in
   turn, because where a message lives on the web is a fact about the service
   rather than about the registry. `tests/load.js` resolves the chain the same
   way the engine does, so the tests exercise the real files.
@@ -222,14 +222,14 @@ key. What matters while working:
 
 ## Providers
 
-- A mailbox is a **provider**: `gmail`, `hey`, or `imap`, listed in that order
-  because IMAP is the answer for a server the other two do not name and a
+- A mailbox is a **provider**: `gmail`, `outlook`, `hey`, or `imap`, listed in that order
+  because IMAP is the answer for a server the other three do not name and a
   chooser that opened with it would ask the question backwards. `Provider.js` is
   the only place that knows the differences — which mailboxes exist, what a query
   string means, what the service can be asked to do, and how it signs in.
   Nothing above it branches on a provider id.
 - Two objects make a provider work: something that signs in (`AuthManager`,
-  `HeyAuth`, `ImapAuth`) and something that fetches (`GmailApiClient`,
+  `OutlookAuth`, `HeyAuth`, `ImapAuth`) and something that fetches (`GmailApiClient`,
   `HeyClient`, `ImapClient`).
   `MailAccount` builds one pair through a `Loader` and drives them through an
   identical interface — same method names, same arguments, same callback shape.
@@ -364,6 +364,7 @@ key. What matters while working:
 ## Secrets
 
 - Refresh tokens go to GNOME Keyring over stdin, never through a command line.
+- Outlook access tokens reach curl over stdin and its `oauth2-bearer` config option; the account password never enters Omamail.
 - The OAuth client goes to a 0600 file, never to plugin settings: `shell.json`
   is world-readable.
 - Anything that could carry a credential passes through `OAuth.redact` before

--- a/App.qml
+++ b/App.qml
@@ -931,6 +931,21 @@ Item {
   }
 
   Component {
+    id: outlookSetupPage
+
+    OutlookSetupPage {
+      service: root.service
+      textColor: root.foreground
+      dimColor: root.dim
+      dangerColor: root.danger
+      accentColor: root.accent
+      panelFontFamily: root.fontFamily
+      accountCount: root.service ? root.service.accountCount : 1
+      onRemoveRequested: root.removeCurrentAccountFromEditor()
+    }
+  }
+
+  Component {
     id: imapSetupPage
 
     ImapSetupPage {
@@ -1645,7 +1660,8 @@ Item {
             sourceComponent: root.showPicker
               ? providerPickerPage
               : (setup.kind === "imap" ? imapSetupPage
-                : (setup.kind === "hey" ? heySetupPage : gmailSetupPage))
+                : (setup.kind === "outlook" ? outlookSetupPage
+                  : (setup.kind === "hey" ? heySetupPage : gmailSetupPage)))
           }
           }
         }

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,11 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	account/MailAccount.qml \
 	cache/CacheStore.qml cache/BodyCache.qml \
 	providers/AuthManager.qml providers/GmailApiClient.qml \
+	providers/OutlookAuth.qml \
 	providers/ImapAuth.qml providers/ImapClient.qml \
 	providers/HeyAuth.qml providers/HeyClient.qml \
 	components/ImapSetupPage.qml \
+	components/OutlookSetupPage.qml \
 	components/HeySetupPage.qml \
 	components/ProviderPicker.qml \
 	components/GmailIcon.qml \
@@ -70,6 +72,7 @@ test-js:
 	node tests/test_recipients.js
 	node tests/test_senders.js
 	node tests/test_oauth.js
+	node tests/test_microsoft_oauth.js
 	node tests/test_credentials.js
 	node tests/test_secrets.js
 	node tests/test_gmail_api.js

--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,7 @@ test-qml:
 		exit 1; }
 	QT_QPA_PLATFORM=offscreen QT_QUICK_BACKEND=software \
 		$(QMLTESTRUNNER) -import $(CURDIR)/tests/qml/imports -input tests/qml
+	python3 tests/test_outlook_http.py "$(QMLTESTRUNNER)"
 
 # Both engines on the same fixtures. The QML column is the one that decides
 # anything — the shell runs that engine, not node's — so run it on the machine

--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 **Your mail as a native Omarchy window — not a browser tab.**
 
-Omamail is an Omarchy desktop email client: a Quickshell plugin that reads,
-triages, and answers your mail over the official Gmail API, over the HEY CLI
-client 37signals publish, or over IMAP and SMTP for every other mailbox. It
-runs inside the `omarchy-shell` process you already have, follows your active
-theme, and puts an unread count in the bar.
+Omamail is an Omarchy desktop email client: a Quickshell plugin that reads, triages, and answers your mail over the official Gmail API, through Microsoft OAuth for Outlook, over the HEY CLI client 37signals publish, or over IMAP and SMTP for every other mailbox. It runs inside the `omarchy-shell` process you already have, follows your active theme, and puts an unread count in the bar.
 
 
 <img width="800" alt="Omamail - Reading a message in the three-column window" src="docs/images/full-mail.webp" />
@@ -29,10 +25,7 @@ other IMAP server — including one you run yourself.
   inside Omarchy rather than to look like a web app in a window. Three columns
   when there is room, one when there is not, and nothing on screen that is not
   your mail.
-- **Gmail, HEY and IMAP.** Sign in to Gmail with Google directly, to HEY
-  through the HEY CLI that 37signals publish, or add any IMAP mailbox with an
-  address and an app password. Several accounts at once, each with its own
-  inbox, cache and unread count.
+- **Gmail, Outlook, HEY and IMAP.** Sign in to Gmail with Google, to Outlook with Microsoft, to HEY through the HEY CLI that 37signals publish, or add any other IMAP mailbox with an address and an app password. Several accounts at once, each with its own inbox, cache and unread count.
 - **Keyboard-first.** `j`/`k` to move, `e` to archive, `v` to file, `s` to star, `r` to
   reply, `c` to compose, `Alt+1`…`0` for the mailboxes — hold Alt and the rail says
   which is which — `Alt+A` to switch account, `/` to search, `?` for the rest.
@@ -73,10 +66,7 @@ other IMAP server — including one you run yourself.
   every message read that way instead. The interface itself is unaffected.
 - **Your theme.** Every colour comes from the active Omarchy theme, so the
   mailbox changes the moment the desktop does.
-- **Keyring-backed.** The Gmail refresh token and every IMAP password live in
-  GNOME Keyring — never in a config file, never on a command line. A HEY
-  mailbox has no credential here at all: the HEY CLI holds its own token, and
-  Omamail only ever asks it whether it is signed in.
+- **Keyring-backed.** Gmail and Outlook refresh tokens and every IMAP password live in GNOME Keyring — never in a config file, never on a command line. A HEY mailbox has no credential here at all: the HEY CLI holds its own token, and Omamail only ever asks it whether it is signed in.
 
 ## What it is
 
@@ -117,13 +107,14 @@ Requires Omarchy 4, plus `socat`, `secret-tool`, `openssl`, `xdg-open`, `python3
 
 ## Mailboxes it can open
 
-Adding a mailbox asks which kind first, because the three setups have nothing in
-common.
+Adding a mailbox asks which kind first, because the four setups have nothing in common.
 
 **Gmail** signs in with Google directly. Google issues Gmail API access per
 project, so this route needs an OAuth client you create once — the setup page
 walks through it. In exchange it gets labels, conversations, Gmail's own search
 syntax, and a "report spam" that Google actually learns from.
+
+**Outlook** signs in on Microsoft's own page and uses [Microsoft's supported OAuth route for IMAP and SMTP][microsoft-mail-oauth]. It works with Outlook.com, Hotmail, Live and MSN accounts; Omamail never asks for the Microsoft account password. Until Omamail ships a maintainer-owned public client, the setup page asks for an Application (client) ID from a one-time Microsoft Entra app registration. Make it a public client for personal Microsoft accounts; the sign-in asks for `IMAP.AccessAsUser.All`, `SMTP.Send` and `offline_access` and shows the device code to enter in the Microsoft page it opens.
 
 **HEY** needs no address and no password. HEY publishes no IMAP, no POP and no
 public API, so Omamail reads it through the [HEY CLI][hey-cli] client 37signals
@@ -165,12 +156,7 @@ parts of a message that `hey` does not serve, or out of an endpoint it does not
 expose — so they stay in HEY's own app, which the setup page links to.
 
 
-**IMAP** is an address and a password. Fastmail, iCloud, Zoho, Outlook, GMX,
-Proton via its Bridge, or a server of your own: the servers are filled in from
-the address for the ones this knows, and shown behind a disclosure so they can
-be corrected for the ones it does not. Most providers want an *app password*
-rather than the one you sign in to their website with, and the form says so
-before you find out the hard way.
+**IMAP** is an address and a password. Fastmail, iCloud, Zoho, GMX, Proton via its Bridge, or a server of your own: the servers are filled in from the address for the ones this knows, and shown behind a disclosure so they can be corrected for the ones it does not. Most providers want an *app password* rather than the one you sign in to their website with, and the form says so before you find out the hard way.
 
 What IMAP does not have, the panel does not offer: no labels, no server-side
 conversations, no "report spam" — moving a message to a Junk folder teaches a
@@ -191,7 +177,7 @@ That takes the plugin itself. Nothing it wrote lives inside your Omarchy
 config, so removing those is separate and entirely up to you:
 
 ```bash
-secret-tool clear service omamail    # the refresh token and IMAP passwords
+secret-tool clear service omamail    # refresh tokens and IMAP passwords
 hey auth logout                      # the HEY session, if you added one
 rm -rf ~/.config/omamail             # the OAuth client and account list
 rm -rf ~/.cache/omamail              # cached mail
@@ -297,6 +283,7 @@ thousand of them, evicted least-recently-used.
   written over stdin so it never appears in the process table. Two mailboxes
   share one client, so keying by client alone would have let the second sign-in
   overwrite the first.
+- The Outlook refresh token goes to **GNOME Keyring** under its own provider, client and account keys. The Microsoft Application (client) ID is public configuration and stays with the account entry.
 - The OAuth client goes to `~/.config/omamail/credentials.json`, mode
   `0600`. Not to plugin settings — `shell.json` is world-readable.
 - The access token exists only in memory.
@@ -318,10 +305,9 @@ How to send a change — there is no issue tracker — is in
 [CONTRIBUTING.md](CONTRIBUTING.md). Working agreements are in
 [AGENTS.md](AGENTS.md) and the specification is in [docs/SPEC.md](docs/SPEC.md).
 
-Omamail is an independent project and is not affiliated with Google or
-37signals. Gmail is a trademark of Google LLC; HEY is a trademark of 37signals,
-LLC.
+Omamail is an independent project and is not affiliated with Google, Microsoft or 37signals. Gmail is a trademark of Google LLC; Outlook is a trademark of Microsoft Corporation; HEY is a trademark of 37signals, LLC.
 
 Licensed under the [MIT License](LICENSE).
 
 [hey-cli]: https://github.com/basecamp/hey-cli
+[microsoft-mail-oauth]: https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ syntax, and a "report spam" that Google actually learns from.
 
 **Outlook** signs in on Microsoft's own page and uses [Microsoft's supported OAuth route for IMAP and SMTP][microsoft-mail-oauth]. It works with Outlook.com, Hotmail, Live and MSN accounts; Omamail never asks for the Microsoft account password. Until Omamail ships a maintainer-owned public client, the setup page asks for an Application (client) ID from a one-time Microsoft Entra app registration. Make it a public client for personal Microsoft accounts; the sign-in asks for `IMAP.AccessAsUser.All`, `SMTP.Send` and `offline_access` and shows the device code to enter in the Microsoft page it opens.
 
+Before signing in, enable IMAP in Outlook.com: **Settings > Mail > Forwarding and IMAP > Let devices and apps use IMAP**, then save. Microsoft disables IMAP by default; OAuth consent alone does not enable mailbox access. See [Microsoft's IMAP setup instructions](https://support.microsoft.com/en-us/outlook/pop-imap-and-smtp-settings-for-outlook-com).
+
 **HEY** needs no address and no password. HEY publishes no IMAP, no POP and no
 public API, so Omamail reads it through the [HEY CLI][hey-cli] client 37signals
 ship for exactly this — which means the sign-in, the token and the keyring entry

--- a/Service.qml
+++ b/Service.qml
@@ -368,10 +368,8 @@ Item {
     return next
   }
 
-  // What the IMAP setup form saves: the address, the servers, and which
-  // provider this row is. Written before the password is tried, so a mailbox
-  // that fails to sign in still has its settings to correct rather than an
-  // empty form to fill in again.
+  // What a provider setup form saves: the address, non-secret client or server
+  // configuration, and which provider this row is.
   function configureAccount(index, values) {
     var accounts = accountList.accounts
     if (index < 0 || index >= accounts.length) return
@@ -381,6 +379,8 @@ Item {
     for (var key in accounts[index]) entry[key] = accounts[index][key]
     if (raw.provider !== undefined) entry.provider = raw.provider
     if (raw.email !== undefined) entry.email = raw.email
+    if (raw.clientId !== undefined) entry.clientId = raw.clientId
+    if (raw.clientSecret !== undefined) entry.clientSecret = raw.clientSecret
     if (raw.imap !== undefined) entry.imap = raw.imap
     if (raw.label !== undefined) entry.label = raw.label
 
@@ -946,6 +946,13 @@ Item {
     Qt.callLater(function() { root.signInWithPassword(secret) })
   }
 
+  // OAuth providers save their non-secret client configuration before the
+  // account host that owns the browser flow is built.
+  function configureCurrentAccountAndSignInOAuth(values) {
+    configureCurrentAccount(values)
+    Qt.callLater(function() { root.signIn() })
+  }
+
   function indexOfActiveAccount() {
     var accounts = accountList ? accountList.accounts : []
     for (var i = 0; i < accounts.length; i++) {
@@ -1078,6 +1085,7 @@ Item {
       pluginDir: root.pluginDir
       accountId: entry ? entry.id : ""
       configuredEmail: entry ? entry.email : ""
+      oauthClientId: entry ? entry.clientId : ""
       // Which service this mailbox is, and — for the one that needs them — the
       // servers it talks to. Both come off the account entry, so changing an
       // account's provider in the file rebuilds it as that provider.

--- a/account/Accounts.js
+++ b/account/Accounts.js
@@ -77,7 +77,7 @@ function accountId(email, provider) {
 // anything written before providers existed — is Gmail: that is what every
 // account in an upgraded install actually is, and defaulting to it is what
 // stops an upgrade from presenting a working mailbox as unconfigured.
-var PROVIDERS = ["gmail", "hey", "imap"]
+var PROVIDERS = ["gmail", "outlook", "hey", "imap"]
 var DEFAULT_PROVIDER = "gmail"
 
 function normalizeProvider(value) {
@@ -166,7 +166,8 @@ function makeAccount(account) {
 function repairedAddress(entry) {
   var raw = entry || {}
   if (isValidEmail(raw.email)) return raw
-  if (normalizeProvider(raw.provider) !== "imap") return raw
+  var provider = normalizeProvider(raw.provider)
+  if (provider !== "imap" && provider !== "outlook") return raw
   var username = trimmed((raw.imap || {}).username)
   if (!isValidEmail(username)) return raw
   var next = {}

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -37,6 +37,7 @@ Item {
 
   required property string pluginDir
   property string configuredEmail: ""
+  property string oauthClientId: ""
 
   // Which mailbox this is, and whether it is the one on screen. An inactive
   // account still counts its unread mail; it just does not fetch lists or
@@ -2365,7 +2366,7 @@ Item {
       "https://console.cloud.google.com/apis/library/gmail.googleapis.com"])
   }
 
-  // What both providers do once they are signed in. Named rather than repeated
+  // What every provider does once it is signed in. Named rather than repeated
   // in each component, because the two sign-ins differ in everything except
   // what has to happen afterwards.
   function afterSignIn() {
@@ -2471,7 +2472,8 @@ Item {
   Loader {
     id: authLoader
     sourceComponent: root.providerId === "imap" ? imapAuthComponent
-      : (root.providerId === "hey" ? heyAuthComponent : gmailAuthComponent)
+      : (root.providerId === "outlook" ? outlookAuthComponent
+        : (root.providerId === "hey" ? heyAuthComponent : gmailAuthComponent))
   }
 
   // The client takes the manager as a required property, so it cannot be built
@@ -2479,7 +2481,8 @@ Item {
   Loader {
     id: apiLoader
     active: !!authLoader.item
-    sourceComponent: root.providerId === "imap" ? imapClientComponent
+    sourceComponent: root.providerId === "imap" || root.providerId === "outlook"
+      ? imapClientComponent
       : (root.providerId === "hey" ? heyClientComponent : gmailClientComponent)
   }
 
@@ -2537,6 +2540,24 @@ Item {
       }
       onLoggedOut: root.clearNotice()
       onCredentialsSaved: root.note("Mailbox saved")
+      onSessionUnavailable: function(reason) { root.fail(reason) }
+    }
+  }
+
+  Component {
+    id: outlookAuthComponent
+
+    OutlookAuth {
+      pluginDir: root.pluginDir
+      accountId: root.accountId
+      configuredClientId: root.oauthClientId
+      configuredEmail: root.configuredEmail
+
+      onLoginSucceeded: {
+        root.lastError = lastError
+        root.afterSignIn()
+      }
+      onLoggedOut: root.clearNotice()
       onSessionUnavailable: function(reason) { root.fail(reason) }
     }
   }

--- a/account/Model.js
+++ b/account/Model.js
@@ -52,16 +52,18 @@ function setupHeadline(state, provider, authKind) {
   // plugin never named.
   if (state === "tools_missing")
     return authKind === "cli" ? "Install the HEY CLI" : "Missing system tools"
-  // Three sign-ins, three first steps: a Cloud console, a server and a
-  // password, or nothing at all because the provider's own program holds it.
+  // Four sign-ins, four first steps: a Cloud console, a Microsoft public
+  // client, a server and password, or the provider's own program.
   if (state === "no_credentials") {
     if (authKind === "password") return "Add this mailbox"
     if (authKind === "cli") return "Sign in to " + name
+    if (name === "Outlook") return "Add this Outlook mailbox"
     return "Connect a Google Cloud project"
   }
   if (state === "signing_in") {
     if (authKind === "password") return "Checking the mailbox…"
     if (authKind === "cli") return "Waiting for " + name + "…"
+    if (name === "Outlook") return "Waiting for Microsoft…"
     return "Waiting for Google…"
   }
   if (state === "reconnecting") return "Reconnecting to " + name + "…"
@@ -89,6 +91,8 @@ function setupDetail(state, missingTools, reason, provider, authKind) {
       return "Enter the server and the password for this mailbox. Most providers want an app password rather than the one you sign in to the website with."
     if (authKind === "cli")
       return "The HEY CLI is installed. Signing in opens HEY in your browser; the token it comes back with is the CLI's own, and Omamail never sees it."
+    if (name === "Outlook")
+      return "Add the mailbox and a Microsoft public-client ID. Sign-in happens on Microsoft's page; Omamail never sees the account password."
     return "Gmail has no shared app to sign in through, so this plugin uses an OAuth client you own. It takes about two minutes to create."
   }
   if (state === "signing_in") {

--- a/components/OutlookSetupPage.qml
+++ b/components/OutlookSetupPage.qml
@@ -1,0 +1,304 @@
+import QtQuick
+import qs.Commons
+import qs.Ui
+import "../providers/Outlook.js" as Outlook
+import "../providers/MicrosoftOAuth.js" as Microsoft
+import "../account/Accounts.js" as Accounts
+
+// Outlook.com and Hotmail use Microsoft OAuth. The app registration is a
+// public client: its ID is configuration, not a secret, and the account
+// password is entered only on Microsoft's own page.
+Column {
+  id: root
+
+  required property var service
+  required property color textColor
+  required property color dimColor
+  required property color dangerColor
+  required property color accentColor
+  required property string panelFontFamily
+  property int accountCount: 1
+
+  signal removeRequested()
+
+  readonly property var auth: service ? service.auth : null
+  readonly property bool signedIn: !!auth && auth.loggedIn
+  readonly property bool busy: !!auth && auth.loginBusy
+  readonly property bool usingBuiltinClient: Microsoft.isValidClientId(Microsoft.BUILTIN_CLIENT_ID)
+  readonly property bool toolsMissing: !!auth && auth.toolsChecked && auth.missingTools.length > 0
+
+  spacing: Style.space(16)
+
+  function validatedAddress() {
+    var address = addressField.text.trim()
+    if (Accounts.isValidEmail(address)) return address
+    errorText.text = address === ""
+      ? "Add the Outlook or Hotmail address"
+      : "That is not a full email address"
+    return ""
+  }
+
+  function validatedClientId() {
+    var value = root.usingBuiltinClient ? Microsoft.BUILTIN_CLIENT_ID : clientIdField.text.trim()
+    if (Microsoft.isValidClientId(value)) return value
+    errorText.text = value === ""
+      ? "Add the Application (client) ID from Microsoft Entra"
+      : "That is not a Microsoft Application (client) ID"
+    return ""
+  }
+
+  function accountValues() {
+    var address = validatedAddress()
+    if (address === "") return null
+    var clientId = validatedClientId()
+    if (clientId === "") return null
+    return ({
+      provider: "outlook",
+      email: address,
+      clientId: clientId,
+      clientSecret: "",
+      imap: Outlook.settings(address)
+    })
+  }
+
+  function save() {
+    var values = accountValues()
+    if (!values || !service) return
+    errorText.text = ""
+    service.configureCurrentAccount(values)
+  }
+
+  function signIn() {
+    if (root.busy) return
+    var values = accountValues()
+    if (!values || !service) return
+    errorText.text = ""
+    service.configureCurrentAccountAndSignInOAuth(values)
+  }
+
+  function syncFromStore() {
+    if (!service) return
+    addressField.text = String(service.accountAddress || "")
+    if (auth && auth.configuredClientId)
+      clientIdField.text = String(auth.configuredClientId)
+  }
+
+  Component.onCompleted: syncFromStore()
+
+  Connections {
+    target: root.auth
+    ignoreUnknownSignals: true
+    function onLastErrorChanged() {
+      if (root.auth && root.auth.lastError !== "") errorText.text = root.auth.lastError
+    }
+  }
+
+  ProviderHero {
+    width: parent.width
+    providerId: "outlook"
+    title: "Add an Outlook mailbox"
+    detail: "Outlook.com and Hotmail use Microsoft sign-in. Omamail never sees your password."
+    textColor: root.textColor
+    dimColor: root.dimColor
+    panelFontFamily: root.panelFontFamily
+    onWebsiteRequested: if (root.service) root.service.openProviderWebsite("outlook")
+  }
+
+  Rectangle {
+    width: parent.width
+    visible: root.toolsMissing
+    implicitHeight: missingText.implicitHeight + Style.space(20)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+    border.width: 1
+    border.color: Style.hoverBorderFor(root.textColor, root.accentColor)
+
+    Text {
+      id: missingText
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.margins: Style.space(12)
+      anchors.verticalCenter: parent.verticalCenter
+      text: root.auth
+        ? "Install " + root.auth.missingTools.join(", ") + " before signing in."
+        : ""
+      color: root.textColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.caption
+      wrapMode: Text.WordWrap
+    }
+  }
+
+  Column {
+    width: parent.width
+    spacing: Style.space(10)
+
+    TextField {
+      id: addressField
+      objectName: "outlook-address-field"
+      width: parent.width
+      foreground: root.textColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.bodySmall
+      placeholderText: "Outlook or Hotmail address"
+      onAccepted: if (!root.usingBuiltinClient) clientIdField.forceActiveFocus()
+    }
+
+    TextField {
+      id: clientIdField
+      objectName: "outlook-client-id-field"
+      width: parent.width
+      visible: !root.usingBuiltinClient
+      foreground: root.textColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.bodySmall
+      placeholderText: "Microsoft Application (client) ID"
+      onAccepted: root.signIn()
+    }
+
+    Text {
+      id: errorText
+      objectName: "outlook-error"
+      textFormat: Text.PlainText
+      width: parent.width
+      visible: text !== ""
+      text: ""
+      color: root.dangerColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.caption
+      wrapMode: Text.WordWrap
+    }
+  }
+
+  Column {
+    width: parent.width
+    visible: !root.usingBuiltinClient && !root.signedIn
+    spacing: Style.space(6)
+
+    Text {
+      width: parent.width
+      text: "One-time Microsoft app setup"
+      color: root.textColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.bodySmall
+      font.bold: true
+    }
+
+    Text {
+      width: parent.width
+      text: "1. Register an app for personal Microsoft accounts. 2. Under Authentication, enable public client flows. 3. Copy its Application (client) ID above. Omamail requests only IMAP, SMTP and offline access when you sign in."
+      color: root.dimColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.caption
+      wrapMode: Text.WordWrap
+    }
+
+    LinkLabel {
+      text: "Open Microsoft Entra app registrations..."
+      color: root.textColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.caption
+      tooltipText: "https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade"
+      onActivated: Qt.openUrlExternally(tooltipText)
+    }
+  }
+
+  Rectangle {
+    width: parent.width
+    visible: root.busy && root.auth && root.auth.userCode !== ""
+    implicitHeight: deviceColumn.implicitHeight + Style.space(20)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+    border.width: 1
+    border.color: Style.hoverBorderFor(root.textColor, root.accentColor)
+
+    Column {
+      id: deviceColumn
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.margins: Style.space(12)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(8)
+
+      Text {
+        width: parent.width
+        text: "Enter this code on the Microsoft page opened in your browser:"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+      }
+
+      TextField {
+        width: parent.width
+        readOnly: true
+        text: root.auth ? root.auth.userCode : ""
+        foreground: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.body
+      }
+
+      LinkLabel {
+        text: "Open Microsoft sign-in again..."
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        tooltipText: root.auth ? root.auth.verificationUri : ""
+        onActivated: Qt.openUrlExternally(tooltipText)
+      }
+    }
+  }
+
+  Row {
+    spacing: Style.space(8)
+
+    Button {
+      objectName: "outlook-sign-in"
+      visible: !root.signedIn
+      text: "Sign in with Microsoft..."
+      enabled: !root.busy && addressField.text.trim() !== ""
+        && (root.usingBuiltinClient || clientIdField.text.trim() !== "")
+      foreground: root.textColor
+      bordered: true
+      fontSize: Style.font.bodySmall
+      onClicked: root.signIn()
+    }
+
+    Button {
+      objectName: "outlook-cancel-sign-in"
+      visible: root.busy
+      text: "Cancel"
+      foreground: root.dimColor
+      bordered: false
+      fontSize: Style.font.bodySmall
+      onClicked: if (root.service) root.service.cancelSignIn()
+    }
+
+    Button {
+      visible: root.signedIn
+      text: "Save changes"
+      foreground: root.textColor
+      bordered: true
+      fontSize: Style.font.bodySmall
+      onClicked: root.save()
+    }
+
+    Button {
+      visible: root.signedIn
+      text: "Sign out"
+      foreground: root.textColor
+      bordered: true
+      fontSize: Style.font.bodySmall
+      onClicked: if (root.service) root.service.signOut()
+    }
+
+    Button {
+      visible: root.accountCount > 1
+      text: "Remove account"
+      foreground: root.dangerColor
+      bordered: false
+      fontSize: Style.font.bodySmall
+      onClicked: root.removeRequested()
+    }
+  }
+}

--- a/components/OutlookSetupPage.qml
+++ b/components/OutlookSetupPage.qml
@@ -172,6 +172,30 @@ Column {
 
   Column {
     width: parent.width
+    visible: !root.signedIn
+    spacing: Style.space(6)
+
+    Text {
+      width: parent.width
+      text: "Enable IMAP in Outlook.com before signing in. Under Settings > Mail > Forwarding and IMAP, turn on Let devices and apps use IMAP, then save."
+      color: root.dimColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.caption
+      wrapMode: Text.WordWrap
+    }
+
+    LinkLabel {
+      text: "Open Outlook IMAP help..."
+      color: root.textColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.caption
+      tooltipText: "https://support.microsoft.com/en-us/outlook/pop-imap-and-smtp-settings-for-outlook-com"
+      onActivated: Qt.openUrlExternally(tooltipText)
+    }
+  }
+
+  Column {
+    width: parent.width
     visible: !root.usingBuiltinClient && !root.signedIn
     spacing: Style.space(6)
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,8 +1,6 @@
 # Omamail — Spec
 
-A native Gmail client for Omarchy, built as a Quickshell plugin on the official
-Gmail REST API. Same technology as Omarchy-Spotify: QML views over plain-JS
-logic, running inside the existing `omarchy-shell` process.
+A native mail client for Omarchy, built as a Quickshell plugin over the official Gmail API, Microsoft OAuth plus IMAP/SMTP, the HEY CLI, and standard IMAP/SMTP. Same technology as Omarchy-Spotify: QML views over plain-JS logic, running inside the existing `omarchy-shell` process.
 
 ## Product shape
 
@@ -49,6 +47,13 @@ guided by an in-app four-step walkthrough.
 - Client id/secret → `~/.config/omamail/credentials.json`, mode 0600.
   Not plugin settings: `shell.json` is world-readable.
 - Access token → process memory only
+
+Outlook.com and Hotmail use Microsoft's OAuth device-code flow for delegated IMAP and SMTP access. The user supplies a public-client Application ID until the project has a maintainer-owned registration to ship.
+
+- Tenant: `consumers`; scopes: `offline_access`, `https://outlook.office.com/IMAP.AccessAsUser.All`, `https://outlook.office.com/SMTP.Send`
+- Refresh token → GNOME Keyring, keyed by provider, client and account
+- Application ID → the account entry; it is public configuration and there is no client secret
+- Access token → process memory, handed to curl over stdin and used through its OAuth bearer option
 
 ## Features
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,10 +4,10 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Omamail — mail as a native Omarchy window</title>
-<meta name="description" content="Omamail is an Omarchy desktop email client: a Quickshell plugin that reads, triages and answers Gmail, HEY and any IMAP mailbox in a native window.">
+<meta name="description" content="Omamail is an Omarchy desktop email client: a Quickshell plugin that reads, triages and answers Gmail, Outlook, HEY and any IMAP mailbox in a native window.">
 <link rel="icon" type="image/svg+xml" href="images/omamail.svg">
 <meta property="og:title" content="Omamail — mail as a native Omarchy window">
-<meta property="og:description" content="Read, triage and answer Gmail, HEY and any IMAP mailbox inside the omarchy-shell process you already have.">
+<meta property="og:description" content="Read, triage and answer Gmail, Outlook, HEY and any IMAP mailbox inside the omarchy-shell process you already have.">
 <meta property="og:image" content="https://huacnlee.github.io/omamail/images/og-preview.jpg">
 <meta property="og:url" content="https://huacnlee.github.io/omamail/">
 <meta name="twitter:card" content="summary_large_image">
@@ -430,7 +430,7 @@ figcaption {
 
 .boxes {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   border: 1px solid var(--muted);
 }
 .box {
@@ -762,7 +762,7 @@ footer p:last-child { margin-bottom: 0; }
 █   █ █   █ █   █ █   █ █   █   █   █
  ███  █   █ █   █ █   █ █   █ █████ █████</pre>
     <h1 class="tagline" data-zh="专为 Omarchy 设计的原生邮件应用">Native mail app special design for Omarchy</h1>
-    <p class="standfirst" data-zh="Omamail 是一个 Quickshell 插件：通过 Gmail API、37signals 发布的 HEY CLI，或者 IMAP 与 SMTP，读信、整理、回信。">Omamail reads, triages and answers your mail over the official Gmail API, over the HEY CLI 37signals publish, or over IMAP and SMTP for every other mailbox.</p>
+    <p class="standfirst" data-zh="Omamail 是一个 Quickshell 插件：通过 Gmail API、Microsoft OAuth、37signals 发布的 HEY CLI，或者 IMAP 与 SMTP，读信、整理、回信。">Omamail reads, triages and answers your mail over the official Gmail API, Microsoft OAuth for Outlook, the HEY CLI 37signals publish, or IMAP and SMTP for every other mailbox.</p>
 
     <div class="command">
       <pre><span class="prompt">$ </span><span class="cmd">omarchy plugin add https://github.com/huacnlee/omamail.git --enable</span></pre>
@@ -815,12 +815,17 @@ footer p:last-child { margin-bottom: 0; }
 <section>
   <div class="wrap">
     <h2><span class="idx">02</span> <span data-zh="它能打开的邮箱">Mailboxes it can open</span></h2>
-    <p class="lede" data-zh="三种邮箱，一个窗口。某种邮箱做不到的事，界面上就不提供。">Three kinds of mailbox, one window. What a mailbox cannot do, the panel does not offer.</p>
+    <p class="lede" data-zh="四种邮箱，一个窗口。某种邮箱做不到的事，界面上就不提供。">Four kinds of mailbox, one window. What a mailbox cannot do, the panel does not offer.</p>
     <div class="boxes">
       <div class="box">
         <h3><img class="mark" src="images/gmail.png" width="20" alt="" loading="lazy">Gmail</h3>
         <span class="kind" data-zh="用 GOOGLE 账号登录">SIGN IN WITH GOOGLE</span>
         <p data-zh="标签、会话、Gmail 自己的搜索语法，以及一个 Google 真的会拿去学习的“报告垃圾邮件”。">Labels, conversations, Gmail's own search syntax, and a report-spam that Google actually learns from.</p>
+      </div>
+      <div class="box">
+        <h3><svg class="mark" viewBox="0 0 20 20" aria-hidden="true"><rect x="1.5" y="4" width="17" height="12"/><path d="M1.5 5.5 10 11.5l8.5-6"/></svg>Outlook</h3>
+        <span class="kind" data-zh="用 MICROSOFT 账号登录">SIGN IN WITH MICROSOFT</span>
+        <p data-zh="Outlook.com、Hotmail、Live 和 MSN，使用 OAuth；Omamail 不会看到你的密码。">Outlook.com, Hotmail, Live and MSN over OAuth — Omamail never sees the account password.</p>
       </div>
       <div class="box">
         <h3><img class="mark" src="images/hey.png" width="20" alt="" loading="lazy">HEY</h3>
@@ -830,7 +835,7 @@ footer p:last-child { margin-bottom: 0; }
       <div class="box">
         <h3><svg class="mark" viewBox="0 0 20 20" aria-hidden="true"><rect x="1.5" y="4" width="17" height="12"/><path d="M1.5 5.5 10 11.5l8.5-6"/></svg>IMAP</h3>
         <span class="kind" data-zh="一个地址和一个应用密码">AN ADDRESS AND AN APP PASSWORD</span>
-        <p data-zh="Fastmail、iCloud、Outlook、Yahoo、Zoho、GMX、通过 Bridge 的 Proton，或者你自己的服务器。">Fastmail, iCloud, Outlook, Yahoo, Zoho, GMX, Proton through its Bridge, or a server of your own.</p>
+        <p data-zh="Fastmail、iCloud、Yahoo、Zoho、GMX、通过 Bridge 的 Proton，或者你自己的服务器。">Fastmail, iCloud, Yahoo, Zoho, GMX, Proton through its Bridge, or a server of your own.</p>
       </div>
     </div>
   </div>
@@ -849,7 +854,7 @@ footer p:last-child { margin-bottom: 0; }
       <li><span class="n">06</span><span class="t"><b data-zh="一键退订">Off a list in one click</b><span data-zh="支持一键退订的邮件不必离开窗口就能退掉。在你开口之前，绝不会去请求发件人的地址。">A newsletter that supports one-click unsubscribing is unsubscribed from without leaving the window. Nothing is ever fetched from a sender's address until you ask.</span></span></li>
       <li><span class="n">07</span><span class="t"><b data-zh="图片默认拦下">Images stay blocked</b><span data-zh="加载发件人的图片等于告诉对方这封信被读了、用的哪个地址、什么时候。要加载得你开口，而且只对那一封生效。">Loading a sender's pictures tells them the mail was read, from which address and when. They load when you ask, for that one message.</span></span></li>
       <li><span class="n">08</span><span class="t"><b data-zh="你的主题">Your theme</b><span data-zh="每一个颜色都来自当前的 Omarchy 主题，桌面一换，邮箱立刻跟着换。">Every colour comes from the active Omarchy theme, so the mailbox changes the moment the desktop does.</span></span></li>
-      <li><span class="n">09</span><span class="t"><b data-zh="凭据在钥匙串里">Keyring-backed</b><span data-zh="Gmail 刷新令牌和每一个 IMAP 密码都放在 GNOME Keyring 里：不在配置文件里，也不在命令行上。">The Gmail refresh token and every IMAP password live in GNOME Keyring — never in a config file, never on a command line.</span></span></li>
+      <li><span class="n">09</span><span class="t"><b data-zh="凭据在钥匙串里">Keyring-backed</b><span data-zh="Gmail 和 Outlook 刷新令牌以及每一个 IMAP 密码都放在 GNOME Keyring 里：不在配置文件里，也不在命令行上。">Gmail and Outlook refresh tokens and every IMAP password live in GNOME Keyring — never in a config file, never on a command line.</span></span></li>
       <li><span class="n">10</span><span class="t"><b data-zh="多个邮箱">Several mailboxes</b><span data-zh="每个账号有自己的收件箱、缓存和未读数；列表、标签和头像按账号缓存，所以切换从不等网络。">Each with its own inbox, cache and unread count. List, labels and profile are cached per account, so switching never waits on the network.</span></span></li>
       <li><span class="n">11</span><span class="t"><b data-zh="mailto: 链接">mailto: links</b><span data-zh="插件启用之后，桌面上任何地方点一个地址——浏览器、PDF、通知——都在这里打开撰写。">Once the plugin is enabled, clicking an address anywhere on the desktop opens compose here.</span></span></li>
       <li><span class="n">12</span><span class="t"><b data-zh="撤销发送">Undo send</b><span data-zh="出站邮件默认延迟十秒，够你反悔。设成 0 就立即发送。">Outgoing mail is delayed by ten seconds so you can cancel it. Set it to 0 to send immediately.</span></span></li>
@@ -942,7 +947,7 @@ footer p:last-child { margin-bottom: 0; }
 
 <footer>
   <div class="wrap">
-    <p data-zh="Omamail 是一个独立项目，与 Google 和 37signals 均无关联。Gmail 是 Google LLC 的商标；HEY 是 37signals, LLC 的商标。">Omamail is an independent project and is not affiliated with Google or 37signals. Gmail is a trademark of Google LLC; HEY is a trademark of 37signals, LLC.</p>
+    <p data-zh="Omamail 是一个独立项目，与 Google、Microsoft 和 37signals 均无关联。Gmail 是 Google LLC 的商标；Outlook 是 Microsoft Corporation 的商标；HEY 是 37signals, LLC 的商标。">Omamail is an independent project and is not affiliated with Google, Microsoft or 37signals. Gmail is a trademark of Google LLC; Outlook is a trademark of Microsoft Corporation; HEY is a trademark of 37signals, LLC.</p>
     <p><span data-zh="作者">By</span> <a href="https://github.com/huacnlee">Jason Lee</a> · <a href="https://github.com/huacnlee/omamail/blob/main/LICENSE">MIT</a> · <a href="https://github.com/huacnlee/omamail">github.com/huacnlee/omamail</a> · <a href="https://omarchy.org">omarchy.org</a></p>
   </div>
 </footer>

--- a/message/Unsubscribe.js
+++ b/message/Unsubscribe.js
@@ -156,7 +156,7 @@ function from(listHeader, postHeader) {
   return result
 }
 
-// The Gmail message resource shape, which is what both providers hand back.
+// The Gmail message resource shape, which is what every provider hands back.
 function fromMessage(message) {
   var headers = message && message.payload && Array.isArray(message.payload.headers)
     ? message.payload.headers

--- a/providers/Credentials.js
+++ b/providers/Credentials.js
@@ -391,6 +391,23 @@ function imapKeyringAttributes(accountId) {
     "account", id || UNNAMED_ACCOUNT]
 }
 
+// An Outlook refresh token belongs to both the public OAuth client and the
+// mailbox that granted it. Keeping a separate kind prevents a Hotmail address
+// also added through Gmail or generic IMAP from sharing a secret by accident.
+var OUTLOOK_KEYRING_KIND = "outlook-refresh-token"
+
+function outlookKeyringAttributes(clientId, accountId) {
+  var client = trimmed(clientId)
+  var id = accountKey(accountId)
+  if (!client || !id) return []
+  return [
+    "service", KEYRING_SERVICE,
+    "kind", OUTLOOK_KEYRING_KIND,
+    "client-id", client,
+    "account", id
+  ]
+}
+
 // Entries from before the Omamail rename also predate Calendar permission.
 // Their exact old shape lets the upgrade identify them without using them.
 function renamedKeyringAttributes(clientId, accountId) {

--- a/providers/HeyAuth.qml
+++ b/providers/HeyAuth.qml
@@ -160,7 +160,7 @@ Item {
 
   onAccountIdChanged: {
     // One HEY login serves whichever account row is on screen, so unlike the
-    // other two providers there is nothing keyed by account to drop here.
+    // other providers there is nothing keyed by account to drop here.
   }
 
   // Asked again after the user has installed the program. The setup page has a

--- a/providers/HeyClient.qml
+++ b/providers/HeyClient.qml
@@ -18,7 +18,7 @@ import "../message/Message.js" as Mail
 // `HeyCli.js`. This file is the part in between — which invocation a given
 // request becomes, and how HEY's answer is rebuilt as a message.
 //
-// One difference from the other two is worth stating, because it shapes the
+// One difference from the other providers is worth stating, because it shapes the
 // rest of the file: **HEY is thread-shaped, and there is no RFC 822 anywhere.**
 // A row is a posting, a body is a conversation, and neither arrives as a
 // message with headers — so this client composes the resource rather than
@@ -72,7 +72,7 @@ Item {
   // ------------------------------------------------------------- transport
 
   // One invocation, one answer. `hey` holds the token and refreshes it itself,
-  // so unlike the other two clients there is no credential to fetch first and
+  // so unlike the other clients there is no credential to fetch first and
   // nothing to retry on a 401: a command that failed because the session ended
   // tells the auth object to look again, and the user is asked to sign in.
   function run(args, stdinText, callback, existingHandle) {

--- a/providers/Imap.js
+++ b/providers/Imap.js
@@ -11,7 +11,7 @@
 
 var ID = "imap"
 var NAME = "IMAP"
-var SUMMARY = "Any standard mailbox — Fastmail, iCloud, Outlook, Zoho, your own server."
+var SUMMARY = "Any standard mailbox — Fastmail, iCloud, Zoho, your own server."
 var AUTH = "password"
 
 var CAPABILITIES = {

--- a/providers/ImapAuth.qml
+++ b/providers/ImapAuth.qml
@@ -35,6 +35,8 @@ Item {
   // shape rather than as whatever was in the file.
   property var settings: Imap.normalizeSettings(null)
 
+  readonly property string authMode: "password"
+
   readonly property bool configured: Imap.validateSettings(settings).ok
 
   // The password, once the keyring has answered. Held in this process for as

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -33,6 +33,21 @@ Item {
 
   readonly property string transport: auth ? auth.pluginDir + "/scripts/mail-transport.sh" : ""
 
+  readonly property bool oauthTransport: !!auth && String(auth.authMode || "") === "oauth2"
+
+  function addCredentialFields(fields, credential) {
+    if (oauthTransport) {
+      fields.push(Mail.encodeBase64(String(auth.settings.username || "")))
+      fields.push(Mail.encodeBase64(credential))
+    } else {
+      fields.push(Mail.encodeBase64(credential))
+    }
+  }
+
+  function transportMode(name) {
+    return String(name || "") + (oauthTransport ? "-oauth" : "")
+  }
+
   // What the server said its folders are, learned once per session with a
   // single LIST. Everything that names a folder goes through here: "\\Sent" is
   // "Sent Items" on Exchange and "[Gmail]/Sent Mail" on Gmail, and a client
@@ -123,14 +138,16 @@ Item {
       // a space or a backslash needs no escaping anywhere along the way — and
       // none of it reaches the process table.
       var fields = opening === ""
-        ? [Mail.encodeBase64(url), Mail.encodeBase64(credentials)]
-        : [Mail.encodeBase64(Imap.imapUrl(auth.settings, "")), Mail.encodeBase64(url),
-           Mail.encodeBase64(credentials), Mail.encodeBase64(opening)]
+        ? [Mail.encodeBase64(url)]
+        : [Mail.encodeBase64(Imap.imapUrl(auth.settings, "")), Mail.encodeBase64(url)]
+      root.addCredentialFields(fields, credentials)
+      if (opening !== "") fields.push(Mail.encodeBase64(opening))
       for (var j = 0; j < wanted.length; j++) fields.push(Mail.encodeBase64(wanted[j]))
 
       var process = transportComponent.createObject(root, {
         command: [root.transport],
-        requestLine: (opening === "" ? "imap " : "imap-id ") + fields.join(" ")
+        requestLine: root.transportMode(opening === "" ? "imap" : "imap-id")
+          + " " + fields.join(" ")
       })
       if (!process) {
         root.inFlight = Math.max(0, root.inFlight - 1)
@@ -730,11 +747,12 @@ Item {
         return
       }
       var url = Imap.imapUrl(auth.settings, folder)
-      var fields = [Mail.encodeBase64(url), Mail.encodeBase64(credentials),
-        Mail.encodeBase64(message), Mail.encodeBase64(flagWords)]
+      var fields = [Mail.encodeBase64(url)]
+      root.addCredentialFields(fields, credentials)
+      fields.push(Mail.encodeBase64(message), Mail.encodeBase64(flagWords))
       var process = transportComponent.createObject(root, {
         command: [root.transport],
-        requestLine: "imap-append " + fields.join(" ")
+        requestLine: root.transportMode("imap-append") + " " + fields.join(" ")
       })
       if (!process) {
         root.inFlight = Math.max(0, root.inFlight - 1)
@@ -857,13 +875,14 @@ Item {
       var sender = (fromAddresses.length > 0 && fromAddresses[0].email)
         ? fromAddresses[0].email
         : (settings ? String(settings.username || "") : "") || root.email
-      var fields = [Mail.encodeBase64(smtp), Mail.encodeBase64(credentials),
-        Mail.encodeBase64(sender), Mail.encodeBase64(message)]
+      var fields = [Mail.encodeBase64(smtp)]
+      root.addCredentialFields(fields, credentials)
+      fields.push(Mail.encodeBase64(sender), Mail.encodeBase64(message))
       for (var k = 0; k < recipients.length; k++) fields.push(Mail.encodeBase64(recipients[k]))
 
       var process = transportComponent.createObject(root, {
         command: [root.transport],
-        requestLine: "smtp " + fields.join(" ")
+        requestLine: root.transportMode("smtp") + " " + fields.join(" ")
       })
       if (!process) {
         root.inFlight = Math.max(0, root.inFlight - 1)
@@ -923,16 +942,19 @@ Item {
   // password down and finding out later — leaves the user on a panel that says
   // it is signed in and never loads.
   function verifyCredentials(settings, credentials, callback) {
+    var owner = auth
+    var generation = oauthTransport ? owner.sessionGeneration : undefined
     var url = Imap.imapUrl(settings, "")
     if (url === "") {
       if (typeof callback === "function") callback(false, "This mailbox has no usable server address")
       return
     }
-    var fields = [Mail.encodeBase64(url), Mail.encodeBase64(credentials),
-      Mail.encodeBase64(Imap.capabilityCommand()), Mail.encodeBase64(Imap.listCommand())]
+    var fields = [Mail.encodeBase64(url)]
+    root.addCredentialFields(fields, credentials)
+    fields.push(Mail.encodeBase64(Imap.capabilityCommand()), Mail.encodeBase64(Imap.listCommand()))
     var process = transportComponent.createObject(root, {
       command: [root.transport],
-      requestLine: "imap " + fields.join(" ")
+      requestLine: root.transportMode("imap") + " " + fields.join(" ")
     })
     if (!process) {
       if (typeof callback === "function") callback(false, "Could not start the mail transport")
@@ -941,6 +963,7 @@ Item {
     process.finished.connect(function(status, out, err) {
       if (!root) return
       process.destroy()
+      if (root.auth !== owner || (root.oauthTransport && owner.sessionGeneration !== generation)) return
       if (typeof callback !== "function") return
       var text = Imap.decodeResponse(out, Mail.base64ToBytes, Mail.bytesToLatin1)
       var detail = Imap.decodeResponse(err, Mail.base64ToBytes, Mail.bytesToLatin1)
@@ -965,8 +988,10 @@ Item {
   Connections {
     target: root.auth
     function onVerifyRequested(settings, credentials) {
+      var owner = root.auth
+      var generation = root.oauthTransport ? owner.sessionGeneration : undefined
       root.verifyCredentials(settings, credentials, function(ok, error) {
-        if (root.auth) root.auth.completeSignIn(ok, error)
+        if (root.auth === owner) owner.completeSignIn(ok, error, generation)
       })
     }
     // A mailbox whose server settings changed is a different mailbox: the

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -85,7 +85,7 @@ var PRESETS = [
     imapHost: "outlook.office365.com", imapPort: 993,
     smtpHost: "smtp-mail.outlook.com", smtpPort: 587,
     note: "Microsoft has withdrawn password sign-in for personal accounts; "
-      + "a work or school account may still allow it."
+      + "go back and pick Outlook to sign in with Microsoft instead."
   },
   {
     id: "yahoo",

--- a/providers/MicrosoftOAuth.js
+++ b/providers/MicrosoftOAuth.js
@@ -1,0 +1,177 @@
+.pragma library
+
+.import "OAuth.js" as OAuth
+
+// Microsoft OAuth for installed applications. Outlook uses the device-code
+// flow: the client is public, carries no secret, and does not need a redirect
+// URI or a listener left on the desktop.
+
+var TENANT = "consumers"
+var AUTHORITY = "https://login.microsoftonline.com/" + TENANT + "/oauth2/v2.0"
+var DEVICE_URL = AUTHORITY + "/devicecode"
+var TOKEN_URL = AUTHORITY + "/token"
+
+var SCOPES = [
+  "offline_access",
+  "https://outlook.office.com/IMAP.AccessAsUser.All",
+  "https://outlook.office.com/SMTP.Send"
+]
+
+// A maintainer-owned public-client registration can make Outlook a one-click
+// setup later. Until then, each user supplies the Application (client) ID of
+// their own registration, just as Gmail users supply their own OAuth client.
+var BUILTIN_CLIENT_ID = ""
+
+function trimmed(value) {
+  return String(value === undefined || value === null ? "" : value).trim()
+}
+
+function isValidClientId(value) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    .test(trimmed(value))
+}
+
+function effectiveClientId(value) {
+  var configured = trimmed(value)
+  return isValidClientId(configured) ? configured : trimmed(BUILTIN_CLIENT_ID)
+}
+
+function verificationUri(value) {
+  var text = trimmed(value)
+  var match = text.match(/^https:\/\/([^\/:?#]+)(?::443)?(?:[\/?#]|$)/i)
+  if (!match) return ""
+  var host = match[1].toLowerCase()
+  if (host !== "microsoft.com" && host !== "www.microsoft.com"
+      && host !== "login.microsoftonline.com") return ""
+  return text
+}
+
+function scopeText(scopes) {
+  var values = Array.isArray(scopes) && scopes.length > 0 ? scopes : SCOPES
+  return values.join(" ")
+}
+
+function deviceAuthorizationBody(clientId, scopes) {
+  return OAuth.formBody({ client_id: trimmed(clientId), scope: scopeText(scopes) })
+}
+
+function deviceTokenBody(clientId, deviceCode) {
+  return OAuth.formBody({
+    client_id: trimmed(clientId),
+    grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+    device_code: String(deviceCode || "")
+  })
+}
+
+function refreshTokenBody(clientId, refreshToken, scopes) {
+  return OAuth.formBody({
+    client_id: trimmed(clientId),
+    grant_type: "refresh_token",
+    refresh_token: String(refreshToken || ""),
+    scope: scopeText(scopes)
+  })
+}
+
+function parseJson(text) {
+  try {
+    var parsed = JSON.parse(String(text || ""))
+    return parsed && typeof parsed === "object" ? parsed : null
+  } catch (e) {
+    return null
+  }
+}
+
+function redact(text) {
+  return OAuth.redact(text)
+    .replace(/(device_code|user_code)=[^&\s"']+/gi, "$1=[redacted]")
+    .replace(/"(device_code|user_code)"\s*:\s*"[^"]*"/gi, "\"$1\":\"[redacted]\"")
+    .replace(/\beyJ[A-Za-z0-9._-]{20,}/g, "[redacted]")
+}
+
+function errorMessage(payload, fallback) {
+  var value = payload || {}
+  var code = String(value.error || "")
+  var detail = String(value.error_description || "")
+  if (code === "authorization_declined" || code === "access_denied")
+    return "Microsoft sign-in was cancelled"
+  if (code === "expired_token" || code === "bad_verification_code")
+    return "The Microsoft sign-in code expired. Please try again"
+  if (code === "invalid_client" || code === "unauthorized_client")
+    return "Microsoft rejected this OAuth client. Check the client ID and public-client setting"
+  if (code === "invalid_grant")
+    return "Microsoft rejected the saved session. Sign in again"
+  if (detail) return redact(detail)
+  if (code) return redact(code)
+  return fallback
+}
+
+function parseDeviceResponse(status, text) {
+  var payload = parseJson(text)
+  if (status < 200 || status >= 300 || !payload || !payload.device_code
+      || !payload.user_code || !verificationUri(payload.verification_uri)) {
+    return { ok: false, error: errorMessage(payload,
+      "Could not start Microsoft sign-in. Please try again") }
+  }
+  return {
+    ok: true,
+    deviceCode: String(payload.device_code),
+    userCode: String(payload.user_code),
+    verificationUri: verificationUri(payload.verification_uri),
+    expiresIn: Math.max(60, Number(payload.expires_in) || 900),
+    interval: Math.max(5, Number(payload.interval) || 5),
+    message: String(payload.message || "")
+  }
+}
+
+function parseTokenResponse(status, text, previousRefreshToken) {
+  var payload = parseJson(text)
+  var code = payload ? String(payload.error || "") : ""
+  if (code === "authorization_pending" || code === "slow_down") {
+    return { ok: false, pending: true, slowDown: code === "slow_down", error: "" }
+  }
+  if (status < 200 || status >= 300 || !payload || !payload.access_token) {
+    return {
+      ok: false,
+      pending: false,
+      invalidGrant: code === "invalid_grant",
+      error: errorMessage(payload, "Could not complete Microsoft sign-in. Please try again")
+    }
+  }
+  return {
+    ok: true,
+    accessToken: String(payload.access_token),
+    refreshToken: String(payload.refresh_token || previousRefreshToken || ""),
+    expiresIn: Math.max(60, Number(payload.expires_in) || 3600),
+    scope: String(payload.scope || "")
+  }
+}
+
+function missingMailScopes(granted) {
+  var have = String(granted || "").toLowerCase().split(/\s+/)
+  var missing = []
+  for (var i = 0; i < SCOPES.length; i++) {
+    var scope = SCOPES[i]
+    if (scope === "offline_access") continue
+    if (have.indexOf(scope.toLowerCase()) < 0) missing.push(scope)
+  }
+  return missing
+}
+
+function missingScopeMessage(missing) {
+  if (!Array.isArray(missing) || missing.length === 0) return ""
+  var names = []
+  for (var i = 0; i < missing.length; i++) {
+    var value = String(missing[i] || "")
+    names.push(value.substring(value.lastIndexOf("/") + 1))
+  }
+  return "Microsoft sign-in finished without the " + names.join(" and ")
+    + " permission. Check the app registration and sign in again"
+}
+
+function refreshFailureDisposition(result) {
+  return result && result.invalidGrant ? "signed_out" : "retry"
+}
+
+function refreshRetryDelay(attempt) {
+  return OAuth.refreshRetryDelay(attempt)
+}

--- a/providers/Outlook.js
+++ b/providers/Outlook.js
@@ -1,0 +1,44 @@
+.pragma library
+
+.import "Imap.js" as Imap
+.import "ImapProtocol.js" as Protocol
+
+// Outlook.com is an IMAP mailbox with a sign-in of its own. Keeping it as a
+// provider rather than a password preset matters: Microsoft no longer accepts
+// account passwords for personal mail, while the generic IMAP provider still
+// needs them for servers that do.
+
+var ID = "outlook"
+var NAME = "Outlook"
+var SUMMARY = "Outlook.com and Hotmail, signed in securely with Microsoft."
+var AUTH = "oauth"
+
+var CAPABILITIES = Imap.CAPABILITIES
+var MAILBOXES = Imap.MAILBOXES
+
+function searchQuery(text) {
+  return Imap.searchQuery(text)
+}
+
+function cachedSummaryInSearch(sourceQuery, summary) {
+  return Imap.cachedSummaryInSearch(sourceQuery, summary)
+}
+
+function labelQuery(name) {
+  return Imap.labelQuery(name)
+}
+
+function webHomeUrl() {
+  return "https://outlook.live.com/mail/"
+}
+
+function settings(address) {
+  return Protocol.normalizeSettings({
+    imapHost: "outlook.office365.com",
+    imapPort: 993,
+    smtpHost: "smtp-mail.outlook.com",
+    smtpPort: 587,
+    username: String(address === undefined || address === null ? "" : address).trim(),
+    insecure: false
+  })
+}

--- a/providers/OutlookAuth.qml
+++ b/providers/OutlookAuth.qml
@@ -1,0 +1,553 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+import "ImapProtocol.js" as Imap
+import "Outlook.js" as Outlook
+import "MicrosoftOAuth.js" as Microsoft
+import "Credentials.js" as Credentials
+import "Secrets.js" as Secrets
+
+// Microsoft sign-in for the Outlook provider. The refresh token lives in
+// GNOME Keyring, the access token lives only in this process, and curl receives
+// it over stdin for XOAUTH2 authentication to IMAP and SMTP.
+Item {
+  id: root
+
+  visible: false
+  width: 0
+  height: 0
+
+  required property string pluginDir
+  property string accountId: ""
+  property string configuredClientId: ""
+  readonly property string clientId: Microsoft.effectiveClientId(configuredClientId)
+  property string configuredEmail: ""
+  // Microsoft grants this token for its own mail service. Persisted generic
+  // IMAP settings must never select its destination or disable transport TLS.
+  readonly property var settings: Outlook.settings(configuredEmail)
+  property var scopes: Microsoft.SCOPES
+
+  readonly property string authMode: "oauth2"
+  readonly property bool configured: Imap.validateSettings(settings).ok
+  readonly property bool credentialsPresent: configured && Microsoft.isValidClientId(clientId)
+
+  property string accessToken: ""
+  property double accessTokenExpiresAt: 0
+  property bool loggedIn: false
+  property bool sessionChecked: false
+  property bool savedSessionPresent: false
+  readonly property bool recoveringSession: savedSessionPresent && !loggedIn
+  property bool loginBusy: false
+  property bool refreshBusy: false
+  readonly property bool sessionBusy: !!lookupProcess || refreshBusy || restoreQueued
+  property string lastError: ""
+
+  readonly property var requiredTools: ["secret-tool", "curl", "xdg-open"]
+  property var missingTools: []
+  property bool toolsChecked: false
+  readonly property bool toolsPresent: toolsChecked && missingTools.length === 0
+
+  property var tokenWaiters: []
+  property int sessionGeneration: 0
+  property bool sessionEnabled: true
+  property var lookupProcess: null
+  property bool restoreQueued: false
+  property var keyringJobs: []
+  property var keyringJob: null
+  property int refreshRetryAttempt: 0
+
+  property string deviceCode: ""
+  property string userCode: ""
+  property string verificationUri: ""
+  property double deviceExpiresAt: 0
+  property int devicePollIntervalMs: 5000
+  property string pendingAccessToken: ""
+  property string pendingRefreshToken: ""
+  property double pendingExpiresIn: 0
+
+  property var tokenRequest: null
+  property int tokenRequestSerial: 0
+  readonly property int tokenTimeoutMs: 30000
+
+  signal loginSucceeded()
+  signal loggedOut()
+  signal sessionUnavailable(string reason)
+  signal credentialsSaved()
+  signal verifyRequested(var settings, string credentials)
+
+  function sessionContext() {
+    return { generation: sessionGeneration, accountId: accountId, clientId: clientId }
+  }
+
+  function isCurrent(context) {
+    return !!context && context.generation === sessionGeneration
+      && context.accountId === accountId && context.clientId === clientId
+  }
+
+  function safeError(value) {
+    return Microsoft.redact(String(value || ""))
+  }
+
+  function tokenIsFresh() {
+    return accessToken !== "" && Date.now() + 60000 < accessTokenExpiresAt
+  }
+
+  function resetMemorySession() {
+    accessToken = ""
+    accessTokenExpiresAt = 0
+    loggedIn = false
+  }
+
+  function invalidateAccessToken() {
+    accessToken = ""
+    accessTokenExpiresAt = 0
+  }
+
+  function finishWaiters(token, error) {
+    var context = sessionContext()
+    var pending = tokenWaiters.slice()
+    tokenWaiters = []
+    for (var i = 0; i < pending.length; i++) {
+      // A consumer can synchronously sign out or switch accounts. Remaining
+      // callbacks still belong to the session captured above.
+      var current = isCurrent(context) && sessionEnabled
+      try { pending[i](current ? (token || "") : "",
+        current ? safeError(error) : "Session changed") }
+      catch (e) { /* consumers own their callback errors */ }
+    }
+  }
+
+  function withCredentials(callback) {
+    if (typeof callback !== "function") return
+    if (!sessionEnabled) {
+      callback("", "Signed out")
+      return
+    }
+    if (tokenIsFresh()) {
+      callback(accessToken, "")
+      return
+    }
+    if (!credentialsPresent) {
+      callback("", "Add this Outlook mailbox and its OAuth client first")
+      return
+    }
+    var next = tokenWaiters.slice()
+    next.push(callback)
+    tokenWaiters = next
+    if (refreshBusy || lookupProcess || loginBusy) return
+    startSecretLookup()
+  }
+
+  function restoreSession() {
+    if (!sessionEnabled || loginBusy) return
+    sessionChecked = false
+    if (!credentialsPresent || accountId === "") {
+      savedSessionPresent = false
+      sessionChecked = true
+      resetMemorySession()
+      return
+    }
+    if (lookupProcess || refreshBusy) return
+    startSecretLookup()
+  }
+
+  function startSecretLookup() {
+    // A preceding store/clear must finish before a lookup can observe the key.
+    if (keyringJob || keyringJobs.length > 0) {
+      restoreQueued = true
+      return
+    }
+    restoreQueued = false
+    var context = sessionContext()
+    var attributes = Credentials.outlookKeyringAttributes(clientId, accountId)
+    if (attributes.length === 0) {
+      handleSecretLookup("", context)
+      return
+    }
+    var process = lookupComponent.createObject(root, {
+      context: context,
+      command: ["secret-tool", "lookup"].concat(attributes)
+    })
+    if (!process) {
+      handleSecretLookup("", context)
+      return
+    }
+    lookupProcess = process
+    process.running = true
+  }
+
+  function handleSecretLookup(raw, context) {
+    if (!isCurrent(context) || !sessionEnabled) return
+    var token = String(raw || "")
+    if (token === "") {
+      savedSessionPresent = false
+      resetMemorySession()
+      sessionChecked = true
+      finishWaiters("", "Sign in to Outlook first")
+      return
+    }
+    savedSessionPresent = true
+    refreshWithToken(token, context)
+  }
+
+  function storeRefreshToken(token) {
+    var attributes = Credentials.outlookKeyringAttributes(clientId, accountId)
+    if (!token || attributes.length === 0) return
+    enqueueKeyringJob("store", attributes, String(token))
+  }
+
+  function clearStoredToken() {
+    var attributes = Credentials.outlookKeyringAttributes(clientId, accountId)
+    if (attributes.length === 0) return
+    enqueueKeyringJob("clear", attributes, "")
+  }
+
+  // Jobs own immutable destinations. Serialize them so logout's clear cannot
+  // race a preceding store, even when the account host is reused meanwhile.
+  function enqueueKeyringJob(kind, attributes, token) {
+    var next = keyringJobs.slice()
+    next.push({ kind: kind, attributes: attributes.slice(), token: token,
+      context: sessionContext() })
+    keyringJobs = next
+    runKeyringJob()
+  }
+
+  function runKeyringJob() {
+    if (keyringJob) return
+    if (keyringJobs.length === 0) {
+      if (restoreQueued) Qt.callLater(root.restoreSession)
+      return
+    }
+    var next = keyringJobs.slice()
+    keyringJob = next.shift()
+    keyringJobs = next
+    keyringProcess.command = keyringJob.kind === "store"
+      ? [pluginDir + "/scripts/keyring-store.sh"].concat(keyringJob.attributes)
+      : ["secret-tool", "clear"].concat(keyringJob.attributes)
+    keyringProcess.running = true
+  }
+
+  function postForm(url, body, callback) {
+    var serial = ++tokenRequestSerial
+    var request = new XMLHttpRequest()
+    tokenRequest = request
+    var deadline = tokenDeadlineComponent.createObject(root, { interval: tokenTimeoutMs })
+
+    function disarm() {
+      if (!deadline) return
+      deadline.stop()
+      deadline.destroy()
+      deadline = null
+    }
+
+    request.onreadystatechange = function() {
+      if (request.readyState !== XMLHttpRequest.DONE) return
+      disarm()
+      if (serial !== root.tokenRequestSerial) return
+      if (root.tokenRequest === request) root.tokenRequest = null
+      if (typeof callback === "function") callback(request.status, request.responseText)
+    }
+    request.open("POST", url)
+    request.setRequestHeader("Content-Type", "application/x-www-form-urlencoded")
+    request.send(body)
+
+    if (deadline) {
+      deadline.triggered.connect(function() {
+        if (request.abort) request.abort()
+      })
+      deadline.start()
+    }
+  }
+
+  function refreshWithToken(refreshToken, context) {
+    refreshBusy = true
+    postForm(Microsoft.TOKEN_URL,
+      Microsoft.refreshTokenBody(clientId, refreshToken, scopes),
+      function(status, text) {
+        if (!root.isCurrent(context) || !root.sessionEnabled) return
+        var result = Microsoft.parseTokenResponse(status, text, refreshToken)
+        refreshToken = ""
+        root.refreshBusy = false
+        root.sessionChecked = true
+        if (!result.ok) {
+          root.resetMemorySession()
+          root.lastError = root.safeError(result.error)
+          if (Microsoft.refreshFailureDisposition(result) === "signed_out") {
+            root.savedSessionPresent = false
+            refreshRetry.stop()
+            root.clearStoredToken()
+          } else {
+            root.scheduleRefreshRetry()
+          }
+          root.finishWaiters("", root.lastError)
+          root.sessionUnavailable(root.lastError)
+          return
+        }
+        root.acceptToken(result)
+        root.finishWaiters(root.accessToken, "")
+      })
+  }
+
+  function acceptToken(result) {
+    accessToken = result.accessToken
+    accessTokenExpiresAt = Date.now() + result.expiresIn * 1000
+    loggedIn = true
+    savedSessionPresent = true
+    refreshRetryAttempt = 0
+    refreshRetry.stop()
+    lastError = ""
+    if (result.refreshToken) storeRefreshToken(result.refreshToken)
+  }
+
+  function scheduleRefreshRetry() {
+    if (!savedSessionPresent || refreshRetry.running) return
+    refreshRetry.interval = Microsoft.refreshRetryDelay(refreshRetryAttempt)
+    refreshRetryAttempt++
+    refreshRetry.start()
+  }
+
+  function beginLogin() {
+    if (loginBusy || refreshBusy) return
+    if (!credentialsPresent) {
+      lastError = "Add the mailbox address and Microsoft OAuth client ID first"
+      return
+    }
+    if (!toolsPresent && toolsChecked) {
+      lastError = "Missing " + missingTools.join(", ")
+      return
+    }
+    cancelLogin()
+    sessionEnabled = true
+    var context = sessionContext()
+    lastError = ""
+    loginBusy = true
+    postForm(Microsoft.DEVICE_URL,
+      Microsoft.deviceAuthorizationBody(clientId, scopes),
+      function(status, text) {
+        if (!root.isCurrent(context)) return
+        var result = Microsoft.parseDeviceResponse(status, text)
+        if (!result.ok) {
+          root.failLogin(result.error)
+          return
+        }
+        root.deviceCode = result.deviceCode
+        root.userCode = result.userCode
+        root.verificationUri = result.verificationUri
+        root.deviceExpiresAt = Date.now() + result.expiresIn * 1000
+        root.devicePollIntervalMs = result.interval * 1000
+        Quickshell.execDetached(["xdg-open", root.verificationUri])
+        devicePoll.interval = root.devicePollIntervalMs
+        devicePoll.start()
+      })
+  }
+
+  function pollDeviceCode() {
+    if (!loginBusy || deviceCode === "") return
+    if (Date.now() >= deviceExpiresAt) {
+      failLogin("The Microsoft sign-in code expired. Please try again")
+      return
+    }
+    var context = sessionContext()
+    postForm(Microsoft.TOKEN_URL,
+      Microsoft.deviceTokenBody(clientId, deviceCode),
+      function(status, text) {
+        if (!root.isCurrent(context)) return
+        var result = Microsoft.parseTokenResponse(status, text, "")
+        if (result.pending) {
+          if (result.slowDown) root.devicePollIntervalMs += 5000
+          devicePoll.interval = root.devicePollIntervalMs
+          devicePoll.start()
+          return
+        }
+        if (!result.ok) {
+          root.failLogin(result.error)
+          return
+        }
+        var missing = Microsoft.missingMailScopes(result.scope)
+        if (missing.length > 0) {
+          root.failLogin(Microsoft.missingScopeMessage(missing))
+          return
+        }
+        if (!result.refreshToken) {
+          root.failLogin("Microsoft sign-in did not grant offline access. Check the app registration and sign in again")
+          return
+        }
+        root.pendingAccessToken = result.accessToken
+        root.pendingRefreshToken = result.refreshToken
+        root.pendingExpiresIn = result.expiresIn
+        root.deviceCode = ""
+        root.verifyRequested(root.settings, root.pendingAccessToken)
+      })
+  }
+
+  function completeSignIn(ok, error, generation) {
+    if (generation !== sessionGeneration || !loginBusy || pendingAccessToken === "") return
+    if (!ok) {
+      clearPendingToken()
+      failLogin(error || "Outlook rejected this mailbox sign-in")
+      return
+    }
+    var result = ({
+      accessToken: pendingAccessToken,
+      refreshToken: pendingRefreshToken,
+      expiresIn: pendingExpiresIn
+    })
+    clearPendingToken()
+    loginBusy = false
+    sessionChecked = true
+    acceptToken(result)
+    finishWaiters(accessToken, "")
+    loginSucceeded()
+  }
+
+  function clearPendingToken() {
+    pendingAccessToken = ""
+    pendingRefreshToken = ""
+    pendingExpiresIn = 0
+  }
+
+  function cancelDeviceLogin() {
+    devicePoll.stop()
+    deviceCode = ""
+    userCode = ""
+    verificationUri = ""
+    deviceExpiresAt = 0
+    clearPendingToken()
+  }
+
+  function failLogin(reason) {
+    lastError = safeError(reason || "Microsoft sign-in failed. Please try again")
+    loginBusy = false
+    cancelDeviceLogin()
+    finishWaiters("", lastError)
+    sessionUnavailable(lastError)
+  }
+
+  function cancelLogin() {
+    sessionGeneration++
+    var oldLookup = lookupProcess
+    lookupProcess = null
+    if (oldLookup) oldLookup.running = false
+    restoreQueued = false
+    refreshRetry.stop()
+    cancelDeviceLogin()
+    tokenRequestSerial++
+    if (tokenRequest && tokenRequest.abort) tokenRequest.abort()
+    tokenRequest = null
+    refreshBusy = false
+    loginBusy = false
+    finishWaiters("", "Sign-in cancelled")
+  }
+
+  function logout() {
+    sessionEnabled = false
+    cancelLogin()
+    refreshRetry.stop()
+    refreshRetryAttempt = 0
+    savedSessionPresent = false
+    resetMemorySession()
+    sessionChecked = true
+    lastError = ""
+    finishWaiters("", "Signed out")
+    clearStoredToken()
+    loggedOut()
+  }
+
+  function checkTools() {
+    toolProbe.command = ["sh", "-c",
+      "for tool in " + requiredTools.join(" ")
+        + "; do command -v \"$tool\" >/dev/null 2>&1 || printf '%s\\n' \"$tool\"; done"]
+    toolProbe.running = true
+  }
+
+  function changeIdentity() {
+    sessionEnabled = false
+    resetMemorySession()
+    cancelLogin()
+    savedSessionPresent = false
+    sessionChecked = false
+    sessionEnabled = true
+    var context = sessionContext()
+    Qt.callLater(function() {
+      if (root.isCurrent(context)) root.restoreSession()
+    })
+  }
+
+  onAccountIdChanged: changeIdentity()
+  onClientIdChanged: changeIdentity()
+
+  Component.onCompleted: checkTools()
+
+  Component {
+    id: tokenDeadlineComponent
+    Timer { repeat: false }
+  }
+
+  Timer {
+    id: devicePoll
+    repeat: false
+    onTriggered: root.pollDeviceCode()
+  }
+
+  Timer {
+    id: refreshRetry
+    repeat: false
+    onTriggered: root.restoreSession()
+  }
+
+  Process {
+    id: toolProbe
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        var missing = String(text || "").split("\n")
+        var found = []
+        for (var i = 0; i < missing.length; i++) {
+          var name = missing[i].trim()
+          if (name) found.push(name)
+        }
+        root.missingTools = found
+        root.toolsChecked = true
+      }
+    }
+  }
+
+  Component {
+    id: lookupComponent
+    Process {
+      id: lookup
+      required property var context
+      stdout: StdioCollector { waitForEnd: true }
+      stderr: StdioCollector { waitForEnd: true }
+      onExited: function(exitCode) {
+        if (root.lookupProcess === lookup) root.lookupProcess = null
+        var value = exitCode === 0 ? Secrets.fromKeyring(stdout.text) : ""
+        root.handleSecretLookup(value, context)
+        destroy()
+      }
+    }
+  }
+
+  Process {
+    id: keyringProcess
+    stdinEnabled: true
+    stdout: StdioCollector { waitForEnd: true }
+    stderr: StdioCollector { waitForEnd: true }
+    onStarted: {
+      if (root.keyringJob.kind === "store") write(root.keyringJob.token + "\n")
+      root.keyringJob.token = ""
+    }
+    onExited: function(exitCode) {
+      var job = root.keyringJob
+      root.keyringJob = null
+      if (exitCode !== 0 && root.isCurrent(job.context)) {
+        root.lastError = job.kind === "store"
+          ? "Signed in, but the Microsoft session could not be saved. You may need to sign in again after a restart"
+          : "The Microsoft session could not be removed from the keyring. Try signing out again"
+      }
+      root.runKeyringJob()
+    }
+  }
+
+}

--- a/providers/Registry.js
+++ b/providers/Registry.js
@@ -1,6 +1,7 @@
 .pragma library
 
 .import "Gmail.js" as Gmail
+.import "Outlook.js" as Outlook
 .import "Imap.js" as Imap
 .import "Hey.js" as Hey
 
@@ -8,7 +9,7 @@
 // therefore ask of it.
 //
 // Each provider describes itself in a file of its own next door; this one is
-// the abstraction over the three. Everything above it asks questions here and
+// the abstraction over the four. Everything above it asks questions here and
 // never branches on a provider id — that is the whole point of the seam.
 //
 // A provider answers four questions:
@@ -81,7 +82,7 @@ function mailbox(raw) {
 
 // One provider, normalised. A definition file states only what is true of it;
 // the defaults, and the rule that an undeclared capability is a "no", live here
-// so they cannot drift between three files.
+// so they cannot drift between four files.
 function define(source) {
   var raw = source || {}
   var boxes = []
@@ -114,7 +115,7 @@ function define(source) {
     // that empty string is what removes the link from a mailbox's settings row.
     webHomeUrl: typeof raw.webHomeUrl === "function" ? raw.webHomeUrl : function() { return "" },
     // Where the program a provider runs on lives, for the providers that run on
-    // one. Only HEY does: the other two are spoken to directly.
+    // one. Only HEY does: the other three are spoken to directly.
     clientUrl: String(raw.CLIENT_URL || "")
   }
 }
@@ -125,7 +126,7 @@ function define(source) {
 // service of their own first, then the one that is every other mailbox. IMAP is
 // last because it is the answer for a server this list does not name, and a
 // chooser that opened with it would ask the question backwards.
-var ALL = [define(Gmail), define(Hey), define(Imap)]
+var ALL = [define(Gmail), define(Outlook), define(Hey), define(Imap)]
 
 var DEFAULT_ID = "gmail"
 

--- a/scripts/mail-transport.sh
+++ b/scripts/mail-transport.sh
@@ -15,6 +15,7 @@
 #   imap-id <b64 root url> <b64 url> <b64 user:password> <b64 preamble> <b64 command> ...
 #   imap-append <b64 url> <b64 user:password> <b64 message> <b64 flags>
 #   smtp <b64 url> <b64 user:password> <b64 from> <b64 message> <b64 rcpt> ...
+#   *-oauth uses <b64 username> <b64 bearer token> in place of <b64 user:password>
 #
 # base64 rather than the values themselves, for three reasons that each bite
 # once during this script's life:
@@ -74,14 +75,20 @@ set -- $line
 [ $# -ge 4 ] || fail 'mail-transport.sh: usage: <mode> <url> <credentials> <arg>...'
 
 mode=$1
+case "$mode" in
+  imap-oauth) [ $# -ge 5 ] || fail 'mail-transport.sh: imap-oauth needs a URL, a username, a bearer token and a command' ;;
+  imap-id-oauth) [ $# -ge 7 ] || fail 'mail-transport.sh: imap-id-oauth needs two URLs, a username, a bearer token, a preamble and a command' ;;
+  imap-append-oauth) [ $# -eq 6 ] || fail 'mail-transport.sh: imap-append-oauth needs a URL, a username, a bearer token, a message and flags' ;;
+  smtp-oauth) [ $# -ge 7 ] || fail 'mail-transport.sh: smtp-oauth needs a URL, a username, a bearer token, a sender, a message and a recipient' ;;
+esac
 # Validate ALL config fields before curl can see even the first command. Only
 # message bodies bypass this check: they are uploaded as files, never config.
-# APPEND flags (field 5) remain protected, just like URLs and credentials.
+# APPEND flags remain protected, just like URLs and credentials.
 field_number=0
 for field in "$@"; do
   field_number=$((field_number + 1))
   case "$mode:$field_number" in
-    *:1|smtp:5|imap-append:4) continue ;;
+    *:1|smtp:5|imap-append:4|smtp-oauth:6|imap-append-oauth:5) continue ;;
   esac
   validate_config_fields "$field"
 done
@@ -91,12 +98,29 @@ done
 # and some servers refuse SELECT until the client has sent RFC 2971's ID. The
 # connection is reused across the sections, so a command sent by the first one
 # still applies to the mailbox the next one opens.
-if [ "$mode" = imap-id ]; then
+case "$mode" in
+  imap-oauth|imap-id-oauth|imap-append-oauth|smtp-oauth) oauth=1 ;;
+  *) oauth=0 ;;
+esac
+
+case "$mode" in
+  imap-id|imap-id-oauth) identified=1 ;;
+  *) identified=0 ;;
+esac
+
+if [ "$identified" = 1 ]; then
   [ $# -ge 6 ] || fail 'mail-transport.sh: imap-id needs a root url, a url, credentials, a preamble and a command'
   root_url=$(decode "$2")
   url=$(decode "$3")
-  credentials=$(decode "$4")
-  shift 4
+  if [ "$oauth" = 1 ]; then
+    [ $# -ge 7 ] || fail 'mail-transport.sh: imap-id-oauth needs a root url, a url, a username, a bearer token, a preamble and a command'
+    username=$(decode "$4")
+    bearer=$(decode "$5")
+    shift 5
+  else
+    credentials=$(decode "$4")
+    shift 4
+  fi
   case "$root_url" in
     imaps://*|imap://*) ;;
     *) fail 'mail-transport.sh: refusing a root URL that is not imap(s)' ;;
@@ -104,13 +128,19 @@ if [ "$mode" = imap-id ]; then
   escaped_root_url=$(escape "$root_url")
 else
   url=$(decode "$2")
-  credentials=$(decode "$3")
-  shift 3
+  if [ "$oauth" = 1 ]; then
+    username=$(decode "$3")
+    bearer=$(decode "$4")
+    shift 4
+  else
+    credentials=$(decode "$3")
+    shift 3
+  fi
 fi
 
 case "$mode" in
-  imap|imap-id|imap-append|smtp) ;;
-  *) fail 'mail-transport.sh: mode must be imap, imap-id, imap-append or smtp' ;;
+  imap|imap-id|imap-append|smtp|imap-oauth|imap-id-oauth|imap-append-oauth|smtp-oauth) ;;
+  *) fail 'mail-transport.sh: unsupported mode' ;;
 esac
 
 # The URL is built and validated by Imap.js, which has already refused anything
@@ -124,25 +154,33 @@ case "$url" in
 esac
 
 escaped_url=$(escape "$url")
-escaped_credentials=$(escape "$credentials")
+if [ "$oauth" = 1 ]; then
+  escaped_username=$(escape "$username")
+  escaped_bearer=$(escape "$bearer")
+else
+  escaped_credentials=$(escape "$credentials")
+fi
 
 umask 077
 work=$(mktemp -d "${TMPDIR:-/tmp}/omamail.XXXXXX") || fail 'mail-transport.sh: no temporary directory'
 trap 'rm -rf "$work"' EXIT INT TERM HUP
+
+case "$mode" in smtp|smtp-oauth) sending=1 ;; *) sending=0 ;; esac
+case "$mode" in imap-append|imap-append-oauth) appending=1 ;; *) appending=0 ;; esac
 
 # The config is written to curl's own stdin rather than to a file: it carries
 # the password, and a file holding one would be on disk for as long as curl
 # took to read it. `build_config` prints it; the pipeline below is what feeds
 # it in without it ever being written down.
 build_config() {
-if [ "$mode" = "smtp" ]; then
+if [ "$sending" = 1 ]; then
   [ $# -ge 3 ] || fail 'mail-transport.sh: smtp needs a sender, a message and a recipient'
   sender=$(decode "$1")
   shift 2
 
   printf 'url = "%s"\n' "$escaped_url"
   printf 'noproxy = "*"\n'
-  printf 'user = "%s"\n' "$escaped_credentials"
+  print_authentication
   printf 'max-time = 60\n'
   printf 'connect-timeout = 20\n'
   case "$url" in
@@ -157,10 +195,10 @@ if [ "$mode" = "smtp" ]; then
   # from a file rather than from a string — stdin is already carrying this
   # config. It lands in the 0700 directory the trap removes on any exit.
   printf 'upload-file = "%s"\n' "$(escape "$work/message")"
-elif [ "$mode" = "imap-append" ]; then
+elif [ "$appending" = 1 ]; then
   printf 'url = "%s"\n' "$escaped_url"
   printf 'noproxy = "*"\n'
-  printf 'user = "%s"\n' "$escaped_credentials"
+  print_authentication
   printf 'max-time = 60\n'
   printf 'connect-timeout = 20\n'
   case "$url" in
@@ -188,7 +226,7 @@ else
     # In imap-id the opening command runs against the server rather than a
     # mailbox, so that it lands in front of the SELECT curl derives from the
     # path. Every later section names the mailbox as usual.
-    if [ "$mode" = imap-id ] && [ "$first" = "1" ]; then
+    if [ "$identified" = 1 ] && [ "$first" = "1" ]; then
       printf 'url = "%s"\n' "$escaped_root_url"
       # The opening command's own reply is of no interest, and leaving it on
       # stdout would be worse than useless: the test below reads a non-empty
@@ -207,7 +245,7 @@ else
     # keeps account credentials from being offered through an unrelated proxy.
     # Repeated because `next` resets this curl option with the rest.
     printf 'noproxy = "*"\n'
-    printf 'user = "%s"\n' "$escaped_credentials"
+    print_authentication
     # These are per-transfer options too. Keeping them in every section makes
     # every command give up eventually, rather than only the final one.
     printf 'max-time = 60\n'
@@ -221,12 +259,21 @@ else
 fi
 }
 
+print_authentication() {
+  if [ "$oauth" = 1 ]; then
+    printf 'user = "%s"\n' "$escaped_username"
+    printf 'oauth2-bearer = "%s"\n' "$escaped_bearer"
+  else
+    printf 'user = "%s"\n' "$escaped_credentials"
+  fi
+}
+
 # The SMTP body has to be on disk before curl starts, because the config it is
 # named in is what stdin is carrying.
-if [ "$mode" = "smtp" ]; then
+if [ "$sending" = 1 ]; then
   [ $# -ge 3 ] || fail 'mail-transport.sh: smtp needs a sender, a message and a recipient'
   decode "$2" > "$work/message"
-elif [ "$mode" = "imap-append" ]; then
+elif [ "$appending" = 1 ]; then
   [ $# -eq 2 ] || fail 'mail-transport.sh: imap-append needs one message and its flags'
   decode "$1" > "$work/message"
 fi
@@ -274,7 +321,8 @@ while :; do
 done
 
 printf '%s\n' "$status"
-if { [ "$mode" = "imap" ] || [ "$mode" = "imap-id" ]; } \
+if { [ "$mode" = "imap" ] || [ "$mode" = "imap-id" ] \
+  || [ "$mode" = "imap-oauth" ] || [ "$mode" = "imap-id-oauth" ]; } \
   && [ ! -s "$work/out" ] && [ -s "$work/headers" ]; then
   # libcurl recognises only a single numeric UID as a BODY FETCH. A legal IMAP
   # sequence-set is treated as a generic custom request, whose response is

--- a/tests/qml/tst_outlook_boundaries.qml
+++ b/tests/qml/tst_outlook_boundaries.qml
@@ -1,0 +1,129 @@
+import QtQuick
+import QtTest
+import "../../account" as Account
+import "../../components" as Components
+import "../../message/Message.js" as Mail
+
+Item {
+  Component {
+    id: hostFactory
+    Account.MailAccount {
+      pluginDir: "/tmp/omamail-test"
+      providerId: "outlook"
+      accountId: "outlook:alice@hotmail.com"
+      configuredEmail: "alice@hotmail.com"
+      oauthClientId: "12345678-1234-4abc-9def-1234567890ab"
+      imapSettings: ({ imapHost: "127.0.0.1", imapPort: 1143,
+        smtpHost: "127.0.0.1", smtpPort: 1025, insecure: true,
+        username: "alice@hotmail.com" })
+    }
+  }
+  Component {
+    id: pageFactory
+    Components.OutlookSetupPage {
+      service: null
+      textColor: Qt.rgba(0, 0, 0, 1)
+      dimColor: Qt.rgba(0.5, 0.5, 0.5, 1)
+      dangerColor: Qt.rgba(1, 0, 0, 1)
+      accentColor: Qt.rgba(0, 0, 1, 1)
+      panelFontFamily: "Sans"
+      width: 500
+    }
+  }
+  Component {
+    id: serviceFactory
+    QtObject {
+      property var auth
+      property string accountAddress: "alice@hotmail.com"
+      property int starts: 0
+      function cancelSignIn() { auth.cancelLogin() }
+      function configureCurrentAccountAndSignInOAuth(values) { starts++ }
+    }
+  }
+  TestCase {
+    name: "OutlookBoundaryReview"
+    function readyHost() {
+      var host = createTemporaryObject(hostFactory, parent)
+      verify(host !== null)
+      wait(1)
+      host.auth.cancelLogin()
+      host.auth.accessToken = "synthetic-outlook-token"
+      host.auth.accessTokenExpiresAt = Date.now() + 3600000
+      return host
+    }
+    function assertRequest(handle, mode, url) {
+      verify(handle.process !== null)
+      var fields = handle.process.requestLine.split(" ")
+      compare(fields[0], mode)
+      compare(Mail.bytesToLatin1(Mail.base64ToBytes(fields[2])), "alice@hotmail.com")
+      compare(Mail.bytesToLatin1(Mail.base64ToBytes(fields[3])), "synthetic-outlook-token")
+      compare(Mail.bytesToLatin1(Mail.base64ToBytes(fields[1])), url,
+        "Microsoft's bearer token must not be offered to an unrelated origin")
+    }
+    function test_saved_settings_cannot_redirect_outlook_bearer() {
+      var host = readyHost()
+      var handle = host.api.run("", ["NOOP"], function() {})
+      assertRequest(handle, "imap-oauth", "imaps://outlook.office365.com:993")
+    }
+    function test_saved_settings_cannot_redirect_smtp_bearer() {
+      var host = readyHost()
+      var raw = "From: alice@hotmail.com\r\nTo: bob@example.com\r\nSubject: Test\r\n\r\nSynthetic body"
+      var handle = host.api.sendMessage({ raw: Mail.encodeBase64Url(raw) }, function() {})
+      assertRequest(handle, "smtp-oauth", "smtp://smtp-mail.outlook.com:587")
+      compare(host.auth.settings.insecure, false, "SMTP requires STARTTLS")
+    }
+    function test_saved_settings_cannot_redirect_append_bearer() {
+      var host = readyHost()
+      var handle = host.api.appendMessage("Drafts", "Subject: Test\r\n\r\nBody", "draft", "Failed", function() {})
+      assertRequest(handle, "imap-append-oauth", "imaps://outlook.office365.com:993/Drafts")
+    }
+    function test_settings_reload_cannot_redirect_bearer_or_username() {
+      var host = readyHost()
+      host.imapSettings = ({ imapHost: "other.example", imapPort: 143,
+        smtpHost: "other.example", smtpPort: 25, insecure: true,
+        username: "other@example.com" })
+      assertRequest(host.api.run("", ["NOOP"], function() {}),
+        "imap-oauth", "imaps://outlook.office365.com:993")
+    }
+    function test_generic_imap_keeps_configured_servers() {
+      var host = readyHost()
+      host.providerId = "imap"
+      wait(1)
+      compare(host.auth.settings.imapHost, "127.0.0.1")
+      compare(host.auth.settings.smtpHost, "127.0.0.1")
+    }
+    function test_authentication_errors_are_plain_text() {
+      var page = createTemporaryObject(pageFactory, parent)
+      verify(page !== null)
+      var label = findChild(page, "outlook-error")
+      verify(label !== null)
+      compare(label.textFormat, Text.PlainText,
+        "Server error messages must not be interpreted as resource-bearing HTML")
+    }
+    function test_cancel_matches_google_signin_and_allows_retry() {
+      var host = readyHost()
+      var service = createTemporaryObject(serviceFactory, parent, { auth: host.auth })
+      var page = createTemporaryObject(pageFactory, parent, { service: service })
+      verify(page !== null)
+      var signIn = findChild(page, "outlook-sign-in")
+      var cancel = findChild(page, "outlook-cancel-sign-in")
+      compare(cancel.visible, false)
+      host.auth.loginBusy = true
+      host.auth.userCode = "SYNTHETIC"
+      host.auth.deviceCode = "synthetic-device"
+      compare(cancel.visible, true)
+      compare(signIn.enabled, false)
+      compare(signIn.text, "Sign in with Microsoft...")
+      page.signIn()
+      compare(service.starts, 0, "Enter must not start a second flow while busy")
+      cancel.clicked()
+      compare(host.auth.loginBusy, false)
+      compare(host.auth.deviceCode, "")
+      compare(host.auth.userCode, "")
+      compare(cancel.visible, false)
+      compare(signIn.enabled, true)
+      page.signIn()
+      compare(service.starts, 1)
+    }
+  }
+}

--- a/tests/qml/tst_outlook_security.qml
+++ b/tests/qml/tst_outlook_security.qml
@@ -1,0 +1,251 @@
+import QtQuick
+import QtTest
+import "../../providers" as Providers
+
+Item {
+  Component {
+    id: factory
+    Providers.OutlookAuth {
+      pluginDir: "/tmp/omamail-test"
+      accountId: "outlook:alice@hotmail.com"
+      configuredClientId: "12345678-1234-4abc-9def-1234567890ab"
+      configuredEmail: "alice@hotmail.com"
+      property int reviewRefreshRequests: 0
+      property int reviewResponseStatus: 200
+      property bool deferResponse: false
+      property var responseCallback: null
+      function postForm(url, body, callback) {
+        reviewRefreshRequests++
+        if (deferResponse) {
+          responseCallback = callback
+          return
+        }
+        if (reviewResponseStatus !== 200) {
+          callback(reviewResponseStatus, JSON.stringify({ error: "invalid_grant" }))
+          return
+        }
+        callback(200, JSON.stringify({
+          access_token: "synthetic-access-alice",
+          refresh_token: "synthetic-refresh-alice",
+          expires_in: 3600
+        }))
+      }
+    }
+  }
+  TestCase {
+    name: "OutlookSecurityReview"
+    function startLookup() {
+      var auth = createTemporaryObject(factory, parent)
+      verify(auth !== null)
+      wait(1)
+      auth.restoreSession()
+      compare(auth.sessionBusy, true)
+      return auth
+    }
+    function lookupProcess(auth) {
+      for (var i = 0; i < auth.children.length; i++) {
+        var child = auth.children[i]
+        if (child.command && child.command[0] === "secret-tool"
+            && child.command[1] === "lookup") return child
+      }
+      fail("No pending keyring lookup")
+    }
+    function deliverLookup(auth) {
+      var process = lookupProcess(auth)
+      process.stdout.text = "synthetic-refresh-alice\n"
+      process.running = false
+      process.exited(0)
+    }
+    function finishJob(auth) {
+      for (var i = 0; i < auth.children.length; i++) {
+        var child = auth.children[i]
+        if (child.command && (child.command[0] === "/tmp/omamail-test/scripts/keyring-store.sh"
+            || child.command[1] === "clear")) {
+          var command = child.command.slice()
+          child.started()
+          child.running = false
+          child.exited(0)
+          return command
+        }
+      }
+      fail("No keyring write/clear in progress")
+    }
+    function test_current_lookup_delivers_token_and_stores_for_its_account() {
+      var auth = startLookup()
+      var calls = 0
+      auth.withCredentials(function(token, error) {
+        compare(token, "synthetic-access-alice")
+        compare(error, "")
+        calls++
+      })
+      deliverLookup(auth)
+      compare(calls, 1)
+      compare(auth.loggedIn, true)
+      var command = finishJob(auth)
+      compare(command[command.length - 1], "outlook:alice@hotmail.com")
+      compare(auth.keyringJob, null)
+    }
+    function test_logout_must_discard_pending_keyring_result() {
+      var auth = startLookup()
+      auth.logout()
+      compare(auth.loggedIn, false)
+      deliverLookup(auth)
+      compare(auth.loggedIn, false, "A late lookup must not resurrect the session")
+      compare(auth.reviewRefreshRequests, 0,
+        "A completed lookup must not refresh credentials after logout")
+      compare(auth.loggedIn, false)
+    }
+    function test_account_change_must_discard_old_lookup() {
+      var auth = startLookup()
+      auth.accountId = "outlook:bob@hotmail.com"
+      auth.configuredEmail = "bob@hotmail.com"
+      deliverLookup(auth)
+      compare(auth.keyringJob, null, "Alice's refreshed token must not be queued for Bob's keyring entry")
+      compare(auth.reviewRefreshRequests, 0,
+        "Alice's lookup must not start a refresh in Bob's account")
+    }
+    function test_logout_must_clear_current_account() {
+      var auth = startLookup()
+      // Finish the old lookup without a saved session, then reuse the host.
+      var lookup = lookupProcess(auth)
+      lookup.stdout.text = ""
+      lookup.running = false
+      lookup.exited(1)
+      auth.accountId = "outlook:bob@hotmail.com"
+      auth.configuredEmail = "bob@hotmail.com"
+      auth.logout()
+      for (var i = 0; i < auth.children.length; i++) {
+        var child = auth.children[i]
+        if (child.command && child.command[1] === "clear") {
+          compare(child.command[child.command.length - 1], "outlook:bob@hotmail.com",
+            "Sign-out must clear Bob's token, not Alice's previous lookup key")
+          return
+        }
+      }
+      fail("No keyring clear requested")
+    }
+    function test_failed_restore_must_complete_waiting_requests() {
+      var auth = startLookup()
+      auth.reviewResponseStatus = 400
+      var called = 0
+      auth.withCredentials(function(token, error) { called++ })
+      deliverLookup(auth)
+      compare(called, 1, "A request queued behind restore must receive its authentication failure")
+      compare(auth.tokenWaiters.length, 0)
+    }
+    function test_empty_lookup_completes_all_waiting_requests() {
+      var auth = startLookup()
+      var calls = 0
+      for (var i = 0; i < 2; i++) auth.withCredentials(function(token, error) {
+        compare(token, "")
+        verify(error !== "")
+        calls++
+      })
+      var lookup = lookupProcess(auth)
+      lookup.running = false
+      lookup.exited(1)
+      compare(calls, 2)
+      compare(auth.tokenWaiters.length, 0)
+    }
+    function test_waiter_signout_prevents_token_delivery_to_remaining_waiters() {
+      var auth = startLookup()
+      var calls = 0
+      auth.withCredentials(function(token, error) {
+        compare(token, "synthetic-access-alice")
+        auth.logout()
+        calls++
+      })
+      auth.withCredentials(function(token, error) {
+        compare(token, "")
+        verify(error !== "")
+        calls++
+      })
+      deliverLookup(auth)
+      compare(calls, 2)
+      compare(auth.loggedIn, false)
+    }
+    function test_logout_discards_late_http_response() {
+      var auth = startLookup()
+      auth.deferResponse = true
+      deliverLookup(auth)
+      verify(auth.refreshBusy)
+      var respond = auth.responseCallback
+      auth.logout()
+      respond(200, JSON.stringify({ access_token: "stale", refresh_token: "stale" }))
+      compare(auth.loggedIn, false)
+      compare(auth.accessToken, "")
+      compare(auth.keyringJob.kind, "clear")
+      compare(auth.keyringJobs.length, 0)
+      var called = 0
+      auth.withCredentials(function(token, error) { compare(token, ""); called++ })
+      compare(called, 1)
+      compare(auth.reviewRefreshRequests, 1)
+    }
+    function test_client_change_discards_late_http_response() {
+      var auth = startLookup()
+      auth.deferResponse = true
+      deliverLookup(auth)
+      var respond = auth.responseCallback
+      auth.configuredClientId = "87654321-1234-4abc-9def-1234567890ab"
+      respond(200, JSON.stringify({ access_token: "stale", refresh_token: "stale" }))
+      compare(auth.loggedIn, false)
+      compare(auth.keyringJob, null)
+    }
+    function test_store_then_logout_then_account_change_clears_original_key() {
+      var auth = startLookup()
+      deliverLookup(auth)
+      compare(auth.keyringJob.kind, "store")
+      auth.logout()
+      compare(auth.keyringJobs.length, 1)
+      auth.accountId = "outlook:bob@hotmail.com"
+      auth.configuredEmail = "bob@hotmail.com"
+      var stored = finishJob(auth)
+      compare(stored[stored.length - 1], "outlook:alice@hotmail.com")
+      compare(auth.keyringJob.kind, "clear")
+      var cleared = finishJob(auth)
+      compare(cleared[cleared.length - 1], "outlook:alice@hotmail.com")
+      compare(auth.keyringJob, null)
+    }
+    function test_two_logouts_do_not_drop_second_clear() {
+      var auth = startLookup()
+      auth.logout()
+      auth.accountId = "outlook:bob@hotmail.com"
+      auth.configuredEmail = "bob@hotmail.com"
+      auth.logout()
+      compare(auth.keyringJobs.length, 1)
+      var first = finishJob(auth)
+      var second = finishJob(auth)
+      compare(first[first.length - 1], "outlook:alice@hotmail.com")
+      compare(second[second.length - 1], "outlook:bob@hotmail.com")
+    }
+    function test_old_lookup_cannot_clear_replacement_lookup() {
+      var auth = startLookup()
+      var old = lookupProcess(auth)
+      auth.accountId = "outlook:bob@hotmail.com"
+      auth.configuredEmail = "bob@hotmail.com"
+      wait(1)
+      var current = auth.lookupProcess
+      verify(current !== null && current !== old)
+      old.stdout.text = "synthetic-refresh-alice"
+      old.running = false
+      old.exited(0)
+      compare(auth.lookupProcess, current)
+      compare(auth.reviewRefreshRequests, 0)
+    }
+    function test_verification_from_previous_signin_cannot_accept_new_token() {
+      var auth = startLookup()
+      var oldGeneration = auth.sessionGeneration
+      auth.cancelLogin()
+      auth.loginBusy = true
+      auth.pendingAccessToken = "new-access"
+      auth.pendingRefreshToken = "new-refresh"
+      auth.pendingExpiresIn = 3600
+      auth.completeSignIn(true, "", oldGeneration)
+      compare(auth.loggedIn, false)
+      compare(auth.keyringJob, null)
+      auth.completeSignIn(true, "", auth.sessionGeneration)
+      compare(auth.loggedIn, true)
+      compare(auth.accessToken, "new-access")
+    }
+  }
+}

--- a/tests/test_accounts.js
+++ b/tests/test_accounts.js
@@ -61,6 +61,8 @@ assert.strictEqual(accounts.accountId("  Ada@Example.COM "), "ada@example.com")
 assert.strictEqual(accounts.accountId("nobody"), "")
 assert.strictEqual(accounts.accountId(""), "")
 assert.strictEqual(accounts.accountId(null), "")
+assert.strictEqual(accounts.accountId("Ada@Hotmail.com", "outlook"),
+  "outlook:ada@hotmail.com")
 
 // ------------------------------------------------------------------ labels
 

--- a/tests/test_credentials.js
+++ b/tests/test_credentials.js
@@ -189,6 +189,16 @@ deepEqual(credentials.legacyKeyringAttributes(sharedClient), [
 ])
 assert.strictEqual(credentials.legacyKeyringAttributes(sharedClient).indexOf("account"), -1)
 
+deepEqual(credentials.outlookKeyringAttributes(
+  "12345678-1234-4abc-9def-1234567890ab", "outlook:one@hotmail.com"), [
+  "service", "omamail",
+  "kind", "outlook-refresh-token",
+  "client-id", "12345678-1234-4abc-9def-1234567890ab",
+  "account", "outlook:one@hotmail.com"
+])
+deepEqual(credentials.outlookKeyringAttributes("", "outlook:one@hotmail.com"), [])
+deepEqual(credentials.outlookKeyringAttributes(sharedClient, ""), [])
+
 deepEqual(credentials.renamedKeyringAttributes(sharedClient, "one@gmail.com"), [
   "service", "omarchy-gmail",
   "kind", "refresh-token",

--- a/tests/test_curl_config.py
+++ b/tests/test_curl_config.py
@@ -31,6 +31,10 @@ with tempfile.TemporaryDirectory(prefix="omamail-config-test-") as directory:
         ("mail-transport.sh", ["smtp"], [b"smtps://example.com/", b"user:secret", b"sender@example.com", b"Subject: Hello\r\n\r\nBody\r\n", b"to@example.com", b"next@example.com"], [0, 1, 2, 4, 5]),
         ("mail-transport.sh", ["imap-append"], [b"imaps://example.com/Drafts", b"user:secret", b"Subject: Draft\r\n\r\nBody\r\n", b"draft"], [0, 1, 3]),
         ("mail-transport.sh", ["imap-append"], [b"imaps://example.com/Sent", b"user:secret", b"Subject: Sent\r\n\r\nBody\r\n", b"seen"], [0, 1, 3]),
+        ("mail-transport.sh", ["imap-oauth"], [b"imaps://example.com/INBOX", b"user@example.com", b"bearer-token", b"NOOP"], [0, 1, 2, 3]),
+        ("mail-transport.sh", ["imap-id-oauth"], [b"imaps://example.com/", b"imaps://example.com/INBOX", b"user@example.com", b"bearer-token", b"ID NIL", b"NOOP"], [0, 1, 2, 3, 4, 5]),
+        ("mail-transport.sh", ["smtp-oauth"], [b"smtps://example.com/", b"user@example.com", b"bearer-token", b"sender@example.com", b"Subject: Hello\r\n\r\nBody\r\n", b"to@example.com"], [0, 1, 2, 3, 5]),
+        ("mail-transport.sh", ["imap-append-oauth"], [b"imaps://example.com/Sent", b"user@example.com", b"bearer-token", b"Subject: Sent\r\n\r\nBody\r\n", b"seen"], [0, 1, 2, 4]),
     ]
     count = 0
     for script, prefix, fields, protected in cases:

--- a/tests/test_imap_ordering.sh
+++ b/tests/test_imap_ordering.sh
@@ -37,21 +37,33 @@ log_path, id_reply = sys.argv[1], sys.argv[2]
 
 def handle(conn):
     f = conn.makefile("rwb", buffering=0)
-    f.write(b"* OK [CAPABILITY IMAP4rev1 ID] fake ready\r\n")
+    f.write(b"* OK [CAPABILITY IMAP4rev1 ID AUTH=XOAUTH2] fake ready\r\n")
+    auth_tag = None
     while True:
         line = f.readline()
         if not line:
             break
         text = line.decode("latin1").rstrip("\r\n")
+        if auth_tag is not None:
+            with open(log_path, "a") as fh:
+                fh.write("OAUTH-RESPONSE\n")
+            f.write(("%s OK authenticated\r\n" % auth_tag).encode())
+            auth_tag = None
+            continue
         with open(log_path, "a") as fh:
             # The password is never interesting here and must not be written down.
-            fh.write(re.sub(r"(?i)^(\S+\s+LOGIN)\s+.*$", r"\1", text) + "\n")
+            safe = re.sub(r"(?i)^(\S+\s+LOGIN)\s+.*$", r"\1", text)
+            safe = re.sub(r"(?i)^(\S+\s+AUTHENTICATE)\s+.*$", r"\1", safe)
+            fh.write(safe + "\n")
         parts = text.split(" ", 2)
         if len(parts) < 2:
             continue
         tag, cmd = parts[0], parts[1].upper()
         rest = parts[2].upper() if len(parts) > 2 else ""
-        if cmd == "ID" and id_reply == "bad":
+        if cmd == "AUTHENTICATE":
+            auth_tag = tag
+            f.write(b"+ \r\n")
+        elif cmd == "ID" and id_reply == "bad":
             f.write(("%s BAD Unknown command\r\n" % tag).encode())
         elif cmd == "ID":
             # Untagged, as a real server answers. curl treats this section as a
@@ -62,7 +74,7 @@ def handle(conn):
             f.write(b'* ID ("name" "fake" "version" "1")\r\n')
             f.write(("%s OK done\r\n" % tag).encode())
         elif cmd == "CAPABILITY":
-            f.write(b"* CAPABILITY IMAP4rev1 ID\r\n")
+            f.write(b"* CAPABILITY IMAP4rev1 ID AUTH=XOAUTH2\r\n")
             f.write(("%s OK done\r\n" % tag).encode())
         elif cmd == "SELECT":
             f.write(b"* 2 EXISTS\r\n")
@@ -138,6 +150,19 @@ transport() {
 
 commands() { sed -E 's/^[A-Za-z0-9]+ //' "$work/log" | tr '\n' '|'; }
 fetch_rows() { grep -c '^\* [0-9]* FETCH' "$work/reply" || true; }
+
+# The same real curl must turn the bearer option into XOAUTH2 rather than a
+# password LOGIN. The server log redacts the initial response, so a failure
+# cannot print the synthetic token either.
+start_server ok
+printf 'imap-oauth %s %s %s %s\n' \
+  "$(b64 "imap://127.0.0.1:$port")" "$(b64 'jane@example.com')" \
+  "$(b64 'synthetic-access-token')" "$(b64 'NOOP')" \
+  | ./scripts/mail-transport.sh > "$work/out" 2>/dev/null || true
+stop_server
+[ "$(head -1 "$work/out")" = "0" ] || fail "OAuth IMAP should have succeeded, curl exited $(head -1 "$work/out")"
+[ "$(commands)" = 'CAPABILITY|AUTHENTICATE|OAUTH-RESPONSE|NOOP|LOGOUT|' ] \
+  || fail "the bearer token must select XOAUTH2, saw: $(commands)"
 
 # The mode that carries the fix: the opening command runs against the server,
 # the mailbox is opened after it, and the answer still reaches the caller.
@@ -242,7 +267,7 @@ if not gate:
     sys.exit("test_imap_ordering.sh: ID must be sent only to a server that advertised it")
 if block.index("Imap.idCommand()") < gate.start():
     sys.exit("test_imap_ordering.sh: the ID command must sit behind the capability check")
-if "imap-id " not in block:
+if 'transportMode(opening === "" ? "imap" : "imap-id")' not in block:
     sys.exit("test_imap_ordering.sh: the ID command must travel in the transport's imap-id mode")
 SRC
 

--- a/tests/test_microsoft_oauth.js
+++ b/tests/test_microsoft_oauth.js
@@ -1,0 +1,85 @@
+const assert = require("assert")
+const { load, deepEqual } = require("./load")
+
+const microsoft = load("providers/MicrosoftOAuth.js")
+const outlook = load("providers/Outlook.js")
+
+const clientId = "12345678-1234-4abc-9def-1234567890ab"
+deepEqual(outlook.settings("jane@hotmail.com"), {
+  imapHost: "outlook.office365.com",
+  imapPort: 993,
+  smtpHost: "smtp-mail.outlook.com",
+  smtpPort: 587,
+  username: "jane@hotmail.com",
+  aliases: [],
+  insecure: false
+})
+assert.strictEqual(microsoft.isValidClientId(clientId), true)
+assert.strictEqual(microsoft.isValidClientId("not-a-guid"), false)
+assert.strictEqual(microsoft.isValidClientId(""), false)
+assert.strictEqual(microsoft.effectiveClientId("  " + clientId + "  "), clientId)
+
+const deviceBody = microsoft.deviceAuthorizationBody(clientId)
+assert.ok(deviceBody.indexOf("client_id=" + clientId) >= 0)
+assert.ok(deviceBody.indexOf("offline_access") >= 0)
+assert.ok(deviceBody.indexOf("IMAP.AccessAsUser.All") >= 0)
+assert.ok(deviceBody.indexOf("SMTP.Send") >= 0)
+
+assert.strictEqual(microsoft.verificationUri("https://microsoft.com/devicelogin"),
+  "https://microsoft.com/devicelogin")
+assert.strictEqual(microsoft.verificationUri("https://login.microsoftonline.com/common/oauth2/deviceauth"),
+  "https://login.microsoftonline.com/common/oauth2/deviceauth")
+assert.strictEqual(microsoft.verificationUri("http://microsoft.com/devicelogin"), "")
+assert.strictEqual(microsoft.verificationUri("https://microsoft.com.evil.example/devicelogin"), "")
+
+const device = microsoft.parseDeviceResponse(200, JSON.stringify({
+  device_code: "device-secret",
+  user_code: "ABCD-EFGH",
+  verification_uri: "https://microsoft.com/devicelogin",
+  expires_in: 900,
+  interval: 7
+}))
+assert.strictEqual(device.ok, true)
+assert.strictEqual(device.deviceCode, "device-secret")
+assert.strictEqual(device.userCode, "ABCD-EFGH")
+assert.strictEqual(device.interval, 7)
+assert.strictEqual(microsoft.parseDeviceResponse(200, JSON.stringify({
+  device_code: "secret", user_code: "code", verification_uri: "file:///tmp/trap"
+})).ok, false, "the token service cannot make the desktop open a local URI")
+
+deepEqual(microsoft.parseTokenResponse(400,
+  JSON.stringify({ error: "authorization_pending" }), ""), {
+  ok: false, pending: true, slowDown: false, error: ""
+})
+assert.strictEqual(microsoft.parseTokenResponse(400,
+  JSON.stringify({ error: "slow_down" }), "").slowDown, true)
+
+const token = microsoft.parseTokenResponse(200, JSON.stringify({
+  access_token: "access",
+  refresh_token: "refresh",
+  expires_in: 3600,
+  scope: microsoft.SCOPES.join(" ")
+}), "")
+assert.strictEqual(token.ok, true)
+assert.strictEqual(token.accessToken, "access")
+assert.strictEqual(token.refreshToken, "refresh")
+deepEqual(microsoft.missingMailScopes(token.scope), [])
+assert.strictEqual(microsoft.missingMailScopes(
+  "https://outlook.office.com/IMAP.AccessAsUser.All").length, 1)
+assert.ok(microsoft.missingScopeMessage([
+  "https://outlook.office.com/SMTP.Send"
+]).indexOf("SMTP.Send") >= 0)
+
+const rotated = microsoft.parseTokenResponse(200, JSON.stringify({
+  access_token: "next", expires_in: 3600
+}), "saved-refresh")
+assert.strictEqual(rotated.refreshToken, "saved-refresh")
+
+const invalid = microsoft.parseTokenResponse(400,
+  JSON.stringify({ error: "invalid_grant", error_description: "expired" }), "")
+assert.strictEqual(invalid.invalidGrant, true)
+assert.strictEqual(microsoft.refreshFailureDisposition(invalid), "signed_out")
+assert.ok(microsoft.redact('{"access_token":"eyJsecret.payload.signature","device_code":"secret"}')
+  .indexOf("secret") < 0)
+
+console.log("test_microsoft_oauth.js ok")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -30,6 +30,12 @@ assert.strictEqual(model.setupHeadline("no_credentials", "IMAP", "password"),
   "Add this mailbox", "only one of the two sends anyone to a Cloud console")
 assert.strictEqual(model.setupHeadline("no_credentials", "Gmail", "oauth"),
   "Connect a Google Cloud project")
+assert.strictEqual(model.setupHeadline("no_credentials", "Outlook", "oauth"),
+  "Add this Outlook mailbox")
+assert.strictEqual(model.setupHeadline("signing_in", "Outlook", "oauth"),
+  "Waiting for Microsoft…")
+assert.ok(model.setupDetail("no_credentials", [], "", "Outlook", "oauth")
+  .indexOf("Microsoft") >= 0)
 // The unavailable detail comes from the provider, because only it knows why.
 assert.strictEqual(model.setupDetail("unavailable", [], "no API yet", "HEY"), "no API yet")
 assert.strictEqual(model.setupActionLabel("unavailable", "HEY"), "",

--- a/tests/test_outlook_http.py
+++ b/tests/test_outlook_http.py
@@ -1,0 +1,178 @@
+"""Exercise OutlookAuth's native QML HTTP deadline and cancellation.
+
+Only the test engine's Microsoft endpoint is replaced with a loopback fixture;
+postForm, its 30-second Timer, and XMLHttpRequest are the production code.
+Process mocks prevent keyring or mail-server access. This does not claim a live
+Microsoft sign-in: the fixed trusted Microsoft endpoint, native Qt redirect
+handling, and absence of a response-size limit remain the production boundary.
+"""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+ROOT = Path(__file__).resolve().parents[1]
+received = threading.Event()
+release = threading.Event()
+requests = []
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_):
+        pass
+
+    def answer(self, body):
+        try:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        except (BrokenPipeError, ConnectionResetError):
+            pass  # Aborting the native request is precisely what is tested.
+
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers["Content-Length"]))
+        requests.append((self.path, body))
+        if self.path == "/hang":
+            release.wait(40)
+            return
+        if self.path == "/delayed":
+            received.set()
+            release.wait(5)
+            self.answer(b'{"access_token":"stale-access","refresh_token":"stale-refresh"}')
+            return
+        self.send_error(404)
+
+    def do_GET(self):
+        if self.path == "/received":
+            self.answer(b"true" if received.wait(5) else b"false")
+        elif self.path == "/release":
+            release.set()
+            self.answer(b"true")
+        else:
+            self.send_error(404)
+
+
+QML = r'''
+import QtQuick
+import QtTest
+import @PROVIDERS@ as Providers
+import @MICROSOFT@ as Microsoft
+
+Item {
+  Component {
+    id: factory
+    Providers.OutlookAuth {
+      pluginDir: "/unused-outlook-http-fixture"
+      accountId: "outlook:synthetic@example.com"
+      configuredEmail: "synthetic@example.com"
+      configuredClientId: "12345678-1234-4abc-9def-1234567890ab"
+    }
+  }
+  TestCase {
+    name: "OutlookNativeHttp"
+    property string endpoint: @ENDPOINT@
+    function readyAuth(path) {
+      var auth = createTemporaryObject(factory, parent)
+      verify(auth !== null)
+      wait(1)
+      auth.cancelLogin()
+      Microsoft.TOKEN_URL = endpoint + path
+      return auth
+    }
+    function control(path) {
+      var done = false
+      var request = new XMLHttpRequest()
+      request.onreadystatechange = function() {
+        if (request.readyState === XMLHttpRequest.DONE) done = true
+      }
+      request.open("GET", endpoint + path)
+      request.send()
+      tryVerify(function() { return done }, 6000)
+      compare(request.status, 200)
+      compare(request.responseText, "true")
+    }
+    function test_1_native_deadline_completes_waiters() {
+      var auth = readyAuth("/hang")
+      compare(auth.tokenTimeoutMs, 30000)
+      var started = Date.now()
+      auth.refreshWithToken("synthetic-refresh", auth.sessionContext())
+      verify(auth.refreshBusy)
+      verify(auth.tokenRequest !== null)
+      var calls = 0
+      auth.withCredentials(function(token, error) {
+        compare(token, "")
+        verify(error !== "")
+        calls++
+      })
+      tryCompare(auth, "refreshBusy", false, 35000)
+      verify(Date.now() - started >= 29000, "The fixture must reach the actual deadline")
+      compare(calls, 1)
+      compare(auth.tokenWaiters.length, 0)
+      compare(auth.tokenRequest, null)
+      compare(auth.loggedIn, false)
+      compare(auth.accessToken, "")
+      compare(auth.keyringJob, null)
+      wait(100)
+      compare(calls, 1, "Aborting the request must complete its waiters only once")
+    }
+    function test_2_cancel_discards_native_response() {
+      var auth = readyAuth("/delayed")
+      auth.refreshWithToken("synthetic-refresh", auth.sessionContext())
+      var calls = 0
+      auth.withCredentials(function(token, error) {
+        compare(token, "")
+        verify(error !== "")
+        calls++
+      })
+      control("/received")
+      auth.cancelLogin()
+      compare(calls, 1)
+      compare(auth.tokenRequest, null)
+      compare(auth.refreshBusy, false)
+      control("/release")
+      wait(300)
+      compare(calls, 1)
+      compare(auth.tokenWaiters.length, 0)
+      compare(auth.loggedIn, false)
+      compare(auth.accessToken, "")
+      compare(auth.keyringJob, null, "A cancelled response must never save a refresh token")
+      compare(auth.keyringJobs.length, 0)
+    }
+  }
+}
+'''
+
+
+def main():
+    runner = sys.argv[1] if len(sys.argv) > 1 else "/usr/lib/qt6/bin/qmltestrunner"
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with tempfile.TemporaryDirectory(prefix="omamail-outlook-http-") as directory:
+            source = QML.replace("@PROVIDERS@", json.dumps((ROOT / "providers").as_uri()))
+            source = source.replace("@MICROSOFT@", json.dumps((ROOT / "providers/MicrosoftOAuth.js").as_uri()))
+            source = source.replace("@ENDPOINT@", json.dumps(f"http://127.0.0.1:{server.server_port}"))
+            fixture = Path(directory) / "tst_outlook_http.qml"
+            fixture.write_text(source)
+            env = dict(os.environ, QT_QPA_PLATFORM="offscreen", QT_QUICK_BACKEND="software",
+                       QT_QPA_PLATFORMTHEME="", NO_PROXY="127.0.0.1,localhost", no_proxy="127.0.0.1,localhost")
+            subprocess.run([runner, "-import", str(ROOT / "tests/qml/imports"),
+                            "-input", str(fixture)], env=env, check=True, timeout=50)
+        assert [path for path, _ in requests] == ["/hang", "/delayed"], requests
+        assert all(b"refresh_token=synthetic-refresh" in body for _, body in requests)
+        print("Outlook native HTTP: deadline and cancellation passed with synthetic credentials")
+    finally:
+        release.set()
+        server.shutdown()
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_provider.js
+++ b/tests/test_provider.js
@@ -10,8 +10,9 @@ const provider = load("providers/Registry.js")
 //
 // The order is the order the chooser lists them in: the two hosted mailboxes
 // with a service of their own, then the one that is every other mailbox.
-deepEqual(provider.ids(), ["gmail", "hey", "imap"])
+deepEqual(provider.ids(), ["gmail", "outlook", "hey", "imap"])
 assert.strictEqual(provider.get("gmail").name, "Gmail")
+assert.strictEqual(provider.get("outlook").name, "Outlook")
 assert.strictEqual(provider.get("imap").name, "IMAP")
 assert.strictEqual(provider.get("hey").name, "HEY")
 
@@ -31,12 +32,14 @@ assert.strictEqual(provider.exists("imap"), true)
 
 assert.strictEqual(provider.can("gmail", "labels"), true)
 assert.strictEqual(provider.can("imap", "labels"), false)
+assert.strictEqual(provider.can("outlook", "labels"), false)
 // Separate questions. `labels` is whether a message can carry several at once,
 // which is what the reader's strip draws; `move` is whether the user gets to
 // say where it goes. IMAP answers no and yes -- one folder per message is the
 // very thing that makes a move the plain operation there.
 assert.strictEqual(provider.can("gmail", "move"), true)
 assert.strictEqual(provider.can("imap", "move"), true)
+assert.strictEqual(provider.can("outlook", "move"), true)
 assert.strictEqual(provider.can("hey", "move"), false, "HEY's destinations are its own")
 assert.strictEqual(provider.can("gmail", "spam"), true)
 assert.strictEqual(provider.can("imap", "spam"), false, "IMAP has no junk verb worth offering")
@@ -54,6 +57,7 @@ assert.strictEqual(provider.can("gmail", "webBox"), true)
 assert.strictEqual(provider.can("hey", "web"), true)
 assert.strictEqual(provider.can("hey", "webBox"), false)
 assert.strictEqual(provider.can("imap", "webBox"), false)
+assert.strictEqual(provider.can("outlook", "webBox"), false)
 
 // And the address builders agree with the capabilities, so a caller that asked
 // anyway gets nothing rather than somewhere else's mailbox.
@@ -80,6 +84,7 @@ assert.strictEqual(provider.can("hey", "archive"), false, "HEY has no archive")
 assert.strictEqual(provider.isConnectable("gmail"), true)
 assert.strictEqual(provider.isConnectable("imap"), true)
 assert.strictEqual(provider.isConnectable("hey"), true)
+assert.strictEqual(provider.isConnectable("outlook"), true)
 
 assert.strictEqual(provider.unavailableReason("gmail"), "")
 assert.strictEqual(provider.unavailableReason("imap"), "")
@@ -149,6 +154,7 @@ assert.strictEqual(provider.query("imap", "inbox", "", ""), "folder:INBOX")
 assert.strictEqual(provider.query("imap", "unread", "", ""), "folder:INBOX UNSEEN")
 assert.strictEqual(provider.query("imap", "sent", "", ""), "folder:\\Sent")
 assert.strictEqual(provider.query("imap", "drafts", "", ""), "folder:\\Drafts")
+assert.strictEqual(provider.query("outlook", "unread", "", ""), "folder:INBOX UNSEEN")
 
 // A typed search wins over everything, and is shaped by the provider.
 assert.strictEqual(provider.query("gmail", "trash", "from:jane", ""), "from:jane",
@@ -173,6 +179,7 @@ assert.strictEqual(provider.query("gmail", "inbox", "   ", ""), "in:inbox",
 // request is rejected and the mailbox stays empty.
 assert.strictEqual(provider.query("imap", "inbox", "", "in:inbox"), "folder:INBOX")
 assert.strictEqual(provider.query("hey", "inbox", "", "in:inbox"), "box:imbox")
+assert.strictEqual(provider.query("outlook", "inbox", "", "in:inbox"), "folder:INBOX")
 
 // HEY's own queries, which the client reads back as commands.
 assert.strictEqual(provider.query("hey", "inbox", "", ""), "box:imbox")
@@ -201,6 +208,7 @@ assert.strictEqual(provider.cachedSummaryInSearch("hey", "label:4711", {}), true
 assert.strictEqual(provider.unreadQuery("gmail"),
   "in:inbox is:unread -category:promotions -category:social -category:forums")
 assert.strictEqual(provider.unreadQuery("imap"), "folder:INBOX UNSEEN")
+assert.strictEqual(provider.unreadQuery("outlook"), "folder:INBOX UNSEEN")
 assert.strictEqual(provider.unreadQuery("hey"), "box:imbox unseen")
 
 // Named by exclusion on purpose, and the reason is which way it fails. Asking
@@ -241,6 +249,7 @@ assert.ok(provider.labelQuery("imap", "Old Mail").indexOf("TEXT") < 0)
 assert.strictEqual(provider.webHomeUrl("gmail"), "https://mail.google.com/mail/u/0/")
 assert.strictEqual(provider.webHomeUrl("hey"), "https://app.hey.com")
 assert.strictEqual(provider.webHomeUrl("imap"), "", "an IMAP server is not a website")
+assert.strictEqual(provider.webHomeUrl("outlook"), "https://outlook.live.com/mail/")
 
 // ------------------------------------------------------------------ logos
 
@@ -256,10 +265,12 @@ assert.strictEqual(provider.mark("hey"), "hey-mark.png")
 assert.strictEqual(provider.logo("hey"), "hey.png")
 assert.strictEqual(provider.mark("imap"), "")
 assert.strictEqual(provider.logo("imap"), "")
+assert.strictEqual(provider.logo("outlook"), "")
 
 // ------------------------------------------------------------------- auth
 
 assert.strictEqual(provider.authKind("gmail"), "oauth")
+assert.strictEqual(provider.authKind("outlook"), "oauth")
 assert.strictEqual(provider.authKind("imap"), "password")
 // A sign-in this plugin does not perform itself: `hey` owns the browser, the
 // token and the keyring entry it lives in.
@@ -269,6 +280,7 @@ assert.strictEqual(provider.usesCli("gmail"), false)
 assert.strictEqual(provider.usesOAuth("hey"), false)
 assert.strictEqual(provider.usesPassword("hey"), false)
 assert.strictEqual(provider.usesOAuth("gmail"), true)
+assert.strictEqual(provider.usesOAuth("outlook"), true)
 assert.strictEqual(provider.usesOAuth("imap"), false)
 assert.strictEqual(provider.usesPassword("imap"), true)
 assert.strictEqual(provider.usesPassword("gmail"), false)

--- a/tests/test_transport.sh
+++ b/tests/test_transport.sh
@@ -101,6 +101,12 @@ check "the credentials reach curl" "$config" 'user = "jane@example.org:hunter2"'
 check "the command reaches curl" "$config" 'request = "UID SEARCH UNSEEN"'
 check "mail transport bypasses desktop HTTP/SOCKS proxies" "$config" 'noproxy = "*"'
 
+oauth_request="imap-oauth $(b64 'imaps://outlook.office365.com:993/INBOX') $(b64 'jane@hotmail.com') $(b64 'access-token') $(b64 'UID SEARCH UNSEEN')"
+oauth_config=$(config_for "$oauth_request")
+check "OAuth keeps the username separate" "$oauth_config" 'user = "jane@hotmail.com"'
+check "the bearer token reaches curl's OAuth option" "$oauth_config" 'oauth2-bearer = "access-token"'
+check_absent "OAuth does not turn the token into a password" "$oauth_config" 'user = "jane@hotmail.com:access-token"'
+
 # libcurl puts a custom multi-UID FETCH in its protocol-header callback rather
 # than stdout. The transport returns that channel when present, or the client
 # sees a successful request with an empty message list.


### PR DESCRIPTION
## Summary
Adds first-class OAuth authentication for personal Outlook.com, Hotmail, Live, and MSN mailboxes.

The implementation uses Microsoft device-code OAuth with a user-supplied public Application (client) ID, requests the IMAP and SMTP delegated scopes, and authenticates both IMAP and SMTP with XOAUTH2. No client secret or mailbox password is stored or required. Refresh tokens are kept in the desktop keyring with account- and client-specific attributes.

The setup page explains the Entra app registration requirements, supports multiple accounts, and keeps Outlook server settings fixed to Microsoft endpoints.

## Testing
`make validate` passes, including JavaScript, shell, curl-boundary, QML security, and provider tests. Manual testing confirmed sign-in, mail sync, and account operation with a personal Outlook account.

## Release Notes
Omamail can now be used with Outlook.com and Hotmail accounts after registering a public client application in Microsoft Entra ID.