### PR TITLE
Add Reply-To, draft editing shortcuts, and imported signatures

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -1255,6 +1255,7 @@ Item {
     function onActiveAccountIdChanged() {
       root.clearChecksIfForeign()
       root.cursorId = ""
+      root.closeLabelPopups()
     }
     function onSidebarWidthChanged() { root.sidebarWidth = root.service.sidebarWidth }
     function onListWidthChanged() { root.listWidth = root.service.listWidth }
@@ -1463,12 +1464,82 @@ Item {
     })
   }
 
+
   function confirmDelete(request) {
     if (!service) return
     if (request.kind === "event" && request.event) {
       service.calendarController.deleteEvent(request.sourceId, request.event)
       calendarView.closeDetail()
     }
+    if (request.kind === "label" && request.labelId) service.deleteLabel(request.labelId, request.accountId)
+  }
+
+  // ------------------------------------------------------------ labels
+
+  // Every label popup — the menu, the name prompt, the move picker, the
+  // delete confirmation — is opened for one account and answers to it by
+  // id, whatever the window has switched to since. An IMAP label id is a
+  // folder name, which another account may well have too, so the open
+  // account is no guide to whose folder was meant. And a switch closes
+  // them: a prompt about a mailbox no longer on screen is a trap.
+  function openLabelMenu(labelId, path, sceneX, sceneY) {
+    if (!service) return
+    labelMenu.accountId = service.activeAccountId
+    labelMenu.canManage = service.canManageLabels
+    labelMenu.monitored = service.monitoredLabelIds.indexOf(labelId) >= 0
+    labelMenu.openAt(labelId, path, sceneX, sceneY)
+  }
+
+  function closeLabelPopups() {
+    labelMenu.close()
+    namePrompt.close()
+    labelMovePicker.close()
+    if (confirmDeleteDialog.request && confirmDeleteDialog.request.kind === "label") confirmDeleteDialog.close()
+  }
+
+  function labelDelimiterFor(id, accountId) {
+    var label = service ? service.labelById(id, accountId) : null
+    return Model.labelDelimiter(label)
+  }
+
+  function labelPathFor(id, accountId) {
+    var label = service ? service.labelById(id, accountId) : null
+    return label ? String(label.name || label.rawName || "") : ""
+  }
+
+  // A name asked for, then handed to the service with what it was for. The
+  // prompt is one component serving three asks, told apart by `kind`.
+  function askLabelName(kind, subject, title, initial, hint, accountId) {
+    namePrompt.accountId = String(accountId || "")
+    namePrompt.openFor(kind, subject, title, initial, hint)
+  }
+
+  function labelNamed(kind, subject, text, accountId) {
+    if (!service) return
+    if (kind === "rename") service.renameLabel(subject, text, accountId)
+    else if (kind === "create") service.createLabel(subject, text, accountId)
+  }
+
+  function copyAddress(address) {
+    var text = String(address || "").trim()
+    // Straight to wl-copy as one argument: no shell, and an address that
+    // starts with a dash is not an address.
+    if (text === "" || text.charAt(0) === "-") return
+    Quickshell.execDetached(["wl-copy", text])
+    notice = "Copied " + text
+    noticeTimer.restart()
+  }
+
+  function searchAddress(field, address) {
+    if (!service) return
+    var query = Provider.addressQuery(service.providerId, field, address)
+    if (query === "") return
+    // In the provider's own words, so it must not pass through the typed
+    // search's wrapping a second time; the box shows the words for it.
+    var text = (field === "to" ? "to: " : "from: ") + String(address || "").trim()
+    service.searchAddress(query, text)
+    searchBar.setQuery(text)
+    backToList()
   }
 
   FloatingWindow {
@@ -1773,6 +1844,9 @@ Item {
             root.backToList()
           }
           onFolderToggled: function(path) { root.service.toggleFolder(path) }
+          onLabelMenuRequested: function(labelId, path, sceneX, sceneY) {
+            root.openLabelMenu(labelId, path, sceneX, sceneY)
+          }
         }
 
         // Narrow windows lose the sidebar; the same mailboxes come back as a
@@ -1981,6 +2055,9 @@ Item {
           onComposeRequested: function(mode) { root.startCompose(mode) }
           onMailtoRequested: function(url) {
             root.openDraft(Mailto.parse(url))
+          }
+          onAddressMenuRequested: function(addresses, sceneX, sceneY) {
+            addressMenu.openAt(addresses, sceneX, sceneY)
           }
           onActionRequested: function(action) {
             if (!root.service || root.service.selectedId === "") return
@@ -2561,6 +2638,93 @@ Item {
         onManageRequested: {
           root.openSettings()
         }
+      }
+
+      LabelMenu {
+        id: labelMenu
+        objectName: "label-menu"
+        anchors.fill: parent
+        textColor: root.foreground
+        urgentColor: root.urgent
+        dimColor: root.dim
+        popupBackgroundColor: root.popupBackground
+        popupBorderColor: root.popupBorder
+        panelFontFamily: root.fontFamily
+        onRenameRequested: function(labelId) {
+          var owner = labelMenu.accountId
+          var path = root.labelPathFor(labelId, owner)
+          var delimiter = root.labelDelimiterFor(labelId, owner)
+          root.askLabelName("rename", labelId, "Rename " + path,
+            Model.labelLeaf(path, delimiter), "The new name for this label. Labels beneath it move with it.", owner)
+        }
+        onCreateRequested: function(path, beneath) {
+          var owner = labelMenu.accountId
+          var labels = root.service ? root.service.labelsOf(owner) : []
+          var delimiter = Model.labelDelimiter(labels.length > 0 ? labels[0] : null)
+          var parent = beneath ? path : Model.labelParent(path, delimiter)
+          root.askLabelName("create", parent,
+            parent === "" ? "New label" : "New label under " + parent, "",
+            "Its name at this level; nesting is the parent it goes under.", owner)
+        }
+        onMoveRequested: function(labelId) {
+          var owner = labelMenu.accountId
+          var delimiter = root.labelDelimiterFor(labelId, owner)
+          labelMovePicker.accountId = owner
+          labelMovePicker.openFor(labelId,
+            Model.labelMoveTargets(root.service ? root.service.labelsOf(owner) : [], root.labelPathFor(labelId, owner), delimiter))
+        }
+        onMonitorToggled: function(labelId) { if (root.service) root.service.toggleMonitored(labelId, labelMenu.accountId) }
+        onDeleteRequested: function(labelId) {
+          var owner = labelMenu.accountId
+          var path = root.labelPathFor(labelId, owner)
+          confirmDeleteDialog.openFor({
+            kind: "label", labelId: labelId, name: path, accountId: owner,
+            message: "The label and every label beneath it are removed from the server. "
+              + "On Gmail the messages keep their other labels; on IMAP the folder and its mail are deleted."
+          })
+        }
+      }
+
+      NamePrompt {
+        id: namePrompt
+        objectName: "name-prompt"
+        anchors.fill: parent
+        textColor: root.foreground
+        dimColor: root.dim
+        accentColor: root.accent
+        popupBackgroundColor: root.popupBackground
+        popupBorderColor: root.popupBorder
+        panelFontFamily: root.fontFamily
+        onSubmitted: function(kind, subject, text) { root.labelNamed(kind, subject, text, namePrompt.accountId) }
+      }
+
+      LabelMovePicker {
+        id: labelMovePicker
+        objectName: "label-move-picker"
+        anchors.fill: parent
+        textColor: root.foreground
+        accentColor: root.accent
+        dimColor: root.dim
+        popupBackgroundColor: root.popupBackground
+        popupBorderColor: root.popupBorder
+        panelFontFamily: root.fontFamily
+        onTargetChosen: function(labelId, parentPath) {
+          if (root.service) root.service.moveLabel(labelId, parentPath, labelMovePicker.accountId)
+        }
+      }
+
+      AddressMenu {
+        id: addressMenu
+        objectName: "address-menu"
+        anchors.fill: parent
+        textColor: root.foreground
+        dimColor: root.dim
+        popupBackgroundColor: root.popupBackground
+        popupBorderColor: root.popupBorder
+        panelFontFamily: root.fontFamily
+        canSearch: !!root.service && Provider.addressQuery(root.service.providerId, "from", "a@b.c") !== ""
+        onCopyRequested: function(address) { root.copyAddress(address) }
+        onSearchRequested: function(field, address) { root.searchAddress(field, address) }
       }
 
       LabelPicker {

--- a/App.qml
+++ b/App.qml
@@ -605,6 +605,11 @@ Item {
     if (next !== "" && next !== service.selectedId) openMember(next)
   }
 
+  function openOrEdit(id) {
+    if (service && service.mailboxKey === "drafts" && editDraft(id)) return true
+    return openMessage(id)
+  }
+
   function editDraft(id) {
     if (!service || service.mailboxKey !== "drafts") return false
     var draftId = String(id || "")
@@ -1101,7 +1106,10 @@ Item {
     }
     if (id === "cursorDown") return moveCursor(1)
     if (id === "cursorUp") return moveCursor(-1)
-    if (id === "open") return openMessage(cursorId)
+    // In Drafts, opening a draft from the keyboard is editing it: the
+    // message is what was being written. A click still previews, so the
+    // list can be read through without a composer opening on every row.
+    if (id === "open") return openOrEdit(cursorId)
     if (id === "backToList") return backToList()
     if (id === "nextMember") return stepMember(1)
     if (id === "previousMember") return stepMember(-1)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 QMLLINT := /usr/lib/qt6/bin/qmllint
 QML_FILES := Service.qml BarWidget.qml App.qml \
-	account/MailAccount.qml account/BatchAction.qml account/Rsvp.qml account/NewMailNotification.qml \
+	account/MailAccount.qml account/BatchAction.qml account/Rsvp.qml account/LabelActions.qml account/NewMailNotification.qml \
 	cache/CacheStore.qml cache/BodyCache.qml \
 	providers/AuthManager.qml providers/GmailApiClient.qml \
 	providers/OutlookAuth.qml \
@@ -46,6 +46,10 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/SearchBar.qml \
 	components/AppMenu.qml \
 	components/AccountSwitcher.qml \
+	components/LabelMenu.qml \
+	components/LabelMovePicker.qml \
+	components/NamePrompt.qml \
+	components/AddressMenu.qml \
 	components/AccountRemovalDialog.qml \
 	components/BackBar.qml \
 	components/SettingsPage.qml \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 QMLLINT := /usr/lib/qt6/bin/qmllint
 QML_FILES := Service.qml BarWidget.qml App.qml \
-	account/MailAccount.qml account/BatchAction.qml account/Rsvp.qml account/LabelActions.qml account/NewMailNotification.qml \
+	account/MailAccount.qml account/BatchAction.qml account/Rsvp.qml account/LabelActions.qml account/Unsubscribe.qml account/NewMailNotification.qml \
 	cache/CacheStore.qml cache/BodyCache.qml \
 	providers/AuthManager.qml providers/GmailApiClient.qml \
 	providers/OutlookAuth.qml \
@@ -75,6 +75,7 @@ test: test-js test-shell test-qml
 # they can be tested without a compositor. These run anywhere node does.
 test-js:
 	node tests/test_compose_recovery.js
+	node tests/test_signature.js
 	node tests/test_outbox.js
 	node tests/test_recipients.js
 	node tests/test_senders.js

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ and the client itself are console-only; there is no CLI for them.
 
 ## Using it
 
+Right-click does the rest. On a label in the rail: rename it, make a label beside or beneath it, move it under another, delete it, or watch it for new mail — a watched label counts its unread on every refresh and shows an eye. On the reader's From or To line: copy the address, or search the mailbox for mail from it or to it.
+
 | Key | What it does |
 | --- | --- |
 | `j` / `k` | Move down / up |

--- a/Service.qml
+++ b/Service.qml
@@ -236,6 +236,10 @@ Item {
     var entry = Accounts.find(accountList, String(accountId || ""))
     return entry ? String(entry.email || "") : ""
   }
+  readonly property string activeSignatureHtml: {
+    var entry = Accounts.find(accountList, activeAccountId)
+    return entry ? String(entry.signatureHtml || "") : ""
+  }
   readonly property string calendarAccountId: current && String(current.accountId || "") !== ""
     ? String(current.accountId) : "__no_google_account__"
 
@@ -563,6 +567,13 @@ Item {
     saveAccounts()
   }
 
+  function setAccountSignatureHtml(id, html) {
+    var next = Accounts.setSignatureHtml(accountList, id, html)
+    if (Accounts.serialize(next) === Accounts.serialize(accountList)) return
+    accountList = next
+    saveAccounts()
+  }
+
   function setAccountSignature(id, text) {
     var next = Accounts.setSignature(accountList, id, text)
     if (Accounts.serialize(next) === Accounts.serialize(accountList)) return
@@ -848,7 +859,8 @@ Item {
         // The name as it was typed, empty when none was, so a field editing
         // it shows what is there rather than the address standing in for it.
         label: String(accounts[i].label || ""),
-        signature: String(accounts[i].signature || "")
+        signature: String(accounts[i].signature || ""),
+        signatureHtml: String(accounts[i].signatureHtml || "")
       })
     }
     return out
@@ -1514,7 +1526,7 @@ Item {
     // routing it was missing.
     var values = fields || ({})
     var host = sendHostFor(values)
-    return host ? host.send(withSourceDraftId(values)) : false
+    return host ? host.send(withSignatures(withSourceDraftId(values), host)) : false
   }
 
   // The mailbox a submission is sent from.
@@ -1582,6 +1594,21 @@ Item {
     }
     return null
   }
+
+  // The signatures ride with the fields rather than being read by the
+  // account: the account holds no copy of its own entry, and the window
+  // holds no signature. Both readings — text and markup — go, because the
+  // message carries both.
+  function withSignatures(fields, host) {
+    var values = {}
+    var source = fields || ({})
+    for (var key in source) values[key] = source[key]
+    var entry = Accounts.find(accountList, host ? String(host.accountId || "") : activeAccountId)
+    values.signature = entry ? String(entry.signature || "") : ""
+    values.signatureHtml = entry ? String(entry.signatureHtml || "") : ""
+    return values
+  }
+
   function saveDraft(fields, callback) {
     var values = fields || ({})
     var target = draftOwner(values)
@@ -1590,7 +1617,7 @@ Item {
       if (typeof callback === "function") callback(null, "The mailbox for this draft is unavailable")
       return null
     }
-    return host.saveDraft(withSourceDraftId(values), callback)
+    return host.saveDraft(withSignatures(withSourceDraftId(values), host), callback)
   }
   function fail(text) { if (current) current.fail(text) }
   function note(text) { if (current) current.note(text) }

--- a/Service.qml
+++ b/Service.qml
@@ -529,6 +529,33 @@ Item {
   // rather than on every keystroke, but it is also rebuilt by the write it
   // causes — so the value it hands back on the way out is routinely the one
   // already on disk, and a file round trip for it would be pure cost.
+  // The labels the open mailbox watches, and the switch for one of them.
+  readonly property var monitoredLabelIds: {
+    var entry = Accounts.find(accountList, activeAccountId)
+    return entry && Array.isArray(entry.monitored) ? entry.monitored : []
+  }
+
+  function toggleMonitored(labelId, accountId) {
+    var owner = labelOwner(accountId)
+    if (!owner) return
+    var next = Accounts.toggleMonitored(accountList, owner.accountId, labelId)
+    if (Accounts.serialize(next) === Accounts.serialize(accountList)) return
+    accountList = next
+    saveAccounts()
+    owner.labelActions.refreshMonitored()
+  }
+
+  // The watched ids an account's rename or move left behind, written to its
+  // entry: a watch follows the folder it named to that folder's new id.
+  function setMonitoredIds(index, ids) {
+    var account = accountAt(index)
+    if (!account) return
+    var next = Accounts.setMonitored(accountList, account.accountId, ids)
+    if (Accounts.serialize(next) === Accounts.serialize(accountList)) return
+    accountList = next
+    saveAccounts()
+  }
+
   function setAccountLabel(id, text) {
     var next = Accounts.setLabel(accountList, id, text)
     if (Accounts.serialize(next) === Accounts.serialize(accountList)) return
@@ -1372,6 +1399,61 @@ Item {
     }
     eachHost(function(host) { host.search(text) })
   }
+  readonly property bool canManageLabels: !!current && current.labelActions.canManageLabels
+
+  // A label change is dispatched to the account that owned the menu or
+  // dialog it was asked in, named by its id — not to whichever account is
+  // open when the answer arrives. A label id is a folder name on IMAP and
+  // two accounts can hold the same one, so the open account is no guide;
+  // and an account removed in the meantime gets nothing, with a word about
+  // it. No id at all means the open account, for a caller with no menu.
+  function labelOwner(accountId, mustBeReady) {
+    var id = String(accountId || "")
+    var owner = id === "" ? current : findAccount(id)
+    if (!owner) {
+      if (current) current.fail("That mailbox is no longer set up, so nothing was changed")
+      return null
+    }
+    if (mustBeReady === true && !owner.ready) {
+      owner.fail("That mailbox is signed out, so nothing was changed")
+      return null
+    }
+    return owner
+  }
+  function labelById(id, accountId) {
+    var owner = String(accountId || "") === "" ? current : findAccount(accountId)
+    return owner ? owner.labelActions.labelById(id) : null
+  }
+  function labelsOf(accountId) {
+    var owner = String(accountId || "") === "" ? current : findAccount(accountId)
+    return owner ? owner.labels : []
+  }
+  function createLabel(parentPath, leaf, accountId) {
+    var owner = labelOwner(accountId, true)
+    return owner ? owner.labelActions.createLabel(parentPath, leaf) : false
+  }
+  function renameLabel(id, leaf, accountId) {
+    var owner = labelOwner(accountId, true)
+    return owner ? owner.labelActions.renameLabel(id, leaf) : false
+  }
+  function moveLabel(id, parentPath, accountId) {
+    var owner = labelOwner(accountId, true)
+    return owner ? owner.labelActions.moveLabel(id, parentPath) : false
+  }
+  function deleteLabel(id, accountId) {
+    var owner = labelOwner(accountId, true)
+    return owner ? owner.labelActions.deleteLabel(id) : false
+  }
+
+  // An address search is built in one provider's words, so a merged list
+  // — several providers at once — is refused the way a move is.
+  function searchAddress(query, text) {
+    if (unified) {
+      fail("Searching by address needs one mailbox on screen")
+      return
+    }
+    if (current) current.search(text, query)
+  }
   // Labels belong to one service and one mailbox within it, so a unified view
   // draws none and this cannot be reached from one. `main`'s second argument
   // is kept: dropping it would have left #83's picker unable to say which
@@ -1770,6 +1852,8 @@ Item {
       mayAdoptLegacyToken: index === 0 && (!entry || entry.provider === "gmail")
       settings: root.settings
       bodyMode: root.bodyMode
+      // The labels this mailbox watches for new mail, off its own entry.
+      monitoredIds: entry ? entry.monitored : []
       // Every mailbox obeys the one answer: it is about what the reader is
       // willing to tell a sender, not about which account the mail came to.
       alwaysShowImages: root.alwaysShowImages
@@ -1786,6 +1870,7 @@ Item {
       onInboxUnreadChanged: root.recount()
       onReplySent: root.replySent()
       onReplyFailed: root.forwardReplyFailure(index)
+      onMonitoredMigrated: function(ids) { root.setMonitoredIds(index, ids) }
 
       // What a merged list is made of, and everything a merged list says
       // about itself. `recount` is not enough and is deliberately not used:

--- a/account/Accounts.js
+++ b/account/Accounts.js
@@ -196,6 +196,9 @@ function makeAccount(account) {
     jmap: makeJmapSettings(raw.jmap),
     label: trimmed(raw.label),
     signature: trimmed(raw.signature),
+    // The labels watched for new mail, by id. A fact about the mailbox, so
+    // it lives beside its name rather than in the window's file.
+    monitored: idList(raw.monitored),
     // Whether this row is the setup form's working state rather than a
     // mailbox. It used to be inferred from the id being empty, and that read
     // a mailbox whose address had been corrupted as a draft and dropped it at
@@ -469,6 +472,54 @@ function discardDraftAt(list, index) {
 // Empty is not a name and clears it, which is what puts the address back:
 // `label()` falls through to the local part, so there is no state in which a
 // mailbox has nothing to be called.
+// What to call this mailbox.
+//
+// Two of these can differ only in their domain, and be elided to the same
+// handful of characters in a list, so a name is the one thing that reliably
+// tells them apart at a glance. The field has been on an account entry and
+// preferred by `label()` since accounts were a list; nothing ever offered a
+// way to set it.
+//
+// Empty is not a name and clears it, which is what puts the address back:
+// `label()` falls through to the local part, so there is no state in which a
+// mailbox has nothing to be called.
+function idList(value) {
+  var list = Array.isArray(value) ? value : []
+  var out = []
+  for (var i = 0; i < list.length; i++) {
+    var item = trimmed(list[i])
+    if (item !== "" && out.indexOf(item) < 0) out.push(item)
+  }
+  return out
+}
+
+// The watched list replaced whole: what a rename or a move leaves it as,
+// once the ids it held have followed the folders they named.
+function setMonitored(list, id, labelIds) {
+  var next = copyList(list)
+  var at = indexOfId(next.accounts, id)
+  if (at < 0) return next
+  var entry = makeAccount(next.accounts[at])
+  entry.monitored = idList(labelIds)
+  next.accounts[at] = entry
+  return next
+}
+
+// A label watched, or no longer: the id toggled in the account's list.
+function toggleMonitored(list, id, labelId) {
+  var next = copyList(list)
+  var at = indexOfId(next.accounts, id)
+  if (at < 0) return next
+  var entry = makeAccount(next.accounts[at])
+  var key = trimmed(labelId)
+  if (key === "") return next
+  var index = entry.monitored.indexOf(key)
+  if (index >= 0) entry.monitored.splice(index, 1)
+  else entry.monitored.push(key)
+  next.accounts[at] = entry
+  return next
+}
+
 function setLabel(list, id, text) {
   var next = copyList(list)
   var at = indexOfId(next.accounts, id)

--- a/account/Accounts.js
+++ b/account/Accounts.js
@@ -196,6 +196,10 @@ function makeAccount(account) {
     jmap: makeJmapSettings(raw.jmap),
     label: trimmed(raw.label),
     signature: trimmed(raw.signature),
+    // The signature as markup, imported from a file and rebuilt by
+    // `Signature.js` before it is stored: never the file's own bytes. Sent as
+    // the HTML alternative under the plain signature above.
+    signatureHtml: trimmed(raw.signatureHtml),
     // The labels watched for new mail, by id. A fact about the mailbox, so
     // it lives beside its name rather than in the window's file.
     monitored: idList(raw.monitored),
@@ -541,6 +545,25 @@ function setLabel(list, id, text) {
 // Stored as typed, with no separator added. A client that inserts "-- " turns
 // every signature into two decisions — what it says, and whether the line it
 // grew is wanted — and the user who wants one can type it.
+// The sign-off belongs to the mailbox rather than to the window. Two accounts
+// are two identities, and one signature under both is wrong for whichever it
+// was not written for — so it sits beside the label, which is the other thing
+// here the user chose and the server did not. Nothing about it is secret; the
+// keyring holds what is.
+//
+// Stored as typed, with no separator added. A client that inserts "-- " turns
+// every signature into two decisions — what it says, and whether the line it
+// grew is wanted — and the user who wants one can type it.
+function setSignatureHtml(list, id, html) {
+  var next = copyList(list)
+  var at = indexOfId(next.accounts, id)
+  if (at < 0) return next
+  var entry = makeAccount(next.accounts[at])
+  entry.signatureHtml = trimmed(html)
+  next.accounts[at] = entry
+  return next
+}
+
 function setSignature(list, id, text) {
   var next = copyList(list)
   var at = indexOfId(next.accounts, id)

--- a/account/LabelActions.qml
+++ b/account/LabelActions.qml
@@ -1,0 +1,277 @@
+import QtQuick
+import "Model.js" as Model
+import "../providers/Registry.js" as Provider
+
+// Changes to the label list — create beside or beneath a label, rename it,
+// move it under another, delete it — and the counts of the labels watched
+// for new mail. Every change goes to the provider first and reads the list
+// back from the server after: a label is the server's fact, not this
+// window's, and a Gmail label's id is only known once Gmail has made it.
+// Beside the account rather than in it, which is at its size ceiling.
+QtObject {
+  id: labelActions
+
+  required property var account
+
+  // The account.labels watched for new mail, by id: set from the account entry, and
+  // counted on every refresh the way the inbox is. A count that grew says so
+  // on the status line; the rail's row carries the number either way.
+  //
+  // A few requests at a time, not one per watched label at once: a dozen
+  // watched folders on a slow IMAP server would otherwise open a dozen
+  // connections on every poll. The handles are kept so the account can
+  // drop the lot when it signs out or goes away.
+  property bool monitoredLoading: false
+  readonly property int monitorConcurrency: 3
+  property var monitorHandles: []
+  property var monitorQueue: []
+  property var monitorGrown: []
+  property int monitorRemaining: 0
+  // Which poll a count belongs to: one abandoned by `abortMonitored` may
+  // still answer, and its answer must not be taken off the next poll's tally.
+  property int monitorSerial: 0
+
+  function refreshMonitored() {
+    var ids = Array.isArray(account.monitoredIds) ? account.monitoredIds : []
+    if (!account.ready || monitoredLoading || ids.length === 0) return
+    monitoredLoading = true
+    monitorSerial++
+    monitorQueue = ids.map(function(id) { return String(id) })
+    monitorGrown = []
+    monitorRemaining = monitorQueue.length
+    for (var i = 0; i < monitorConcurrency; i++) nextMonitorCount()
+  }
+
+  function nextMonitorCount() {
+    if (monitorQueue.length === 0) return
+    var labelId = monitorQueue[0]
+    monitorQueue = monitorQueue.slice(1)
+    var serial = monitorSerial
+    var answered = false
+    var handle = account.api.getLabelCounts(labelId, function(counts, error) {
+      if (!labelActions || serial !== monitorSerial || answered) return
+      answered = true
+      monitorHandles = monitorHandles.filter(function(h) { return h !== handle })
+      if (!error && counts) recordMonitorCount(labelId, counts)
+      monitorCountDone()
+    })
+    // A provider that answered before returning, or that made no request
+    // at all, leaves nothing to keep; the rest are held for `abortMonitored`.
+    if (!handle && !answered) { answered = true; monitorCountDone(); return }
+    if (handle && !answered) monitorHandles = monitorHandles.concat([handle])
+  }
+
+  function monitorCountDone() {
+    monitorRemaining--
+    if (monitorRemaining > 0) { nextMonitorCount(); return }
+    monitoredLoading = false
+    if (monitorGrown.length > 0) account.note(Model.monitoredNote(monitorGrown))
+    monitorGrown = []
+    account.cache.putLabels(account.labels)
+  }
+
+  function recordMonitorCount(labelId, counts) {
+    var index = Model.indexById(account.labels, labelId)
+    if (index < 0) return
+    var before = Math.max(0, Math.floor(Number(account.labels[index].unread) || 0))
+    var after = Math.max(0, Math.floor(Number(counts.unread) || 0))
+    var updated = {}
+    for (var key in account.labels[index]) updated[key] = account.labels[index][key]
+    updated.unread = after
+    updated.total = Math.max(0, Math.floor(Number(counts.total) || 0))
+    account.labels = Model.replaceById(account.labels, updated)
+    if (after > before && monitoredSeen[labelId] !== undefined)
+      monitorGrown = monitorGrown.concat([{ name: String(updated.name || labelId), delta: after - before }])
+    var seen = {}
+    for (var k in monitoredSeen) seen[k] = monitoredSeen[k]
+    seen[labelId] = after
+    monitoredSeen = seen
+  }
+
+  // Every count still in flight, dropped, and the queue with it: what a
+  // sign-out or the account's end does with a poll that is half done.
+  function abortMonitored() {
+    var handles = monitorHandles
+    monitorSerial++
+    monitorHandles = []
+    monitorQueue = []
+    monitorRemaining = 0
+    monitorGrown = []
+    monitoredLoading = false
+    for (var i = 0; i < handles.length; i++) account.abortRequest(handles[i])
+  }
+
+  // A sign-out drops the counts in flight along with everything else.
+  readonly property bool ready: !!account && account.ready
+  onReadyChanged: if (!ready) abortMonitored()
+  Component.onDestruction: abortMonitored()
+
+  // The last count each watched label was seen at, so a refresh knows growth
+  // from the first read. Not persisted: a restart reads once and says nothing.
+  property var monitoredSeen: ({})
+
+  // Whether the label list can be changed from here, and the four changes:
+  // create beside or beneath a label, rename it, move it under another,
+  // delete it. Every one goes to the provider first and reloads the list
+  // from the server after — a label is the server's fact, not this window's,
+  // and a Gmail label's id is only known once Gmail has made it.
+  readonly property bool canManageLabels: Provider.can(account.providerId, "manageLabels")
+
+  function labelById(id) {
+    var index = Model.indexById(account.labels, id)
+    return index >= 0 ? account.labels[index] : null
+  }
+
+  // The path as a person reads it: the decoded name, which on IMAP is what
+  // LIST's modified-UTF-7 spelled and on Gmail is the name itself. The wire
+  // name — the id — is what goes back to the server for a folder it has.
+  function labelPathOf(label) {
+    return label ? String(label.name || label.rawName || "") : ""
+  }
+
+  function labelByPath(path) {
+    for (var i = 0; i < account.labels.length; i++) if (labelPathOf(account.labels[i]) === String(path || "")) return account.labels[i]
+    return null
+  }
+
+  // A name the list already has is refused before it reaches the server:
+  // a server that accepted it would leave two rows reading the same, and
+  // the one the window follows or watches after the change is found by
+  // its path, which would then name the wrong row.
+  function takenProblem(name) {
+    return labelByPath(name) ? "There is already a label named " + name : ""
+  }
+
+  function createLabel(parentPath, leaf) {
+    if (!account.ready || !canManageLabels) return false
+    var parent = labelByPath(parentPath)
+    var delimiter = Model.labelDelimiter(parent || (account.labels.length > 0 ? account.labels[0] : null))
+    var problem = Model.labelNestProblem(parentPath, delimiter) || Model.labelNameProblem(leaf, delimiter)
+    var name = Model.labelPathJoin(parentPath, leaf, delimiter)
+    problem = problem || takenProblem(name)
+    if (problem !== "") { account.fail(problem); return false }
+    account.api.createLabel(name, function(payload, error) {
+      if (!labelActions) return
+      if (error) { account.fail("Could not create " + name + ": " + String(error)); return }
+      account.note("Created " + name)
+      reloadLabels()
+    })
+    return true
+  }
+
+  function renameLabel(id, leaf) {
+    var label = labelById(id)
+    if (!account.ready || !canManageLabels || !label) return false
+    var delimiter = Model.labelDelimiter(label)
+    var problem = Model.labelNameProblem(leaf, delimiter)
+    if (problem !== "") { account.fail(problem); return false }
+    var path = labelPathOf(label)
+    var name = Model.labelPathJoin(Model.labelParent(path, delimiter), leaf, delimiter)
+    if (name === path) return false
+    problem = takenProblem(name)
+    if (problem !== "") { account.fail(problem); return false }
+    var before = account.labels
+    account.api.renameLabel(String(label.id), name, function(payload, error) {
+      if (!labelActions) return
+      if (error) { account.fail("Could not rename " + path + ": " + String(error)); return }
+      account.note("Renamed to " + name)
+      afterLabelMoved(label, name, before)
+    })
+    return true
+  }
+
+  function moveLabel(id, newParentPath) {
+    var label = labelById(id)
+    if (!account.ready || !canManageLabels || !label) return false
+    var delimiter = Model.labelDelimiter(label)
+    var problem = Model.labelNestProblem(newParentPath, delimiter)
+    if (problem !== "") { account.fail(problem); return false }
+    var path = labelPathOf(label)
+    var name = Model.labelPathJoin(newParentPath, Model.labelLeaf(path, delimiter), delimiter)
+    if (name === path) return false
+    problem = takenProblem(name)
+    if (problem !== "") { account.fail(problem); return false }
+    var before = account.labels
+    account.api.renameLabel(String(label.id), name, function(payload, error) {
+      if (!labelActions) return
+      if (error) { account.fail("Could not move " + path + ": " + String(error)); return }
+      account.note("Moved to " + name)
+      afterLabelMoved(label, name, before)
+    })
+    return true
+  }
+
+  function deleteLabel(id) {
+    var label = labelById(id)
+    if (!account.ready || !canManageLabels || !label) return false
+    var path = labelPathOf(label)
+    var before = account.labels
+    account.api.deleteLabel(String(label.id), function(payload, error) {
+      if (!labelActions) return
+      if (error) { account.fail("Could not delete " + path + ": " + String(error)); return }
+      account.note("Deleted " + path)
+      // The list this window was looking at may have been the label just
+      // deleted; the inbox is the honest place to stand then.
+      if (account.rawLabelId === String(label.id)) account.selectMailbox("inbox")
+      migrations = migrations.concat([{ before: before, oldPath: path, newPath: "", delimiter: Model.labelDelimiter(label) }])
+      reloadLabels()
+    })
+    return true
+  }
+
+  // The label on screen follows its own rename. Its new wire name is the
+  // server's to spell, so the list is read again first and the label is
+  // found by the name it now has; a rename of a label not on screen only
+  // reloads. The watched ids follow the same way, once the fresh listing
+  // says what the moved folders are called now.
+  //
+  // The moves waiting on a listing are a queue, not a slot: two changes
+  // made before the first listing lands are applied in order, and a listing
+  // that fails leaves them waiting for the next one rather than dropping
+  // them — a watch that did not follow its folder would poll a name the
+  // server no longer has.
+  property string followLabelPath: ""
+  property var migrations: []
+  property bool reloadRetried: false
+
+  function afterLabelMoved(label, newPath, before) {
+    var wasOpen = account.rawQuery !== "" && account.rawQuery === Provider.labelQuery(account.providerId, String(label.rawName || label.name || ""))
+    followLabelPath = wasOpen ? String(newPath || "") : ""
+    migrations = migrations.concat([{ before: before, oldPath: labelPathOf(label), newPath: String(newPath || ""),
+      delimiter: Model.labelDelimiter(label) }])
+    reloadLabels()
+  }
+
+  function reloadLabels() {
+    if (!account.ready) return
+    account.api.getLabels(function(result, error) {
+      if (!labelActions) return
+      if (error) {
+        // The change went through; the listing did not. One more try, and
+        // after that the moves wait for the next listing a change brings.
+        followLabelPath = ""
+        account.fail("Could not read the labels back: " + String(error))
+        if (!reloadRetried) { reloadRetried = true; Qt.callLater(reloadLabels) }
+        return
+      }
+      reloadRetried = false
+      account.labels = result
+      account.cache.putLabels(result)
+      var moves = migrations
+      migrations = []
+      if (moves.length > 0) {
+        var watched = Array.isArray(account.monitoredIds) ? account.monitoredIds : []
+        var next = watched
+        for (var m = 0; m < moves.length; m++)
+          next = Model.migrateMonitoredIds(next, moves[m].before, result, moves[m].oldPath, moves[m].newPath, moves[m].delimiter)
+        if (next !== watched) account.monitoredMigrated(next)
+      }
+      if (followLabelPath !== "") {
+        var moved = labelByPath(followLabelPath)
+        followLabelPath = ""
+        if (moved) account.selectLabel(String(moved.rawName || moved.name || ""), String(moved.id || ""))
+        else account.selectMailbox("inbox")
+      }
+    })
+  }
+}

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -2243,9 +2243,31 @@ Item {
         return
       }
       root.reportSendSuccess(sentPayload)
+      if (payload && String(payload.draftId || "") !== "") root.forgetSentDraft(String(payload.draftId))
     })
     return true
   }
+
+  // The draft a sent message was opened from is done with: the server's copy
+  // goes, and so does its row. A failure here is a footnote on a message
+  // that was sent, so it is noted rather than reported as a failure.
+  function forgetSentDraft(draftId) {
+    if (!api || typeof api.deleteDraft !== "function") return
+    api.deleteDraft(draftId, function(payload, error) {
+      if (!root) return
+      if (error) {
+        root.note("Sent, but the draft it came from could not be removed: " + String(error))
+        return
+      }
+      if (Model.indexById(root.messages, draftId) >= 0) {
+        root.messages = Model.removeById(root.messages, draftId)
+        root.rememberList()
+      }
+      if (root.selectedId === draftId) root.clearSelection()
+      root.refreshCounts()
+    })
+  }
+
 
   function deliverPending() {
     if (!sendPending) return false
@@ -2267,8 +2289,34 @@ Item {
     return true
   }
 
+  // A mailbox whose token was just refused is not ready until the next
+  // lookup answers — and the next lookup is asked for by the next request.
+  // A save or a send that arrived in that window failed as "not ready" for
+  // a mailbox that was signed in a second ago. So the credentials are asked
+  // for first, which is what any other request does, and the work goes on
+  // once they are back; a mailbox with nothing to look up fails at once.
+  function whenReady(callback) {
+    if (ready) { callback(true); return }
+    if (!auth || !auth.configured || auth.loginBusy || typeof auth.withCredentials !== "function") {
+      callback(false)
+      return
+    }
+    auth.withCredentials(function(credentials, error) {
+      if (!root) return
+      callback(!!credentials && root.ready)
+    })
+  }
+
   function saveDraft(fields, callback) {
-    if (!ready || !api || typeof api.saveDraft !== "function") {
+    if (!ready) {
+      whenReady(function(ok) {
+        if (!root) return
+        if (ok) root.saveDraft(fields, callback)
+        else if (typeof callback === "function") callback(null, "The mailbox is not ready to save drafts")
+      })
+      return null
+    }
+    if (!api || typeof api.saveDraft !== "function") {
       if (typeof callback === "function") callback(null, "The mailbox is not ready to save drafts")
       return null
     }
@@ -2288,6 +2336,9 @@ Item {
       to: String(values.to || "").trim(),
       cc: String(values.cc || "").trim(),
       bcc: String(values.bcc || "").trim(),
+      replyTo: String(values.replyTo || "").trim(),
+      signature: String(values.signature || ""),
+      signatureHtml: String(values.signatureHtml || ""),
       subject: String(values.subject || ""),
       body: String(values.body || ""),
       attachments: Array.isArray(values.attachments) ? values.attachments : [],
@@ -2298,11 +2349,33 @@ Item {
     })
     return api.saveDraft(payload, function(saved, error) {
       if (typeof callback === "function") callback(saved, error)
+      // The Drafts list on screen is what the server had before the save: the
+      // copy replaced is gone there and the new one is not yet listed, so
+      // a list left as it was showed both — the old row until the next poll,
+      // and a second row for every save. Read it again from the server now.
+      if (!error && root && root.mailboxKey === "drafts") {
+        root.listSerial++
+        root.nextPageToken = ""
+        root.loadMessages(false, true, "")
+      } else if (!error && root) {
+        root.refreshCounts()
+      }
     })
   }
 
+
   function send(fields) {
-    if (!ready || sending || sendPending) return false
+    if (sending || sendPending) return false
+    if (!ready) {
+      // Asked for its credentials first, like a save: a token refused a
+      // moment ago is looked up again rather than the send refused.
+      whenReady(function(ok) {
+        if (!root) return
+        if (ok) root.send(fields)
+        else root.reportSendFailure("The mailbox is not ready to send")
+      })
+      return true
+    }
     var values = fields || ({})
     var files = Array.isArray(values.attachments) ? values.attachments : []
     var hasFiles = false
@@ -2337,6 +2410,9 @@ Item {
       to: to,
       cc: String(values.cc || "").trim(),
       bcc: String(values.bcc || "").trim(),
+      replyTo: String(values.replyTo || "").trim(),
+      signature: String(values.signature || ""),
+      signatureHtml: String(values.signatureHtml || ""),
       subject: String(values.subject || ""),
       body: body,
       attachments: Array.isArray(values.attachments) ? values.attachments : [],
@@ -2348,6 +2424,9 @@ Item {
       // draft behind on every provider.
       draftId: String(values.draftId || "")
     })
+    // The draft this was opened from rides on the queued payload; the send
+    // itself carries only the raw message and the thread.
+    payload.draftId = String(values.draftId || "")
 
     var queued = Outbox.schedule(payload, Date.now(), undoSendSeconds)
     if (!queued) return deliver(payload)
@@ -2380,114 +2459,14 @@ Item {
 
   // ----------------------------------------------------------- unsubscribe
 
-  // Three ways off a list, and `Unsubscribe.plan` picks between them so that
-  // nothing here branches on a header. In order of how little the user has to
-  // do: a POST the sender has promised is enough, a message to the address
-  // they nominated, or their page in a browser.
-  function unsubscribe() {
-    if (unsubscribing || unsubscribeDone !== "") return
-    var info = selectedUnsubscribe
-    var how = Unsub.plan(info, canSend)
-    if (how === "") return
-    clearNotice()
+  // See `Unsubscribe.qml`: the account file is at its size ceiling.
+  function unsubscribe() { unsubscribeAction.run() }
 
-    if (how === "browser") {
-      Qt.openUrlExternally(info.url)
-      // What happened is that a page opened. Whether the list acted on it is
-      // between the user and that page, and saying "unsubscribed" here would
-      // be this panel taking credit for work it cannot see.
-      unsubscribeDone = "The unsubscribe page is open in your browser"
-      return
-    }
-
-    if (how === "mail") {
-      if (!ready) {
-        fail("Sign in before unsubscribing")
-        return
-      }
-      unsubscribing = true
-      api.sendMessage(Mail.buildSendPayload({
-        // The address the newsletter was sent to. A list that only ever knew
-        // an alias has no reason to act on a request from anywhere else.
-        from: receivedAsAddress,
-        fromName: receivedAsName,
-        accountAddress: ownAddress,
-        to: info.mail.to,
-        subject: info.mail.subject,
-        body: info.mail.body
-      }), function(payload, error) {
-        root.unsubscribing = false
-        if (error) {
-          root.fail(error)
-          return
-        }
-        root.unsubscribeDone = "Unsubscribe request sent to " + info.mail.to
-      })
-      return
-    }
-
-    postUnsubscribe(info.postUrl)
+  Unsubscribe {
+    id: unsubscribeAction
+    account: root
   }
 
-  // The RFC 8058 one-click request: a fixed body, to an https address on the
-  // public internet that this sender put in a header saying a single POST
-  // would do it. `Unsubscribe.isPostableUrl` is where both of those conditions
-  // are checked, and it borrows the judgement that decides whether a message
-  // may load a picture.
-  //
-  // Qt's XHR follows redirects without rechecking the destination. The Python
-  // worker instead resolves and checks every IP, connects to that exact answer
-  // while retaining the original TLS hostname, and never follows a redirect.
-  // URL bytes remain data throughout: there is no shell or curl config.
-  //
-  // The reply is never read beyond its status. It is a document from whoever
-  // sent the mail, and the only question being asked of it is whether the
-  // address is off the list.
-  function postUnsubscribe(url) {
-    if (!Unsub.isPostableUrl(url)) {
-      fail("That unsubscribe address is not one this can post to")
-      return
-    }
-    unsubscribing = true
-    var request = unsubscribeComponent.createObject(root, {
-      command: ["python3", pluginDir + "/scripts/unsubscribe.py"],
-      requestLine: [Mail.encodeBase64(String(url)),
-        Mail.encodeBase64(Unsub.postContentType()),
-        Mail.encodeBase64(Unsub.postBody())].join(" ")
-    })
-    if (!request) {
-      unsubscribing = false
-      fail("The unsubscribe request could not be sent")
-      return
-    }
-    request.finished.connect(function(exitCode, status) {
-      if (!root) return
-      request.destroy()
-      root.unsubscribing = false
-      root.unsubscribeDone = ""
-      if (exitCode !== 0 || status === 0) {
-        root.fail("The unsubscribe request could not be sent")
-        return
-      }
-      if (status >= 200 && status < 300) {
-        root.unsubscribeDone = "Unsubscribed from this list"
-        return
-      }
-      // A 3xx is a server answering a one-click request with "go and ask over
-      // there". It has not done what its own header promised, and the address
-      // it points at was never judged — so it is reported as a refusal rather
-      // than followed.
-      root.fail(status >= 300 && status < 400
-        ? "This list answered with a redirect instead of unsubscribing (" + status + ")"
-        : "This list refused the unsubscribe request (" + status + ")")
-    })
-    request.running = true
-  }
-
-  // One process per request, created and destroyed around it. The same shape
-  // the mail transport uses, for the same reason: the URL crosses on stdin
-  // base64-encoded, so a header a stranger wrote never reaches the process
-  // table and nothing has to be escaped on the way.
   Component {
     id: imageFetchComponent
 
@@ -2509,39 +2488,6 @@ Item {
     }
   }
 
-  Component {
-    id: unsubscribeComponent
-
-    Process {
-      id: unsubscribeProcess
-
-      property string requestLine: ""
-      signal finished(int exitCode, int status)
-
-      stdinEnabled: true
-      stdout: StdioCollector { waitForEnd: true }
-      stderr: StdioCollector { waitForEnd: true }
-
-      onStarted: {
-        // One line, because Quickshell's Process.write() never closes stdin and
-        // the script would wait forever for an EOF that does not come.
-        write(requestLine + "\n")
-        requestLine = ""
-      }
-
-      onExited: function(exitCode) {
-        // "<transport error code> <http status>", and nothing else is read.
-        var parts = String(unsubscribeProcess.stdout.text || "").trim().split(/\s+/)
-        var code = Math.floor(Number(parts[0]))
-        var status = Math.floor(Number(parts[1]))
-        if (exitCode !== 0 || parts.length < 2 || !isFinite(code) || !isFinite(status)) {
-          unsubscribeProcess.finished(exitCode === 0 ? 1 : exitCode, 0)
-          return
-        }
-        unsubscribeProcess.finished(code, status)
-      }
-    }
-  }
 
   Component {
     id: attachmentSaveComponent

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -165,6 +165,7 @@ Item {
 
   property string mailboxKey: "inbox"
   property string searchQuery: ""
+  property string searchRaw: ""
   // A query picked from a list rather than typed: a Gmail label, an IMAP
   // folder. Kept apart from `searchQuery` because that one gets shaped into a
   // search — an IMAP folder wrapped in a TEXT search would go looking for the
@@ -441,6 +442,7 @@ Item {
   // are search operators, IMAP's name a folder. Opaque from here on — it is
   // handed back to the client that produced it, and used as a cache key.
   readonly property string effectiveQuery: rawQuery !== "" ? rawQuery
+    : searchRaw !== "" ? searchRaw
     : Provider.query(providerId, mailboxKey, searchQuery, defaultQuery)
   readonly property bool hasMore: nextPageToken !== ""
   // A cached search can already have rows on screen while this stays true.
@@ -516,8 +518,11 @@ Item {
   function refresh() {
     if (!ready) return
     refreshCounts()
+    labelActions.refreshMonitored()
     if (active && (windowOpen || !listLoaded)) loadMessages(false)
   }
+
+  property var monitoredIds: []
 
   function refreshCounts() {
     if (!ready || countLoading) return
@@ -2024,7 +2029,6 @@ Item {
     return true
   }
 
-  // The batch — several ticked rows at once — lives in `BatchAction.qml`.
   function actMany(ids, action) { return batchAction.run(ids, action) }
 
   BatchAction {
@@ -2625,6 +2629,14 @@ Item {
   }
 
   function notify(arrivals) { newMailNotification.notify(arrivals) }
+  readonly property alias labelActions: labelActions
+  // The watched ids after a rename or move changed what they name.
+  signal monitoredMigrated(var ids)
+
+  LabelActions {
+    id: labelActions
+    account: root
+  }
 
   // ------------------------------------------------------------ navigation
 
@@ -2632,6 +2644,7 @@ Item {
     if (mailboxKey === key && searchQuery === "" && rawQuery === "") return
     mailboxKey = String(key || "inbox")
     searchQuery = ""
+    searchRaw = ""
     rawQuery = ""
     rawLabelId = ""
     clearSelection()
@@ -2641,10 +2654,13 @@ Item {
     loadMessages(false)
   }
 
-  function search(text) {
+  // `raw`: an app-built query in the provider's words, sent as it is.
+  function search(text, raw) {
     var query = String(text || "").trim()
-    if (query === searchQuery && rawQuery === "") return
+    var built = String(raw || "").trim()
+    if (query === searchQuery && built === searchRaw && rawQuery === "") return
     searchQuery = query
+    searchRaw = built
     // Typing in the search box leaves whatever label was selected.
     rawQuery = ""
     rawLabelId = ""
@@ -2661,6 +2677,7 @@ Item {
     var id = String(labelId || "")
     if (query === "" || (query === rawQuery && id === rawLabelId)) return
     searchQuery = ""
+    searchRaw = ""
     rawQuery = query
     rawLabelId = id
     clearSelection()
@@ -2817,9 +2834,7 @@ Item {
 
   // The client takes the manager as a required property, so it cannot be built
   // until there is one.
-  // A test's stand-in for the provider: a component the loader prefers when
-  // set, so the account can be driven against a controlled client without a
-  // server or a credential. Never set outside a test.
+  // A test's stand-in for the provider.
   property Component clientOverride: null
 
   Loader {

--- a/account/Model.js
+++ b/account/Model.js
@@ -1700,3 +1700,128 @@ function labelDelimiter(label) {
 function togglePath(paths, path) {
   return toggleId(paths, path)
 }
+
+// ------------------------------------------------------------ label names
+
+// A label's path taken apart and put together with the delimiter its
+// provider nests with: "/" for Gmail, whatever the server said for IMAP.
+// The path helpers take the delimiter `labelDelimiter` gives: a separator
+// to split on, or "" for a server with no hierarchy, where every path is a
+// leaf, nothing has a parent, and nothing can be put under anything.
+function labelLeaf(path, delimiter) {
+  var text = String(path || "")
+  var sep = String(delimiter === undefined || delimiter === null ? "/" : delimiter)
+  if (sep === "") return text
+  var at = text.lastIndexOf(sep)
+  return at < 0 ? text : text.slice(at + sep.length)
+}
+
+function labelParent(path, delimiter) {
+  var text = String(path || "")
+  var sep = String(delimiter === undefined || delimiter === null ? "/" : delimiter)
+  if (sep === "") return ""
+  var at = text.lastIndexOf(sep)
+  return at < 0 ? "" : text.slice(0, at)
+}
+
+function labelPathJoin(parent, leaf, delimiter) {
+  var head = String(parent || "")
+  var tail = String(leaf || "").trim()
+  var sep = String(delimiter === undefined || delimiter === null ? "/" : delimiter)
+  if (head === "" || sep === "") return tail
+  return head + sep + tail
+}
+
+// Whether a name typed for a label is one the provider can take: not empty,
+// and not carrying the delimiter, which would make two labels of one.
+function labelNameProblem(name, delimiter) {
+  var text = String(name || "").trim()
+  var sep = String(delimiter === undefined || delimiter === null ? "/" : delimiter)
+  if (text === "") return "A label needs a name"
+  if (sep !== "" && text.indexOf(sep) >= 0) return "A name cannot contain " + sep + "; use New sub-label to nest"
+  return ""
+}
+
+// What a server with no hierarchy says to a label asked to go under
+// another, or "" where nesting is possible.
+function labelNestProblem(parentPath, delimiter) {
+  var sep = String(delimiter === undefined || delimiter === null ? "/" : delimiter)
+  if (sep !== "" || String(parentPath || "") === "") return ""
+  return "This server keeps its folders in one flat list, so nothing can go under " + String(parentPath)
+}
+
+// Where a label may be moved: every other label that is not beneath it, plus
+// the top level. Moving a label under its own descendant would swallow it.
+function labelMoveTargets(labels, movingPath, delimiter) {
+  var all = Array.isArray(labels) ? labels : []
+  var sep = String(delimiter === undefined || delimiter === null ? "/" : delimiter)
+  var moving = String(movingPath || "")
+  var out = [{ id: "", name: "Top level", path: "" }]
+  // No hierarchy: the top level is the only place, and the label is there.
+  if (sep === "") return out
+  for (var i = 0; i < all.length; i++) {
+    var label = all[i]
+    if (!label || label.system) continue
+    var path = String(label.name || label.rawName || "")
+    if (path === "" || path === moving) continue
+    if (moving !== "" && path.indexOf(moving + sep) === 0) continue
+    if (path === labelParent(moving, sep)) continue
+    out.push({ id: String(label.id || ""), name: path, path: path })
+  }
+  return out
+}
+
+// The watched ids after a folder was renamed or moved, or deleted. An IMAP
+// folder's id is its wire name, so a rename changes the id of the folder
+// and of every folder beneath it; a watch on any of them follows to the id
+// the fresh listing gives that path. A Gmail id survives a rename and is
+// kept as it is. A watch on a folder the listing no longer has — deleted,
+// or gone with its parent — is dropped rather than polled forever. The
+// same array comes back when nothing changed, so a caller can tell.
+function migrateMonitoredIds(monitored, before, after, oldPath, newPath, delimiter) {
+  var ids = Array.isArray(monitored) ? monitored : []
+  var was = Array.isArray(before) ? before : []
+  var now = Array.isArray(after) ? after : []
+  var sep = String(delimiter === undefined || delimiter === null ? "/" : delimiter)
+  var from = String(oldPath || "")
+  var to = String(newPath || "")
+  function pathOf(label) { return label ? String(label.name || label.rawName || "") : "" }
+  function byPath(list, path) {
+    for (var i = 0; i < list.length; i++) if (pathOf(list[i]) === path) return list[i]
+    return null
+  }
+  var out = []
+  var changed = false
+  for (var k = 0; k < ids.length; k++) {
+    var id = String(ids[k] || "")
+    if (id === "") { changed = true; continue }
+    var still = indexById(now, id)
+    var old = indexById(was, id)
+    var path = old >= 0 ? pathOf(was[old]) : ""
+    var under = from !== "" && path !== "" && (path === from || (sep !== "" && path.indexOf(from + sep) === 0))
+    if (under && to !== "") {
+      var moved = byPath(now, to + path.slice(from.length))
+      if (moved && String(moved.id || "") !== "") {
+        if (String(moved.id) !== id) changed = true
+        if (out.indexOf(String(moved.id)) < 0) out.push(String(moved.id))
+        continue
+      }
+    }
+    if (still >= 0 && !(under && to === "")) { out.push(id); continue }
+    changed = true
+  }
+  return changed ? out : ids
+}
+
+// "3 new in Receipts", or the two labels with the most, for the status line.
+function monitoredNote(grown) {
+  var list = Array.isArray(grown) ? grown.slice() : []
+  if (list.length === 0) return ""
+  list.sort(function(a, b) { return Number(b.delta || 0) - Number(a.delta || 0) })
+  var parts = []
+  for (var i = 0; i < list.length && i < 2; i++)
+    parts.push(Math.max(1, Math.floor(Number(list[i].delta) || 1)) + " new in " + String(list[i].name || ""))
+  var more = list.length - parts.length
+  return parts.join(", ") + (more > 0 ? " and " + more + " more" : "")
+}
+

--- a/account/Unsubscribe.qml
+++ b/account/Unsubscribe.qml
@@ -1,0 +1,158 @@
+import QtQuick
+import Quickshell.Io
+import "../message/Message.js" as Mail
+import "../message/Unsubscribe.js" as Unsub
+
+// Unsubscribing from the list the open message came from: a browser page, a
+// mail to the list, or a POST through `scripts/unsubscribe.py`, whichever
+// the headers offer. Beside the account rather than in it, which is at its
+// size ceiling; its state (`unsubscribing`, `unsubscribeDone`) stays on the
+// account, where the reader reads it.
+QtObject {
+  id: unsubscribeAction
+
+  required property var account
+
+
+  // Three ways off a list, and `Unsubscribe.plan` picks between them so that
+  // nothing here branches on a header. In order of how little the user has to
+  // do: a POST the sender has promised is enough, a message to the address
+  // they nominated, or their page in a browser.
+  function run() {
+    if (account.unsubscribing || account.unsubscribeDone !== "") return
+    var info = account.selectedUnsubscribe
+    var how = Unsub.plan(info, account.canSend)
+    if (how === "") return
+    account.clearNotice()
+
+    if (how === "browser") {
+      Qt.openUrlExternally(info.url)
+      // What happened is that a page opened. Whether the list acted on it is
+      // between the user and that page, and saying "unsubscribed" here would
+      // be this panel taking credit for work it cannot see.
+      account.unsubscribeDone = "The unsubscribe page is open in your browser"
+      return
+    }
+
+    if (how === "mail") {
+      if (!account.ready) {
+        account.fail("Sign in before account.unsubscribing")
+        return
+      }
+      account.unsubscribing = true
+      account.api.sendMessage(Mail.buildSendPayload({
+        // The address the newsletter was sent to. A list that only ever knew
+        // an alias has no reason to act on a request from anywhere else.
+        from: account.receivedAsAddress,
+        fromName: account.receivedAsName,
+        accountAddress: account.ownAddress,
+        to: info.mail.to,
+        subject: info.mail.subject,
+        body: info.mail.body
+      }), function(payload, error) {
+        account.unsubscribing = false
+        if (error) {
+          account.fail(error)
+          return
+        }
+        account.unsubscribeDone = "Unsubscribe request sent to " + info.mail.to
+      })
+      return
+    }
+
+    postUnsubscribe(info.postUrl)
+  }
+
+  // The RFC 8058 one-click request: a fixed body, to an https address on the
+  // public internet that this sender put in a header saying a single POST
+  // would do it. `Unsubscribe.isPostableUrl` is where both of those conditions
+  // are checked, and it borrows the judgement that decides whether a message
+  // may load a picture.
+  //
+  // Qt's XHR follows redirects without rechecking the destination. The Python
+  // worker instead resolves and checks every IP, connects to that exact answer
+  // while retaining the original TLS hostname, and never follows a redirect.
+  // URL bytes remain data throughout: there is no shell or curl config.
+  //
+  // The reply is never read beyond its status. It is a document from whoever
+  // sent the mail, and the only question being asked of it is whether the
+  // address is off the list.
+  function postUnsubscribe(url) {
+    if (!Unsub.isPostableUrl(url)) {
+      account.fail("That unsubscribe address is not one this can post to")
+      return
+    }
+    account.unsubscribing = true
+    var request = unsubscribeComponent.createObject(account, {
+      command: ["python3", account.pluginDir + "/scripts/unsubscribe.py"],
+      requestLine: [Mail.encodeBase64(String(url)),
+        Mail.encodeBase64(Unsub.postContentType()),
+        Mail.encodeBase64(Unsub.postBody())].join(" ")
+    })
+    if (!request) {
+      account.unsubscribing = false
+      account.fail("The unsubscribe request could not be sent")
+      return
+    }
+    request.finished.connect(function(exitCode, status) {
+      if (!root) return
+      request.destroy()
+      account.unsubscribing = false
+      account.unsubscribeDone = ""
+      if (exitCode !== 0 || status === 0) {
+        account.fail("The unsubscribe request could not be sent")
+        return
+      }
+      if (status >= 200 && status < 300) {
+        account.unsubscribeDone = "Unsubscribed from this list"
+        return
+      }
+      // A 3xx is a server answering a one-click request with "go and ask over
+      // there". It has not done what its own header promised, and the address
+      // it points at was never judged — so it is reported as a refusal rather
+      // than followed.
+      account.fail(status >= 300 && status < 400
+        ? "This list answered with a redirect instead of account.unsubscribing (" + status + ")"
+        : "This list refused the unsubscribe request (" + status + ")")
+    })
+    request.running = true
+  }
+
+  // One process per request, created and destroyed around it. The same shape
+  // the mail transport uses, for the same reason: the URL crosses on stdin
+  // base64-encoded, so a header a stranger wrote never reaches the process
+  // table and nothing has to be escaped on the way.
+
+  readonly property Component unsubscribeComponent: Component {
+
+    Process {
+      id: unsubscribeProcess
+
+      property string requestLine: ""
+      signal finished(int exitCode, int status)
+
+      stdinEnabled: true
+      stdout: StdioCollector { waitForEnd: true }
+      stderr: StdioCollector { waitForEnd: true }
+
+      onStarted: {
+        // One line, because Quickshell's Process.write() never closes stdin and
+        // the script would wait forever for an EOF that does not come.
+        write(requestLine + "\n")
+        requestLine = ""
+      }
+
+      onExited: function(exitCode) {
+        // "<transport error code> <http status>", and nothing else is read.
+        var parts = String(unsubscribeProcess.stdout.text || "").trim().split(/\s+/)
+        var code = Math.floor(Number(parts[0]))
+        var status = Math.floor(Number(parts[1]))
+        if (exitCode !== 0 || parts.length < 2 || !isFinite(code) || !isFinite(status)) {
+          unsubscribeProcess.finished(exitCode === 0 ? 1 : exitCode, 0)
+          return
+        }
+        unsubscribeProcess.finished(code, status)
+      }
+    }
+  }
+}

--- a/components/AddressMenu.qml
+++ b/components/AddressMenu.qml
@@ -1,0 +1,192 @@
+import QtQuick
+import QtQuick.Controls as QQC
+import qs.Commons
+import qs.Ui
+import "Menu.js" as Menu
+
+// The menu an address opens on a right-click in the reader's header: copy
+// it, or find the mail from it or to it. A line with several addresses asks
+// which one first, then offers the same three rows for it.
+Item {
+  id: root
+
+  required property color textColor
+  required property color dimColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
+  required property string panelFontFamily
+
+  // [{ name, email }] — what the line held. One means straight to the rows.
+  property var addresses: []
+  property string chosen: ""
+  property bool canSearch: true
+  property int cursorIndex: -1
+  readonly property bool opened: menu.opened
+  readonly property bool choosing: chosen === "" && addresses.length > 1
+  readonly property var menuRows: choosing ? pickRows.rows : [copyRow, fromRow, toRow]
+
+  signal copyRequested(string address)
+  signal searchRequested(string field, string address)
+
+  anchors.fill: parent
+  z: 50
+
+  property real anchorX: 0
+  property real anchorY: 0
+
+  function openAt(list, sceneX, sceneY) {
+    var rows = []
+    var seen = {}
+    var given = Array.isArray(list) ? list : []
+    for (var i = 0; i < given.length; i++) {
+      var email = String(given[i] && given[i].email ? given[i].email : "").trim()
+      if (email === "" || seen[email]) continue
+      seen[email] = true
+      rows.push({ name: String(given[i].name || given[i].display || ""), email: email })
+    }
+    if (rows.length === 0) return
+    addresses = rows
+    chosen = rows.length === 1 ? rows[0].email : ""
+    var local = root.mapFromGlobal(sceneX, sceneY)
+    anchorX = local.x
+    anchorY = local.y
+    menu.open()
+  }
+
+  function place() {
+    if (!menu.visible) return
+    var tall = menu.height > 0 ? menu.height : menu.implicitHeight
+    var placed = Menu.position(anchorX, anchorY, menu.width, tall, root.width, root.height)
+    menu.x = placed.x
+    menu.y = placed.y
+  }
+
+  function selectableRows() {
+    var values = []
+    for (var i = 0; i < menuRows.length; i++) values.push({
+      selectable: true, visible: menuRows[i].visible, enabled: menuRows[i].enabled
+    })
+    return values
+  }
+  function moveCursor(step) { cursorIndex = Menu.nextSelectable(selectableRows(), cursorIndex, step) }
+  function runCursor() { if (cursorIndex >= 0) menuRows[cursorIndex].activated() }
+  function close() { menu.close() }
+
+  function pick(email) {
+    chosen = String(email || "")
+    cursorIndex = 0
+    place()
+  }
+
+  QQC.Popup {
+    id: menu
+    width: Style.space(240)
+    implicitHeight: rows.implicitHeight + Style.space(8)
+    padding: Style.space(4)
+    modal: false
+    focus: true
+    closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
+    onHeightChanged: root.place()
+    onOpened: {
+      root.cursorIndex = Menu.firstSelectable(root.selectableRows())
+      root.place()
+    }
+    background: Rectangle {
+      radius: Style.cornerRadius
+      color: root.popupBackgroundColor
+      border.width: 1
+      border.color: root.popupBorderColor
+    }
+
+    contentItem: Column {
+      id: rows
+      spacing: Style.space(2)
+
+      focus: true
+      Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_J || event.key === Qt.Key_Down) {
+          root.moveCursor(1); event.accepted = true
+        } else if (event.key === Qt.Key_K || event.key === Qt.Key_Up) {
+          root.moveCursor(-1); event.accepted = true
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter
+            || event.key === Qt.Key_O) {
+          root.runCursor(); event.accepted = true
+        }
+      }
+
+      // The address the rows are about. A stranger wrote it.
+      Text {
+        width: menu.width - menu.leftPadding - menu.rightPadding
+        leftPadding: Style.space(9)
+        topPadding: Style.space(4)
+        bottomPadding: Style.space(6)
+        textFormat: Text.PlainText
+        text: root.choosing ? "Which address?" : root.chosen
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        elide: Text.ElideMiddle
+      }
+
+      // Choosing: one row per address on the line.
+      Column {
+        id: pickRows
+        visible: root.choosing
+        width: parent.width
+        spacing: Style.space(2)
+        property var rows: []
+
+        Repeater {
+          id: pickRepeater
+          model: root.choosing ? root.addresses : []
+          onItemAdded: function(index, item) { pickRows.rows = collect() }
+          onItemRemoved: function(index, item) { pickRows.rows = collect() }
+          function collect() {
+            var out = []
+            for (var i = 0; i < pickRepeater.count; i++) out.push(pickRepeater.itemAt(i))
+            return out
+          }
+
+          MenuActionRow {
+            required property var modelData
+            width: menu.width - menu.leftPadding - menu.rightPadding
+            textColor: root.textColor
+            panelFontFamily: root.panelFontFamily
+            collection: pickRows.rows
+            cursorIndex: root.cursorIndex
+            text: modelData.name !== "" && modelData.name !== modelData.email
+              ? modelData.name + " <" + modelData.email + ">" : modelData.email
+            onActivated: root.pick(modelData.email)
+          }
+        }
+      }
+
+      MenuRow {
+        id: copyRow
+        visible: !root.choosing
+        text: "Copy address"
+        onActivated: { var address = root.chosen; menu.close(); root.copyRequested(address) }
+      }
+      MenuRow {
+        id: fromRow
+        visible: !root.choosing && root.canSearch
+        text: "Search mail from"
+        onActivated: { var address = root.chosen; menu.close(); root.searchRequested("from", address) }
+      }
+      MenuRow {
+        id: toRow
+        visible: !root.choosing && root.canSearch
+        text: "Search mail to"
+        onActivated: { var address = root.chosen; menu.close(); root.searchRequested("to", address) }
+      }
+    }
+  }
+
+  component MenuRow: MenuActionRow {
+    width: menu.width - menu.leftPadding - menu.rightPadding
+    textColor: root.textColor
+    panelFontFamily: root.panelFontFamily
+    collection: root.menuRows
+    cursorIndex: root.cursorIndex
+  }
+}

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -76,6 +76,9 @@ DropArea {
   property string inReplyTo: ""
   property bool ccVisible: false
   property bool bccVisible: false
+  // Where answers should go when that is not the sender. Hidden like Bcc
+  // until asked for: most mail has no use for it.
+  property bool replyToVisible: false
   property string fromEmail: ""
   property var replyRecipients: []
   property bool fromWasChosen: false
@@ -102,6 +105,7 @@ DropArea {
   onInReplyToChanged: noteDraftChanged()
   onCcVisibleChanged: noteDraftChanged()
   onBccVisibleChanged: noteDraftChanged()
+  onReplyToVisibleChanged: noteDraftChanged()
   onFromEmailChanged: noteDraftChanged()
   onDraftAttachmentsChanged: noteDraftChanged()
   onForwardedAttachmentsChanged: noteDraftChanged()
@@ -161,6 +165,7 @@ DropArea {
     toField.text = ""
     ccField.text = ""
     bccField.text = ""
+    replyToField.text = ""
     subjectField.text = ""
     bodyEdit.text = ""
     placedBody = ""
@@ -174,6 +179,7 @@ DropArea {
     inReplyTo = ""
     ccVisible = false
     bccVisible = false
+    replyToVisible = false
     fromEmail = ""
     replyRecipients = []
     fromWasChosen = false
@@ -214,6 +220,7 @@ DropArea {
       to: toField.text,
       cc: ccField.text,
       bcc: bccField.text,
+      replyTo: replyToField.text,
       subject: subjectField.text,
       body: bodyEdit.text,
       placedBody: placedBody,
@@ -243,6 +250,7 @@ DropArea {
     inReplyTo = String(saved.inReplyTo || "")
     ccVisible = saved.ccVisible === true
     bccVisible = saved.bccVisible === true
+    replyToVisible = saved.replyToVisible === true || String(saved.replyTo || "") !== ""
     fromEmail = String(saved.fromEmail || "")
     replyRecipients = Array.isArray(saved.replyRecipients)
       ? saved.replyRecipients.slice() : []
@@ -256,6 +264,7 @@ DropArea {
     toField.text = String(saved.to || "")
     ccField.text = String(saved.cc || "")
     bccField.text = String(saved.bcc || "")
+    replyToField.text = String(saved.replyTo || "")
     subjectField.text = String(saved.subject || "")
     bodyEdit.text = String(saved.body || "")
     placedBody = String(saved.placedBody || "")
@@ -505,6 +514,8 @@ DropArea {
     ccVisible = ccField.text !== ""
     bccField.text = String(values.bcc || "")
     bccVisible = bccField.text !== ""
+    replyToField.text = String(values.replyTo || "")
+    replyToVisible = replyToField.text !== ""
     subjectField.text = String(values.subject || "")
     if (mode === "draft") {
       // Somebody wrote this and it was saved. None of it was placed, so all of
@@ -607,6 +618,7 @@ DropArea {
       to: String(draft.to || ""),
       cc: String(draft.cc || ""),
       bcc: String(draft.bcc || ""),
+      replyTo: String(draft.replyTo || ""),
       subject: String(draft.subject || ""),
       body: String(draft.body || ""),
       attachments: attachments,
@@ -714,6 +726,7 @@ DropArea {
       to: toField.text,
       cc: ccField.text,
       bcc: bccField.text,
+      replyTo: replyToField.text,
       subject: subjectField.text,
       body: bodyEdit.text,
       attachments: root.allOutgoingAttachments(),
@@ -1089,6 +1102,17 @@ DropArea {
           fontSize: Style.font.caption
           onClicked: root.bccVisible = !root.bccVisible
         }
+
+        Button {
+          id: replyToToggle
+          objectName: "compose-reply-to-toggle"
+          text: "Reply-To"
+          tooltipText: "Ask for answers at another address"
+          foreground: root.replyToVisible ? root.textColor : root.dimColor
+          bordered: false
+          fontSize: Style.font.caption
+          onClicked: root.replyToVisible = !root.replyToVisible
+        }
       }
 
       TextField {
@@ -1304,6 +1328,46 @@ DropArea {
         popupBorderColor: root.popupBorderColor
         panelFontFamily: root.panelFontFamily
         onChosen: function(contact) { root.acceptBcc(contact) }
+      }
+
+      PanelSeparator {
+        anchors.bottom: parent.bottom
+        width: parent.width
+        foreground: root.textColor
+      }
+    }
+
+    Item {
+      visible: root.replyToVisible
+      width: parent.width
+      implicitHeight: replyToField.implicitHeight + Style.space(14)
+
+      Text {
+        id: replyToLabel
+        anchors.left: parent.left
+        anchors.leftMargin: root.formInset
+        anchors.verticalCenter: parent.verticalCenter
+        width: root.formLabelWidth
+        horizontalAlignment: Text.AlignRight
+        text: "Reply-To"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+      }
+
+      TextField {
+        id: replyToField
+        objectName: "compose-reply-to-field"
+        anchors.left: replyToLabel.right
+        anchors.leftMargin: root.formLabelGap
+        anchors.right: parent.right
+        anchors.rightMargin: Style.space(18)
+        anchors.verticalCenter: parent.verticalCenter
+        foreground: root.textColor
+        accent: root.accentColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        onTextChanged: root.noteDraftChanged()
       }
 
       PanelSeparator {

--- a/components/LabelMenu.qml
+++ b/components/LabelMenu.qml
@@ -1,0 +1,180 @@
+import QtQuick
+import QtQuick.Controls as QQC
+import qs.Commons
+import qs.Ui
+import "Menu.js" as Menu
+
+// The menu a label opens on a right-click: what can be done to the label
+// itself, as opposed to the messages in it. Every row that changes the
+// server's list is offered only where the provider can be asked
+// (`canManage`); an ancestor no label names (`labelId` empty) offers only the
+// two rows that make something beneath or beside it.
+Item {
+  id: root
+
+  required property color textColor
+  required property color urgentColor
+  required property color dimColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
+  required property string panelFontFamily
+
+  property string labelId: ""
+  // Whose label this is: the account open when the popup opened, by id,
+  // so the answer goes to it even if the window has moved on since.
+  property string accountId: ""
+  property string labelPath: ""
+  property bool monitored: false
+  property bool canManage: false
+  property int cursorIndex: -1
+  readonly property var menuRows: [renameRow, newRow, newSubRow, moveRow, monitorRow, deleteRow]
+  readonly property bool opened: menu.opened
+  readonly property bool real: labelId !== ""
+
+  signal renameRequested(string labelId)
+  // `beneath` false means beside: under the same parent this label has.
+  signal createRequested(string labelPath, bool beneath)
+  signal moveRequested(string labelId)
+  signal monitorToggled(string labelId)
+  signal deleteRequested(string labelId)
+
+  anchors.fill: parent
+  z: 50
+
+  property real anchorX: 0
+  property real anchorY: 0
+
+  function openAt(id, path, sceneX, sceneY) {
+    labelId = String(id || "")
+    labelPath = String(path || "")
+    var local = root.mapFromGlobal(sceneX, sceneY)
+    anchorX = local.x
+    anchorY = local.y
+    menu.open()
+  }
+
+  function place() {
+    if (!menu.visible) return
+    var tall = menu.height > 0 ? menu.height : menu.implicitHeight
+    var placed = Menu.position(anchorX, anchorY, menu.width, tall, root.width, root.height)
+    menu.x = placed.x
+    menu.y = placed.y
+  }
+
+  function selectableRows() {
+    var values = []
+    for (var i = 0; i < menuRows.length; i++) values.push({
+      selectable: true, visible: menuRows[i].visible, enabled: menuRows[i].enabled
+    })
+    return values
+  }
+  function moveCursor(step) { cursorIndex = Menu.nextSelectable(selectableRows(), cursorIndex, step) }
+  function runCursor() { if (cursorIndex >= 0) menuRows[cursorIndex].activated() }
+  function close() { menu.close() }
+
+  // The parent a new sibling goes under: the label's own parent, which is
+  // the path with its last segment taken off by whoever handles the signal.
+  QQC.Popup {
+    id: menu
+    width: Style.space(220)
+    implicitHeight: rows.implicitHeight + Style.space(8)
+    padding: Style.space(4)
+    modal: false
+    focus: true
+    closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
+    onHeightChanged: root.place()
+    onOpened: {
+      root.cursorIndex = Menu.firstSelectable(root.selectableRows())
+      root.place()
+    }
+    background: Rectangle {
+      radius: Style.cornerRadius
+      color: root.popupBackgroundColor
+      border.width: 1
+      border.color: root.popupBorderColor
+    }
+
+    contentItem: Column {
+      id: rows
+      spacing: Style.space(2)
+
+      focus: true
+      Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_J || event.key === Qt.Key_Down) {
+          root.moveCursor(1); event.accepted = true
+        } else if (event.key === Qt.Key_K || event.key === Qt.Key_Up) {
+          root.moveCursor(-1); event.accepted = true
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter
+            || event.key === Qt.Key_O) {
+          root.runCursor(); event.accepted = true
+        }
+      }
+
+      // The label's name, so the menu says which one it is about.
+      Text {
+        width: menu.width - menu.leftPadding - menu.rightPadding
+        leftPadding: Style.space(9)
+        topPadding: Style.space(4)
+        bottomPadding: Style.space(6)
+        textFormat: Text.PlainText
+        text: root.labelPath
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        elide: Text.ElideMiddle
+      }
+
+      MenuRow {
+        id: renameRow
+        visible: root.canManage && root.real
+        text: "Rename..."
+        onActivated: { var id = root.labelId; menu.close(); root.renameRequested(id) }
+      }
+      MenuRow {
+        id: newRow
+        visible: root.canManage
+        text: "New label beside..."
+        onActivated: { var path = root.labelPath; menu.close(); root.createRequested(path, false) }
+      }
+      MenuRow {
+        id: newSubRow
+        visible: root.canManage
+        text: "New sub-label..."
+        onActivated: { var path = root.labelPath; menu.close(); root.createRequested(path, true) }
+      }
+      MenuRow {
+        id: moveRow
+        visible: root.canManage && root.real
+        text: "Move to..."
+        onActivated: { var id = root.labelId; menu.close(); root.moveRequested(id) }
+      }
+
+      MenuSeparatorLine {
+        width: menu.width - menu.leftPadding - menu.rightPadding
+        lineColor: root.textColor
+      }
+
+      MenuRow {
+        id: monitorRow
+        visible: root.real
+        text: root.monitored ? "Stop monitoring" : "Monitor for new mail"
+        onActivated: { var id = root.labelId; menu.close(); root.monitorToggled(id) }
+      }
+      MenuRow {
+        id: deleteRow
+        visible: root.canManage && root.real
+        text: "Delete..."
+        tone: root.urgentColor
+        onActivated: { var id = root.labelId; menu.close(); root.deleteRequested(id) }
+      }
+    }
+  }
+
+  component MenuRow: MenuActionRow {
+    width: menu.width - menu.leftPadding - menu.rightPadding
+    textColor: root.textColor
+    panelFontFamily: root.panelFontFamily
+    collection: root.menuRows
+    cursorIndex: root.cursorIndex
+  }
+}

--- a/components/LabelMovePicker.qml
+++ b/components/LabelMovePicker.qml
@@ -1,0 +1,157 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Controls as QQC
+import qs.Commons
+import qs.Ui
+import "../account/Model.js" as Model
+import "Menu.js" as Menu
+
+// Where a label goes: the top level, or under another label. The rows are
+// `Model.labelMoveTargets` — not the label itself, nothing beneath it, not
+// the parent it already has — walked with j/k and taken with Enter or o.
+Item {
+  id: root
+
+  required property color textColor
+  required property color accentColor
+  required property color dimColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
+  required property string panelFontFamily
+
+  property string labelId: ""
+  // Whose label this is: the account open when the popup opened, by id,
+  // so the answer goes to it even if the window has moved on since.
+  property string accountId: ""
+  property var targets: []
+  property int cursorIndex: 0
+  readonly property bool opened: menu.opened
+
+  signal targetChosen(string labelId, string parentPath)
+
+  anchors.fill: parent
+  z: 55
+
+  function openFor(id, rows) {
+    labelId = String(id || "")
+    targets = Array.isArray(rows) ? rows : []
+    cursorIndex = 0
+    menu.open()
+  }
+
+  function close() { menu.close() }
+
+  function moveCursor(delta) {
+    var count = targets.length
+    if (count === 0) return
+    cursorIndex = Model.wrappedIndex(cursorIndex, delta, count)
+  }
+
+  function choose(index) {
+    if (index < 0 || index >= targets.length) return
+    var target = targets[index]
+    menu.close()
+    root.targetChosen(labelId, String(target.path || ""))
+  }
+
+  QQC.Popup {
+    id: menu
+    anchors.centerIn: parent
+    width: Math.min(Style.space(320), parent.width - Style.space(32))
+    implicitHeight: Math.min(parent.height - Style.space(64), list.implicitHeight + Style.space(24))
+    padding: Style.space(8)
+    modal: true
+    focus: true
+    closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
+    background: Rectangle {
+      radius: Style.cornerRadius
+      color: root.popupBackgroundColor
+      border.width: 1
+      border.color: root.popupBorderColor
+    }
+
+    contentItem: Flickable {
+      id: flick
+      WheelScroller { view: flick }
+      contentWidth: width
+      contentHeight: list.implicitHeight
+      clip: true
+      boundsBehavior: Flickable.StopAtBounds
+      ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+      focus: true
+
+      Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_J || event.key === Qt.Key_Down) {
+          root.moveCursor(1); event.accepted = true
+        } else if (event.key === Qt.Key_K || event.key === Qt.Key_Up) {
+          root.moveCursor(-1); event.accepted = true
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter
+            || event.key === Qt.Key_O) {
+          root.choose(root.cursorIndex); event.accepted = true
+        }
+      }
+
+      Column {
+        id: list
+        width: flick.width
+        spacing: Style.space(2)
+
+        Text {
+          width: parent.width
+          leftPadding: Style.space(9)
+          bottomPadding: Style.space(4)
+          text: "Move under"
+          color: root.dimColor
+          font.family: root.panelFontFamily
+          font.pixelSize: Style.font.caption
+        }
+
+        Repeater {
+          model: root.targets
+
+          Rectangle {
+            id: row
+            required property var modelData
+            required property int index
+            readonly property bool hasCursor: root.cursorIndex === row.index
+
+            width: parent.width
+            implicitHeight: Style.spacing.popupRowHeight
+            radius: Style.cornerRadius
+            color: rowHover.hovered || hasCursor
+              ? Style.hoverFillFor(root.textColor, root.accentColor) : "transparent"
+            border.width: hasCursor ? Style.normalBorderWidth : 0
+            border.color: Style.hoverBorderFor(root.textColor, root.accentColor)
+
+            ActionIcon {
+              id: rowIcon
+              anchors.left: parent.left
+              anchors.leftMargin: Style.space(8)
+              anchors.verticalCenter: parent.verticalCenter
+              name: row.modelData.path === "" ? "inbox" : "label"
+              iconSize: Style.font.iconSmall
+              color: root.textColor
+            }
+
+            Text {
+              anchors.left: rowIcon.right
+              anchors.leftMargin: Style.space(8)
+              anchors.right: parent.right
+              anchors.rightMargin: Style.space(8)
+              anchors.verticalCenter: parent.verticalCenter
+              textFormat: Text.PlainText
+              text: row.modelData.name
+              color: root.textColor
+              font.family: root.panelFontFamily
+              font.pixelSize: Style.font.bodySmall
+              elide: Text.ElideMiddle
+            }
+
+            HoverHandler { id: rowHover }
+            TapHandler { gesturePolicy: TapHandler.ReleaseWithinBounds; onTapped: root.choose(row.index) }
+          }
+        }
+      }
+    }
+  }
+}

--- a/components/MailboxSidebar.qml
+++ b/components/MailboxSidebar.qml
@@ -25,6 +25,9 @@ Item {
   signal mailboxSelected(string key)
   signal labelSelected(string labelId, string name)
   signal folderToggled(string path)
+  // A right-click on a label row: the label's id ("" for an ancestor no label
+  // names), its path, and where the menu goes.
+  signal labelMenuRequested(string labelId, string path, real sceneX, real sceneY)
   signal calendarRequested()
 
   // The numbered list App.qml also gives the keys, so a badge and the key that
@@ -123,12 +126,18 @@ Item {
           // label is not written in the Latin alphabet — a Chinese label would
           // put a single hanzi in a 16px slot, which is neither an icon nor a
           // readable name. The tooltip carries the name instead.
-          icon: "label"
+          icon: modelData.selectable && !!root.service
+            && (root.service.monitoredLabelIds || []).indexOf(modelData.id) >= 0 ? "eye" : "label"
           depth: modelData.depth
           foldable: modelData.hasChildren
           expanded: modelData.expanded
           selectable: modelData.selectable
           fullPath: modelData.path
+          monitored: modelData.selectable && !!root.service
+            && (root.service.monitoredLabelIds || []).indexOf(modelData.id) >= 0
+          onMenuRequested: function(sceneX, sceneY) {
+            root.labelMenuRequested(modelData.selectable ? modelData.id : "", modelData.path, sceneX, sceneY)
+          }
           slotNumber: modelData.selectable ? Model.slotNumberOf(root.slots, "label", modelData.id) : 0
           count: modelData.unread
           selected: modelData.selectable && !root.calendarSelected && !!root.service
@@ -186,6 +195,10 @@ Item {
     property string fullPath: ""
     signal activated()
     signal foldRequested()
+    signal menuRequested(real sceneX, real sceneY)
+    // Watched for new mail: the row keeps its count in the accent even while
+    // it is not the one open, and the glyph says so.
+    property bool monitored: false
 
     // The badge names the key, not the position: the tenth row is opened by
     // Alt+0, so it says 0. A row past the tenth has no key and no badge.
@@ -316,6 +329,13 @@ Item {
         if (fold.visible && at.x >= fold.x && at.x < fold.x + fold.width
             && at.y >= fold.y && at.y < fold.y + fold.height) return
         entry.activated()
+      }
+    }
+    TapHandler {
+      acceptedButtons: Qt.RightButton
+      onTapped: {
+        var scene = entry.mapToGlobal(0, entry.height)
+        entry.menuRequested(scene.x, scene.y)
       }
     }
 

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -52,6 +52,9 @@ Item {
   signal composeRequested(string mode)
   signal mailtoRequested(string url)
   signal actionRequested(string action)
+  // A right-click on the From line or the To line: the addresses on it, and
+  // where the menu goes. What is done with them is the window's decision.
+  signal addressMenuRequested(var addresses, real sceneX, real sceneY)
 
   // ------------------------------------------------------- the conversation
 
@@ -338,6 +341,7 @@ Item {
       }
 
       Text {
+        id: fromLine
         width: parent.width
         textFormat: Text.PlainText
         text: root.summary
@@ -348,9 +352,20 @@ Item {
         font.pixelSize: Style.font.bodySmall
         elide: Text.ElideRight
         horizontalAlignment: root.headerAlignment
+
+        TapHandler {
+          acceptedButtons: Qt.RightButton
+          onTapped: function(eventPoint) {
+            var scene = fromLine.mapToGlobal(eventPoint.position.x, eventPoint.position.y)
+            root.addressMenuRequested(root.summary ? [root.summary.from] : [], scene.x, scene.y)
+          }
+        }
       }
 
+      // Everyone the message went to — To, Cc and Bcc, which a sent message
+      // carries — so a right-click on the line can name any of them.
       Text {
+        id: toLine
         width: parent.width
         textFormat: Text.PlainText
         text: root.summary
@@ -361,6 +376,16 @@ Item {
         font.pixelSize: Style.font.caption
         elide: Text.ElideRight
         horizontalAlignment: root.headerAlignment
+
+        TapHandler {
+          acceptedButtons: Qt.RightButton
+          onTapped: function(eventPoint) {
+            if (!root.summary) return
+            var all = (root.summary.to || []).concat(root.summary.cc || [], root.summary.bcc || [])
+            var scene = toLine.mapToGlobal(eventPoint.position.x, eventPoint.position.y)
+            root.addressMenuRequested(all, scene.x, scene.y)
+          }
+        }
       }
     }
   }

--- a/components/NamePrompt.qml
+++ b/components/NamePrompt.qml
@@ -1,0 +1,135 @@
+import QtQuick
+import QtQuick.Controls as QQC
+import qs.Commons
+import qs.Ui
+
+// One name, asked for: a new label's, or a label's new one. A small modal
+// popup rather than a page, because the answer is a word and the place it
+// applies to is still on screen behind it.
+Item {
+  id: root
+
+  required property color textColor
+  required property color dimColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
+  required property color accentColor
+  required property string panelFontFamily
+
+  // What the answer is for, handed back with it so one prompt serves every
+  // caller: `kind` names the operation, `subject` the label it is about.
+  property string kind: ""
+  // Whose label this is: the account open when the popup opened, by id,
+  // so the answer goes to it even if the window has moved on since.
+  property string accountId: ""
+  property string subject: ""
+  property string title: ""
+  property string hint: ""
+  readonly property bool opened: dialog.opened
+
+  signal submitted(string kind, string subject, string text)
+
+  anchors.fill: parent
+  z: 55
+
+  function openFor(kindValue, subjectValue, titleText, initialText, hintText) {
+    kind = String(kindValue || "")
+    subject = String(subjectValue || "")
+    title = String(titleText || "")
+    hint = String(hintText || "")
+    field.text = String(initialText || "")
+    dialog.open()
+  }
+
+  function close() { dialog.close() }
+
+  function submit() {
+    var text = String(field.text || "").trim()
+    if (text === "") return
+    dialog.close()
+    root.submitted(kind, subject, text)
+  }
+
+  QQC.Popup {
+    id: dialog
+    anchors.centerIn: parent
+    width: Math.min(Style.space(360), parent.width - Style.space(32))
+    padding: Style.space(18)
+    modal: true
+    focus: true
+    closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
+    onOpened: {
+      field.selectAll()
+      field.forceActiveFocus()
+    }
+    background: Rectangle {
+      radius: Style.cornerRadius
+      color: root.popupBackgroundColor
+      border.width: 1
+      border.color: root.popupBorderColor
+    }
+
+    contentItem: Column {
+      spacing: Style.space(10)
+
+      Text {
+        width: parent.width
+        textFormat: Text.PlainText
+        text: root.title
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        font.bold: true
+        wrapMode: Text.WordWrap
+      }
+
+      TextField {
+        id: field
+        objectName: "name-prompt-field"
+        width: parent.width
+        foreground: root.textColor
+        accent: root.accentColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        onAccepted: root.submit()
+      }
+
+      Text {
+        width: parent.width
+        visible: root.hint !== ""
+        textFormat: Text.PlainText
+        text: root.hint
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+      }
+
+      Row {
+        anchors.right: parent.right
+        spacing: Style.space(8)
+
+        Button {
+          text: "Cancel"
+          foreground: root.dimColor
+          bordered: false
+          fontFamily: root.panelFontFamily
+          fontSize: Style.font.caption
+          onClicked: dialog.close()
+        }
+
+        Button {
+          objectName: "name-prompt-ok"
+          text: "OK"
+          foreground: root.textColor
+          bordered: true
+          accent: root.accentColor
+          fontFamily: root.panelFontFamily
+          fontSize: Style.font.caption
+          enabled: String(field.text || "").trim() !== ""
+          onClicked: root.submit()
+        }
+      }
+    }
+  }
+}

--- a/components/SearchBar.qml
+++ b/components/SearchBar.qml
@@ -39,6 +39,13 @@ Item {
     root.cleared()
   }
 
+  // A search the app built shows its words here, so the field and the list
+  // agree about what is on screen. Nothing is submitted: the caller has run
+  // the search already.
+  function setQuery(text) {
+    field.text = String(text || "")
+  }
+
   TextField {
     id: field
     anchors.fill: parent

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -1,7 +1,10 @@
 import QtQuick
+import Quickshell.Io
 import qs.Commons
 import qs.Ui
 import "../message/Direction.js" as Direction
+import "../message/Signature.js" as Signature
+import "../message/Html.js" as Html
 
 // Where mailboxes are managed.
 //
@@ -95,6 +98,77 @@ Column {
     var next = signatureAccount(activeId) || signatureAccounts[0]
     selectedNameAccountId = String(next.id || "")
     nameEdit.text = String(next.label || "")
+  }
+
+  // The imported markup for the selected mailbox, and the import in flight.
+  readonly property string selectedSignatureHtml: {
+    var entry = signatureAccount(selectedSignatureAccountId)
+    return entry ? String(entry.signatureHtml || "") : ""
+  }
+  property bool importing: false
+  property string importNote: ""
+  property bool importFailed: false
+  property string importStage: ""
+
+  function importSignature() {
+    if (importing || !service) return
+    importing = true
+    importNote = ""
+    importFailed = false
+    importStage = "pick"
+    signatureImporter.command = [root.attachScript, "pick"]
+    signatureImporter.running = true
+  }
+
+  function finishImport(text) {
+    var result = null
+    try { result = JSON.parse(String(text || "")) } catch (e) { result = null }
+    if (!result || result.ok !== true) {
+      var reason = result && result.error ? String(result.error) : ""
+      importing = false
+      if (reason !== "" && reason !== "cancelled") { importNote = reason; importFailed = true }
+      return
+    }
+    if (importStage === "pick") {
+      var paths = Array.isArray(result.paths) ? result.paths : []
+      if (paths.length === 0) { importing = false; return }
+      importStage = "read"
+      signatureImporter.command = [root.attachScript, "read", String(paths[0])]
+      signatureImporter.running = true
+      return
+    }
+    importing = false
+    var mime = String(result.mimeType || "").toLowerCase()
+    var name = String(result.filename || "").toLowerCase()
+    var imported
+    if (mime.indexOf("image/") === 0) {
+      imported = Signature.importImage(String(result.data || ""))
+    } else if (mime === "text/html" || mime === "application/xhtml+xml" || /\.x?html?$/.test(name)) {
+      imported = Signature.importHtml(Qt.atob(String(result.data || "")))
+    } else {
+      imported = { problem: "Choose a PNG, JPEG, GIF or WebP picture, or an HTML file" }
+    }
+    importNote = Signature.importNote(imported)
+    importFailed = String(imported.problem || "") !== ""
+    if (importFailed) return
+    service.setAccountSignatureHtml(selectedSignatureAccountId, imported.html)
+    // The words for a text-only client, unless the editor already has some.
+    if (String(imported.plain || "") !== "" && String(signatureEdit.text || "").trim() === "") {
+      signatureEdit.text = imported.plain
+      saveSignature()
+    }
+  }
+
+  readonly property string attachScript: {
+    var url = String(Qt.resolvedUrl("../scripts/attachment.sh"))
+    return decodeURIComponent(url.replace(/^file:\/\//, ""))
+  }
+
+  Process {
+    id: signatureImporter
+    stdout: StdioCollector { waitForEnd: true }
+    stderr: StdioCollector { waitForEnd: true }
+    onExited: root.finishImport(String(stdout.text || ""))
   }
 
   function saveSignature() {
@@ -708,6 +782,82 @@ Column {
         color: root.dimColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.bodySmall
+      }
+    }
+
+    // A signature from a file: a picture, or markup another tool wrote. What
+    // is imported is rebuilt by Signature.js — scripts, styles, handlers,
+    // frames, forms, remote images and unknown attributes do not survive —
+    // and the preview draws what was stored, so it is the sent thing that is
+    // shown. The words go into the plain editor above for text-only clients.
+    Row {
+      width: parent.width
+      spacing: Style.space(8)
+
+      Button {
+        objectName: "settings-signature-import"
+        text: root.importing ? "Importing" : "Import from file..."
+        tooltipText: "A PNG, JPEG, GIF or WebP picture, or an HTML file"
+        foreground: root.textColor
+        bordered: true
+        accent: root.accentColor
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.caption
+        enabled: !root.importing && root.selectedSignatureAccountId !== ""
+        onClicked: root.importSignature()
+      }
+
+      Button {
+        objectName: "settings-signature-remove-html"
+        visible: root.selectedSignatureHtml !== ""
+        text: "Remove imported markup"
+        foreground: root.dimColor
+        bordered: false
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.caption
+        onClicked: {
+          if (root.service) root.service.setAccountSignatureHtml(root.selectedSignatureAccountId, "")
+          root.importNote = ""
+        }
+      }
+    }
+
+    Text {
+      width: parent.width
+      visible: root.importNote !== ""
+      textFormat: Text.PlainText
+      text: root.importNote
+      color: root.importFailed ? root.urgentColor : root.dimColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.caption
+      wrapMode: Text.WordWrap
+    }
+
+    Rectangle {
+      objectName: "settings-signature-preview"
+      width: parent.width
+      visible: root.selectedSignatureHtml !== ""
+      implicitHeight: Math.min(Style.space(220), signaturePreview.implicitHeight + Style.space(20))
+      radius: Style.cornerRadius
+      color: Style.normalFillFor(root.textColor, root.accentColor)
+      clip: true
+
+      TextEdit {
+        id: signaturePreview
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.margins: Style.space(10)
+        readOnly: true
+        selectByMouse: false
+        wrapMode: TextEdit.Wrap
+        textFormat: TextEdit.RichText
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        // The stored markup, and nothing else: the same string that is sent.
+        text: Html.documentFor(root.selectedSignatureHtml, {
+          foreground: root.textColor, background: "transparent", link: root.accentColor })
       }
     }
 

--- a/compose/Recovery.js
+++ b/compose/Recovery.js
@@ -50,6 +50,7 @@ function draft(value) {
     to: text(row.to),
     cc: text(row.cc),
     bcc: text(row.bcc),
+    replyTo: text(row.replyTo),
     subject: text(row.subject),
     body: text(row.body),
     // What the compose window placed in the body rather than what was typed
@@ -65,6 +66,7 @@ function draft(value) {
     inReplyTo: text(row.inReplyTo),
     ccVisible: row.ccVisible === true,
     bccVisible: row.bccVisible === true,
+    replyToVisible: row.replyToVisible === true,
     fromEmail: text(row.fromEmail),
     replyRecipients: people(row.replyRecipients),
     fromWasChosen: row.fromWasChosen === true,

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -87,7 +87,7 @@ used to exist, and they had.
 |---|---|---|---|
 | `cursorDown` | `j`, `Down` | mail | Move down |
 | `cursorUp` | `k`, `Up` | mail | Move up |
-| `open` | `Return`, `o` | mail | Open the selected message |
+| `open` | `Return`, `Enter`, `o` | mail | Open the selected message |
 | `backToList` | `u` | reader | Back to the list |
 | `nextMember` | `n` | reader | Next message in the conversation |
 | `previousMember` | `p` | reader | Previous message in the conversation |
@@ -112,7 +112,7 @@ used to exist, and they had.
 | `calendarToday` | `t` | calendar | Go to today |
 | `calendarWeek` | `w` | calendar | Show week view |
 | `calendarMonth` | `m` | calendar | Show month view |
-| `send` | `Ctrl+Return` | compose | Send |
+| `send` | `Ctrl+Return`, `Ctrl+Enter` | compose | Send |
 | `undoSend` | `Alt+Z` | all | Undo send |
 | `search` | `/` | mail | Search |
 | `goMailbox` | `Ctrl+1`, `Ctrl+2`, `Ctrl+3`, `Ctrl+4`, `Ctrl+5`, `Ctrl+6`, `Ctrl+7`, `Ctrl+8`, `Ctrl+9`, `Ctrl+0` | mail | Go to that mailbox |
@@ -134,7 +134,7 @@ used to exist, and they had.
 The bare `?` opens the complete key sheet from mail. In a text-entry context it
 stays text, like every other bare character except `Escape`.
 
-In Drafts, `Enter` and `o` preview the selected draft. Press `c` to edit it. In every other mailbox, `c` starts a new message.
+In Drafts, `Enter`, `o` and `c` open the selected draft in the composer, with what was written in it; a click previews it, as in every other mailbox. Leaving the composer saves the draft back over the one it came from; sending it takes that draft away. In every other mailbox, `c` starts a new message.
 
 `Space` or `x` toggles the cursor row's selection in the list or reader context. Shift+click applies the clicked row's next checked state to the inclusive range from the cursor: an unchecked endpoint selects the range, and a checked endpoint clears it. Selections outside the range remain unchanged; the cursor then moves to the clicked row.
 

--- a/keys/Keymap.js
+++ b/keys/Keymap.js
@@ -37,7 +37,7 @@ var BINDINGS = [
   // — stepping through with j used to mark half a mailbox read without anyone
   // looking at it — so with the reader up there has to be a key that says open,
   // or the only way to read the next message is to leave and come back.
-  { id: "open", keys: ["Return", "o"], contexts: MAIL,
+  { id: "open", keys: ["Return", "Enter", "o"], contexts: MAIL,
     group: "Moving", label: "Open the selected message",
     hintKey: "o", hint: { list: "open", reader: "open" } },
   { id: "backToList", keys: ["u"], contexts: ["reader"],
@@ -122,7 +122,9 @@ var BINDINGS = [
     group: "Calendar", label: "Show week view" },
   { id: "calendarMonth", keys: ["m"], contexts: ["calendar"],
     group: "Calendar", label: "Show month view" },
-  { id: "send", keys: ["Ctrl+Return"], contexts: ["compose"],
+  // Both Enters: the main keyboard's is Return, the numpad's is Enter, and
+  // a hand on the numpad expects the same thing of them.
+  { id: "send", keys: ["Ctrl+Return", "Ctrl+Enter"], contexts: ["compose"],
     group: "Writing", label: "Send", hint: { compose: "send" } },
   { id: "undoSend", keys: ["Alt+Z"], contexts: ANY,
     survivesOverlay: true,
@@ -306,7 +308,12 @@ function displayFor(binding) {
   if (binding.display) return binding.display
   var keys = binding.keys || []
   var out = []
-  for (var i = 0; i < keys.length; i++) out.push(readableSequence(keys[i]))
+  // Return and the numpad's Enter are two keys with one keycap name; the
+  // sheet names the keycap once.
+  for (var i = 0; i < keys.length; i++) {
+    var readable = readableSequence(keys[i])
+    if (out.indexOf(readable) < 0) out.push(readable)
+  }
   return out.join(", ")
 }
 

--- a/message/Message.js
+++ b/message/Message.js
@@ -1,6 +1,6 @@
 .pragma library
-
 .import "Direction.js" as Direction
+.import "Signature.js" as Signature
 
 // Everything that turns a Gmail API message resource into something a row or a
 // reader can show. Two things force real work here rather than a few property
@@ -916,6 +916,9 @@ function draftFields(summary, body) {
     to: draftAddressText(source.to),
     cc: draftAddressText(source.cc),
     bcc: draftAddressText(source.bcc),
+    // A Reply-To the draft was saved with comes back into the field it was
+    // typed in, or the next save would drop it.
+    replyTo: String(source.replyTo && source.replyTo.email ? source.replyTo.email : ""),
     subject: subject === "(no subject)" ? "" : subject,
     body: String(body || ""),
     threadId: String(source.threadId || ""),
@@ -1168,16 +1171,89 @@ function nestedBoundary(outer) {
   return mimeBoundary("alt_" + String(outer || ""))
 }
 
-// The body as a part of its own: the plain text alone, or the plain text and
-// an HTML twin stating the direction when there is one worth stating. Written
-// once because the shape has to be the same whether the body stands as the
-// whole message or as the first part of a `multipart/mixed`.
-//
-// Stated only when the message runs right to left. Left to right is what a
-// bare `text/plain` already means to every client, so saying it would add an
-// HTML part to every message ever sent in order to repeat the default — the
-// same reason `Html.js` gives a document no `dir` when nothing chose one.
-function pushBodyPart(lines, body, direction, boundary) {
+// The body with an HTML signature: the plain text as the plain part, and an
+// HTML part that is the same text escaped, paragraph by paragraph, with the
+// stored signature markup in place of the plain signature at the end. The
+// signature's data: images travel as related parts by cid, because Gmail's
+// web client draws no data: image in HTML mail and a related part it does.
+// `multipart/related` holds the alternative and the images; `mixed` holds
+// that and any attachments, as before.
+function htmlBodyWithSignature(body, plainSignature, signatureHtml, direction) {
+  var text = String(body === undefined || body === null ? "" : body)
+  var sign = String(plainSignature === undefined || plainSignature === null ? "" : plainSignature).trim()
+  var dir = Direction.isRightToLeft(direction) ? " dir=\"rtl\"" : ""
+  // The first occurrence: the writer's own sign-off comes before any quote
+  // that happens to repeat it. A plain signature the writer took out of the
+  // body is not put back as markup — the two readings must say the same.
+  var at = sign === "" ? -1 : text.indexOf(sign)
+  if (sign !== "" && at < 0)
+    return "<html><body" + dir + ">" + escapedParagraphs(text) + "</body></html>"
+  var before, after
+  if (at >= 0) {
+    before = text.slice(0, at)
+    after = text.slice(at + sign.length)
+  } else {
+    // A signature that is only a picture has no words to find: it goes
+    // where the plain one would have, before the quote if there is one.
+    var quoteAt = text.search(/(^|\n)>/)
+    before = quoteAt >= 0 ? text.slice(0, quoteAt) : text
+    after = quoteAt >= 0 ? text.slice(quoteAt) : ""
+  }
+  return "<html><body" + dir + ">" + escapedParagraphs(before)
+    + String(signatureHtml || "") + escapedParagraphs(after) + "</body></html>"
+}
+
+function escapedParagraphs(text) {
+  var lines = String(text || "").replace(/\r\n/g, "\n").split("\n")
+  var out = []
+  for (var i = 0; i < lines.length; i++) {
+    out.push(lines[i].replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;"))
+  }
+  var joined = out.join("<br>")
+  return joined === "" ? "" : "<div>" + joined + "</div>"
+}
+
+function pushSignedBodyPart(lines, values, direction, boundary) {
+  var swapped = Signature.inlineParts(values.signatureHtml, "sig")
+  var html = htmlBodyWithSignature(values.body, values.signature, swapped.html, direction)
+  var alt = nestedBoundary(boundary)
+  var related = swapped.parts.length > 0 ? boundary : ""
+  if (related !== "") {
+    lines.push("Content-Type: multipart/related; boundary=\"" + related + "\"; type=\"multipart/alternative\"")
+    lines.push("")
+    lines.push("--" + related)
+  }
+  lines.push("Content-Type: multipart/alternative; boundary=\"" + alt + "\"")
+  lines.push("")
+  lines.push("--" + alt)
+  lines.push("Content-Type: text/plain; charset=UTF-8")
+  lines.push("Content-Transfer-Encoding: base64")
+  lines.push("")
+  lines.push(base64Body(values.body))
+  lines.push("--" + alt)
+  lines.push("Content-Type: text/html; charset=UTF-8")
+  lines.push("Content-Transfer-Encoding: base64")
+  lines.push("")
+  lines.push(base64Body(html))
+  lines.push("--" + alt + "--")
+  for (var i = 0; i < swapped.parts.length; i++) {
+    var part = swapped.parts[i]
+    lines.push("--" + related)
+    lines.push("Content-Type: " + part.mimeType)
+    lines.push("Content-Transfer-Encoding: base64")
+    lines.push("Content-ID: <" + part.cid + ">")
+    lines.push("Content-Disposition: inline")
+    lines.push("")
+    lines.push(mimeBase64(part.data))
+  }
+  if (related !== "") lines.push("--" + related + "--")
+}
+
+function pushBodyPart(lines, body, direction, boundary, values) {
+  if (values && String(values.signatureHtml || "") !== "") {
+    pushSignedBodyPart(lines, values, direction, boundary)
+    return
+  }
   if (!Direction.isRightToLeft(direction)) {
     lines.push("Content-Type: text/plain; charset=UTF-8")
     lines.push("Content-Transfer-Encoding: base64")
@@ -1213,6 +1289,9 @@ function buildRawMessage(fields) {
   lines.push(foldHeader("To", values.to || ""))
   if (values.cc) lines.push(foldHeader("Cc", values.cc))
   if (values.bcc) lines.push(foldHeader("Bcc", values.bcc))
+  // Where answers should go when that is not the sender: one header, folded
+  // like the rest, so a line break typed into it cannot start a second one.
+  if (values.replyTo) lines.push(foldHeader("Reply-To", values.replyTo))
   lines.push(foldHeader("Subject", values.subject || ""))
   var inReplyTo = referenceValue(values.inReplyTo)
   if (inReplyTo) {
@@ -1244,7 +1323,7 @@ function buildRawMessage(fields) {
   var direction = outgoingDirection(values.body)
 
   if (!calendar && included.length === 0) {
-    pushBodyPart(lines, values.body, direction, mimeBoundary(values.boundary))
+    pushBodyPart(lines, values.body, direction, mimeBoundary(values.boundary), values)
     return lines.join("\r\n") + "\r\n"
   }
 
@@ -1253,7 +1332,7 @@ function buildRawMessage(fields) {
     lines.push("Content-Type: multipart/mixed; boundary=\"" + mixedBoundary + "\"")
     lines.push("")
     lines.push("--" + mixedBoundary)
-    pushBodyPart(lines, values.body, direction, nestedBoundary(mixedBoundary))
+    pushBodyPart(lines, values.body, direction, nestedBoundary(mixedBoundary), values)
     for (var includedIndex = 0; includedIndex < included.length; includedIndex++) {
       var file = included[includedIndex]
       var filename = String(file.filename || "attachment")

--- a/message/Signature.js
+++ b/message/Signature.js
@@ -1,0 +1,205 @@
+.pragma library
+.import "Html.js" as Html
+
+// A signature imported from a file: a picture, or a page of markup somebody
+// else's tool wrote. What is stored is never the file. A picture is checked
+// to be the raster it claims and wrapped in one `<img>`; markup goes through
+// the same gate the reader trusts for a stranger's message — `Html.sanitize`,
+// which drops scripts, handlers and every fetch — and is then walked once
+// more here against a short list of what can never be in a signature, so
+// the argument does not rest on one pass. The formatting the file carries
+// — colours, faces, sizes, tables, alignment — is kept: it is what the
+// owner imported the file for. Scripts, styles blocks, forms, frames,
+// objects, event handlers, remote images and every address that is not a
+// public link, a mailto or an inline picture do not survive, and the count
+// of what was dropped is reported so the preview can say so.
+
+var MAX_HTML_BYTES = 256 * 1024
+var MAX_IMAGE_BYTES = 512 * 1024
+var MAX_DATA_IMAGES = 8
+
+// What can never be in a signature, whatever the sanitiser kept: elements
+// that run, embed, or take input, and attributes that name an address or a
+// handler. Everything else — inline style without a url(), class, colour,
+// face, size, alignment, table geometry — stays.
+var FORBIDDEN_ELEMENTS = ["script", "style", "iframe", "frame", "frameset", "object", "embed", "applet",
+  "form", "input", "button", "select", "textarea", "option", "svg", "math", "template", "link", "meta",
+  "base", "video", "audio", "source", "track", "canvas", "noscript"]
+var FORBIDDEN_ATTRIBUTES = ["action", "formaction", "background", "srcset", "poster", "xlink:href",
+  "data", "codebase", "usemap", "ping", "manifest", "longdesc", "profile"]
+
+var RASTERS = [
+  { mime: "image/png", magic: [0x89, 0x50, 0x4e, 0x47] },
+  { mime: "image/jpeg", magic: [0xff, 0xd8, 0xff] },
+  { mime: "image/gif", magic: [0x47, 0x49, 0x46, 0x38] },
+  { mime: "image/webp", magic: [0x52, 0x49, 0x46, 0x46], at12: [0x57, 0x45, 0x42, 0x50] }
+]
+
+function base64Prefix(data, count) {
+  var text = String(data || "").replace(/[^A-Za-z0-9+\/=]/g, "")
+  var alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+  var bytes = []
+  var bits = 0
+  var value = 0
+  for (var i = 0; i < text.length && bytes.length < count; i++) {
+    var ch = text.charAt(i)
+    if (ch === "=") break
+    var index = alphabet.indexOf(ch)
+    if (index < 0) return []
+    value = (value << 6) | index
+    bits += 6
+    if (bits >= 8) {
+      bits -= 8
+      bytes.push((value >> bits) & 0xff)
+    }
+  }
+  return bytes
+}
+
+// The raster a base64 body is, by its first bytes, or "" for anything else.
+// The declared type is not consulted: an SVG named PNG is the case this
+// exists to refuse, because SVG is a document with scripts in it.
+function rasterKind(base64) {
+  var head = base64Prefix(base64, 16)
+  for (var r = 0; r < RASTERS.length; r++) {
+    var raster = RASTERS[r]
+    var ok = head.length >= raster.magic.length
+    for (var i = 0; ok && i < raster.magic.length; i++) if (head[i] !== raster.magic[i]) ok = false
+    if (ok && raster.at12) {
+      ok = head.length >= 16
+      for (var j = 0; ok && j < 4; j++) if (head[8 + j] !== raster.at12[j]) ok = false
+    }
+    if (ok) return raster.mime
+  }
+  return ""
+}
+
+function base64Bytes(base64) {
+  var text = String(base64 || "").replace(/[^A-Za-z0-9+\/=]/g, "")
+  var padding = text.length > 0 && text.charAt(text.length - 1) === "=" ? (text.charAt(text.length - 2) === "=" ? 2 : 1) : 0
+  return Math.floor(text.length * 3 / 4) - padding
+}
+
+// A picture as a signature: one image, its type read from its bytes.
+function importImage(base64, options) {
+  var settings = options || {}
+  var limit = Math.max(1, Math.floor(Number(settings.maxImageBytes) || MAX_IMAGE_BYTES))
+  var mime = rasterKind(base64)
+  if (mime === "") return { html: "", plain: "", problem: "That file is not a PNG, JPEG, GIF or WebP image" }
+  var size = base64Bytes(base64)
+  if (size > limit) return { html: "", plain: "", problem: "That image is larger than " + Math.round(limit / 1024) + " KB" }
+  var clean = String(base64 || "").replace(/[^A-Za-z0-9+\/=]/g, "")
+  return { html: "<p><img src=\"data:" + mime + ";base64," + clean + "\"></p>", plain: "", dropped: 0, images: 1, problem: "" }
+}
+
+function dataImageOk(value, limit) {
+  var match = /^data:(image\/(?:png|jpe?g|gif|webp));base64,([A-Za-z0-9+\/=]+)$/i.exec(String(value || ""))
+  if (!match) return false
+  if (base64Bytes(match[2]) > limit) return false
+  var kind = rasterKind(match[2])
+  return kind !== "" && (kind === match[1].toLowerCase() || (kind === "image/jpeg" && /jpe?g/i.test(match[1])))
+}
+
+function hrefOk(value) {
+  var url = String(value || "").trim()
+  if (/^mailto:[^\s<>"]+$/i.test(url)) return true
+  var match = /^https?:\/\/([^\/?#:]+)/i.exec(url)
+  return !!match && Html.isPublicHost(match[1])
+}
+
+// The second walk: drop what can never be here, count it, keep the rest.
+function prune(node, ctx) {
+  var kept = []
+  for (var i = 0; i < node.children.length; i++) {
+    var child = node.children[i]
+    if (child.type === "text") { kept.push(child); continue }
+    if (child.type !== "element") { ctx.dropped++; continue }
+    var name = String(child.name || "").toLowerCase()
+    if (FORBIDDEN_ELEMENTS.indexOf(name) >= 0) { ctx.dropped++; continue }
+    var attrs = []
+    var list = Array.isArray(child.attrs) ? child.attrs : []
+    for (var a = 0; a < list.length; a++) {
+      var attr = list[a]
+      var attrName = String(attr.name || "").toLowerCase()
+      var value = String(attr.value === undefined ? "" : attr.value)
+      if (attrName.indexOf("on") === 0 || FORBIDDEN_ATTRIBUTES.indexOf(attrName) >= 0) { ctx.dropped++; continue }
+      if (attrName === "href" && !hrefOk(value)) { ctx.dropped++; continue }
+      if (attrName === "src") {
+        if (name !== "img" || !dataImageOk(value, ctx.imageLimit) || ctx.images >= MAX_DATA_IMAGES) { ctx.dropped++; continue }
+        ctx.images++
+      }
+      // A style that fetches, runs, or hides text is dropped whole: a
+      // signature has no business carrying invisible words.
+      if (attrName === "style" && /url\s*\(|expression\s*\(|@import|behavior\s*:|javascript:|display\s*:\s*none|visibility\s*:\s*hidden|opacity\s*:\s*0(?![.\d])|font-size\s*:\s*0(?![.\d])|font-size\s*:\s*0?\.\d|text-indent\s*:\s*-/i.test(value)) { ctx.dropped++; continue }
+      attrs.push({ name: attrName, value: value })
+    }
+    child.attrs = attrs
+    child.name = name
+    if (name === "img" && attrs.filter(function(x) { return x.name === "src" }).length === 0) { ctx.dropped++; continue }
+    prune(child, ctx)
+    kept.push(child)
+  }
+  node.children = kept
+}
+
+function sourceRemovals(source) {
+  var text = String(source || "")
+  var count = 0
+  var patterns = [/<\s*(script|style|iframe|object|embed|form|input|svg|template|link|meta)\b/gi,
+    /\son[a-z]+\s*=/gi, /javascript\s*:/gi, /url\s*\(/gi, /\sbackground\s*=/gi]
+  for (var i = 0; i < patterns.length; i++) {
+    var found = text.match(patterns[i])
+    if (found) count += found.length
+  }
+  return count
+}
+
+// Markup as a signature. Returns what is stored (`html`), the plain text a
+// text-only client sees (`plain`), how many things were dropped, and a
+// problem where the file cannot be a signature at all.
+function importHtml(html, options) {
+  var settings = options || {}
+  var source = String(html === undefined || html === null ? "" : html)
+  if (source.length > Math.max(1, Math.floor(Number(settings.maxHtmlBytes) || MAX_HTML_BYTES)))
+    return { html: "", plain: "", dropped: 0, images: 0, problem: "That file is too large for a signature" }
+  var cleaned = Html.sanitize(source, { allowRemoteImages: false, keepColors: true })
+  // What the sanitiser took out is counted from the source, since it reports
+  // only images: every script, frame, form and handler the file carried is a
+  // removal the preview should own up to.
+  var ctx = { dropped: sourceRemovals(source) + cleaned.blockedImages, images: 0,
+    imageLimit: Math.max(1, Math.floor(Number(settings.maxImageBytes) || MAX_IMAGE_BYTES)) }
+  var document = Html.parse(cleaned.html)
+  prune(document, ctx)
+  var text = Html.serialize(document)
+  var read = Html.readTree(document)
+  var plain = String(read && read.text !== undefined ? read.text : read || "").replace(/[ \t]+\n/g, "\n").trim()
+  if (text.trim() === "" || (plain === "" && ctx.images === 0))
+    return { html: "", plain: "", dropped: ctx.dropped, images: 0, problem: "Nothing in that file can be a signature" }
+  return { html: text, plain: plain, dropped: ctx.dropped, images: ctx.images, problem: "" }
+}
+
+// What the preview says about the import.
+function importNote(result) {
+  if (!result) return ""
+  if (result.problem) return result.problem
+  var parts = []
+  if (result.images > 0) parts.push(result.images === 1 ? "1 image" : result.images + " images")
+  if (result.dropped > 0) parts.push(result.dropped + " unsafe or unsupported " + (result.dropped === 1 ? "part" : "parts") + " removed")
+  return parts.length === 0 ? "Imported" : "Imported: " + parts.join(", ")
+}
+
+// The data: images a stored signature carries, each swapped for a cid: so
+// the message can carry them as parts; a client that hides data: images in
+// HTML mail still shows a related part.
+function inlineParts(html, prefix) {
+  var text = String(html || "")
+  var parts = []
+  var stem = String(prefix || "sig")
+  var out = text.replace(/src="data:(image\/(?:png|jpe?g|gif|webp));base64,([A-Za-z0-9+\/=]+)"/gi,
+    function(all, mime, data) {
+      var id = stem + (parts.length + 1) + "@omamail"
+      parts.push({ cid: id, mimeType: mime.toLowerCase(), data: data })
+      return "src=\"cid:" + id + "\""
+    })
+  return { html: out, parts: parts }
+}

--- a/providers/Gmail.js
+++ b/providers/Gmail.js
@@ -29,6 +29,7 @@ var MARK = "gmail.png"
 
 var CAPABILITIES = {
   labels: true,
+  manageLabels: true,
   // Adding a label and taking INBOX away, which is archive with a destination.
   move: true,
   threads: true,
@@ -108,6 +109,14 @@ function cachedSummaryInSearch(sourceQuery, summary) {
 
 // Selecting a label in the sidebar. A Gmail label is a search operator, which
 // is why this is a different string from the one a typed search produces.
+// Mail from, or to, one address: Gmail's own operators, which the search
+// box already accepts verbatim.
+function addressQuery(field, address) {
+  var value = String(address === undefined || address === null ? "" : address).trim()
+  if (value === "" || /[\s"]/.test(value)) return ""
+  return (field === "to" ? "to:" : "from:") + value
+}
+
 function labelQuery(name) {
   var value = String(name === undefined || name === null ? "" : name).trim()
   return value === "" ? "" : "label:" + value

--- a/providers/GmailApiClient.qml
+++ b/providers/GmailApiClient.qml
@@ -331,6 +331,32 @@ Item {
     })
   }
 
+  // Labels, changed. A nested label is a name with "/" in it, so a move is a
+  // rename to the new path; Gmail renames the labels beneath it with it.
+  function createLabel(name, callback) {
+    return request("POST", Api.labelsPath(), null, {
+      name: String(name || ""),
+      labelListVisibility: "labelShow",
+      messageListVisibility: "show"
+    }, function(status, payload, error) {
+      if (typeof callback === "function") callback(payload, error)
+    })
+  }
+
+  function renameLabel(id, name, callback) {
+    return request("PATCH", Api.labelPath(id), null, { name: String(name || "") },
+      function(status, payload, error) {
+        if (typeof callback === "function") callback(payload, error)
+      })
+  }
+
+  function deleteLabel(id, callback) {
+    return request("DELETE", Api.labelPath(id), null, null,
+      function(status, payload, error) {
+        if (typeof callback === "function") callback(payload, error)
+      })
+  }
+
   // One id or a list of them: a row that stands for a conversation is trashed
   // as its members, and the list arrives here flat.
   //

--- a/providers/GmailApiClient.qml
+++ b/providers/GmailApiClient.qml
@@ -444,6 +444,39 @@ Item {
 
   // The message list names Gmail's message id. The update endpoint names its
   // enclosing draft resource, so resolve that immutable id before replacing it.
+  // The draft a sent message was opened from, taken away: found the same way
+  // an update finds it, then deleted. Gmail's own drafts.send would do this
+  // itself; a message sent as raw leaves the draft behind.
+  function deleteDraft(messageId, callback) {
+    var handle = newHandle()
+    function find(pageToken) {
+      root.request("GET", Api.draftsPath(), Api.draftListQuery(pageToken), null,
+        function(status, body, error) {
+          if (handle.aborted) return
+          if (error) {
+            if (typeof callback === "function") callback(null, error)
+            return
+          }
+          var draftId = Api.draftIdForMessage(body, messageId)
+          if (draftId !== "") {
+            root.request("DELETE", Api.draftPath(draftId), null, null,
+              function(deleteStatus, gone, deleteError) {
+                if (typeof callback === "function") callback(gone, deleteError)
+              }, false, handle)
+            return
+          }
+          var next = String(body && body.nextPageToken || "")
+          if (next !== "") {
+            find(next)
+            return
+          }
+          if (typeof callback === "function") callback(null, "")
+        }, false, handle)
+    }
+    find("")
+    return handle
+  }
+
   function updateDraft(messageId, payload, callback) {
     var handle = newHandle()
 

--- a/providers/Hey.js
+++ b/providers/Hey.js
@@ -124,6 +124,14 @@ function cachedSummaryInSearch(sourceQuery, summary) {
 // Selecting a label in the sidebar. HEY addresses a label by id, not by name —
 // `hey label <id>` takes nothing else — so the id is what the sidebar carries
 // as a label's `rawName` and what arrives here.
+// HEY's search takes words, not operators, so an address is searched as a
+// word: from and to cannot be told apart, and that is said by answering the
+// same query for both rather than by pretending.
+function addressQuery(field, address) {
+  var value = String(address === undefined || address === null ? "" : address).trim()
+  return value === "" ? "" : "search:" + value
+}
+
 function labelQuery(name) {
   var value = String(name === undefined || name === null ? "" : name).trim()
   return value === "" ? "" : "label:" + value

--- a/providers/HeyClient.qml
+++ b/providers/HeyClient.qml
@@ -526,6 +526,17 @@ Item {
     return act(verb, ids, callback)
   }
 
+  // HEY's labels are HEY's own. The capability is off, so no button reaches
+  // these; they exist so every client answers the same calls.
+  function createLabel(name, callback) { return refuseLabelChange(callback) }
+  function renameLabel(id, name, callback) { return refuseLabelChange(callback) }
+  function deleteLabel(id, callback) { return refuseLabelChange(callback) }
+  function refuseLabelChange(callback) {
+    if (typeof callback === "function")
+      Qt.callLater(function() { if (root) callback(null, "HEY labels are managed on HEY") })
+    return newHandle()
+  }
+
   // One id or a list of them. A HEY message id is `<posting>:<topic>`, and a
   // conversation's members all share the topic — so a list arriving from a row
   // that stands for a conversation can name the same posting more than once.

--- a/providers/HeyClient.qml
+++ b/providers/HeyClient.qml
@@ -639,6 +639,11 @@ Item {
     return handle
   }
 
+  function deleteDraft(messageId, callback) {
+    if (typeof callback === "function") Qt.callLater(function() { if (root) callback(null, "") })
+    return newHandle()
+  }
+
   function saveDraft(payload, callback) {
     var handle = newHandle()
     var raw = payload && payload.raw ? String(payload.raw) : ""

--- a/providers/Imap.js
+++ b/providers/Imap.js
@@ -22,6 +22,7 @@ var CAPABILITIES = {
   // `labels: false` is about the strip the reader draws, not about whether a
   // message can be put somewhere else.
   move: true,
+  manageLabels: true,
   // No server-side conversation id. Threading falls back to References, which
   // is what every other IMAP client does.
   threads: false,
@@ -102,6 +103,14 @@ function cachedSummaryInSearch(sourceQuery, summary) {
 // Selecting a folder in the sidebar. This cannot go through `searchQuery`: a
 // folder wrapped in a TEXT search would look for the folder's own name inside
 // the inbox rather than opening it.
+// Mail from, or to, one address, in the inbox: IMAP's FROM and TO criteria
+// match the header as a substring, which is what an address search wants.
+function addressQuery(field, address) {
+  var value = String(address === undefined || address === null ? "" : address).trim()
+  if (value === "") return ""
+  return "folder:INBOX " + (field === "to" ? "TO " : "FROM ") + JSON.stringify(value)
+}
+
 function labelQuery(name) {
   var value = String(name === undefined || name === null ? "" : name).trim()
   return value === "" ? "" : "folder:" + JSON.stringify(value)

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -745,6 +745,28 @@ Item {
     return handle
   }
 
+  // The folder list, changed. No mailbox is selected for these — the URL is
+  // the server alone — and the cached listing is dropped so the next read
+  // sees the server's answer rather than this client's memory of it.
+  function createLabel(name, callback) {
+    return changeFolders([Imap.createCommand(name)], callback)
+  }
+
+  function renameLabel(id, name, callback) {
+    return changeFolders([Imap.renameCommand(id, name)], callback)
+  }
+
+  function deleteLabel(id, callback) {
+    return changeFolders([Imap.deleteCommand(id)], callback)
+  }
+
+  function changeFolders(commands, callback) {
+    return root.run("", commands, function(text, error) {
+      if (!error) root.foldersLoaded = false
+      if (typeof callback === "function") callback(null, error)
+    })
+  }
+
   // One id or a list of them, the way every other verb here already takes one.
   // A row that stands for a conversation is trashed as its members, and the
   // list arrives here flat — `applyPlan` groups by folder either way, so a

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -905,6 +905,35 @@ Item {
     return handle
   }
 
+  // The draft a sent message was opened from, taken away with the same
+  // commands a save uses to remove the copy it replaced.
+  function deleteDraft(messageId, callback) {
+    var handle = newHandle()
+    ensureFolders(function(folderError) {
+      if (handle.aborted) return
+      if (folderError) {
+        if (typeof callback === "function") callback(null, folderError)
+        return
+      }
+      var groups = Imap.groupByFolder([String(messageId || "")])
+      if (groups.length === 0) {
+        if (typeof callback === "function") callback(null, "")
+        return
+      }
+      var folder = groups[0].folder
+      var plan = Imap.draftReplacementPlan(String(messageId || ""), folder)
+      if (plan.commands.length === 0) {
+        if (typeof callback === "function") callback(null, plan.warning)
+        return
+      }
+      root.run(folder, plan.commands, function(text, error) {
+        if (handle.aborted) return
+        if (typeof callback === "function") callback(null, error)
+      }, handle)
+    })
+    return handle
+  }
+
   // `MailAccount` builds the same payload for either provider: a base64url
   // `raw` field, because that is what Gmail's send endpoint takes. SMTP wants
   // the message itself and the envelope separately, so it is decoded back and

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -1041,6 +1041,67 @@ function decodeMailbox(name) {
   return out
 }
 
+// The other direction, for a name the user typed that is about to be sent in
+// CREATE or RENAME: printable US-ASCII passes through, "&" is spelled "&-",
+// and everything else goes into a base64 run of its UTF-16 code units with
+// "," standing in for "/" and no padding — RFC 3501 section 5.1.3. What comes
+// back from LIST decodes to the same text, and `tests/test_imap.js` holds the
+// round trip.
+function encodeMailbox(name) {
+  var text = String(name === undefined || name === null ? "" : name)
+  var out = ""
+  var run = ""
+  function flush() {
+    if (run === "") return
+    var bytes = []
+    for (var i = 0; i < run.length; i++) {
+      var code = run.charCodeAt(i)
+      bytes.push((code >> 8) & 0xff, code & 0xff)
+    }
+    var alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+,"
+    var encoded = ""
+    for (var b = 0; b < bytes.length; b += 3) {
+      var n = (bytes[b] << 16) | ((b + 1 < bytes.length ? bytes[b + 1] : 0) << 8)
+        | (b + 2 < bytes.length ? bytes[b + 2] : 0)
+      encoded += alphabet.charAt((n >> 18) & 63) + alphabet.charAt((n >> 12) & 63)
+      if (b + 1 < bytes.length) encoded += alphabet.charAt((n >> 6) & 63)
+      if (b + 2 < bytes.length) encoded += alphabet.charAt(n & 63)
+    }
+    out += "&" + encoded + "-"
+    run = ""
+  }
+  for (var at = 0; at < text.length; at++) {
+    var ch = text.charAt(at)
+    var code = text.charCodeAt(at)
+    if (code >= 0x20 && code <= 0x7e) {
+      flush()
+      out += ch === "&" ? "&-" : ch
+    } else {
+      run += ch
+    }
+  }
+  flush()
+  return out
+}
+
+// The three commands that change the folder list. A name the server already
+// has travels exactly as LIST spelled it — the wire name, encoded once by
+// the server — and a name the user typed is encoded here. Encoding a wire
+// name again turns its "&" into "&-" and names a folder that does not exist.
+// A RENAME carries every folder beneath the old name with it, which is what
+// moving a folder under another parent is.
+function createCommand(name) {
+  return "CREATE " + quote(encodeMailbox(name))
+}
+
+function renameCommand(fromWire, toName) {
+  return "RENAME " + quote(fromWire) + " " + quote(encodeMailbox(toName))
+}
+
+function deleteCommand(wireName) {
+  return "DELETE " + quote(wireName)
+}
+
 // The SPECIAL-USE attributes this plugin cares about, mapped to the folder the
 // server named. A server that advertises none leaves the map empty and
 // `resolveFolder` falls back to the plain word.

--- a/providers/Registry.js
+++ b/providers/Registry.js
@@ -68,6 +68,9 @@ function capabilities(values) {
     webBox: raw.webBox === true,
     // Free-text search the server runs.
     search: raw.search === true,
+    // The label or folder list can be changed from here: created, renamed,
+    // moved under another, deleted. HEY's labels are HEY's own.
+    manageLabels: raw.manageLabels === true,
     // Sends mail. A read-only provider still shows a reader; it just cannot
     // answer from it.
     send: raw.send === true
@@ -114,6 +117,7 @@ function define(source) {
     cachedSummaryInSearch: typeof raw.cachedSummaryInSearch === "function"
       ? raw.cachedSummaryInSearch : function() { return false },
     labelQuery: typeof raw.labelQuery === "function" ? raw.labelQuery : function() { return "" },
+    addressQuery: typeof raw.addressQuery === "function" ? raw.addressQuery : function() { return "" },
     // Where a message and a mailbox live on the web, for the provider that has
     // a web UI worth opening. A provider that declares no `web` capability
     // never reaches these, and answers "" if something asks anyway.
@@ -294,6 +298,12 @@ function cachedSummaryInSearch(id, sourceQuery, summary) {
 // own labels are — an operator for Gmail, a folder for IMAP.
 function labelQuery(id, name) {
   return get(id).labelQuery(name)
+}
+
+// The query that finds mail from, or to, one address on this provider, or ""
+// where the provider cannot ask that.
+function addressQuery(id, field, address) {
+  return get(id).addressQuery(field, address)
 }
 
 // What the unread badge counts. A lookup rather than a second definition that

--- a/tests/qml/tst_app_compose_pending.qml
+++ b/tests/qml/tst_app_compose_pending.qml
@@ -346,7 +346,23 @@ Item {
         "once the newer draft is durable, recovery follows the older failed draft")
     }
 
-    function test_open_previews_a_draft_and_compose_edits_it() {
+    // A click on a draft previews it, as a click does in every mailbox; the
+    // keys are what edit it.
+    function test_a_click_previews_a_draft() {
+      mailService.mailboxKey = "drafts"
+      app.openMessage("draft-7")
+      wait(30)
+      compare(mailService.selectedId, "draft-7")
+      compare(app.currentView, "reader")
+      compare(app.composing, false)
+      app.back()
+      mailService.mailboxKey = "inbox"
+    }
+
+    // In Drafts, opening a draft is editing it: `o` selects the draft and,
+    // once its body has loaded, the composer opens on it with what was
+    // written — no second key. `c` still does the same.
+    function test_open_edits_a_draft_once_its_body_has_loaded() {
       var compose = composeView()
       mailService.mailboxKey = "drafts"
       app.cursorId = "draft-7"
@@ -354,9 +370,7 @@ Item {
       app.runShortcut("open", "o")
 
       compare(mailService.selectedId, "draft-7")
-      compare(app.currentView, "reader",
-        "a draft opens in the same reader as every other message")
-      compare(app.composing, false)
+      compare(app.composing, false, "nothing to edit until the body is here")
 
       mailService.selectedMessage = ({
         id: "draft-7",
@@ -381,13 +395,7 @@ Item {
       mailService.detailLoading = false
       wait(30)
 
-      compare(app.composing, false,
-        "loading the draft body must not turn the preview into an editor")
-
-      app.runShortcut("compose", "c")
-      wait(30)
-
-      compare(app.composing, true)
+      compare(app.composing, true, "the loaded body opens the composer")
       compare(compose.mode, "draft")
       compare(compose.fromEmail, "me@example.com")
       compare(named(compose, "compose-to-field").text,

--- a/tests/qml/tst_label_ownership.qml
+++ b/tests/qml/tst_label_ownership.qml
@@ -1,0 +1,276 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../.." as Omamail
+import "../../account/Accounts.js" as Accounts
+
+// A label change goes to the account whose menu asked for it. Ada and Bob
+// both have a folder named Work — an IMAP id is a folder name, unique in one
+// account and no further — so a rename or a delete confirmed after the
+// window switched to Bob must still reach Ada's server and never Bob's, and
+// a switch closes the popups that were about Ada. The watched ids follow a
+// renamed folder to its new name, on to disk, and a deleted folder's watch
+// goes with it. The counts a poll asks for are bounded.
+Item {
+  width: 900
+  height: 600
+
+  QtObject {
+    id: shellStore
+    function updateEntryInline(_id, _entry) {}
+    function hide(_id) {}
+  }
+
+  QtObject {
+    id: record
+    property var renames: []
+    property var deletes: []
+    property var creates: []
+    property var listing: ({})
+    property string listingError: ""
+    property int inFlight: 0
+    property int mostInFlight: 0
+    property int counted: 0
+    function reset() { renames = []; deletes = []; creates = []; listing = {}; listingError = ""; inFlight = 0; mostInFlight = 0; counted = 0 }
+  }
+
+  Component {
+    id: controlledClient
+    QtObject {
+      property var auth: null
+      property string email: ""
+      function handle() { return ({ aborted: false }) }
+      function later(fn) { Qt.callLater(fn); return handle() }
+      function listMessages() { return handle() }
+      function getMessages() { return handle() }
+      function getMessage() { return handle() }
+      function trashMessage() { return handle() }
+      function untrashMessage() { return handle() }
+      function batchModify() { return handle() }
+      function modifyMessage() { return handle() }
+      function getLabels(callback) {
+        var mine = record.listing[email] || []
+        var refused = record.listingError
+        record.listingError = ""
+        return later(function() { callback(refused !== "" ? [] : mine, refused) })
+      }
+      function getLabelCounts(id, callback) {
+        record.inFlight++
+        if (record.inFlight > record.mostInFlight) record.mostInFlight = record.inFlight
+        return later(function() {
+          record.inFlight--
+          record.counted++
+          callback({ id: id, unread: 1, total: 1, threadsUnread: 1 }, "")
+        })
+      }
+      function getProfile(callback) { return later(function() { callback({ email: email }, "") }) }
+      function getSendAs(callback) { return later(function() { callback([], "") }) }
+      function getAttachment() { return handle() }
+      function saveDraft() { return handle() }
+      function deleteDraft() { return handle() }
+      function sendMessage() { return handle() }
+      function createLabel(name, callback) {
+        record.creates = record.creates.concat([email + ":" + name])
+        return later(function() { callback(null, "") })
+      }
+      function renameLabel(id, name, callback) {
+        record.renames = record.renames.concat([email + ":" + id + ">" + name])
+        return later(function() { callback(null, "") })
+      }
+      function deleteLabel(id, callback) {
+        record.deletes = record.deletes.concat([email + ":" + id])
+        return later(function() { callback(null, "") })
+      }
+      function abortRequest(h) { if (h) h.aborted = true }
+    }
+  }
+
+  Omamail.Service {
+    id: mailService
+    shell: shellStore
+    manifest: ({ id: "omamail", __sourceDir: "/tmp/omamail-test" })
+  }
+
+  Omamail.App { id: app; service: mailService }
+
+  TestCase {
+    name: "LabelOwnership"
+    when: windowShown
+
+    readonly property string ada: "ada@example.com"
+    readonly property string bob: "bob@example.com"
+    readonly property string adaId: "imap:ada@example.com"
+    readonly property string bobId: "imap:bob@example.com"
+
+    function entry(email, monitored) {
+      return {
+        email: email, provider: "imap", clientId: "", clientSecret: "",
+        imap: { imapHost: "imap.example.com", imapPort: 993, smtpHost: "smtp.example.com", smtpPort: 465,
+          username: email, aliases: [], insecure: false },
+        label: "", signature: "", monitored: monitored || []
+      }
+    }
+
+    function folder(id) { return ({ id: id, name: id, rawName: id, delimiter: "/", unread: 0, system: false }) }
+
+    function seed(entries, activeId) {
+      var list = Accounts.emptyList()
+      for (var i = 0; i < entries.length; i++) list = Accounts.add(list, entries[i])
+      list = Accounts.setActive(list, activeId)
+      mailService.activeIndex = -1
+      mailService.accountList = list
+      mailService.accountsLoaded = true
+      wait(0)
+      mailService.refreshCurrent()
+      for (var h = 0; h < entries.length; h++) {
+        var account = mailService.accountAt(h)
+        verify(account !== null)
+        account.clientOverride = controlledClient
+        account.auth.toolsChecked = true
+        account.auth.missingTools = []
+        account.auth.passwordChecked = true
+        account.auth.password = "test-password"
+        tryCompare(account, "ready", true)
+        // The stand-in says whose it is, so the record can tell the two apart.
+        account.api.email = entries[h].email
+        account.labels = [folder("Work"), folder("Work/2026"), folder("Receipts")]
+      }
+    }
+
+    function popup(name) {
+      function find(item) {
+        if (item.objectName === name) return item
+        var kids = item.children || []
+        for (var i = 0; i < kids.length; i++) { var f = find(kids[i]); if (f) return f }
+        return null
+      }
+      return find(app)
+    }
+
+    function switchTo(id) {
+      mailService.accountList = Accounts.setActive(mailService.accountList, id)
+      tryCompare(mailService, "activeAccountId", id)
+    }
+
+    function init() { record.reset(); app.resetNavigation() }
+
+    // The menu opens for Ada. The window switches to Bob — straight through
+    // the service, as a key would — and the popups close. The answers the
+    // prompt and the confirmation would have given still name Ada, and
+    // reach Ada's server alone.
+    function test_a_change_goes_to_the_account_whose_menu_asked() {
+      seed([entry(ada), entry(bob)], adaId)
+      var menu = popup("label-menu")
+      verify(menu !== null)
+      app.openLabelMenu("Work", "Work", 10, 10)
+      compare(menu.accountId, adaId)
+      tryCompare(menu, "opened", true)
+      switchTo(bobId)
+      tryCompare(menu, "opened", false, 1000, "a switch closes the menu")
+      app.labelNamed("rename", "Work", "Jobs", adaId)
+      tryCompare(record, "renames", [ada + ":Work>Jobs"])
+      app.confirmDelete({ kind: "label", labelId: "Work/2026", name: "Work/2026", accountId: adaId })
+      tryCompare(record, "deletes", [ada + ":Work/2026"])
+      app.labelNamed("create", "Receipts", "2026", adaId)
+      tryCompare(record, "creates", [ada + ":Receipts/2026"])
+      compare(mailService.activeAccountId, bobId, "Bob stayed open throughout")
+      for (var i = 0; i < record.renames.length; i++) verify(record.renames[i].indexOf(bob) < 0)
+    }
+
+    // The account the menu was about is gone: nothing is sent anywhere, and
+    // the open account says why.
+    function test_a_change_for_a_removed_account_goes_nowhere() {
+      seed([entry(ada), entry(bob)], bobId)
+      compare(mailService.renameLabel("Work", "Jobs", "imap:gone@example.com"), false)
+      compare(mailService.deleteLabel("Work", "imap:gone@example.com"), false)
+      wait(20)
+      compare(record.renames.length, 0)
+      compare(record.deletes.length, 0)
+      verify(mailService.accountAt(1).lastError.indexOf("no longer set up") >= 0, mailService.accountAt(1).lastError)
+    }
+
+    // A watch on Work/2026 follows the rename of Work to Jobs, into the
+    // account's entry and the file; a watch on a deleted folder is dropped.
+    function test_watched_ids_follow_a_rename_and_leave_with_a_delete() {
+      seed([entry(ada, ["Work/2026", "Receipts"])], adaId)
+      deepEqualIds(mailService.monitoredLabelIds, ["Work/2026", "Receipts"])
+      record.listing[ada] = [folder("Jobs"), folder("Jobs/2026"), folder("Receipts")]
+      verify(mailService.renameLabel("Work", "Jobs", adaId))
+      tryCompare(record, "renames", [ada + ":Work>Jobs"])
+      tryVerify(function() { return mailService.monitoredLabelIds.indexOf("Jobs/2026") >= 0 }, 1000)
+      deepEqualIds(mailService.monitoredLabelIds, ["Jobs/2026", "Receipts"])
+      deepEqualIds(Accounts.find(mailService.accountList, adaId).monitored, ["Jobs/2026", "Receipts"])
+      verify(mailService.accountsWritePayload.indexOf("Jobs/2026") >= 0, "and it is on its way to disk")
+      verify(mailService.accountsWritePayload.indexOf("Work/2026") < 0)
+
+      record.listing[ada] = [folder("Jobs"), folder("Jobs/2026")]
+      verify(mailService.deleteLabel("Receipts", adaId))
+      tryCompare(record, "deletes", [ada + ":Receipts"])
+      tryVerify(function() { return mailService.monitoredLabelIds.indexOf("Receipts") < 0 }, 1000)
+      deepEqualIds(mailService.monitoredLabelIds, ["Jobs/2026"])
+    }
+
+    // A name the list already has is refused before it reaches the server.
+    function test_a_name_already_taken_is_refused() {
+      seed([entry(ada)], adaId)
+      compare(mailService.renameLabel("Receipts", "Work", adaId), false)
+      compare(mailService.createLabel("", "Work", adaId), false)
+      compare(mailService.moveLabel("Receipts", "Work", adaId), true, "a name nobody has goes through")
+      wait(20)
+      compare(record.renames.length, 1)
+      compare(record.creates.length, 0)
+      verify(mailService.accountAt(0).lastError.indexOf("already a label named") >= 0
+        || mailService.accountAt(0).lastError === "", mailService.accountAt(0).lastError)
+    }
+
+    // The listing after a rename fails once: the watch waits, and follows
+    // with the listing that does land. Two changes before a listing are
+    // both applied.
+    function test_a_failed_listing_keeps_the_watch_waiting() {
+      seed([entry(ada, ["Work/2026", "Receipts"])], adaId)
+      record.listing[ada] = [folder("Jobs"), folder("Jobs/2026"), folder("Receipts")]
+      record.listingError = "the server hung up"
+      verify(mailService.renameLabel("Work", "Jobs", adaId))
+      tryCompare(record, "renames", [ada + ":Work>Jobs"])
+      tryVerify(function() { return mailService.monitoredLabelIds.indexOf("Jobs/2026") >= 0 }, 2000)
+      deepEqualIds(mailService.monitoredLabelIds, ["Jobs/2026", "Receipts"])
+
+      record.listing[ada] = [folder("Tasks"), folder("Tasks/2026")]
+      var account = mailService.accountAt(0)
+      account.labels = [folder("Jobs"), folder("Jobs/2026"), folder("Receipts")]
+      verify(mailService.renameLabel("Jobs", "Tasks", adaId))
+      verify(mailService.deleteLabel("Receipts", adaId))
+      tryVerify(function() { return mailService.monitoredLabelIds.indexOf("Tasks/2026") >= 0 }, 2000)
+      deepEqualIds(mailService.monitoredLabelIds, ["Tasks/2026"])
+    }
+
+    // A signed-out owner changes nothing, and says so.
+    function test_a_signed_out_owner_changes_nothing() {
+      seed([entry(ada), entry(bob)], adaId)
+      var bobs = mailService.accountAt(1)
+      bobs.auth.password = ""
+      bobs.auth.passwordChecked = true
+      bobs.clientOverride = null
+      tryCompare(bobs, "ready", false)
+      compare(mailService.renameLabel("Work", "Jobs", bobId), false)
+      wait(20)
+      compare(record.renames.length, 0)
+      verify(bobs.lastError.indexOf("signed out") >= 0, bobs.lastError)
+    }
+
+    // Five watched folders are counted three at a time, and all five are.
+    function test_the_counts_a_poll_asks_for_are_bounded() {
+      seed([entry(ada, ["a", "b", "c", "d", "e"])], adaId)
+      var account = mailService.accountAt(0)
+      account.labels = [folder("a"), folder("b"), folder("c"), folder("d"), folder("e")]
+      account.labelActions.refreshMonitored()
+      tryVerify(function() { return record.counted === 5 }, 1000)
+      verify(record.mostInFlight <= 3, "at most three at once: " + record.mostInFlight)
+      verify(record.mostInFlight >= 2, "and more than one: " + record.mostInFlight)
+      tryCompare(account.labelActions, "monitoredLoading", false)
+    }
+
+    function deepEqualIds(actual, expected) {
+      compare(JSON.stringify(actual), JSON.stringify(expected))
+    }
+  }
+}

--- a/tests/test_accounts.js
+++ b/tests/test_accounts.js
@@ -830,3 +830,19 @@ assert.strictEqual(nothingActive.activeId, "eve@example.com")
 // Out of range is no edit.
 assert.strictEqual(frozen(accounts.replaceAt(cidActive, 3, account("x@example.com"))), beforeReplace)
 assert.strictEqual(frozen(accounts.replaceAt(cidActive, -1, account("x@example.com"))), beforeReplace)
+// Monitored labels ride with the mailbox and survive its other edits.
+{
+  const watched = accounts.toggleMonitored(named, "me@gmail.com", "Label_7")
+  deepEqual(watched.accounts[0].monitored, ["Label_7"])
+  deepEqual(accounts.toggleMonitored(watched, "me@gmail.com", "Label_7").accounts[0].monitored, [],
+    "toggling again stops watching")
+  const two = accounts.toggleMonitored(watched, "me@gmail.com", "Label_9")
+  deepEqual(two.accounts[0].monitored, ["Label_7", "Label_9"])
+  deepEqual(accounts.setLabel(two, "me@gmail.com", "Work").accounts[0].monitored, ["Label_7", "Label_9"],
+    "naming the mailbox keeps what it watches")
+  deepEqual(accounts.toggleMonitored(two, "nobody@example.org", "x").accounts[0].monitored, ["Label_7", "Label_9"])
+  deepEqual(accounts.toggleMonitored(two, "me@gmail.com", "  ").accounts[0].monitored, ["Label_7", "Label_9"])
+  deepEqual(accounts.load(accounts.serialize(two)).accounts[0].monitored, ["Label_7", "Label_9"],
+    "and it is written to disk and read back")
+}
+

--- a/tests/test_accounts.js
+++ b/tests/test_accounts.js
@@ -846,3 +846,13 @@ assert.strictEqual(frozen(accounts.replaceAt(cidActive, -1, account("x@example.c
     "and it is written to disk and read back")
 }
 
+
+// An HTML signature sits beside the plain one and survives its edits.
+{
+  const rich = accounts.setSignatureHtml(named, "me@gmail.com", " <p>Ada</p> ")
+  assert.strictEqual(rich.accounts[0].signatureHtml, "<p>Ada</p>")
+  assert.strictEqual(accounts.setSignature(rich, "me@gmail.com", "Ada").accounts[0].signatureHtml, "<p>Ada</p>")
+  assert.strictEqual(accounts.setSignatureHtml(rich, "me@gmail.com", "").accounts[0].signatureHtml, "")
+  assert.strictEqual(accounts.load(accounts.serialize(rich)).accounts[0].signatureHtml, "<p>Ada</p>")
+}
+

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -868,4 +868,22 @@ assert.strictEqual(imap.decodeResponse("", mail.base64ToBytes, mail.bytesToLatin
 assert.strictEqual(imap.decodeResponse("abc", null, null), "",
   "no decoder is an empty response, not a crash")
 
+// A folder name the user typed goes out in modified UTF-7 and comes back the
+// same: the round trip through `decodeMailbox` is the whole assertion.
+assert.strictEqual(imap.encodeMailbox("Receipts"), "Receipts")
+assert.strictEqual(imap.encodeMailbox("Tom & Jerry"), "Tom &- Jerry")
+assert.strictEqual(imap.encodeMailbox("日本語"), "&ZeVnLIqe-")
+assert.strictEqual(imap.decodeMailbox(imap.encodeMailbox("日本語")), "日本語")
+assert.strictEqual(imap.decodeMailbox(imap.encodeMailbox("Tom & Jerry/2026")), "Tom & Jerry/2026")
+assert.strictEqual(imap.decodeMailbox(imap.encodeMailbox("Café ☕")), "Café ☕")
+assert.strictEqual(imap.encodeMailbox(""), "")
+assert.strictEqual(imap.createCommand("Archive/2026"), "CREATE \"Archive/2026\"")
+assert.strictEqual(imap.renameCommand("Old", "Archive/New"), "RENAME \"Old\" \"Archive/New\"")
+assert.strictEqual(imap.deleteCommand("A \"quoted\" one"), "DELETE \"A \\\"quoted\\\" one\"")
+assert.strictEqual(imap.createCommand("日本語"), "CREATE \"&ZeVnLIqe-\"")
+// A name the server listed goes back as listed; only the typed name is
+// encoded. Encoding "Entw&APw-rfe" again would name "Entw&-APw-rfe".
+assert.strictEqual(imap.deleteCommand("Entw&APw-rfe"), "DELETE \"Entw&APw-rfe\"")
+assert.strictEqual(imap.renameCommand("Entw&APw-rfe", "Entwürfe/Alt"), "RENAME \"Entw&APw-rfe\" \"Entw&APw-rfe/Alt\"")
+
 console.log("Imap.js ok")

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -398,6 +398,7 @@ deepEqual(message.draftFields({
   to: "first@example.com, second@example.com",
   cc: "copy@example.com",
   bcc: "hidden@example.com",
+  replyTo: "",
   subject: "Saved subject",
   body: "Saved body",
   threadId: "thread-7",
@@ -444,6 +445,71 @@ assert.ok(message.buildRawMessage({
   to: "jane@example.com", bcc: "hidden@example.com", body: "x"
 }).indexOf("Bcc: hidden@example.com\r\n") >= 0,
   "a mailto bcc has to leave as a Bcc header or it is not blind")
+assert.ok(message.buildRawMessage({
+  to: "jane@example.com", replyTo: "team@example.com", body: "x"
+}).indexOf("Reply-To: team@example.com\r\n") >= 0, "a reply-to leaves as its header")
+assert.ok(message.buildRawMessage({ to: "jane@example.com", body: "x" }).indexOf("Reply-To") < 0,
+  "and no header at all when none was given")
+{
+  const injected = message.buildRawMessage({
+    to: "jane@example.com", replyTo: "team@example.com\r\nBcc: attacker@example.net", body: "x"
+  })
+  assert.ok(injected.indexOf("\r\nBcc: attacker@example.net\r\n") < 0,
+    "a line break in the reply-to cannot smuggle a header")
+}
+// An HTML signature makes the message two readings and, with a picture, a
+// related part per picture: the text part still carries the plain signature,
+// the HTML part carries the markup with the picture by cid.
+{
+  const PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+  const signed = message.buildRawMessage({
+    to: "jane@example.com", subject: "Hi", body: "Hello <you>\n\nAda\nAnalyst",
+    signature: "Ada\nAnalyst",
+    signatureHtml: '<p><b>Ada</b><br>Analyst</p><p><img src="data:image/png;base64,' + PNG + '"></p>'
+  })
+  assert.ok(signed.indexOf("Content-Type: multipart/related;") > 0, "a picture makes it related")
+  assert.ok(signed.indexOf("Content-Type: multipart/alternative;") > 0)
+  assert.ok(signed.indexOf("Content-ID: <sig1@omamail>") > 0)
+  assert.ok(signed.indexOf("Content-Disposition: inline") > 0)
+  const html = Buffer.from(signed.split("Content-Type: text/html; charset=UTF-8\r\nContent-Transfer-Encoding: base64\r\n\r\n")[1].split("\r\n--")[0].replace(/\r\n/g, ""), "base64").toString("utf8")
+  assert.ok(html.indexOf("Hello &lt;you&gt;") >= 0, "the body is escaped in the HTML part")
+  assert.ok(html.indexOf("<b>Ada</b>") > 0, "and the signature markup replaces the plain signature")
+  assert.ok(html.indexOf('src="cid:sig1@omamail"') > 0)
+  assert.strictEqual(html.indexOf("data:"), -1)
+  assert.strictEqual((html.match(/Analyst/g) || []).length, 1, "the plain signature is not repeated under the markup")
+  // The two readings agree: a sign-off the writer removed is not put back
+  // in the HTML, the writer's own sign-off is the one replaced rather than a
+  // quoted copy, and a picture-only signature sits before the quote.
+  const removed = message.buildRawMessage({
+    to: "jane@example.com", body: "Hi Jane, thanks", signature: "Ada", signatureHtml: "<p><b>Ada</b></p>"
+  })
+  const removedHtml = Buffer.from(removed.split("Content-Type: text/html; charset=UTF-8\r\nContent-Transfer-Encoding: base64\r\n\r\n")[1].split("\r\n--")[0].replace(/\r\n/g, ""), "base64").toString("utf8")
+  assert.strictEqual(removedHtml.indexOf("<b>Ada</b>"), -1, "a removed sign-off stays removed")
+  const quoted = message.buildRawMessage({
+    to: "jane@example.com", body: "Thanks\n\nAda\n\n> hi\n> Ada", signature: "Ada", signatureHtml: "<p><b>Ada</b></p>"
+  })
+  const quotedHtml = Buffer.from(quoted.split("Content-Type: text/html; charset=UTF-8\r\nContent-Transfer-Encoding: base64\r\n\r\n")[1].split("\r\n--")[0].replace(/\r\n/g, ""), "base64").toString("utf8")
+  assert.ok(quotedHtml.indexOf("<b>Ada</b>") < quotedHtml.indexOf("&gt; hi"), "the writer's own sign-off is the one replaced")
+  assert.ok(quotedHtml.indexOf("&gt; Ada") > 0, "and the quoted copy stays quoted")
+  const picture = message.buildRawMessage({
+    to: "jane@example.com", body: "Thanks\n\n> hi", signature: "", signatureHtml: '<p><img src="data:image/png;base64,' + PNG + '"></p>'
+  })
+  const pictureHtml = Buffer.from(picture.split("Content-Type: text/html; charset=UTF-8\r\nContent-Transfer-Encoding: base64\r\n\r\n")[1].split("\r\n--")[0].replace(/\r\n/g, ""), "base64").toString("utf8")
+  assert.ok(pictureHtml.indexOf("<img") < pictureHtml.indexOf("&gt; hi"), "a picture signature sits before the quote")
+  const plainOnly = message.buildRawMessage({
+    to: "jane@example.com", body: "Hi\n\nAda", signature: "Ada", signatureHtml: "<p><b>Ada</b></p>"
+  })
+  assert.ok(plainOnly.indexOf("multipart/related") < 0, "no picture, no related part")
+  assert.ok(plainOnly.indexOf("multipart/alternative") > 0)
+  const withFile = message.buildRawMessage({
+    to: "jane@example.com", body: "Hi", signatureHtml: "<p>Ada</p>",
+    attachments: [{ filename: "a.txt", mimeType: "text/plain", data: "aGk=" }]
+  })
+  assert.ok(withFile.indexOf("multipart/mixed") > 0 && withFile.indexOf("multipart/alternative") > 0,
+    "an attachment wraps the signed body in mixed")
+  assert.ok(message.buildRawMessage({ to: "j@e.com", body: "Hi" }).indexOf("text/html") < 0,
+    "no signature markup, no HTML part, as before")
+}
 // A non-ASCII subject has to go back out as an encoded word or Gmail rejects
 // the whole raw message.
 assert.ok(raw.indexOf("Subject: =?UTF-8?B?" + Buffer.from("你好", "utf8").toString("base64") + "?=") >= 0)
@@ -1214,3 +1280,6 @@ assert.strictEqual(message.composeBody("   \n  ", "> quoted"), "\n\n> quoted")
 assert.strictEqual(message.composeBody("\n\n", ""), "")
 
 console.log("test_message.js ok")
+// A draft reopened from the server keeps the Reply-To it was saved with.
+assert.strictEqual(message.draftFields({ replyTo: { email: "team@example.com" }, to: [] }, "x").replyTo, "team@example.com")
+assert.strictEqual(message.draftFields({ replyTo: { email: "" }, to: [] }, "x").replyTo, "")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -1356,3 +1356,97 @@ const deep = { id: "m", a: { b: { c: { d: { e: 1 } } } } }
 const alsoDeep = { id: "m", a: { b: { c: { d: { e: 1 } } } } }
 assert.strictEqual(model.sameSummaries([deep], [alsoDeep]), false,
   "the comparison stops rather than following an unbounded structure")
+
+// ------------------------------------------------------------ label names
+{
+  assert.strictEqual(model.labelLeaf("Archive/2026/Q1", "/"), "Q1")
+  assert.strictEqual(model.labelLeaf("Receipts", "/"), "Receipts")
+  assert.strictEqual(model.labelParent("Archive/2026/Q1", "/"), "Archive/2026")
+  assert.strictEqual(model.labelParent("Receipts", "/"), "")
+  assert.strictEqual(model.labelPathJoin("Archive", " 2026 ", "/"), "Archive/2026")
+  assert.strictEqual(model.labelPathJoin("", "Receipts", "/"), "Receipts")
+  assert.strictEqual(model.labelPathJoin("a", "b", "."), "a.b")
+  assert.strictEqual(model.labelDelimiter({ delimiter: "." }), ".")
+  assert.strictEqual(model.labelDelimiter({}), "/")
+  assert.strictEqual(model.labelNameProblem("  ", "/"), "A label needs a name")
+  assert.strictEqual(model.labelNameProblem("a/b", "/").indexOf("cannot contain /") > 0, true)
+  assert.strictEqual(model.labelNameProblem("Receipts", "/"), "")
+
+  const labels = [
+    { id: "INBOX", name: "INBOX", system: true },
+    { id: "Archive", rawName: "Archive" },
+    { id: "Archive/2026", rawName: "Archive/2026" },
+    { id: "Archive/2026/Q1", rawName: "Archive/2026/Q1" },
+    { id: "Receipts", rawName: "Receipts" }]
+  deepEqual(model.labelMoveTargets(labels, "Archive/2026", "/").map(function (t) { return t.path }),
+    ["", "Receipts"], "not itself, not its children, not its current parent, never a system label")
+  deepEqual(model.labelMoveTargets(labels, "Receipts", "/").map(function (t) { return t.path }),
+    ["", "Archive", "Archive/2026", "Archive/2026/Q1"])
+  assert.strictEqual(model.labelMoveTargets(labels, "Receipts", "/")[0].name, "Top level")
+}
+
+assert.strictEqual(model.monitoredNote([{ name: "Receipts", delta: 3 }]), "3 new in Receipts")
+assert.strictEqual(model.monitoredNote([{ name: "A", delta: 1 }, { name: "B", delta: 4 }, { name: "C", delta: 2 }]),
+  "4 new in B, 2 new in C and 1 more")
+assert.strictEqual(model.monitoredNote([]), "")
+
+// ------------------------------------------------------------ label paths
+{
+  // A server with no hierarchy — IMAP's NIL delimiter, passed on as "" —
+  // has leaves only: nothing has a parent and nothing goes under anything.
+  assert.strictEqual(model.labelLeaf("a/b", ""), "a/b")
+  assert.strictEqual(model.labelParent("a/b", ""), "")
+  assert.strictEqual(model.labelPathJoin("", "a/b", ""), "a/b")
+  assert.strictEqual(model.labelNameProblem("a/b", ""), "", "a slash is only a slash")
+  assert.ok(model.labelNameProblem("a/b", "/").indexOf("cannot contain /") >= 0)
+  assert.strictEqual(model.labelNestProblem("", ""), "")
+  assert.strictEqual(model.labelNestProblem("Work", "/"), "")
+  assert.ok(model.labelNestProblem("Work", "").indexOf("flat list") >= 0)
+  deepEqual(model.labelMoveTargets([{ id: "a", name: "a" }, { id: "b", name: "b" }], "a", ""),
+    [{ id: "", name: "Top level", path: "" }], "nowhere to move to but where it is")
+  assert.strictEqual(model.labelLeaf("a.b", "."), "b")
+  assert.strictEqual(model.labelParent("a.b", "."), "a")
+  assert.strictEqual(model.labelLeaf("a.b", undefined), "a.b", "no word from the provider means a slash")
+  assert.strictEqual(model.labelPathJoin("a", "b", undefined), "a/b")
+}
+
+// ------------------------------------------------------------ watched ids
+{
+  // On IMAP a folder's id is its wire name: a rename changes it, and every
+  // folder beneath it. The watch follows to the id the fresh listing gives
+  // the same path.
+  const before = [
+    { id: "Work", name: "Work", delimiter: "/" }, { id: "Work/2026", name: "Work/2026", delimiter: "/" },
+    { id: "Work/2026/Q1", name: "Work/2026/Q1", delimiter: "/" }, { id: "Receipts", name: "Receipts", delimiter: "/" }]
+  const after = [
+    { id: "Jobs", name: "Jobs", delimiter: "/" }, { id: "Jobs/2026", name: "Jobs/2026", delimiter: "/" },
+    { id: "Jobs/2026/Q1", name: "Jobs/2026/Q1", delimiter: "/" }, { id: "Receipts", name: "Receipts", delimiter: "/" }]
+  deepEqual(model.migrateMonitoredIds(["Work", "Receipts", "Work/2026/Q1"], before, after, "Work", "Jobs", "/"),
+    ["Jobs", "Receipts", "Jobs/2026/Q1"])
+  deepEqual(model.migrateMonitoredIds(["Work/2026"], before, after, "Work", "Jobs", "/"), ["Jobs/2026"])
+  // A move: the same, with the new path under another parent.
+  const moved = [
+    { id: "Archive", name: "Archive", delimiter: "/" }, { id: "Archive/Work", name: "Archive/Work", delimiter: "/" },
+    { id: "Archive/Work/2026", name: "Archive/Work/2026", delimiter: "/" }, { id: "Receipts", name: "Receipts", delimiter: "/" }]
+  deepEqual(model.migrateMonitoredIds(["Work/2026", "Receipts"], before, moved, "Work", "Archive/Work", "/"),
+    ["Archive/Work/2026", "Receipts"])
+  // A watch on a folder the listing no longer has is dropped, deleted
+  // parent and children alike; the rest stay.
+  const gone = [{ id: "Receipts", name: "Receipts", delimiter: "/" }]
+  deepEqual(model.migrateMonitoredIds(["Work", "Work/2026", "Receipts"], before, gone, "Work", "", "/"), ["Receipts"])
+  // The same array back when nothing it held was touched: Gmail keeps its
+  // ids across a rename, and a watch on a folder beside the renamed one is
+  // not a change either.
+  const same = ["Receipts"]
+  assert.strictEqual(model.migrateMonitoredIds(same, before, after, "Work", "Jobs", "/"), same)
+  const gmail = [{ id: "Label_1", name: "Work" }, { id: "Label_2", name: "Work/2026" }]
+  const gmailAfter = [{ id: "Label_1", name: "Jobs" }, { id: "Label_2", name: "Jobs/2026" }]
+  const kept = ["Label_2"]
+  assert.strictEqual(model.migrateMonitoredIds(kept, gmail, gmailAfter, "Work", "Jobs", "/"), kept)
+  // With no hierarchy only the folder itself is renamed; "Work/2026" is
+  // another folder and stays watched under its own id.
+  const flatBefore = [{ id: "Work", name: "Work", delimiter: "" }, { id: "Work/2026", name: "Work/2026", delimiter: "" }]
+  const flatAfter = [{ id: "Jobs", name: "Jobs", delimiter: "" }, { id: "Work/2026", name: "Work/2026", delimiter: "" }]
+  deepEqual(model.migrateMonitoredIds(["Work", "Work/2026"], flatBefore, flatAfter, "Work", "Jobs", ""), ["Jobs", "Work/2026"])
+  deepEqual(model.migrateMonitoredIds(null, before, after, "Work", "Jobs", "/"), [])
+}

--- a/tests/test_provider.js
+++ b/tests/test_provider.js
@@ -37,6 +37,18 @@ assert.strictEqual(provider.exists("imap"), true)
 assert.strictEqual(provider.can("gmail", "labels"), true)
 assert.strictEqual(provider.can("imap", "labels"), false)
 assert.strictEqual(provider.can("outlook", "labels"), false)
+assert.strictEqual(provider.can("gmail", "manageLabels"), true)
+assert.strictEqual(provider.can("imap", "manageLabels"), true)
+assert.strictEqual(provider.can("hey", "manageLabels"), false, "HEY's labels are HEY's own")
+
+// Mail from or to an address, in each provider's own words.
+assert.strictEqual(provider.addressQuery("gmail", "from", "ada@example.com"), "from:ada@example.com")
+assert.strictEqual(provider.addressQuery("gmail", "to", " ada@example.com "), "to:ada@example.com")
+assert.strictEqual(provider.addressQuery("gmail", "from", "a b"), "", "a space would end the operator")
+assert.strictEqual(provider.addressQuery("imap", "from", "ada@example.com"), 'folder:INBOX FROM "ada@example.com"')
+assert.strictEqual(provider.addressQuery("imap", "to", 'a"b'), 'folder:INBOX TO "a\\"b"')
+assert.strictEqual(provider.addressQuery("hey", "to", "ada@example.com"), "search:ada@example.com")
+assert.strictEqual(provider.addressQuery("imap", "from", ""), "")
 
 // The operators people bring from webmail, in IMAP's words.
 assert.strictEqual(provider.query("imap", "inbox", "from: ada@example.com", ""),

--- a/tests/test_signature.js
+++ b/tests/test_signature.js
@@ -1,0 +1,99 @@
+const assert = require("assert")
+const { load, deepEqual } = require("./load")
+
+const signature = load("message/Signature.js")
+
+// One-pixel rasters, as base64.
+const PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+const GIF = "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+const SVG = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"></svg>').toString("base64")
+
+// A picture: only a real raster, by its bytes, within the cap.
+assert.strictEqual(signature.rasterKind(PNG), "image/png")
+assert.strictEqual(signature.rasterKind(GIF), "image/gif")
+assert.strictEqual(signature.rasterKind(SVG), "", "an SVG is a document, whatever it is named")
+assert.strictEqual(signature.rasterKind(""), "")
+{
+  const ok = signature.importImage(PNG)
+  assert.strictEqual(ok.problem, "")
+  assert.ok(ok.html.indexOf('<img src="data:image/png;base64,' + PNG + '"') > 0)
+  assert.ok(signature.importImage(SVG).problem.indexOf("not a PNG") >= 0)
+  assert.ok(signature.importImage(PNG, { maxImageBytes: 10 }).problem.indexOf("larger") >= 0)
+}
+
+// Markup: everything that could run, fetch or hide is gone; the words stay.
+{
+  const hostile = '<html><head><style>p{display:none}</style><script>alert(1)</script></head>'
+    + '<body><p onmouseover="steal()" style="color:red" class="x">Ada <b>Lovelace</b></p>'
+    + '<p style="background:url(https://evil.example.net/bg.png);color:blue">styled</p>'
+    + '<a href="javascript:alert(1)">click</a> <a href="https://example.com/x?y=1">site</a> '
+    + '<a href="http://127.0.0.1/admin">local</a> <a href="mailto:ada@example.com">mail</a>'
+    + '<img src="https://tracker.example.net/p.gif"><img src="data:image/png;base64,' + PNG + '" width="16" height="16" alt="logo">'
+    + '<img src="data:image/svg+xml;base64,' + SVG + '"><img src="data:image/png;base64,' + SVG + '">'
+    + '<iframe src="https://evil.example.net"></iframe><object data="x"></object><form action="https://evil.example.net"><input name="pw"></form>'
+    + '<div background="https://evil.example.net/bg.png">In a <span style="font-size:0">hidden</span> box</div>'
+    + '<table><tr><td colspan="2" bgcolor="#fff">cell</td></tr></table></body></html>'
+  const result = signature.importHtml(hostile)
+  assert.strictEqual(result.problem, "")
+  const html = result.html
+  const forbidden = ["<script", "<style", "onmouseover", "javascript:", "tracker.example.net", "127.0.0.1",
+    "svg", "<iframe", "<object", "<form", "<input", "background=", "url(", "evil.example.net", "font-size:0"]
+  forbidden.forEach(function (needle) {
+    assert.strictEqual(html.toLowerCase().indexOf(needle.toLowerCase()), -1, "must not survive: " + needle)
+  })
+  assert.ok(html.indexOf("Ada") >= 0 && html.indexOf("Lovelace") >= 0, "the words stay")
+  assert.ok(html.indexOf('style="color:red"') > 0, "the formatting stays: an inline colour")
+  assert.ok(html.indexOf("<b>Lovelace</b>") > 0)
+  assert.ok(html.indexOf('href="https://example.com/x?y=1"') > 0, "a public link stays")
+  assert.ok(html.indexOf('href="mailto:ada@example.com"') > 0, "a mailto stays")
+  assert.strictEqual((html.match(/<img /g) || []).length, 1, "only the real raster survives")
+  assert.ok(html.indexOf('width="16"') > 0 && html.indexOf('height="16"') > 0)
+  assert.strictEqual(result.images, 1)
+  assert.ok(result.dropped >= 6, "and the removals are counted: " + result.dropped)
+  assert.ok(result.plain.indexOf("Ada Lovelace") >= 0, "a text-only client gets the words")
+  assert.strictEqual(result.plain.indexOf("alert"), -1)
+  assert.strictEqual(html.indexOf("<"), 0, "what is stored is markup rebuilt from the tree")
+}
+
+// Formatting is what the file was imported for: colours, a face, a table.
+{
+  const styled = signature.importHtml('<table style="border:1px solid #ccc"><tr><td align="left"><font color="#333" face="Arial" size="2">Ada</font><br><span style="color:#888">Analyst</span></td></tr></table>')
+  assert.strictEqual(styled.problem, "")
+  assert.ok(styled.html.indexOf('color="#333"') > 0 && styled.html.indexOf('face="Arial"') > 0, "a font's colour and face stay")
+  assert.ok(styled.html.indexOf("color:#888") > 0, "an inline colour stays")
+  assert.ok(styled.html.indexOf("border:1px solid #ccc") > 0, "a border stays")
+  assert.strictEqual(styled.dropped, 0, "nothing needed removing")
+}
+
+// Nothing usable, and too big, are refused rather than stored empty.
+assert.ok(signature.importHtml("<script>x()</script>").problem.indexOf("Nothing") >= 0)
+assert.ok(signature.importHtml("x".repeat(300 * 1024)).problem.indexOf("too large") >= 0)
+assert.ok(signature.importHtml("").problem !== "")
+
+// Text with a break in it stays two lines, and a stored signature round-trips
+// through the importer unchanged in what it says.
+{
+  const first = signature.importHtml("<p>Ada Lovelace<br>Analyst</p>")
+  assert.strictEqual(first.problem, "")
+  assert.ok(first.plain.indexOf("Ada Lovelace") >= 0 && first.plain.indexOf("Analyst") >= 0)
+  const again = signature.importHtml(first.html)
+  assert.strictEqual(again.plain, first.plain)
+}
+
+// Sending: each data image becomes a cid part.
+{
+  const swapped = signature.inlineParts('<p><img src="data:image/png;base64,' + PNG + '"> and <img src="data:image/gif;base64,' + GIF + '"></p>', "sig")
+  assert.strictEqual(swapped.parts.length, 2)
+  assert.strictEqual(swapped.parts[0].cid, "sig1@omamail")
+  assert.strictEqual(swapped.parts[1].mimeType, "image/gif")
+  assert.ok(swapped.html.indexOf('src="cid:sig1@omamail"') > 0)
+  assert.strictEqual(swapped.html.indexOf("data:"), -1)
+  deepEqual(signature.inlineParts("<p>no images</p>").parts, [])
+}
+
+assert.strictEqual(signature.importNote({ problem: "", images: 1, dropped: 0 }), "Imported: 1 image")
+assert.strictEqual(signature.importNote({ problem: "", images: 0, dropped: 3 }), "Imported: 3 unsafe or unsupported parts removed")
+assert.strictEqual(signature.importNote({ problem: "", images: 0, dropped: 0 }), "Imported")
+assert.strictEqual(signature.importNote({ problem: "bad" }), "bad")
+
+console.log("test_signature.js ok")

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -125,7 +125,7 @@ grep -q 'remoteImageData: remoteImagesAllowed ? remoteImageData : null' account/
   || fail "Qt must receive prepared image bytes rather than a pending remote source"
 grep -q 'command: \["python3", pluginDir + "/scripts/image-fetch.py"\]' account/MailAccount.qml \
   || fail "remote images must use the public-IP-checked Python transport"
-grep -q 'command: \["python3", pluginDir + "/scripts/unsubscribe.py"\]' account/MailAccount.qml \
+grep -q 'command: \["python3", account.pluginDir + "/scripts/unsubscribe.py"\]' account/Unsubscribe.qml \
   || fail "one-click unsubscribe must use the public-IP-checked Python transport"
 # Redirect and DNS policy require behavioral tests, not a matching config line.
 


### PR DESCRIPTION
**Stacked on #113.** This branch contains label management, address shortcuts and monitoring from #113 plus the compose changes below. #109 and #112 have merged.

## What changes

- **Reply-To.** A toggle beside Cc and Bcc opens a Reply-To field. It is written as one folded header (a line break typed into it cannot start a second header), carried through drafts, send and local recovery, and comes back into the field when a draft is reopened from the server.
- **Drafts round-trip.** In Drafts, Enter, `o` and `c` open the selected draft in the composer with what was written; a click still previews. Leaving the composer saves back over the draft it came from, and the Drafts list is read again from the server so the replaced copy goes and the new one appears at once. Sending removes the draft it came from on Gmail (`drafts.delete`, found the way an update finds it) and IMAP (the same commands a save uses to remove the copy it replaced). HEY draft deletion is currently a success no-op and remains incomplete. A save or a send asks for the mailbox's credentials first rather than refusing a mailbox whose token was refused a moment ago.
- **Numpad Enter.** `Enter` opens and `Ctrl+Enter` sends, beside Return; the help sheet names the keycap once.
- **Signature from a file.** Settings imports a signature from a picture or an HTML file, with a preview and a note of what was removed.

## Security argument for the import

What is stored is never the file. A picture is checked to be the raster it claims by its first bytes — an SVG named `.png` is refused — and wrapped in one `<img src="data:…">` within a size cap. Markup goes through `Html.sanitize`, the gate the reader already trusts for a stranger's message, and is then walked once more by `message/Signature.js` against a short list of what can never be in a signature: script, style, iframe, frame, object, embed, form and every input, svg, template, link, meta, media; every `on*` handler and every attribute that names an address; every `href` that is not a public http(s) link or a mailto; every `src` that is not an inline raster; and every inline style that fetches (`url(`), runs (`expression(`, `behavior:`), or hides text (`display:none`, `visibility:hidden`, zero opacity or font size, negative indent). What the file carries as formatting — colours, faces, sizes, tables, alignment — is kept, because that is what the owner imported it for. The preview draws the stored markup: the sent thing.

`tests/test_signature.js` holds an adversarial fixture with a script, a style block, an event handler, a `javascript:` link, a loopback link, a tracking image, an SVG passed off as PNG, a frame, an object, a form, a `background=` URL, a `url()` in a style and a zero font size, and asserts none of it survives while the words, the public link, the mailto, the real raster and the formatting do.

## Sending

A message with an HTML signature goes as `multipart/alternative` (`text/plain`, `text/html`), inside `multipart/related` when the signature carries pictures, each picture a part by `cid:` — Gmail's web client draws no `data:` image in HTML mail. The HTML twin escapes the body paragraph by paragraph and puts the signature markup where the plain signature stands; a plain signature the writer took out of the body is not put back as markup, and a picture-only signature sits before the quote. `tests/test_message.js` covers the shapes.

## Verification

Reviewer `QT_QPA_PLATFORMTHEME= make validate` passed on `8c22860da25dd99995e279e673f67151c8c8bfdd`: JavaScript/shell checks, 492 QML cases, 4 native Outlook HTTP cases, 64 sidebar text cases, qmllint and plugin validation.

Reviewer re-review on `8c22860da25dd99995e279e673f67151c8c8bfdd` confirms the two previously reported signature defects remain: changing the selected account during an import writes to the later account, and HTML placement replaces the first matching substring rather than the actual sign-off. The actual SettingsPage ownership probe and Node greeting-placement assertion fail. Qt UTF-8 import and the actual hosted unsubscribe completion probe pass.

HEY's adapter discards Reply-To and HTML/CID signature content while the UI offers them; its new draft-delete method performs no server deletion. Provider capability handling and accurate UI wording remain necessary. No live HEY or other real mailbox was used by the reviewer.

This head retains #113's folder-identity and watch-migration blockers. Security: BLOCK. Before-and-after UI screenshots and a visible-difference explanation are missing; UI evidence: BLOCK. Product decisions for Reply-To, draft key behavior, rich signatures and inherited #113 features remain pending. Required manual light/dark wide/compact screen validation remains unverified. The former #109/#112 prerequisite fixes have merged.

## Release Notes

- Compose has a Reply-To field.
- A draft opens into the composer from Enter, `o` or `c`, and is saved back over itself; Gmail and IMAP drafts are removed after sending.
- The numpad's Enter works like Return.
- A signature can be imported from a picture or an HTML file, with the file's formatting kept and anything that could run, fetch or hide text removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8PEgfKnNP3iPhiDZGSbx6
