### PR TITLE
Add a JMAP provider, so a mailbox that offers it threads and searches on the server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,15 +222,25 @@ key. What matters while working:
 
 ## Providers
 
-- A mailbox is a **provider**: `gmail`, `hey`, or `imap`, listed in that order
-  because IMAP is the answer for a server the other two do not name and a
-  chooser that opened with it would ask the question backwards. `Provider.js` is
+- A mailbox is a **provider**: `gmail`, `hey`, `jmap`, or `imap`, listed in that
+  order because IMAP is the answer for a server the others do not name and a
+  chooser that opened with it would ask the question backwards. JMAP sits ahead
+  of it for the same reason: fewer servers speak it, so it is the more specific
+  answer. `Provider.js` is
   the only place that knows the differences — which mailboxes exist, what a query
   string means, what the service can be asked to do, and how it signs in.
   Nothing above it branches on a provider id.
 - Two objects make a provider work: something that signs in (`AuthManager`,
-  `HeyAuth`, `ImapAuth`) and something that fetches (`GmailApiClient`,
-  `HeyClient`, `ImapClient`).
+  `HeyAuth`, `JmapAuth`, `ImapAuth`) and something that fetches
+  (`GmailApiClient`, `HeyClient`, `JmapClient`, `ImapClient`).
+- A capability a provider declares is a **ceiling**, not a promise. `Imap.js`
+  declares `archive` true and lets the client find out whether the server has
+  anywhere to put it; `Jmap.js` does the same for `send`, `archive` and `spam`,
+  and its client withdraws what this account cannot do in `unsupported`, which
+  `MailAccount.accountRefuses` reads. Anything gating an action on a capability
+  must consult both — `refuseUnavailableAction` checked only the provider once,
+  and a key bound in every mail context then did what the hidden button would
+  not have.
   `MailAccount` builds one pair through a `Loader` and drives them through an
   identical interface — same method names, same arguments, same callback shape.
   Adding a provider is those two files and a registry entry.

--- a/App.qml
+++ b/App.qml
@@ -931,6 +931,21 @@ Item {
   }
 
   Component {
+    id: jmapSetupPage
+
+    JmapSetupPage {
+      service: root.service
+      textColor: root.foreground
+      dimColor: root.dim
+      dangerColor: root.danger
+      accentColor: root.accent
+      panelFontFamily: root.fontFamily
+      accountCount: root.service ? root.service.accountCount : 1
+      onRemoveRequested: root.removeCurrentAccountFromEditor()
+    }
+  }
+
+  Component {
     id: imapSetupPage
 
     ImapSetupPage {
@@ -1645,7 +1660,8 @@ Item {
             sourceComponent: root.showPicker
               ? providerPickerPage
               : (setup.kind === "imap" ? imapSetupPage
-                : (setup.kind === "hey" ? heySetupPage : gmailSetupPage))
+                : (setup.kind === "jmap" ? jmapSetupPage
+                : (setup.kind === "hey" ? heySetupPage : gmailSetupPage)))
           }
           }
         }

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	cache/CacheStore.qml cache/BodyCache.qml \
 	providers/AuthManager.qml providers/GmailApiClient.qml \
 	providers/ImapAuth.qml providers/ImapClient.qml \
+	providers/JmapAuth.qml providers/JmapClient.qml \
 	providers/HeyAuth.qml providers/HeyClient.qml \
-	components/ImapSetupPage.qml \
+	components/ImapSetupPage.qml components/JmapSetupPage.qml \
 	components/HeySetupPage.qml \
 	components/ProviderPicker.qml \
 	components/GmailIcon.qml \
@@ -95,6 +96,7 @@ test-js:
 	node tests/test_menu.js
 	node tests/test_provider.js
 	node tests/test_imap.js
+	node tests/test_jmap.js
 	node tests/test_hey.js
 
 test-shell: test-shell-portable test-shell-libcurl

--- a/Service.qml
+++ b/Service.qml
@@ -1083,6 +1083,7 @@ Item {
       // account's provider in the file rebuilds it as that provider.
       providerId: entry ? entry.provider : Provider.DEFAULT_ID
       imapSettings: entry ? entry.imap : null
+      jmapSettings: entry ? entry.jmap : null
       // Only a Gmail account has a client-keyed refresh token to inherit, and
       // only the first one may claim it.
       mayAdoptLegacyToken: index === 0 && (!entry || entry.provider === "gmail")

--- a/account/Accounts.js
+++ b/account/Accounts.js
@@ -77,7 +77,7 @@ function accountId(email, provider) {
 // anything written before providers existed — is Gmail: that is what every
 // account in an upgraded install actually is, and defaulting to it is what
 // stops an upgrade from presenting a working mailbox as unconfigured.
-var PROVIDERS = ["gmail", "hey", "imap"]
+var PROVIDERS = ["gmail", "hey", "jmap", "imap"]
 var DEFAULT_PROVIDER = "gmail"
 
 function normalizeProvider(value) {
@@ -122,6 +122,18 @@ function makeImapSettings(raw) {
 // Such an entry is kept — it holds the OAuth client or the server settings the
 // sign-in needs — but it is not addressable, and the guard in indexOfId is what
 // keeps it out of every lookup.
+// What a JMAP account needs, which is less than IMAP: one host, because the
+// session resource names the account, the API URL and the ports itself. The
+// token is the secret and lives in the keyring. A host here is not trusted —
+// `Jmap.isValidHost` checks it again before it can reach a URL.
+function makeJmapSettings(raw) {
+  var values = raw || {}
+  return {
+    host: trimmed(values.host),
+    username: trimmed(values.username)
+  }
+}
+
 function makeAccount(account) {
   var raw = account || {}
   var email = trimmed(raw.email)
@@ -133,6 +145,7 @@ function makeAccount(account) {
     clientId: trimmed(raw.clientId),
     clientSecret: trimmed(raw.clientSecret),
     imap: makeImapSettings(raw.imap),
+    jmap: makeJmapSettings(raw.jmap),
     label: trimmed(raw.label),
     signature: trimmed(raw.signature),
     // Whether this row is the setup form's working state rather than a
@@ -433,7 +446,9 @@ function carriesData(entry) {
   var raw = entry || {}
   if (trimmed(raw.id) !== "") return true
   var imap = raw.imap || {}
+  var jmap = raw.jmap || {}
   return trimmed(imap.username) !== "" || trimmed(imap.imapHost) !== ""
+    || trimmed(jmap.host) !== "" || trimmed(jmap.username) !== ""
     || trimmed(raw.clientId) !== "" || trimmed(raw.clientSecret) !== ""
 }
 

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -1332,9 +1332,14 @@ Item {
   // Every action moves the list immediately and reconciles afterwards. Waiting
   // for Google before the row moves makes the panel feel broken on a slow
   // connection, and the failure path puts the row back.
+  // `accountRefuses` as well as `Provider.can`: a provider may declare a
+  // capability as a ceiling and leave the real answer to the account, which is
+  // what a JMAP mailbox does for send, archive and the junk verb. Checking only
+  // the provider makes this guard a no-op for such an account, and the key
+  // binding then does what the hidden button would not have.
   function refuseUnavailableAction(action) {
     var needs = Model.actionCapability(action)
-    if (needs === "" || Provider.can(providerId, needs)) return false
+    if (needs === "" || (Provider.can(providerId, needs) && !accountRefuses(needs))) return false
     note(Model.actionUnavailable(action, Provider.badge(providerId)))
     return true
   }

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -50,6 +50,7 @@ Item {
   // Server settings for an IMAP account, straight off the account entry. Unused
   // by the others, and normalised before anything can dial one.
   property var imapSettings: null
+  property var jmapSettings: null
   // Only the mailbox that predates multi-account may claim the old
   // client-keyed refresh token. See AuthManager.mayAdoptLegacyToken.
   property bool mayAdoptLegacyToken: true
@@ -105,8 +106,19 @@ Item {
   // What the panel may offer for this account. A button the service cannot
   // honour is worse than a missing one: it fails after the user has committed
   // to it, with the row already moved.
+  // A provider states what its kind of mailbox can do; an account may still be
+  // less than that — a token scoped without send, a server with no Archive. A
+  // client that knows says so in `unsupported`; one that does not refuses
+  // nothing, so this reads the same on every provider.
+  function accountRefuses(capability) {
+    var refused = api && api.unsupported ? api.unsupported : []
+    return refused.indexOf(String(capability)) >= 0
+  }
+
   readonly property bool canArchive: Provider.can(providerId, "archive")
+    && !accountRefuses("archive")
   readonly property bool canReportSpam: Provider.can(providerId, "spam")
+    && !accountRefuses("spam")
   readonly property bool canStar: Provider.can(providerId, "star")
   readonly property bool hasLabels: Provider.can(providerId, "labels")
   readonly property bool canOpenOnWeb: Provider.can(providerId, "web")
@@ -114,6 +126,7 @@ Item {
   // filtered right now, has an address in the provider's web app at all.
   readonly property bool canOpenWebInbox: Provider.can(providerId, "webBox")
   readonly property bool canSend: Provider.can(providerId, "send")
+    && !accountRefuses("send")
   // The key-bound actions this mailbox cannot honour, for the hint row. The
   // buttons are hidden by the three properties above; the keys are bound
   // whatever provider is open, so the row that says what the keyboard does here
@@ -2471,7 +2484,8 @@ Item {
   Loader {
     id: authLoader
     sourceComponent: root.providerId === "imap" ? imapAuthComponent
-      : (root.providerId === "hey" ? heyAuthComponent : gmailAuthComponent)
+      : (root.providerId === "jmap" ? jmapAuthComponent
+      : (root.providerId === "hey" ? heyAuthComponent : gmailAuthComponent))
   }
 
   // The client takes the manager as a required property, so it cannot be built
@@ -2480,7 +2494,8 @@ Item {
     id: apiLoader
     active: !!authLoader.item
     sourceComponent: root.providerId === "imap" ? imapClientComponent
-      : (root.providerId === "hey" ? heyClientComponent : gmailClientComponent)
+      : (root.providerId === "jmap" ? jmapClientComponent
+      : (root.providerId === "hey" ? heyClientComponent : gmailClientComponent))
   }
 
   Component {
@@ -2525,6 +2540,24 @@ Item {
   }
 
   Component {
+    id: jmapAuthComponent
+
+    JmapAuth {
+      pluginDir: root.pluginDir
+      accountId: root.accountId
+      configuredHost: root.jmapSettings ? String(root.jmapSettings.host || "") : ""
+
+      onLoginSucceeded: {
+        root.lastError = lastError
+        root.afterSignIn()
+      }
+      onLoggedOut: root.clearNotice()
+      onCredentialsSaved: root.note("Mailbox saved")
+      onSessionUnavailable: function(reason) { root.fail(reason) }
+    }
+  }
+
+  Component {
     id: heyAuthComponent
 
     HeyAuth {
@@ -2549,6 +2582,11 @@ Item {
   Component {
     id: heyClientComponent
     HeyClient { auth: authLoader.item }
+  }
+
+  Component {
+    id: jmapClientComponent
+    JmapClient { auth: authLoader.item }
   }
 
   Component {
@@ -2617,6 +2655,16 @@ Item {
 
   // The unread count is one label read — cheap enough to keep running while
   // the panel is closed, which is the only way the bar badge stays honest.
+  // A client that can be told when the mailbox moved says so. Nothing here
+  // asks which provider that is: `ignoreUnknownSignals` means the clients with
+  // no such signal simply never fire it, and the poll timer below is what
+  // covers them — and covers this one whenever its connection is down.
+  Connections {
+    target: root.api
+    ignoreUnknownSignals: true
+    function onMailboxChanged() { root.refresh() }
+  }
+
   Timer {
     id: pollTimer
     interval: root.refreshIntervalSec * 1000

--- a/components/JmapSetupPage.qml
+++ b/components/JmapSetupPage.qml
@@ -1,0 +1,293 @@
+import QtQuick
+import qs.Commons
+import qs.Ui
+import "../providers/JmapProtocol.js" as Jmap
+import "../account/Accounts.js" as Accounts
+
+// Connecting a JMAP mailbox: an address, the server, and an API token.
+//
+// Shorter than the IMAP page next door, and not by omission. JMAP has one
+// endpoint rather than four, and the session resource reports the ports, the
+// account id and what the token is allowed to do — so there is nothing here
+// for the user to get wrong except the two things only they know.
+Column {
+  id: root
+
+  required property var service
+  required property color textColor
+  required property color dimColor
+  required property color dangerColor
+  required property color accentColor
+  required property string panelFontFamily
+  property int accountCount: 1
+  property bool tokenVisible: false
+
+  signal removeRequested()
+
+  readonly property var auth: service ? service.auth : null
+  readonly property bool signedIn: !!auth && auth.loggedIn
+  readonly property bool busy: !!auth && auth.loginBusy
+  readonly property bool toolsMissing: !!auth && auth.toolsChecked && auth.missingTools.length > 0
+
+  // What we know about the server the user named, which for a known host is
+  // where to mint the token.
+  readonly property var preset: Jmap.presetFor(hostField.text)
+
+  spacing: Style.space(16)
+
+  function validatedAddress() {
+    var address = String(addressField.text || "").trim()
+    if (!Accounts.isValidEmail(address)) {
+      errorText.text = "Enter the address of this mailbox"
+      return ""
+    }
+    return address
+  }
+
+  function settingsNow() {
+    return { host: Jmap.normalizeHost(hostField.text), username: String(addressField.text || "").trim() }
+  }
+
+  function save() {
+    if (!service) return
+    var address = validatedAddress()
+    if (address === "") return
+    if (!Jmap.isValidHost(hostField.text)) {
+      errorText.text = "Enter the address of the JMAP server"
+      return
+    }
+    errorText.text = ""
+    service.configureCurrentAccount({ provider: "jmap", email: address, jmap: settingsNow() })
+  }
+
+  function signIn() {
+    if (!service) return
+    var address = validatedAddress()
+    if (address === "") return
+    if (!Jmap.isValidHost(hostField.text)) {
+      errorText.text = "Enter the address of the JMAP server"
+      return
+    }
+    errorText.text = ""
+    service.configureCurrentAccountAndSignIn(
+      { provider: "jmap", email: address, jmap: settingsNow() }, tokenField.text)
+  }
+
+  function syncFromStore() {
+    if (!auth) return
+    addressField.text = service ? service.accountAddress : ""
+    if (auth.configuredHost !== "") hostField.text = auth.configuredHost
+  }
+
+  Component.onCompleted: syncFromStore()
+
+  Connections {
+    target: root.auth
+    ignoreUnknownSignals: true
+    function onLastErrorChanged() {
+      if (root.auth && root.auth.lastError !== "") errorText.text = root.auth.lastError
+    }
+  }
+
+  // ------------------------------------------------------------------ hero
+
+  Column {
+    width: parent.width
+    spacing: Style.space(4)
+
+    Text {
+      width: parent.width
+      text: "Add a JMAP mailbox"
+      color: root.textColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.heading
+      font.bold: true
+    }
+
+    Text {
+      width: parent.width
+      text: "Fastmail, or a server of your own that speaks JMAP. Threads, search and moves come from the server rather than being worked out here."
+      color: root.dimColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.bodySmall
+      wrapMode: Text.WordWrap
+    }
+  }
+
+  Rectangle {
+    width: parent.width
+    visible: root.toolsMissing
+    implicitHeight: missingText.implicitHeight + Style.space(20)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+    border.width: 1
+    border.color: Style.hoverBorderFor(root.textColor, root.accentColor)
+
+    Text {
+      id: missingText
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.margins: Style.space(12)
+      anchors.verticalCenter: parent.verticalCenter
+      text: root.auth
+        ? "Install " + root.auth.missingTools.join(", ")
+          + " first — they hold the token and talk to the server."
+        : ""
+      color: root.textColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.caption
+      wrapMode: Text.WordWrap
+    }
+  }
+
+  // -------------------------------------------------------------- the form
+
+  Column {
+    width: parent.width
+    spacing: Style.space(10)
+
+    TextField {
+      id: addressField
+      objectName: "jmap-address-field"
+      width: parent.width
+      foreground: root.textColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.bodySmall
+      placeholderText: "Email address — you@example.com"
+      onAccepted: hostField.forceActiveFocus()
+    }
+
+    TextField {
+      id: hostField
+      objectName: "jmap-host-field"
+      width: parent.width
+      foreground: root.textColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.bodySmall
+      // A custom domain on Fastmail is still Fastmail, and the address cannot
+      // say so — which is why this is asked rather than guessed.
+      placeholderText: "JMAP server — api.fastmail.com"
+      onAccepted: tokenField.forceActiveFocus()
+    }
+
+    // Where the token is minted, for a host we know. Nothing is fetched from
+    // the server to work this out; it is a fact about the service.
+    Rectangle {
+      width: parent.width
+      visible: !!root.preset
+      implicitHeight: noteColumn.implicitHeight + Style.space(20)
+      radius: Style.cornerRadius
+      color: Style.normalFillFor(root.textColor, root.accentColor)
+      border.width: 1
+      border.color: Style.hoverBorderFor(root.textColor, root.accentColor)
+
+      Column {
+        id: noteColumn
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.margins: Style.space(12)
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: Style.space(6)
+
+        Text {
+          width: parent.width
+          textFormat: Text.PlainText
+          text: root.preset
+            ? root.preset.label + " issues API tokens at " + root.preset.tokenHint
+              + ". Give it access to mail only."
+            : ""
+          color: root.textColor
+          font.family: root.panelFontFamily
+          font.pixelSize: Style.font.caption
+          wrapMode: Text.WordWrap
+        }
+
+        LinkLabel {
+          objectName: "jmap-token-guide"
+          visible: !!root.preset && root.preset.tokenUrl !== ""
+          text: "Create an API token..."
+          color: root.textColor
+          font.family: root.panelFontFamily
+          font.pixelSize: Style.font.caption
+          tooltipText: root.preset ? root.preset.tokenUrl : ""
+          onActivated: if (root.preset) Qt.openUrlExternally(root.preset.tokenUrl)
+        }
+      }
+    }
+
+    TextField {
+      id: tokenField
+      objectName: "jmap-token-field"
+      width: parent.width
+      visible: !root.signedIn
+      foreground: root.textColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.bodySmall
+      echoMode: root.tokenVisible ? TextInput.Normal : TextInput.Password
+      placeholderText: "API token"
+      onAccepted: root.signIn()
+    }
+
+    Text {
+      width: parent.width
+      visible: root.signedIn
+      text: "Signed in. The token is in the keyring; sign out to replace it."
+      color: root.dimColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.caption
+      wrapMode: Text.WordWrap
+    }
+
+    Text {
+      id: errorText
+      width: parent.width
+      visible: text !== ""
+      text: ""
+      color: root.dangerColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.caption
+      wrapMode: Text.WordWrap
+    }
+  }
+
+  Row {
+    spacing: Style.space(8)
+
+    Button {
+      visible: !root.signedIn
+      text: root.busy ? "Checking" : "Connect the mailbox"
+      enabled: !root.busy && addressField.text.trim() !== "" && tokenField.text !== ""
+      foreground: root.textColor
+      bordered: true
+      fontSize: Style.font.bodySmall
+      onClicked: root.signIn()
+    }
+
+    Button {
+      visible: root.signedIn
+      text: "Save changes"
+      foreground: root.textColor
+      bordered: true
+      fontSize: Style.font.bodySmall
+      onClicked: root.save()
+    }
+
+    Button {
+      visible: root.signedIn
+      text: "Sign out"
+      foreground: root.textColor
+      bordered: true
+      fontSize: Style.font.bodySmall
+      onClicked: if (root.service) root.service.signOut()
+    }
+
+    Button {
+      visible: root.accountCount > 1
+      text: "Remove account"
+      foreground: root.dangerColor
+      bordered: false
+      fontSize: Style.font.bodySmall
+      onClicked: root.removeRequested()
+    }
+  }
+}

--- a/components/JmapSetupPage.qml
+++ b/components/JmapSetupPage.qml
@@ -215,17 +215,42 @@ Column {
       }
     }
 
-    TextField {
-      id: tokenField
-      objectName: "jmap-token-field"
+    Item {
       width: parent.width
       visible: !root.signedIn
-      foreground: root.textColor
-      font.family: root.panelFontFamily
-      font.pixelSize: Style.font.bodySmall
-      echoMode: root.tokenVisible ? TextInput.Normal : TextInput.Password
-      placeholderText: "API token"
-      onAccepted: root.signIn()
+      implicitHeight: tokenField.implicitHeight
+
+      TextField {
+        id: tokenField
+        objectName: "jmap-token-field"
+        anchors.left: parent.left
+        anchors.right: parent.right
+        // Masked by default: this window is shoulder-surfable. Readable on
+        // demand, because an API token is a long opaque string nobody can
+        // check by eye after pasting it.
+        password: !root.tokenVisible
+        rightPadding: horizontalPadding + Style.space(26)
+        foreground: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        placeholderText: "API token"
+        onAccepted: root.signIn()
+      }
+
+      IconButton {
+        anchors.right: parent.right
+        anchors.rightMargin: Style.space(4)
+        anchors.verticalCenter: tokenField.verticalCenter
+        visible: tokenField.text !== ""
+        iconName: root.tokenVisible ? "eyeOff" : "eye"
+        tooltipText: root.tokenVisible ? "Hide the token" : "Show the token"
+        foreground: root.dimColor
+        hoverColor: root.textColor
+        iconSize: Style.font.iconSmall
+        size: Style.space(22)
+        fontFamily: root.panelFontFamily
+        onClicked: root.tokenVisible = !root.tokenVisible
+      }
     }
 
     Text {

--- a/providers/Credentials.js
+++ b/providers/Credentials.js
@@ -382,12 +382,26 @@ function legacyKeyringAttributes(clientId) {
 // are two entries rather than one overwriting the other.
 var IMAP_KEYRING_KIND = "imap-password"
 
+// A JMAP account keeps a bearer token rather than a password. Kept under a
+// kind of its own so a mailbox that is moved from IMAP to JMAP does not read
+// the old password back as a token.
+var JMAP_KEYRING_KIND = "jmap-token"
+
 function imapKeyringAttributes(accountId) {
   var id = accountKey(accountId)
   // As above: an empty attribute value is a wildcard to secret-tool, which
   // would hand back some other account's password. An account with no name yet
   // gets the literal placeholder, which no address can collide with.
   return ["service", KEYRING_SERVICE, "kind", IMAP_KEYRING_KIND,
+    "account", id || UNNAMED_ACCOUNT]
+}
+
+function jmapKeyringAttributes(accountId) {
+  var id = accountKey(accountId)
+  // As above: an empty attribute value is a wildcard to secret-tool, which
+  // would hand back some other account's password. An account with no name yet
+  // gets the literal placeholder, which no address can collide with.
+  return ["service", KEYRING_SERVICE, "kind", JMAP_KEYRING_KIND,
     "account", id || UNNAMED_ACCOUNT]
 }
 

--- a/providers/Jmap.js
+++ b/providers/Jmap.js
@@ -1,0 +1,93 @@
+.pragma library
+
+// What a JMAP mailbox is, as far as the panel is concerned.
+//
+// The protocol is `JmapProtocol.js` and the transport is `JmapClient.qml`.
+// This file answers the four questions `Registry.js` asks of every provider.
+//
+// It sits beside `imap` rather than replacing it. Both are protocols rather
+// than services, and most mailboxes still speak only the older one — but where
+// a server speaks JMAP, three of the compromises `Imap.js` documents stop
+// being necessary.
+
+var ID = "jmap"
+var NAME = "JMAP"
+var SUMMARY = "A mailbox that speaks JMAP — Fastmail, or a server of your own."
+var AUTH = "password"
+
+var CAPABILITIES = {
+  // A message is in a set of mailboxes and carries arbitrary keywords, so a
+  // labels-style reader is defensible. Not yet: Fastmail presents folders, and
+  // a reader that drew a label strip would draw an empty one.
+  labels: false,
+  // The reason to prefer this provider. `Imap.js` declares false and threads on
+  // References, which is what every IMAP client has to do; JMAP gives every
+  // message a server-side `threadId`.
+  threads: true,
+  // Only if the account has a mailbox with the Archive role, which the client
+  // learns from `Mailbox/get`. This is the ceiling, not the guarantee.
+  archive: true,
+  // The ceiling, not the guarantee. `Imap.js` refuses this outright because
+  // moving a message to a folder teaches an arbitrary server nothing, and a
+  // "Report spam" button that quietly means "move" is a promise a provider
+  // cannot keep. That is still true of a JMAP server we know nothing about —
+  // so the client withdraws it per account, from `JmapProtocol.junkTrains`,
+  // and only a host known to learn from its Junk mailbox keeps the button.
+  spam: true,
+  // `$flagged` is the keyword every JMAP server agrees on.
+  star: true,
+  move: true,
+  // Not a concession to batching but the shape of the protocol: a request is a
+  // list of method calls, and one `Email/set` moves as many messages as fit.
+  batch: true,
+  // `Email/query` filters server-side, so this is a real search rather than
+  // IMAP's TEXT criterion over headers and body.
+  search: true,
+  // The ceiling. Whether this account may actually send is a property of the
+  // token rather than of the protocol: a token minted without the submission
+  // scope reports `canSend: false` from the session, and the client answers
+  // accordingly rather than offering a button the server would refuse.
+  send: true,
+  // Still false, and not for want of knowing the address: `Registry.webMessageUrl`
+  // takes a provider id and a message id, with no account and therefore no host
+  // in scope. A generic JMAP provider cannot answer it honestly for one host
+  // and not another through that seam, and widening the seam for an "open in
+  // the browser" link is not worth what it would cost everything above it.
+  web: false,
+  webBox: false
+}
+
+// Roles, not folder names. RFC 8621 gives a mailbox an optional role, and
+// `JmapProtocol.filterFor` swaps the role for the id this account uses — the
+// same move `Imap.js` makes with its SPECIAL-USE placeholders, without needing
+// a fallback name, because a role is not a name a server may translate.
+var MAILBOXES = [
+  { key: "inbox", label: "Inbox", icon: "inbox", query: "role:inbox" },
+  { key: "unread", label: "Unread", icon: "unread", query: "role:inbox unread" },
+  { key: "starred", label: "Flagged", icon: "star", query: "role:inbox flagged" },
+  { key: "sent", label: "Sent", icon: "sent", query: "role:sent" },
+  { key: "drafts", label: "Drafts", icon: "compose", query: "role:drafts" },
+  { key: "archive", label: "Archive", icon: "archive", query: "role:archive", optional: true },
+  // Browsable as a mailbox even though `spam` is declared false: the capability
+  // is about offering a "Report spam" verb, not about being able to read the
+  // folder the server already files things into.
+  { key: "spam", label: "Junk", icon: "spam", query: "role:junk", optional: true },
+  { key: "trash", label: "Trash", icon: "trash", query: "role:trash", optional: true }
+]
+
+// The search box. `Email/query`'s `text` condition is what the user means by
+// typing words — the server decides what it matches — so unlike IMAP this
+// needs no argument about which headers count.
+//
+// JSON.stringify does the quoting because `JmapProtocol.parseQuery` reads the
+// same two escapes back out.
+function searchQuery(text) {
+  var value = String(text === undefined || text === null ? "" : text).trim()
+  return value === "" ? "" : "role:inbox text " + JSON.stringify(value)
+}
+
+// Choosing a mailbox in the sidebar, which is not a search for its name.
+function labelQuery(name) {
+  var value = String(name === undefined || name === null ? "" : name).trim()
+  return value === "" ? "" : "mailbox:" + JSON.stringify(value)
+}

--- a/providers/JmapAuth.qml
+++ b/providers/JmapAuth.qml
@@ -1,0 +1,292 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+import "JmapProtocol.js" as Jmap
+import "Credentials.js" as Credentials
+import "Secrets.js" as Secrets
+
+// A JMAP account's sign-in, which is a server address and an API token.
+//
+// The counterpart to `AuthManager` and `ImapAuth`, and deliberately the same
+// shape from outside: `MailAccount` asks any of them whether it is `loggedIn`
+// and asks for a credential with one call whose callback takes
+// `(value, error)`.
+//
+// Simpler than either. There is no browser and no refresh, because a token is
+// issued once by the user and lasts until they revoke it — and unlike a
+// password there is no username to pair it with, since the session resource
+// names the account itself.
+//
+// The token lives in GNOME Keyring, written over stdin so it never reaches the
+// process table, and keyed by account so two mailboxes cannot overwrite each
+// other.
+Item {
+  id: root
+
+  visible: false
+  width: 0
+  height: 0
+
+  required property string pluginDir
+
+  property string accountId: ""
+
+  // The server this account is on, as the user typed it. Normalised here
+  // rather than trusted, so a host from a hand-edited accounts.json passes the
+  // same check as one typed into the form.
+  property string configuredHost: ""
+  readonly property string host: Jmap.normalizeHost(configuredHost)
+  readonly property bool configured: Jmap.isValidHost(configuredHost)
+
+  // The token, once the keyring has answered. Held for as long as the account
+  // exists, exactly as the access token and the IMAP password are: every
+  // request needs it, and a keyring round trip per request would be slow and,
+  // on some setups, a stream of authorisation prompts.
+  property string token: ""
+  property bool tokenChecked: false
+  readonly property bool loggedIn: configured && token !== ""
+
+  // The names `MailAccount` reads without knowing which provider it holds.
+  readonly property bool credentialsPresent: configured
+  property bool loginBusy: false
+  readonly property bool sessionBusy: secretLookup.running || keyringStore.running
+  readonly property bool recoveringSession: configured && !tokenChecked
+  property string lastError: ""
+
+  // secret-tool keeps the token; curl is the client's transport for the parts
+  // that are not XHR. Neither is exotic, and both are checked before the setup
+  // page offers to save anything.
+  readonly property var requiredTools: ["secret-tool", "curl"]
+  property var missingTools: []
+  property bool toolsChecked: false
+  readonly property bool toolsPresent: toolsChecked && missingTools.length === 0
+
+  property var credentialWaiters: []
+  property bool lookupHandled: false
+  property string pendingToken: ""
+
+  signal loginSucceeded()
+  signal loggedOut()
+  signal sessionUnavailable(string reason)
+  signal credentialsSaved()
+
+  // The client owns the transport, so it performs the check and reports back
+  // through `completeSignIn`.
+  signal verifyRequested(string host, string token)
+
+  // A token is a bearer credential: anything holding it is the account. It must
+  // never reach an error string, which is shown on screen and may be copied
+  // into a bug report.
+  function safeError(value) {
+    var text = String(value || "")
+    if (root.pendingToken !== "") text = text.split(root.pendingToken).join("<token>")
+    if (root.token !== "") text = text.split(root.token).join("<token>")
+    return text
+  }
+
+  function finishWaiters(value, error) {
+    var pending = credentialWaiters.slice()
+    credentialWaiters = []
+    for (var i = 0; i < pending.length; i++) {
+      try { pending[i](value || "", safeError(error)) }
+      catch (e) { /* consumers own their callback errors */ }
+    }
+  }
+
+  // The one entry point the transport uses.
+  function withToken(callback) {
+    if (typeof callback !== "function") return
+    if (!configured) {
+      callback("", "Add this mailbox's server address first")
+      return
+    }
+    if (token !== "") {
+      callback(token, "")
+      return
+    }
+    if (tokenChecked) {
+      callback("", "No token saved for this mailbox. Sign in again")
+      return
+    }
+
+    var next = credentialWaiters.slice()
+    next.push(callback)
+    credentialWaiters = next
+    if (secretLookup.running) return
+    startSecretLookup()
+  }
+
+  function restoreSession() {
+    if (!configured) {
+      tokenChecked = true
+      return
+    }
+    if (secretLookup.running) return
+    startSecretLookup()
+  }
+
+  function startSecretLookup() {
+    var attributes = Credentials.jmapKeyringAttributes(accountId)
+    if (attributes.length === 0) {
+      handleSecretLookup("")
+      return
+    }
+    lookupHandled = false
+    secretLookup.command = ["secret-tool", "lookup"].concat(attributes)
+    secretLookup.running = true
+  }
+
+  function handleSecretLookup(line) {
+    if (lookupHandled) return
+    lookupHandled = true
+    tokenChecked = true
+    var value = String(line || "")
+    if (value === "") {
+      finishWaiters("", "No token saved for this mailbox. Sign in again")
+      // Only a mailbox otherwise ready to go is worth complaining about: an
+      // account still being typed into has no token by design.
+      if (configured) sessionUnavailable("Sign in to this mailbox")
+      return
+    }
+    token = value
+    finishWaiters(token, "")
+    loginSucceeded()
+  }
+
+  // Called by the setup page once the form is filled in. The token is verified
+  // by using it — a server that answers the session resource will answer
+  // everything else — rather than being written down first and failing later.
+  function signIn(secret) {
+    var value = String(secret || "").trim()
+    if (value === "") {
+      lastError = "Enter this mailbox's API token"
+      return false
+    }
+    if (!configured) {
+      lastError = "Enter the address of the JMAP server"
+      return false
+    }
+    lastError = ""
+    loginBusy = true
+    pendingToken = value
+    verifyRequested(host, value)
+    return true
+  }
+
+  function completeSignIn(ok, error) {
+    loginBusy = false
+    if (!ok) {
+      pendingToken = ""
+      lastError = safeError(error) || "The server refused that token"
+      return
+    }
+    token = pendingToken
+    pendingToken = ""
+    tokenChecked = true
+    lastError = ""
+    storeToken()
+    loginSucceeded()
+  }
+
+  function storeToken() {
+    var attributes = Credentials.jmapKeyringAttributes(accountId)
+    if (attributes.length === 0 || token === "") return
+    keyringWriteSecret = token
+    keyringStore.command = [pluginDir + "/scripts/keyring-store.sh"].concat(attributes)
+    keyringStore.running = true
+  }
+
+  property string keyringWriteSecret: ""
+
+  function logout() {
+    token = ""
+    pendingToken = ""
+    tokenChecked = true
+    var attributes = Credentials.jmapKeyringAttributes(accountId)
+    if (attributes.length > 0) {
+      keyringClear.command = ["secret-tool", "clear"].concat(attributes)
+      keyringClear.running = true
+    }
+    loggedOut()
+  }
+
+  // A token does not expire, so there is nothing to refresh — but a server that
+  // has started refusing it should not be asked a hundred more times with the
+  // same value.
+  function invalidateAccessToken() {
+    token = ""
+    tokenChecked = false
+  }
+
+  // The Gmail manager has these; a token account reaches neither, and
+  // `MailAccount` should not have to ask which provider it holds.
+  function beginLogin() { /* the setup form drives sign-in, not a browser */ }
+  function cancelLogin() { loginBusy = false }
+
+  onAccountIdChanged: {
+    // A different mailbox has a different token. Dropping the one in memory is
+    // what stops a rename from leaving the previous account's credential in
+    // front of the new one's server.
+    token = ""
+    tokenChecked = false
+    lookupHandled = false
+  }
+
+  Component.onCompleted: {
+    toolProbe.command = ["sh", "-c",
+      "for tool in secret-tool curl; do command -v \"$tool\" >/dev/null 2>&1 || echo \"$tool\"; done"]
+    toolProbe.running = true
+  }
+
+  Process {
+    id: toolProbe
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        var missing = String(text || "").split("\n")
+        var found = []
+        for (var i = 0; i < missing.length; i++) {
+          var name = missing[i].trim()
+          if (name) found.push(name)
+        }
+        root.missingTools = found
+        root.toolsChecked = true
+      }
+    }
+  }
+
+  Process {
+    id: secretLookup
+    stdout: StdioCollector { id: secretOutput; waitForEnd: true }
+    stderr: StdioCollector { waitForEnd: true }
+    onExited: function(exitCode) {
+      // One trailing newline is the pipe's; everything else is the secret.
+      var value = exitCode === 0 ? Secrets.fromKeyring(secretOutput.text) : ""
+      root.handleSecretLookup(value)
+    }
+  }
+
+  Process {
+    id: keyringStore
+    stdinEnabled: true
+    stdout: StdioCollector { waitForEnd: true }
+    stderr: StdioCollector { waitForEnd: true }
+    onStarted: {
+      write(root.keyringWriteSecret + "\n")
+      root.keyringWriteSecret = ""
+    }
+    onExited: function(exitCode) {
+      root.keyringWriteSecret = ""
+      if (exitCode !== 0)
+        root.lastError = "Signed in, but the token could not be saved. "
+          + "You may need to enter it again after a restart"
+    }
+  }
+
+  Process {
+    id: keyringClear
+    stdout: StdioCollector { waitForEnd: true }
+    stderr: StdioCollector { waitForEnd: true }
+  }
+}

--- a/providers/JmapClient.qml
+++ b/providers/JmapClient.qml
@@ -44,8 +44,13 @@ Item {
   // same engine is underneath here.
   readonly property int requestTimeoutMs: 30000
 
+  // No `children` list, unlike `GmailApiClient`: that one fans a page out into
+  // a metadata request per message and has to be able to abort the fan-out.
+  // Every chain here is sequential and threads one handle through, so a list
+  // of children would never be filled and would imply a cancellation shape
+  // this client does not have.
   function newHandle() {
-    return { aborted: false, timedOut: false, xhr: null, deadline: null, children: [] }
+    return { aborted: false, timedOut: false, xhr: null, deadline: null }
   }
 
   // Stopped and destroyed together, because a Timer that outlives its request
@@ -63,9 +68,6 @@ Item {
     clearDeadline(handle)
     if (handle.xhr && handle.xhr.abort) handle.xhr.abort()
     handle.xhr = null
-    var children = handle.children || []
-    for (var i = 0; i < children.length; i++) abortRequest(children[i])
-    handle.children = []
   }
 
   function parseJson(text) {
@@ -691,6 +693,19 @@ Item {
 
   function applyPlan(ids, plan, callback, existingHandle) {
     var handle = existingHandle || newHandle()
+    // Checked before the empty test, because an unresolvable move looks
+    // identical to an empty plan and must not be reported as done. Saying yes
+    // here moves the row out of the list and notes "Archived" for a request no
+    // server was ever sent.
+    if (Jmap.planUnresolved(plan)) {
+      if (typeof callback === "function") {
+        var missing = Jmap.roleName(plan.moveRole)
+        Qt.callLater(function() {
+          callback(false, "This mailbox has no " + missing + " folder to move it to")
+        })
+      }
+      return handle
+    }
     if (Jmap.planIsEmpty(plan) || !Array.isArray(ids) || ids.length === 0) {
       if (typeof callback === "function") Qt.callLater(function() { callback(true, "") })
       return handle
@@ -752,10 +767,16 @@ Item {
   }
 
   // An attachment is a blob like the message itself.
+  // The handle is threaded into the fetch rather than kept beside it: a handle
+  // that only guards the callback suppresses the answer while the request runs
+  // on, so closing the reader would leave a message download and a blob fetch
+  // in flight. `ImapClient.getAttachment` returns its `getMessage` handle for
+  // the same reason.
   function getAttachment(messageId, attachmentId, callback) {
     var handle = newHandle()
-    getMessage(messageId, true, function(message, error) {
+    getMessages([messageId], true, function(list, error) {
       if (!root || handle.aborted) return
+      var message = list && list.length > 0 ? list[0] : null
       if (error || !message) {
         if (typeof callback === "function") callback(null, error || "That message is no longer here")
         return
@@ -764,7 +785,7 @@ Item {
       if (typeof callback === "function")
         callback(part && part.body ? part.body.data : null,
           part ? "" : "That attachment is no longer on the message")
-    })
+    }, handle)
     return handle
   }
 

--- a/providers/JmapClient.qml
+++ b/providers/JmapClient.qml
@@ -1,0 +1,1116 @@
+import QtQuick
+import Quickshell.Io
+
+import "JmapProtocol.js" as Jmap
+import "../message/Message.js" as Mail
+
+// Authenticated transport for a JMAP account.
+//
+// It holds no state about the mailbox — only about requests in flight and the
+// session resource, which is a fact about the server rather than about what is
+// on screen — so the service can cancel a page load without knowing how it was
+// issued.
+//
+// Two things differ from `GmailApiClient.qml`, and both are the protocol
+// rather than a preference:
+//
+//   - Every call is a POST of the same shape to one URL. There are no paths,
+//     so nothing here builds one.
+//   - A 200 is not success. The reply carries a result per method call, and
+//     any of them may have failed on its own; `Jmap.methodError` reads that.
+Item {
+  id: root
+
+  visible: false
+  width: 0
+  height: 0
+
+  required property var auth
+
+  property int inFlight: 0
+  readonly property bool busy: inFlight > 0
+
+  // The session resource, once fetched. Null until the first request has been
+  // made, because there is nothing to ask for before an account is signed in.
+  property var session: null
+  readonly property bool ready: !!session && session.ok === true
+
+  // How long a request may hang before it is given up on.
+  //
+  // Qt's QML XMLHttpRequest has no `timeout` and no `ontimeout` — the
+  // properties do not exist, and assigning one is worse than useless because
+  // it reads back exactly what was written. A `Timer` calling `abort()` is the
+  // whole of what is available. This is measured in `GmailApiClient.qml`; the
+  // same engine is underneath here.
+  readonly property int requestTimeoutMs: 30000
+
+  function newHandle() {
+    return { aborted: false, timedOut: false, xhr: null, deadline: null, children: [] }
+  }
+
+  // Stopped and destroyed together, because a Timer that outlives its request
+  // is a timer that aborts the next one to reuse the object.
+  function clearDeadline(handle) {
+    if (!handle || !handle.deadline) return
+    handle.deadline.stop()
+    handle.deadline.destroy()
+    handle.deadline = null
+  }
+
+  function abortRequest(handle) {
+    if (!handle) return
+    handle.aborted = true
+    clearDeadline(handle)
+    if (handle.xhr && handle.xhr.abort) handle.xhr.abort()
+    handle.xhr = null
+    var children = handle.children || []
+    for (var i = 0; i < children.length; i++) abortRequest(children[i])
+    handle.children = []
+  }
+
+  function parseJson(text) {
+    try {
+      return JSON.parse(String(text || ""))
+    } catch (e) {
+      return null
+    }
+  }
+
+  // The one place an XHR is issued.
+  // `callback(status, payload, error, raw)` — `raw` is the untouched response
+  // text, because a downloaded message is RFC822 rather than JSON and parsing
+  // it as JSON would throw the whole body away.
+  function send(method, url, token, body, callback, handle, contentType) {
+    var xhr = new XMLHttpRequest()
+    handle.xhr = xhr
+
+    xhr.onreadystatechange = function() {
+      if (xhr.readyState !== XMLHttpRequest.DONE) return
+      // The account this client belongs to can be removed while a request is
+      // still in the air; the reply then arrives for an object that is gone.
+      if (!root) return
+      if (handle.xhr === xhr) handle.xhr = null
+      if (handle.aborted) {
+        root.inFlight = Math.max(0, root.inFlight - 1)
+        return
+      }
+      root.clearDeadline(handle)
+      root.inFlight = Math.max(0, root.inFlight - 1)
+
+      var payload = root.parseJson(xhr.responseText)
+      var ok = xhr.status >= 200 && xhr.status < 300
+      if (!ok) {
+        // An aborted request arrives here exactly as a failed one does:
+        // `abort()` drives readyState to DONE with status 0. All the timeout
+        // has to do is say which of the two silences this was.
+        var failure = handle.timedOut
+          ? "The server did not answer in time"
+          : Jmap.responseError(xhr.status, payload, "The server could not be reached")
+        if (typeof callback === "function") callback(xhr.status, payload, failure, "")
+        return
+      }
+      if (typeof callback === "function") callback(xhr.status, payload, "", xhr.responseText)
+    }
+
+    xhr.open(String(method || "GET"), String(url))
+    xhr.setRequestHeader("Authorization", "Bearer " + token)
+    xhr.setRequestHeader("Accept", "application/json")
+
+    // Armed around the send rather than around the whole call: everything
+    // before this was local, and the wait being bounded is the wait on the
+    // network.
+    root.clearDeadline(handle)
+    handle.deadline = deadlineComponent.createObject(root, { interval: root.requestTimeoutMs })
+    if (handle.deadline) {
+      handle.deadline.triggered.connect(function() {
+        if (!root || handle.aborted) return
+        handle.timedOut = true
+        if (handle.xhr && handle.xhr.abort) handle.xhr.abort()
+      })
+      handle.deadline.start()
+    }
+
+    if (body !== undefined && body !== null) {
+      // A blob upload is the message's own bytes under its own type; anything
+      // else is a JMAP request, which is JSON.
+      var raw = String(contentType || "")
+      if (raw !== "") {
+        xhr.setRequestHeader("Content-Type", raw)
+        xhr.send(String(body))
+      } else {
+        xhr.setRequestHeader("Content-Type", "application/json")
+        xhr.send(JSON.stringify(body))
+      }
+    } else {
+      xhr.send()
+    }
+  }
+
+  // ----------------------------------------------------------- the session
+
+  // Fetched once and kept. It carries the account id every later call needs,
+  // the URL they are posted to, and whether this server can send or push at
+  // all — so a panel never offers a verb the token was not scoped for.
+  //
+  // `callback(session, error)`.
+  function withSession(callback, existingHandle) {
+    var handle = existingHandle || newHandle()
+    if (root.ready) {
+      if (typeof callback === "function") callback(root.session, "")
+      return handle
+    }
+
+    auth.withToken(function(token, tokenError) {
+      if (!root) return
+      if (handle.aborted) return
+      if (!token) {
+        if (typeof callback === "function") callback(null, tokenError || "Not signed in")
+        return
+      }
+
+      var url = Jmap.sessionUrl(auth.host)
+      if (url === "") {
+        if (typeof callback === "function") callback(null, "This mailbox has no server address")
+        return
+      }
+
+      root.inFlight++
+      root.send("GET", url, token, null, function(status, payload, error) {
+        if (!root) return
+        if (error) {
+          if (typeof callback === "function") callback(null, error)
+          return
+        }
+        var parsed = Jmap.parseSession(payload, auth.host)
+        if (!parsed.ok) {
+          if (typeof callback === "function") callback(null, parsed.error)
+          return
+        }
+        root.session = parsed
+        if (typeof callback === "function") callback(parsed, "")
+      }, handle)
+    })
+
+    return handle
+  }
+
+  // Discards the cached session, so the next call fetches it again. Used when
+  // a token is replaced: the account id and the scopes may both differ.
+  function forgetSession() {
+    root.session = null
+    root.mailboxesKnown = false
+    root.knownRoles = ({})
+    root.knownNames = ({})
+    root.knownMailboxes = []
+  }
+
+  // ------------------------------------------------------------ method calls
+
+  // Posts an assembled request and hands back the whole body. A 200 whose
+  // methodResponses contain a failed call is reported as that failure, because
+  // every caller above would otherwise have to check for it and one of them
+  // would forget.
+  //
+  // `callback(body, error)`.
+  function call(request, callback, existingHandle) {
+    var handle = existingHandle || newHandle()
+
+    withSession(function(session, sessionError) {
+      if (!root || handle.aborted) return
+      if (!session) {
+        if (typeof callback === "function") callback(null, sessionError)
+        return
+      }
+      auth.withToken(function(token, tokenError) {
+        if (!root || handle.aborted) return
+        if (!token) {
+          if (typeof callback === "function") callback(null, tokenError || "Not signed in")
+          return
+        }
+        root.inFlight++
+        root.send("POST", session.apiUrl, token, request, function(status, payload, error) {
+          if (!root) return
+          if (error) {
+            // A token revoked between the session fetch and this call leaves a
+            // cached session for an account we can no longer reach.
+            if (status === 401) root.forgetSession()
+            if (typeof callback === "function") callback(null, error)
+            return
+          }
+          var failed = Jmap.methodError(payload)
+          if (failed !== "") {
+            if (typeof callback === "function") callback(null, failed)
+            return
+          }
+          if (typeof callback === "function") callback(payload, "")
+        }, handle)
+      })
+    }, handle)
+
+    return handle
+  }
+
+  // ------------------------------------------------------------------ reads
+
+  // Mailbox ids must be known before a query naming a role can become a
+  // filter, and on a cold client they are not. This fetches them once; every
+  // later page carries `Mailbox/get` along and keeps them current.
+  //
+  // `callback(error)`.
+  function withMailboxes(callback, existingHandle) {
+    var handle = existingHandle || newHandle()
+    if (root.mailboxesKnown) {
+      if (typeof callback === "function") callback("")
+      return handle
+    }
+    withSession(function(session, sessionError) {
+      if (!root || handle.aborted) return
+      if (!session) {
+        if (typeof callback === "function") callback(sessionError)
+        return
+      }
+      root.call(Jmap.mailboxesRequest(session.accountId), function(body, error) {
+        if (!root || handle.aborted) return
+        if (error) {
+          if (typeof callback === "function") callback(error)
+          return
+        }
+        var boxes = Jmap.responseFor(body, "mailboxes")
+        root.rememberMailboxes(boxes ? (boxes.payload.list || []) : [])
+        if (typeof callback === "function") callback("")
+      }, handle)
+    }, handle)
+    return handle
+  }
+
+  // A page of a mailbox: what mailboxes exist, which messages match, and the
+  // headers of those messages — in one round trip, because the fetch names the
+  // query's result rather than waiting for it.
+  //
+  // `callback(result, error)` where result is
+  // `{ mailboxes, messages, total, position, state }`.
+  function page(query, limit, position, callback, existingHandle) {
+    var handle = existingHandle || newHandle()
+
+    withMailboxes(function(mailboxError) {
+      if (!root || handle.aborted) return
+      if (mailboxError) {
+        if (typeof callback === "function") callback(null, mailboxError)
+        return
+      }
+
+      var parsed = Jmap.parseQuery(query)
+      var filter = Jmap.filterFor(parsed, root.mailboxIndex())
+      if (filter === null) {
+        // A mailbox this account does not have is an empty list, not an error:
+        // the sidebar offers Archive and Junk to every account, and a server
+        // need not have either.
+        if (typeof callback === "function")
+          callback({ mailboxes: root.knownMailboxes, messages: [], total: 0,
+                     position: 0, state: "" }, "")
+        return
+      }
+
+      root.call(Jmap.pageRequest(root.session.accountId, filter, limit, position),
+        function(body, error) {
+          if (!root || handle.aborted) return
+          if (error) {
+            if (typeof callback === "function") callback(null, error)
+            return
+          }
+          var boxes = Jmap.responseFor(body, "mailboxes")
+          var matched = Jmap.responseFor(body, "query")
+          var messages = Jmap.responseFor(body, "messages")
+          if (boxes) root.rememberMailboxes(boxes.payload.list || [])
+          if (typeof callback !== "function") return
+          callback({
+            mailboxes: root.knownMailboxes,
+            messages: messages ? (messages.payload.list || []) : [],
+            total: matched && typeof matched.payload.total === "number" ? matched.payload.total : 0,
+            position: matched && typeof matched.payload.position === "number" ? matched.payload.position : 0,
+            state: messages ? String(messages.payload.state || "") : ""
+          }, "")
+        }, handle)
+    }, handle)
+
+    return handle
+  }
+
+  // What changed since a state string, for the poll. The reply is small when
+  // nothing has, which is what makes polling a stage rather than a placeholder.
+  //
+  // `callback({ created, updated, destroyed, newState, hasMore }, error)`.
+  function changes(sinceState, callback, existingHandle) {
+    var handle = existingHandle || newHandle()
+
+    withSession(function(session, sessionError) {
+      if (!root || handle.aborted) return
+      if (!session) {
+        if (typeof callback === "function") callback(null, sessionError)
+        return
+      }
+      root.call(Jmap.changesRequest(session.accountId, sinceState),
+        function(body, error) {
+          if (!root || handle.aborted) return
+          if (error) {
+            if (typeof callback === "function") callback(null, error)
+            return
+          }
+          var moved = Jmap.responseFor(body, "changes")
+          var created = Jmap.responseFor(body, "created")
+          if (typeof callback !== "function") return
+          if (!moved) {
+            callback(null, "The server did not say what had changed")
+            return
+          }
+          callback({
+            created: created ? (created.payload.list || []) : [],
+            createdIds: moved.payload.created || [],
+            updated: moved.payload.updated || [],
+            destroyed: moved.payload.destroyed || [],
+            newState: String(moved.payload.newState || ""),
+            hasMore: moved.payload.hasMoreChanges === true
+          }, "")
+        }, handle)
+    }, handle)
+
+    return handle
+  }
+
+  // --------------------------------------------------------------- mailboxes
+
+  // Mailbox ids by role and by name, which is what a query is resolved
+  // against. Kept on the client rather than in the protocol module because it
+  // is per-account state, and the protocol module is a pure library the node
+  // tests load without a compositor.
+  property var knownRoles: ({})
+  property var knownNames: ({})
+  property var knownMailboxes: []
+  // Distinct from "knownMailboxes is empty": an account really can have no
+  // mailbox with a role, and retrying the fetch on every page would be a round
+  // trip per keystroke.
+  property bool mailboxesKnown: false
+
+  function mailboxIndex() {
+    return { roles: root.knownRoles, names: root.knownNames }
+  }
+
+  function rememberMailboxes(list) {
+    var roles = {}
+    var names = {}
+    var boxes = Array.isArray(list) ? list : []
+    for (var i = 0; i < boxes.length; i++) {
+      var box = boxes[i] || {}
+      var id = String(box.id || "")
+      if (id === "") continue
+      var role = String(box.role || "")
+      if (role !== "") roles[role] = id
+      var name = String(box.name || "")
+      if (name !== "") names[name] = id
+    }
+    root.knownRoles = roles
+    root.knownNames = names
+    root.knownMailboxes = boxes
+    root.mailboxesKnown = true
+  }
+
+  // ------------------------------------------------- the panel's interface
+  //
+  // From here down is the shape `GmailApiClient` wears and `ImapClient` copies:
+  // `MailAccount` calls these without knowing which provider it holds.
+
+  // Rows already fetched by the last page. `listMessages` hands the panel a
+  // list of ids and the panel immediately asks for those same messages, so
+  // without this the one round trip the page request saved would be spent
+  // again on the very next call.
+  // What this *account* cannot do, whatever the provider declares. The
+  // provider states a ceiling; only the session knows whether this token was
+  // scoped to send, and only the server knows whether it has an Archive
+  // mailbox or a Junk one that learns.
+  //
+  // `MailAccount` reads it without asking which provider it holds: a client
+  // that has no such property simply refuses nothing.
+  readonly property var unsupported: {
+    var out = []
+    if (!root.ready) return out
+    // A token minted without the submission scope would otherwise be offered a
+    // Send button the server refuses.
+    if (!root.session.canSend) out.push("send")
+    // Moving to Junk teaches an arbitrary server nothing.
+    if (!root.session.junkTrains) out.push("spam")
+    // A server need not have somewhere to archive to.
+    if (root.mailboxesKnown && !root.knownRoles["archive"]) out.push("archive")
+    return out
+  }
+
+  property var rowCache: ({})
+
+  function cacheRows(list) {
+    var next = {}
+    var entries = Array.isArray(list) ? list : []
+    for (var i = 0; i < entries.length; i++) {
+      var id = String(entries[i].id || "")
+      if (id !== "") next[id] = entries[i]
+    }
+    root.rowCache = next
+  }
+
+  function rolesById() {
+    var out = {}
+    for (var role in root.knownRoles) {
+      if (root.knownRoles.hasOwnProperty(role)) out[root.knownRoles[role]] = role
+    }
+    return out
+  }
+
+  function listMessages(query, maxResults, pageToken, callback, progress) {
+    var limit = Math.max(1, Math.min(100, Math.floor(Number(maxResults)) || 25))
+    var offset = Math.max(0, Math.floor(Number(pageToken)) || 0)
+
+    return page(query, limit, offset, function(result, error) {
+      if (typeof callback !== "function") return
+      if (error) {
+        callback(null, error)
+        return
+      }
+      root.cacheRows(result.messages)
+      var ids = []
+      var threadIds = []
+      for (var i = 0; i < result.messages.length; i++) {
+        ids.push(String(result.messages[i].id || ""))
+        threadIds.push(String(result.messages[i].threadId || ""))
+      }
+      var next = offset + ids.length
+      callback({
+        ids: ids,
+        // Unlike IMAP, these are the server's own conversation ids rather than
+        // an empty list the reader has to reconstruct from References.
+        threadIds: threadIds,
+        nextPageToken: ids.length > 0 && next < result.total ? String(next) : "",
+        estimate: result.total
+      }, "")
+    })
+  }
+
+  // Headers come from the page that already fetched them; a body does not, and
+  // is the raw message so `Message.parseRfc822` reads it exactly as it reads
+  // IMAP's.
+  function getMessages(ids, full, callback, existingHandle, progress) {
+    var handle = existingHandle || newHandle()
+    var wanted = Array.isArray(ids) ? ids : []
+    if (wanted.length === 0) {
+      if (typeof callback === "function") Qt.callLater(function() { callback([], "") })
+      return handle
+    }
+
+    var missing = []
+    for (var i = 0; i < wanted.length; i++) {
+      if (!root.rowCache[wanted[i]]) missing.push(wanted[i])
+    }
+
+    function deliver(rows) {
+      if (!root || handle.aborted) return
+      if (typeof callback !== "function") return
+      if (!full) {
+        callback(Jmap.messagesFrom(rows, root.rolesById()), "")
+        return
+      }
+      root.withBodies(rows, callback, handle, progress)
+    }
+
+    if (missing.length === 0) {
+      var cached = []
+      for (var j = 0; j < wanted.length; j++) cached.push(root.rowCache[wanted[j]])
+      // Still asynchronous: a caller that got its answer before it had finished
+      // setting itself up would be a different kind of bug on every provider.
+      Qt.callLater(function() { deliver(cached) })
+      return handle
+    }
+
+    withSession(function(session, sessionError) {
+      if (!root || handle.aborted) return
+      if (!session) {
+        if (typeof callback === "function") callback(null, sessionError)
+        return
+      }
+      root.call(Jmap.getRequest(session.accountId, wanted), function(body, error) {
+        if (!root || handle.aborted) return
+        if (error) {
+          if (typeof callback === "function") callback(null, error)
+          return
+        }
+        var found = Jmap.responseFor(body, "messages")
+        var rows = found ? (found.payload.list || []) : []
+        deliver(rows)
+      }, handle)
+    }, handle)
+
+    return handle
+  }
+
+  // One download per message, which is what opening a message costs on IMAP
+  // too. Fetched in sequence rather than at once: a thread of twenty is twenty
+  // whole messages, and firing them together is how a home connection stalls.
+  function withBodies(rows, callback, handle, progress) {
+    var out = []
+    var index = 0
+
+    function next() {
+      if (!root || handle.aborted) return
+      if (index >= rows.length) {
+        if (typeof callback === "function") callback(out, "")
+        return
+      }
+      var row = rows[index]
+      index++
+      var url = Jmap.downloadUrlFor(root.session, row.blobId, "message/rfc822", "message.eml")
+      if (url === "") {
+        out.push(Jmap.messageFrom(row, root.rolesById()))
+        next()
+        return
+      }
+      auth.withToken(function(token, tokenError) {
+        if (!root || handle.aborted) return
+        if (!token) {
+          if (typeof callback === "function") callback(null, tokenError || "Not signed in")
+          return
+        }
+        root.inFlight++
+        root.send("GET", url, token, null, function(status, payload, error, raw) {
+          if (!root || handle.aborted) return
+          if (error) {
+            if (typeof callback === "function") callback(null, error)
+            return
+          }
+          var message = Jmap.messageFrom(row, root.rolesById())
+          // The raw message replaces the synthesised headers with the real
+          // ones, and brings the parts, attachments and calendar entries with
+          // it. The snippet JMAP already sent is kept: it is the server's own.
+          var parsed = Mail.parseRfc822(String(raw || ""))
+          if (parsed) message.payload = parsed
+          out.push(message)
+          if (typeof progress === "function") progress(out.length, rows.length)
+          next()
+        }, handle)
+      })
+    }
+
+    next()
+    return handle
+  }
+
+  function getMessage(id, full, callback) {
+    return getMessages([id], full, function(list, error) {
+      if (typeof callback !== "function") return
+      if (error) callback(null, error)
+      else callback(list && list.length > 0 ? list[0] : null, "")
+    })
+  }
+
+  // The mailboxes, in the shape the sidebar reads labels in.
+  //
+  // This asks the server every time rather than serving `knownMailboxes`. The
+  // ids in that cache are stable and worth keeping — a mailbox does not change
+  // id — but the counts on it are a snapshot of whenever it was filled, and a
+  // sidebar showing a number that stopped moving an hour ago is worse than one
+  // that costs a round trip. `Mailbox/get` is a single cheap call.
+  function getLabels(callback) {
+    var handle = newHandle()
+    withSession(function(session, sessionError) {
+      if (!root || handle.aborted) return
+      if (typeof callback !== "function") return
+      if (!session) {
+        callback([], sessionError)
+        return
+      }
+      root.call(Jmap.mailboxesRequest(session.accountId), function(body, error) {
+        if (!root || handle.aborted) return
+        if (typeof callback !== "function") return
+        if (error) {
+          callback([], error)
+          return
+        }
+        var found = Jmap.responseFor(body, "mailboxes")
+        var boxes = found ? (found.payload.list || []) : []
+        // Refreshes the id map too, so the two never disagree about what
+        // exists.
+        root.rememberMailboxes(boxes)
+        var out = []
+        for (var i = 0; i < boxes.length; i++) {
+          var box = boxes[i] || {}
+          out.push({
+            id: String(box.id || ""),
+            name: String(box.name || ""),
+            rawName: String(box.name || ""),
+            role: String(box.role || ""),
+            unread: typeof box.unreadEmails === "number" ? box.unreadEmails : 0,
+            total: typeof box.totalEmails === "number" ? box.totalEmails : 0
+          })
+        }
+        callback(out, "")
+      }, handle)
+    }, handle)
+    return handle
+  }
+
+  function getLabelCounts(labelId, callback) {
+    return getLabels(function(list, error) {
+      if (typeof callback !== "function") return
+      if (error) {
+        callback(null, error)
+        return
+      }
+      for (var i = 0; i < list.length; i++) {
+        if (list[i].id === String(labelId)) {
+          callback({ unread: list[i].unread, total: list[i].total }, "")
+          return
+        }
+      }
+      callback({ unread: 0, total: 0 }, "")
+    })
+  }
+
+  // The session already names the account, so this costs nothing.
+  function getProfile(callback) {
+    return withSession(function(session, error) {
+      if (typeof callback !== "function") return
+      if (!session) {
+        callback(null, error)
+        return
+      }
+      callback({
+        email: session.username,
+        messagesTotal: 0,
+        threadsTotal: 0,
+        historyId: session.state
+      }, "")
+    })
+  }
+
+  // ----------------------------------------------------------------- writes
+
+  function applyPlan(ids, plan, callback, existingHandle) {
+    var handle = existingHandle || newHandle()
+    if (Jmap.planIsEmpty(plan) || !Array.isArray(ids) || ids.length === 0) {
+      if (typeof callback === "function") Qt.callLater(function() { callback(true, "") })
+      return handle
+    }
+    withSession(function(session, sessionError) {
+      if (!root || handle.aborted) return
+      if (!session) {
+        if (typeof callback === "function") callback(false, sessionError)
+        return
+      }
+      root.call(Jmap.updateRequest(session.accountId, ids, plan), function(body, error) {
+        if (!root || handle.aborted) return
+        if (typeof callback !== "function") return
+        if (error) {
+          callback(false, error)
+          return
+        }
+        var reply = Jmap.responseFor(body, "update")
+        var failures = reply ? Jmap.setFailures(reply.payload) : []
+        if (failures.length > 0) {
+          // A batch can half succeed, so the count is the honest answer rather
+          // than a flat failure that would put every row back.
+          callback(false, failures.length + " of " + ids.length
+            + " could not be changed: " + (failures[0].description || failures[0].type))
+          return
+        }
+        // The rows we hold are now stale in exactly the way we just asked for.
+        root.rowCache = ({})
+        callback(true, "")
+      }, handle)
+    }, handle)
+    return handle
+  }
+
+  function modifyMessage(id, addLabelIds, removeLabelIds, callback) {
+    return batchModify([id], addLabelIds, removeLabelIds, callback)
+  }
+
+  function batchModify(ids, addLabelIds, removeLabelIds, callback) {
+    var handle = newHandle()
+    withMailboxes(function(error) {
+      if (!root || handle.aborted) return
+      if (error) {
+        if (typeof callback === "function") callback(false, error)
+        return
+      }
+      root.applyPlan(ids, Jmap.planFromLabels(addLabelIds, removeLabelIds, root.knownRoles),
+        callback, handle)
+    }, handle)
+    return handle
+  }
+
+  function trashMessage(id, callback) {
+    return batchModify([id], ["TRASH"], [], callback)
+  }
+
+  function untrashMessage(id, callback) {
+    return batchModify([id], [], ["TRASH"], callback)
+  }
+
+  // An attachment is a blob like the message itself.
+  function getAttachment(messageId, attachmentId, callback) {
+    var handle = newHandle()
+    getMessage(messageId, true, function(message, error) {
+      if (!root || handle.aborted) return
+      if (error || !message) {
+        if (typeof callback === "function") callback(null, error || "That message is no longer here")
+        return
+      }
+      var part = Mail.partForAttachment(message.payload, attachmentId)
+      if (typeof callback === "function")
+        callback(part && part.body ? part.body.data : null,
+          part ? "" : "That attachment is no longer on the message")
+    })
+    return handle
+  }
+
+  // ------------------------------------------------------------------ sending
+  //
+  // JMAP has no method that takes a finished message and sends it: a
+  // submission names an `Email` the server already holds. So the raw message
+  // the panel built is uploaded as a blob, imported into the account, and then
+  // submitted — three round trips where SMTP takes one.
+  //
+  // Worth it for the same reason the read path downloads raw:
+  // `Message.buildRawMessage` already produces a correct message, attachments
+  // and alternatives included, and rebuilding that as a structured `Email`
+  // would be a second implementation of MIME that could disagree with the
+  // first.
+
+  property var identities: []
+
+  function withIdentities(callback, existingHandle) {
+    var handle = existingHandle || newHandle()
+    if (root.identities.length > 0) {
+      if (typeof callback === "function") callback(root.identities, "")
+      return handle
+    }
+    withSession(function(session, sessionError) {
+      if (!root || handle.aborted) return
+      if (!session) {
+        if (typeof callback === "function") callback([], sessionError)
+        return
+      }
+      if (!session.canSend) {
+        if (typeof callback === "function")
+          callback([], "This token was not given permission to send mail")
+        return
+      }
+      root.call(Jmap.identitiesRequest(session.accountId), function(body, error) {
+        if (!root || handle.aborted) return
+        if (error) {
+          if (typeof callback === "function") callback([], error)
+          return
+        }
+        var found = Jmap.responseFor(body, "identities")
+        root.identities = found ? (found.payload.list || []) : []
+        if (typeof callback === "function") callback(root.identities, "")
+      }, handle)
+    }, handle)
+    return handle
+  }
+
+  // The addresses this mailbox may send as, in the shape Gmail's endpoint
+  // returns so nothing above the provider has to know the difference.
+  function getSendAs(callback) {
+    return withIdentities(function(list, error) {
+      if (typeof callback !== "function") return
+      if (error) {
+        // Not a failure worth stopping on: a mailbox that cannot send still
+        // shows the address it receives at.
+        callback([{ email: root.session ? root.session.username : "", name: "",
+                    isDefault: true, isPrimary: true }], "")
+        return
+      }
+      callback(Jmap.identitiesFrom(list), "")
+    })
+  }
+
+  // The message's own bytes, under their own type. The reply names the blob
+  // every later call refers to.
+  function uploadRaw(message, callback, handle) {
+    var url = Jmap.uploadUrlFor(root.session)
+    if (url === "") {
+      if (typeof callback === "function") callback("", "This server does not accept uploads")
+      return
+    }
+    auth.withToken(function(token, tokenError) {
+      if (!root || handle.aborted) return
+      if (!token) {
+        if (typeof callback === "function") callback("", tokenError || "Not signed in")
+        return
+      }
+      root.inFlight++
+      root.send("POST", url, token, message, function(status, payload, error) {
+        if (!root || handle.aborted) return
+        if (typeof callback !== "function") return
+        if (error) {
+          callback("", error)
+          return
+        }
+        var blobId = payload && payload.blobId ? String(payload.blobId) : ""
+        callback(blobId, blobId === "" ? "The server did not accept the message" : "")
+      }, handle, "message/rfc822")
+    })
+  }
+
+  // Upload, then import into a mailbox. `callback(emailId, error)`.
+  function importRaw(payload, mailboxRole, asDraft, callback, handle) {
+    var raw = payload && payload.raw ? String(payload.raw) : ""
+    if (raw === "") {
+      if (typeof callback === "function") callback("", "There is nothing to send")
+      return
+    }
+    var message = Mail.decodeBase64Url(raw)
+
+    withMailboxes(function(mailboxError) {
+      if (!root || handle.aborted) return
+      if (mailboxError) {
+        if (typeof callback === "function") callback("", mailboxError)
+        return
+      }
+      root.uploadRaw(message, function(blobId, uploadError) {
+        if (!root || handle.aborted) return
+        if (uploadError) {
+          if (typeof callback === "function") callback("", uploadError)
+          return
+        }
+        // A server with no mailbox for this role still imports; the message
+        // simply lands nowhere the sidebar names, which beats refusing to send.
+        var box = String(root.knownRoles[mailboxRole] || "")
+        root.call(Jmap.importRequest(root.session.accountId, blobId, box, asDraft),
+          function(body, error) {
+            if (!root || handle.aborted) return
+            if (typeof callback !== "function") return
+            if (error) {
+              callback("", error)
+              return
+            }
+            var reply = Jmap.responseFor(body, "import")
+            var refused = reply ? Jmap.createError(reply.payload, "draft") : ""
+            if (refused !== "") {
+              callback("", refused)
+              return
+            }
+            var emailId = reply ? Jmap.createdId(reply.payload, "draft") : ""
+            callback(emailId, emailId === "" ? "The server did not keep the message" : "")
+          }, handle)
+      }, handle)
+    }, handle)
+  }
+
+  function saveDraft(payload, callback) {
+    var handle = newHandle()
+    importRaw(payload, "drafts", true, function(emailId, error) {
+      if (!root || handle.aborted) return
+      if (error) {
+        if (typeof callback === "function") callback(null, error)
+        return
+      }
+      // A draft that replaced an earlier one leaves the earlier one behind
+      // unless it is said so.
+      var previous = payload && payload.draftId ? String(payload.draftId) : ""
+      if (previous === "" || previous === emailId) {
+        if (typeof callback === "function") callback({ id: emailId, draftId: emailId }, "")
+        return
+      }
+      root.call(Jmap.destroyRequest(root.session.accountId, [previous]), function() {
+        if (typeof callback === "function") callback({ id: emailId, draftId: emailId }, "")
+      }, handle)
+    }, handle)
+    return handle
+  }
+
+  function sendMessage(payload, callback) {
+    var handle = newHandle()
+
+    withIdentities(function(list, identityError) {
+      if (!root || handle.aborted) return
+      if (identityError) {
+        if (typeof callback === "function") callback(null, identityError)
+        return
+      }
+      var identity = Jmap.pickIdentity(list, root.session ? root.session.username : "")
+      if (!identity) {
+        if (typeof callback === "function")
+          callback(null, "This mailbox has no address it may send from")
+        return
+      }
+
+      // Imported without `$draft`: the submission is what files it, and a send
+      // that fails should not leave something looking like a draft nobody wrote.
+      root.importRaw(payload, "drafts", false, function(emailId, importError) {
+        if (!root || handle.aborted) return
+        if (importError) {
+          if (typeof callback === "function") callback(null, importError)
+          return
+        }
+        var sent = String(root.knownRoles["sent"] || "")
+        root.call(Jmap.submitRequest(root.session.accountId, identity.id, emailId, sent),
+          function(body, error) {
+            if (!root || handle.aborted) return
+            if (typeof callback !== "function") return
+            if (error) {
+              callback(null, error)
+              return
+            }
+            var reply = Jmap.responseFor(body, "submit")
+            var refused = reply ? Jmap.createError(reply.payload, "send") : ""
+            if (refused !== "") {
+              callback(null, refused)
+              return
+            }
+            // The sent copy is now somewhere the inbox listing does not know
+            // about, and the draft it was is gone.
+            root.rowCache = ({})
+            var draftId = payload && payload.draftId ? String(payload.draftId) : ""
+            if (draftId !== "") {
+              root.call(Jmap.destroyRequest(root.session.accountId, [draftId]), function() {
+                callback({ id: emailId, threadId: payload ? payload.threadId : "" }, "")
+              }, handle)
+              return
+            }
+            callback({ id: emailId, threadId: payload ? payload.threadId : "" }, "")
+          }, handle)
+      }, handle)
+    }, handle)
+
+    return handle
+  }
+
+  // A token is verified by using it: a server that answers the session
+  // resource will answer everything else. Nothing is written to the keyring
+  // before this comes back, so a mistyped token fails in the form rather than
+  // silently later.
+  function verifyCredentials(host, token, callback) {
+    var handle = newHandle()
+    var url = Jmap.sessionUrl(host)
+    if (url === "") {
+      if (typeof callback === "function")
+        Qt.callLater(function() { callback(false, "That is not a server address") })
+      return handle
+    }
+    root.inFlight++
+    root.send("GET", url, token, null, function(status, payload, error) {
+      if (!root) return
+      if (typeof callback !== "function") return
+      if (error) {
+        callback(false, error)
+        return
+      }
+      var parsed = Jmap.parseSession(payload, host)
+      if (!parsed.ok) {
+        callback(false, parsed.error)
+        return
+      }
+      // Kept, so the first page after sign-in does not fetch it again.
+      root.session = parsed
+      callback(true, "")
+    }, handle)
+    return handle
+  }
+
+  Connections {
+    target: root.auth
+    function onVerifyRequested(host, token) {
+      root.verifyCredentials(host, token, function(ok, error) {
+        if (root.auth) root.auth.completeSignIn(ok, error)
+      })
+    }
+  }
+
+  // ------------------------------------------------------------------- push
+  //
+  // A held-open connection the server writes to when something moves. It does
+  // not replace the panel's refresh timer — a server may offer no event source,
+  // and a held connection drops — it only makes that timer's work happen sooner.
+  //
+  // `MailAccount` connects to this without knowing which provider it holds:
+  // the clients that cannot push simply never emit it.
+  signal mailboxChanged()
+
+  property bool pushEnabled: true
+  property int pushAttempts: 0
+  property string pushRequest: ""
+  readonly property bool pushing: pushStream.running
+
+  function startPush() {
+    if (!root.pushEnabled || !root.ready) return
+    if (!root.session.canPush) return
+    if (pushStream.running) return
+    var url = Jmap.pushUrlFor(root.session, 300)
+    if (url === "") return
+
+    auth.withToken(function(token, tokenError) {
+      if (!root || !root.pushEnabled) return
+      if (!token) return
+      if (pushStream.running) return
+      // Both fields base64, so the line splits on spaces with no quoting rules
+      // — the same shape every other script here reads.
+      root.pushRequest = Qt.btoa(url) + " " + Qt.btoa(token)
+      pushStream.command = [auth.pluginDir + "/scripts/jmap-push.sh"]
+      pushStream.running = true
+    })
+  }
+
+  function stopPush() {
+    root.pushEnabled = false
+    pushRetry.stop()
+    if (pushStream.running) pushStream.running = false
+  }
+
+  function handlePushLine(line) {
+    if (!root.ready) return
+    var event = Jmap.pushChange(line, root.session.accountId)
+    if (!event.changed) return
+    // The rows we hold may no longer be what the mailbox contains.
+    root.rowCache = ({})
+    root.pushAttempts = 0
+    root.mailboxChanged()
+  }
+
+  // Connect as soon as there is a session to connect with. `ready` turns true
+  // once the first request has fetched one.
+  onReadyChanged: if (root.ready) root.startPush()
+
+  Process {
+    id: pushStream
+    stdinEnabled: true
+    stdout: SplitParser {
+      splitMarker: "\n"
+      onRead: function(line) { root.handlePushLine(line) }
+    }
+    stderr: StdioCollector { waitForEnd: true }
+    onStarted: {
+      write(root.pushRequest + "\n")
+      root.pushRequest = ""
+    }
+    onExited: function(exitCode) {
+      root.pushRequest = ""
+      if (!root.pushEnabled) return
+      // Every stream ends eventually; that is not a fault. Reconnect, backing
+      // off so a server that is down is not dialled twice a second.
+      root.pushAttempts = root.pushAttempts + 1
+      pushRetry.interval = Jmap.pushBackoffMs(root.pushAttempts)
+      pushRetry.start()
+    }
+  }
+
+  Timer {
+    id: pushRetry
+    repeat: false
+    onTriggered: root.startPush()
+  }
+
+  Component {
+    id: deadlineComponent
+
+    Timer {
+      repeat: false
+    }
+  }
+}

--- a/providers/JmapProtocol.js
+++ b/providers/JmapProtocol.js
@@ -1,0 +1,834 @@
+.pragma library
+
+// What a JMAP server is spoken to with.
+//
+// The transport is `JmapClient.qml` and the description the panel reads is
+// `Jmap.js`. This file is the part worth testing: what a session resource
+// means, what one of this provider's query strings decomposes into, and how a
+// batch of method calls is assembled. It knows nothing about QML.
+//
+// JMAP differs from IMAP in one way that shapes everything here: a request is
+// a *list* of method calls, and a later call may name an earlier one's result
+// instead of waiting for it. A page of mail is therefore one round trip rather
+// than a list call plus a fetch per message — which is the whole reason this
+// provider exists alongside `imap`.
+
+var SESSION_PATH = "/jmap/session"
+
+// The capability URNs this provider asks about by name. A server advertises
+// what it supports in the session resource; anything not advertised is a verb
+// the panel must not offer.
+var CORE = "urn:ietf:params:jmap:core"
+var MAIL = "urn:ietf:params:jmap:mail"
+var SUBMISSION = "urn:ietf:params:jmap:submission"
+
+// Servers we know something about that the protocol cannot tell us: where the
+// session lives when the user typed a bare domain, and whether a verb this
+// plugin would otherwise refuse is honest here.
+//
+// `junkTrains` is the interesting field. `Imap.js` declines a spam verb
+// outright because moving a message to a folder teaches a generic server
+// nothing, and a button that quietly means "move" is a promise the provider
+// cannot keep. On a host that learns from its Junk mailbox the button is
+// honest, so the knowledge lives here rather than being assumed of everyone.
+var PRESETS = [
+  {
+    id: "fastmail",
+    label: "Fastmail",
+    hosts: ["fastmail.com", "api.fastmail.com", "fastmail.fm", "messagingengine.com"],
+    sessionHost: "api.fastmail.com",
+    junkTrains: true,
+    tokenUrl: "https://app.fastmail.com/settings/security/tokens",
+    tokenHint: "Settings → Privacy & Security → Manage API tokens",
+    webMessage: "https://app.fastmail.com/mail/search:id%3A",
+    webHome: "https://app.fastmail.com/mail/"
+  }
+]
+
+function trimmed(value) {
+  return String(value === undefined || value === null ? "" : value).trim()
+}
+
+// ------------------------------------------------------------------- hosts
+
+// A host is what the user typed into the setup page, so it may be a bare
+// domain, a host with a scheme in front of it, or a whole session URL pasted
+// out of a wiki. All three are the same server.
+function normalizeHost(value) {
+  var text = trimmed(value).toLowerCase()
+  if (text === "") return ""
+  text = text.replace(/^[a-z][a-z0-9+.-]*:\/\//, "")
+  text = text.replace(/\/.*$/, "")
+  text = text.replace(/:\d+$/, "")
+  return text
+}
+
+function isValidHost(value) {
+  var host = normalizeHost(value)
+  if (host === "") return false
+  if (host.indexOf(".") < 0) return false
+  return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/.test(host)
+}
+
+// Matches on the host itself and on any parent of it, so a preset naming
+// "fastmail.com" also answers for "api.fastmail.com" without listing every
+// subdomain a server might answer on.
+function presetFor(value) {
+  var host = normalizeHost(value)
+  if (host === "") return null
+  for (var i = 0; i < PRESETS.length; i++) {
+    var hosts = PRESETS[i].hosts
+    for (var j = 0; j < hosts.length; j++) {
+      if (host === hosts[j] || host.length > hosts[j].length + 1
+          && host.substring(host.length - hosts[j].length - 1) === "." + hosts[j]) {
+        return PRESETS[i]
+      }
+    }
+  }
+  return null
+}
+
+// Where to ask for the session. A preset redirects to the host that actually
+// serves it — mail arrives at fastmail.com, the API does not live there.
+function sessionUrl(value) {
+  var preset = presetFor(value)
+  var host = preset ? preset.sessionHost : normalizeHost(value)
+  return host === "" ? "" : "https://" + host + SESSION_PATH
+}
+
+// ----------------------------------------------------------------- session
+
+// The session resource answers four questions at once: whether the token
+// works, which account it is for, where method calls go, and whether push is
+// available at all. Setup asks it before saving anything, so a token missing a
+// scope is reported as the missing scope rather than as a failure later on.
+function parseSession(raw, host) {
+  var body = raw && typeof raw === "object" ? raw : null
+  if (!body) return { ok: false, error: "The server did not answer with a JMAP session." }
+
+  var capabilities = body.capabilities && typeof body.capabilities === "object" ? body.capabilities : {}
+  if (!capabilities[CORE]) return { ok: false, error: "The server does not advertise JMAP core." }
+  if (!capabilities[MAIL]) return { ok: false, error: "This token has no access to mail." }
+
+  var accounts = body.primaryAccounts && typeof body.primaryAccounts === "object" ? body.primaryAccounts : {}
+  var accountId = trimmed(accounts[MAIL])
+  if (accountId === "") return { ok: false, error: "The session names no mail account." }
+
+  var core = capabilities[CORE] && typeof capabilities[CORE] === "object" ? capabilities[CORE] : {}
+
+  return {
+    ok: true,
+    error: "",
+    accountId: accountId,
+    apiUrl: trimmed(body.apiUrl),
+    downloadUrl: trimmed(body.downloadUrl),
+    uploadUrl: trimmed(body.uploadUrl),
+    // Absent on a server with no push at all, which is why the client must
+    // keep the polling path rather than treating SSE as the normal case.
+    eventSourceUrl: trimmed(body.eventSourceUrl),
+    username: trimmed(body.username),
+    state: trimmed(body.state),
+    canSend: !!capabilities[SUBMISSION],
+    canPush: trimmed(body.eventSourceUrl) !== "",
+    junkTrains: !!(presetFor(host) && presetFor(host).junkTrains),
+    // Honoured on every batch: a request over the server's stated ceiling is
+    // rejected whole, so the client splits rather than discovering this per call.
+    maxCallsInRequest: typeof core.maxCallsInRequest === "number" ? core.maxCallsInRequest : 16,
+    maxObjectsInGet: typeof core.maxObjectsInGet === "number" ? core.maxObjectsInGet : 500
+  }
+}
+
+// ------------------------------------------------------------------ queries
+
+// This provider's query strings, decomposed. The strings are opaque above
+// `Registry.js` — handed back to the client that produced them and used as a
+// cache key — so this grammar is read here and nowhere else.
+//
+//   role:inbox            the inbox, whatever this server calls it
+//   role:inbox unread     and only what has not been seen
+//   role:inbox flagged
+//   mailbox:"Receipts"    a mailbox chosen by name in the sidebar
+//   role:inbox text "..." what the search box produced
+function parseQuery(query) {
+  var text = trimmed(query)
+  var out = { role: "inbox", mailbox: "", unread: false, flagged: false, text: "" }
+  if (text === "") return out
+
+  var scope = text.match(/^role:(\S+)\s*([\s\S]*)$/)
+  if (scope) {
+    out.role = scope[1].toLowerCase()
+    text = trimmed(scope[2])
+  } else {
+    var named = text.match(/^mailbox:(?:"((?:[^"\\]|\\.)*)"|(\S+))\s*([\s\S]*)$/)
+    if (named) {
+      out.mailbox = named[1] !== undefined ? named[1].replace(/\\(.)/g, "$1") : named[2]
+      out.role = ""
+      text = trimmed(named[3])
+    }
+  }
+
+  var words = text.match(/^([\s\S]*?)\btext\s+"((?:[^"\\]|\\.)*)"\s*$/)
+  if (words) {
+    out.text = words[2].replace(/\\(.)/g, "$1")
+    text = trimmed(words[1])
+  }
+
+  var flags = text.split(/\s+/)
+  for (var i = 0; i < flags.length; i++) {
+    if (flags[i].toLowerCase() === "unread") out.unread = true
+    if (flags[i].toLowerCase() === "flagged") out.flagged = true
+  }
+
+  return out
+}
+
+// A parsed query plus the mailbox ids this account actually has becomes the
+// filter `Email/query` takes. Returns null when the query names a mailbox the
+// account does not have — the caller shows an empty mailbox rather than
+// sending a filter the server would reject.
+function filterFor(parsed, mailboxes) {
+  var wanted = parsed || parseQuery("")
+  var map = mailboxes && typeof mailboxes === "object" ? mailboxes : {}
+  var byRole = map.roles && typeof map.roles === "object" ? map.roles : {}
+  var byName = map.names && typeof map.names === "object" ? map.names : {}
+
+  var id = ""
+  if (wanted.mailbox !== "") id = trimmed(byName[wanted.mailbox])
+  else if (wanted.role !== "" && wanted.role !== "all") id = trimmed(byRole[wanted.role])
+
+  if (wanted.mailbox !== "" && id === "") return null
+  if (wanted.role !== "" && wanted.role !== "all" && id === "") return null
+
+  var conditions = []
+  if (id !== "") conditions.push({ inMailbox: id })
+  // `$seen` and `$flagged` are keywords rather than fields, so "unread" is the
+  // absence of one. `notKeyword` says that in one term; a client that fetched
+  // and filtered would page through mail it then threw away.
+  if (wanted.unread) conditions.push({ notKeyword: "$seen" })
+  if (wanted.flagged) conditions.push({ hasKeyword: "$flagged" })
+  if (wanted.text !== "") conditions.push({ text: wanted.text })
+
+  if (conditions.length === 0) return {}
+  if (conditions.length === 1) return conditions[0]
+  return { operator: "AND", conditions: conditions }
+}
+
+// ------------------------------------------------------------ method calls
+
+// The properties a list row draws. Asked for by name because `Email/get` with
+// no `properties` returns every header and the whole body structure for each
+// message, which is most of a megabyte for a page nobody has opened yet.
+var LIST_PROPERTIES = [
+  "id", "blobId", "threadId", "mailboxIds", "keywords", "size", "receivedAt",
+  "from", "to", "cc", "replyTo", "subject", "preview", "hasAttachment"
+]
+
+// One request, three calls: what mailboxes exist, which messages match, and
+// the headers of those messages. The third names the second's result rather
+// than waiting for it, which is the round trip this provider is here to save.
+function pageRequest(accountId, filter, limit, position) {
+  var account = trimmed(accountId)
+  var count = typeof limit === "number" && limit > 0 ? limit : 25
+  var start = typeof position === "number" && position > 0 ? position : 0
+
+  return {
+    using: [CORE, MAIL],
+    methodCalls: [
+      ["Mailbox/get", { accountId: account, ids: null }, "mailboxes"],
+      ["Email/query", {
+        accountId: account,
+        filter: filter || {},
+        sort: [{ property: "receivedAt", isAscending: false }],
+        position: start,
+        limit: count,
+        calculateTotal: true
+      }, "query"],
+      ["Email/get", {
+        accountId: account,
+        "#ids": { resultOf: "query", name: "Email/query", path: "/ids" },
+        properties: LIST_PROPERTIES
+      }, "messages"]
+    ]
+  }
+}
+
+// Just the mailboxes. Issued once per session, before the first page: a query
+// names a role, and the id that role belongs to is not known until this has
+// answered. Every later page carries `Mailbox/get` along anyway, so this runs
+// exactly once on a cold client.
+function mailboxesRequest(accountId) {
+  return {
+    using: [CORE, MAIL],
+    methodCalls: [
+      ["Mailbox/get", { accountId: trimmed(accountId), ids: null }, "mailboxes"]
+    ]
+  }
+}
+
+// What changed since a state string. The reply is small when nothing has, which
+// is what makes polling a reasonable stage rather than a placeholder for push.
+function changesRequest(accountId, sinceState, maxChanges) {
+  var account = trimmed(accountId)
+  var limit = typeof maxChanges === "number" && maxChanges > 0 ? maxChanges : 50
+  return {
+    using: [CORE, MAIL],
+    methodCalls: [
+      ["Email/changes", { accountId: account, sinceState: trimmed(sinceState), maxChanges: limit }, "changes"],
+      ["Email/get", {
+        accountId: account,
+        "#ids": { resultOf: "changes", name: "Email/changes", path: "/created" },
+        properties: LIST_PROPERTIES
+      }, "created"]
+    ]
+  }
+}
+
+// ---------------------------------------------------------------- responses
+
+// A JMAP request answers 200 while individual calls inside it failed, so the
+// status code is not the answer the way it is for Gmail's REST endpoints.
+// Every reader goes through here rather than indexing into the array, because
+// a server may return the calls in any order and may return fewer than were
+// asked for.
+function responseFor(body, callId) {
+  var responses = body && Array.isArray(body.methodResponses) ? body.methodResponses : []
+  var wanted = trimmed(callId)
+  for (var i = 0; i < responses.length; i++) {
+    var entry = responses[i]
+    if (Array.isArray(entry) && entry.length >= 3 && trimmed(entry[2]) === wanted) {
+      return { name: trimmed(entry[0]), payload: entry[1] || {} }
+    }
+  }
+  return null
+}
+
+// The first call that came back as an error, described the way the panel shows
+// it. "error" is JMAP's name for a failed call, so a response of that name is
+// the failure regardless of which call produced it.
+function methodError(body) {
+  var responses = body && Array.isArray(body.methodResponses) ? body.methodResponses : []
+  for (var i = 0; i < responses.length; i++) {
+    var entry = responses[i]
+    if (Array.isArray(entry) && trimmed(entry[0]) === "error") {
+      var payload = entry[1] || {}
+      var type = trimmed(payload.type)
+      if (type === "unknownMethod") return "This server does not support one of the methods used."
+      if (type === "accountNotFound") return "The account is no longer on this server."
+      if (type === "forbidden") return "This token is not allowed to do that."
+      if (type === "rateLimit") return "The server is rate limiting; try again shortly."
+      return trimmed(payload.description) || (type === "" ? "The server rejected the request." : type)
+    }
+  }
+  return ""
+}
+
+// `Email/set` reports failure per object, so a batch of twenty-five can half
+// succeed. The ids that did not move are named so the list can put them back
+// rather than showing an archive that did not happen.
+function setFailures(payload) {
+  var body = payload && typeof payload === "object" ? payload : {}
+  var notUpdated = body.notUpdated && typeof body.notUpdated === "object" ? body.notUpdated : {}
+  var out = []
+  for (var id in notUpdated) {
+    if (!notUpdated.hasOwnProperty(id)) continue
+    var reason = notUpdated[id] && typeof notUpdated[id] === "object" ? notUpdated[id] : {}
+    out.push({ id: id, type: trimmed(reason.type), description: trimmed(reason.description) })
+  }
+  return out
+}
+
+// HTTP-level failures, which are the ones a method response never sees.
+function responseError(status, payload, fallback) {
+  var code = typeof status === "number" ? status : 0
+  var body = payload && typeof payload === "object" ? payload : {}
+  var detail = trimmed(body.detail) || trimmed(body.description)
+
+  if (code === 401) return "The token was refused. It may have been revoked."
+  if (code === 403) return detail || "The token is missing a scope this needs."
+  if (code === 404) return "No JMAP service answered at that address."
+  if (code === 429) return "The server is rate limiting; try again shortly."
+  if (code === 0) return trimmed(fallback) || "The server could not be reached."
+  if (code >= 500) return "The server failed to answer (" + code + ")."
+  return detail || trimmed(fallback) || "The request failed (" + code + ")."
+}
+
+// ------------------------------------------------------------- messages
+
+// JMAP hands back structured fields; everything above a provider reads the
+// shape Gmail's API returns, which `ImapClient` also builds. So a JMAP message
+// is adapted here rather than the panel learning a second shape.
+//
+// A list row gets synthesised headers and no body: the fields JMAP already
+// sent are exactly the headers a row draws, and asking for the body of
+// twenty-five messages nobody has opened would undo the round trip this
+// provider exists to save. The body arrives later, as the raw message, so
+// `Message.parseRfc822` handles it unchanged.
+
+function addressText(list) {
+  var entries = Array.isArray(list) ? list : []
+  var out = []
+  for (var i = 0; i < entries.length; i++) {
+    var entry = entries[i] || {}
+    var email = trimmed(entry.email)
+    if (email === "") continue
+    var name = trimmed(entry.name)
+    // JSON.stringify quotes and escapes exactly what a display name needs.
+    out.push(name === "" ? email : JSON.stringify(name) + " <" + email + ">")
+  }
+  return out.join(", ")
+}
+
+// Unread is the absence of `$seen`, which is the one inversion in the mapping
+// and the easiest thing to get backwards.
+function labelIdsFor(email, rolesById) {
+  var message = email || {}
+  var keywords = message.keywords && typeof message.keywords === "object" ? message.keywords : {}
+  var ids = []
+  if (!keywords["$seen"]) ids.push("UNREAD")
+  if (keywords["$flagged"]) ids.push("STARRED")
+  if (keywords["$draft"]) ids.push("DRAFT")
+
+  var byId = rolesById && typeof rolesById === "object" ? rolesById : {}
+  var boxes = message.mailboxIds && typeof message.mailboxIds === "object" ? message.mailboxIds : {}
+  for (var id in boxes) {
+    if (!boxes.hasOwnProperty(id) || !boxes[id]) continue
+    var role = String(byId[id] || "")
+    if (role === "inbox") ids.push("INBOX")
+    else if (role === "sent") ids.push("SENT")
+    else if (role === "trash" && ids.indexOf("TRASH") < 0) ids.push("TRASH")
+    else if (role === "drafts" && ids.indexOf("DRAFT") < 0) ids.push("DRAFT")
+    else if (role === "junk") ids.push("SPAM")
+  }
+  return ids
+}
+
+function headersFor(email) {
+  var message = email || {}
+  var headers = []
+  function push(name, value) {
+    var text = trimmed(value)
+    if (text !== "") headers.push({ name: name, value: text })
+  }
+  push("From", addressText(message.from))
+  push("To", addressText(message.to))
+  push("Cc", addressText(message.cc))
+  push("Reply-To", addressText(message.replyTo))
+  push("Subject", message.subject)
+  push("Date", message.receivedAt)
+  // `messageId` is a list in JMAP because the header may legitimately repeat.
+  var ids = Array.isArray(message.messageId) ? message.messageId : []
+  if (ids.length > 0) push("Message-ID", "<" + trimmed(ids[0]) + ">")
+  return headers
+}
+
+// `receivedAt` is ISO 8601; the panel sorts and groups on milliseconds.
+function receivedMs(value) {
+  var parsed = Date.parse(String(value || ""))
+  return isFinite(parsed) ? parsed : 0
+}
+
+function messageFrom(email, rolesById) {
+  var message = email || {}
+  return {
+    id: trimmed(message.id),
+    // The reason this provider exists: the server says which conversation a
+    // message belongs to, so nothing has to be reconstructed from References.
+    threadId: trimmed(message.threadId) || trimmed(message.id),
+    labelIds: labelIdsFor(message, rolesById),
+    internalDate: receivedMs(message.receivedAt),
+    sizeEstimate: typeof message.size === "number" ? message.size : 0,
+    // JMAP sends a preview with every row, so unlike IMAP nothing has to be
+    // built out of a body that was not fetched.
+    snippet: trimmed(message.preview),
+    blobId: trimmed(message.blobId),
+    hasAttachment: message.hasAttachment === true,
+    payload: {
+      partId: "",
+      mimeType: "text/plain",
+      headers: headersFor(message),
+      body: {},
+      parts: []
+    }
+  }
+}
+
+function messagesFrom(list, rolesById) {
+  var entries = Array.isArray(list) ? list : []
+  var out = []
+  for (var i = 0; i < entries.length; i++) out.push(messageFrom(entries[i], rolesById))
+  return out
+}
+
+// ---------------------------------------------------------------- actions
+
+// What an action asks the server to change. JMAP makes this uniform in a way
+// IMAP does not: a keyword and a move are both `Email/set`, so one request
+// shape covers starring, marking read, archiving and trashing alike.
+//
+// `roles` maps a role name to this account's mailbox id.
+function actionPlan(action, roles) {
+  var verb = String(action || "")
+  var map = roles && typeof roles === "object" ? roles : {}
+  var plan = { keywords: {}, moveTo: "", removeFrom: "" }
+
+  if (verb === "read") { plan.keywords["$seen"] = true; return plan }
+  if (verb === "unread") { plan.keywords["$seen"] = null; return plan }
+  if (verb === "star") { plan.keywords["$flagged"] = true; return plan }
+  if (verb === "unstar") { plan.keywords["$flagged"] = null; return plan }
+  if (verb === "archive") { plan.moveTo = trimmed(map.archive); plan.removeFrom = trimmed(map.inbox); return plan }
+  if (verb === "trash") { plan.moveTo = trimmed(map.trash); return plan }
+  if (verb === "untrash") { plan.moveTo = trimmed(map.inbox); return plan }
+  if (verb === "spam") { plan.moveTo = trimmed(map.junk); return plan }
+  return plan
+}
+
+// One `Email/set` for as many messages as the caller has. A move replaces
+// `mailboxIds` outright rather than patching it: a message in Inbox and a
+// user folder that was archived should leave the inbox, and a patch that only
+// added Archive would leave it in both.
+function updateRequest(accountId, ids, plan) {
+  var account = trimmed(accountId)
+  var list = Array.isArray(ids) ? ids : []
+  var wanted = plan || { keywords: {}, moveTo: "", removeFrom: "" }
+  var update = {}
+
+  for (var i = 0; i < list.length; i++) {
+    var id = trimmed(list[i])
+    if (id === "") continue
+    var patch = {}
+    var keywords = wanted.keywords || {}
+    for (var word in keywords) {
+      if (!keywords.hasOwnProperty(word)) continue
+      // A JSON pointer patch, which is how JMAP sets one keyword without
+      // sending the whole set back. null removes it.
+      patch["keywords/" + word] = keywords[word]
+    }
+    if (trimmed(wanted.moveTo) !== "") {
+      var boxes = {}
+      boxes[trimmed(wanted.moveTo)] = true
+      patch["mailboxIds"] = boxes
+    }
+    update[id] = patch
+  }
+
+  return {
+    using: [CORE, MAIL],
+    methodCalls: [
+      ["Email/set", { accountId: account, update: update }, "update"]
+    ]
+  }
+}
+
+// `MailAccount` speaks Gmail's vocabulary to every client: add these label ids,
+// remove those. IMAP translates that into flags and a folder; JMAP translates
+// it into keywords and a mailbox. Doing it here rather than in the client keeps
+// the translation testable without a compositor.
+function planFromLabels(addLabelIds, removeLabelIds, roles) {
+  var added = Array.isArray(addLabelIds) ? addLabelIds : []
+  var removed = Array.isArray(removeLabelIds) ? removeLabelIds : []
+  var map = roles && typeof roles === "object" ? roles : {}
+  var plan = { keywords: {}, moveTo: "", removeFrom: "" }
+
+  function has(list, name) {
+    for (var i = 0; i < list.length; i++) {
+      if (String(list[i]).toUpperCase() === name) return true
+    }
+    return false
+  }
+
+  // Marking read REMOVES the UNREAD label, which sets `$seen` — the inversion
+  // again, now in the other direction.
+  if (has(removed, "UNREAD")) plan.keywords["$seen"] = true
+  if (has(added, "UNREAD")) plan.keywords["$seen"] = null
+  if (has(added, "STARRED")) plan.keywords["$flagged"] = true
+  if (has(removed, "STARRED")) plan.keywords["$flagged"] = null
+
+  // A move is exclusive, so only one destination is honoured. Trash wins over
+  // junk and junk over archive: the more destructive reading of an ambiguous
+  // request is the one the user is least surprised by, because they can see it.
+  if (has(added, "TRASH")) plan.moveTo = trimmed(map.trash)
+  else if (has(added, "SPAM")) plan.moveTo = trimmed(map.junk)
+  else if (has(removed, "INBOX")) plan.moveTo = trimmed(map.archive)
+  else if (has(removed, "TRASH") || has(removed, "SPAM")) plan.moveTo = trimmed(map.inbox)
+  else if (has(added, "INBOX")) plan.moveTo = trimmed(map.inbox)
+
+  return plan
+}
+
+// Whether a plan asks for anything at all. A caller that would otherwise send
+// an `Email/set` with an empty patch for twenty-five messages checks this first.
+function planIsEmpty(plan) {
+  var wanted = plan || {}
+  if (trimmed(wanted.moveTo) !== "") return false
+  var keywords = wanted.keywords || {}
+  for (var word in keywords) {
+    if (keywords.hasOwnProperty(word)) return false
+  }
+  return true
+}
+
+// The session's `downloadUrl` is a URI template, not a URL: it names where the
+// four values go and expects the client to put them there. Used for the raw
+// message behind a list row and for an attachment's octets.
+//
+// Fetching the raw message rather than mapping `bodyStructure` is deliberate:
+// it is the same bytes IMAP hands over, so `Message.parseRfc822` reads it
+// unchanged and every part, attachment and calendar entry is handled by code
+// that already works.
+function downloadUrlFor(session, blobId, type, name) {
+  var state = session || {}
+  var template = trimmed(state.downloadUrl)
+  var id = trimmed(blobId)
+  if (template === "" || id === "") return ""
+  return template
+    .split("{accountId}").join(encodeURIComponent(trimmed(state.accountId)))
+    .split("{blobId}").join(encodeURIComponent(id))
+    .split("{type}").join(encodeURIComponent(trimmed(type) || "application/octet-stream"))
+    .split("{name}").join(encodeURIComponent(trimmed(name) || "message"))
+}
+
+// A get of specific messages, for ids a list has already named.
+function getRequest(accountId, ids, properties) {
+  return {
+    using: [CORE, MAIL],
+    methodCalls: [
+      ["Email/get", {
+        accountId: trimmed(accountId),
+        ids: Array.isArray(ids) ? ids : [],
+        properties: Array.isArray(properties) && properties.length > 0 ? properties : LIST_PROPERTIES
+      }, "messages"]
+    ]
+  }
+}
+
+// ------------------------------------------------------------------ sending
+//
+// The panel hands every client the same thing: a finished RFC822 message,
+// base64url encoded, with any attachments already inside it. IMAP appends it
+// and hands it to SMTP. JMAP has no "send this text" method — a submission
+// names an `Email` the server already holds — so the raw message is uploaded
+// as a blob, imported, and then submitted.
+//
+// Three round trips where SMTP takes one, and worth it for the same reason the
+// read path downloads raw: `Message.buildRawMessage` already produces a correct
+// message with its alternatives, its attachments and its headers, and
+// rebuilding that as a structured `Email` object would be a second
+// implementation of MIME that could disagree with the first.
+
+function uploadUrlFor(session) {
+  var state = session || {}
+  var template = trimmed(state.uploadUrl)
+  if (template === "") return ""
+  return template.split("{accountId}").join(encodeURIComponent(trimmed(state.accountId)))
+}
+
+function identitiesRequest(accountId) {
+  return {
+    using: [CORE, MAIL, SUBMISSION],
+    methodCalls: [
+      ["Identity/get", { accountId: trimmed(accountId), ids: null }, "identities"]
+    ]
+  }
+}
+
+// Which identity a message is sent as. The one whose address is the mailbox's
+// own, then any that may send, then nothing — because a submission with the
+// wrong identity is refused by the server rather than quietly rewritten.
+function pickIdentity(list, email) {
+  var entries = Array.isArray(list) ? list : []
+  var wanted = trimmed(email).toLowerCase()
+  for (var i = 0; i < entries.length; i++) {
+    if (trimmed(entries[i].email).toLowerCase() === wanted) return entries[i]
+  }
+  for (var j = 0; j < entries.length; j++) {
+    if (entries[j].mayDelete !== undefined || trimmed(entries[j].email) !== "") return entries[j]
+  }
+  return null
+}
+
+function identitiesFrom(list) {
+  var entries = Array.isArray(list) ? list : []
+  var out = []
+  for (var i = 0; i < entries.length; i++) {
+    var entry = entries[i] || {}
+    var address = trimmed(entry.email)
+    if (address === "") continue
+    out.push({
+      id: trimmed(entry.id),
+      email: address,
+      name: trimmed(entry.name),
+      isDefault: i === 0,
+      isPrimary: i === 0
+    })
+  }
+  return out
+}
+
+// An uploaded blob becomes a message the account holds. A draft keeps
+// `$draft`; something about to be sent does not, because the submission is
+// what files it and a message that failed to send should not be left looking
+// like one that never was.
+function importRequest(accountId, blobId, mailboxId, asDraft, receivedAt) {
+  var keywords = { "$seen": true }
+  if (asDraft) keywords["$draft"] = true
+  var boxes = {}
+  if (trimmed(mailboxId) !== "") boxes[trimmed(mailboxId)] = true
+  var email = {
+    blobId: trimmed(blobId),
+    mailboxIds: boxes,
+    keywords: keywords
+  }
+  if (trimmed(receivedAt) !== "") email.receivedAt = trimmed(receivedAt)
+  return {
+    using: [CORE, MAIL],
+    methodCalls: [
+      ["Email/import", { accountId: trimmed(accountId), emails: { draft: email } }, "import"]
+    ]
+  }
+}
+
+// The submission, and what to do to the message once it has gone.
+//
+// `onSuccessUpdateEmail` is the part worth getting right: it files the sent
+// copy and clears `$draft` in the same request, so there is no window in which
+// a sent message is still sitting in Drafts. The key is the creation id with a
+// "#" in front, which is how JMAP refers to something this request is making.
+function submitRequest(accountId, identityId, emailId, sentMailboxId) {
+  var update = { "keywords/$draft": null, "keywords/$seen": true }
+  if (trimmed(sentMailboxId) !== "") {
+    var boxes = {}
+    boxes[trimmed(sentMailboxId)] = true
+    update["mailboxIds"] = boxes
+  }
+  var onSuccess = {}
+  onSuccess["#send"] = update
+
+  return {
+    using: [CORE, MAIL, SUBMISSION],
+    methodCalls: [
+      ["EmailSubmission/set", {
+        accountId: trimmed(accountId),
+        create: {
+          send: {
+            emailId: trimmed(emailId),
+            identityId: trimmed(identityId)
+          }
+        },
+        onSuccessUpdateEmail: onSuccess
+      }, "submit"]
+    ]
+  }
+}
+
+// A draft that replaced an earlier one leaves the earlier one behind unless it
+// is said so explicitly.
+function destroyRequest(accountId, ids) {
+  return {
+    using: [CORE, MAIL],
+    methodCalls: [
+      ["Email/set", { accountId: trimmed(accountId), destroy: Array.isArray(ids) ? ids : [] }, "destroy"]
+    ]
+  }
+}
+
+// The id of the one thing a create-shaped request made.
+function createdId(payload, creationId) {
+  var body = payload && typeof payload === "object" ? payload : {}
+  var created = body.created && typeof body.created === "object" ? body.created : {}
+  var entry = created[trimmed(creationId)]
+  return entry && entry.id ? trimmed(entry.id) : ""
+}
+
+// Why a create was refused, in the words the panel shows. `notCreated` is keyed
+// by the same creation id the request used.
+function createError(payload, creationId) {
+  var body = payload && typeof payload === "object" ? payload : {}
+  var refused = body.notCreated && typeof body.notCreated === "object" ? body.notCreated : {}
+  var entry = refused[trimmed(creationId)]
+  if (!entry) return ""
+  var type = trimmed(entry.type)
+  if (type === "forbiddenFrom") return "That address is not one this mailbox may send from."
+  if (type === "forbiddenToSend") return "The server refused to send this message."
+  if (type === "tooLarge") return "That message is too large to send."
+  if (type === "rateLimit") return "Too many messages sent just now; try again shortly."
+  if (type === "invalidEmail") return "The server would not accept that message."
+  return trimmed(entry.description) || (type === "" ? "The message could not be sent." : type)
+}
+
+// -------------------------------------------------------------------- push
+//
+// The session's `eventSourceUrl` is a URI template like the others. A client
+// connects to it and the server holds the connection open, writing a
+// `StateChange` whenever something the client asked about moves.
+//
+// This replaces waiting for the next poll, not the poll itself: a server may
+// expose no event source at all, and a held connection drops. The panel's own
+// refresh timer stays exactly as it was, and this only makes it fire sooner.
+
+// The types worth waking for. `Email` covers new mail and anything that
+// changes a message; `Mailbox` covers a count moving without a message
+// arriving, which is what a read on another device looks like.
+var PUSH_TYPES = "Email,Mailbox"
+
+// `ping` asks the server to write a keepalive every so many seconds, which is
+// what stops a NAT or a proxy from silently discarding an idle connection —
+// the failure mode where push looks like it is working and simply never
+// delivers anything again.
+function pushUrlFor(session, pingSeconds) {
+  var state = session || {}
+  var template = trimmed(state.eventSourceUrl)
+  if (template === "") return ""
+  var ping = Math.floor(Number(pingSeconds))
+  if (!isFinite(ping) || ping < 30) ping = 300
+  return template
+    .split("{types}").join(encodeURIComponent(PUSH_TYPES))
+    .split("{closeafter}").join("no")
+    .split("{ping}").join(String(ping))
+}
+
+// One line of the event stream. Only `data:` lines carry anything; the rest is
+// framing, and a `:` comment is how some servers write a keepalive.
+//
+// Returns whether this line means *this* account has something new. A change
+// for another account on the same connection is not this mailbox's business.
+function pushChange(line, accountId) {
+  var text = String(line === undefined || line === null ? "" : line)
+  var out = { isData: false, changed: false, state: "" }
+  if (text.substring(0, 5) !== "data:") return out
+  out.isData = true
+
+  var body = null
+  try {
+    body = JSON.parse(text.substring(5))
+  } catch (e) {
+    return out
+  }
+  if (!body || typeof body !== "object") return out
+  // A ping is a data line too, and carries no `changed` at all.
+  var changed = body.changed && typeof body.changed === "object" ? body.changed : null
+  if (!changed) return out
+
+  var wanted = trimmed(accountId)
+  var mine = changed[wanted]
+  if (!mine || typeof mine !== "object") return out
+
+  for (var type in mine) {
+    if (!mine.hasOwnProperty(type)) continue
+    if (type === "Email" || type === "Mailbox") {
+      out.changed = true
+      out.state = trimmed(mine[type])
+      return out
+    }
+  }
+  return out
+}
+
+// How long to wait before reconnecting a stream that dropped. Doubling, and
+// capped: a server that is down should not be reconnected to twice a second,
+// and one that blipped should not be waited on for an hour.
+function pushBackoffMs(attempt) {
+  var tries = Math.floor(Number(attempt))
+  if (!isFinite(tries) || tries < 1) tries = 1
+  var delay = 2000 * Math.pow(2, tries - 1)
+  return delay > 300000 ? 300000 : delay
+}

--- a/providers/JmapProtocol.js
+++ b/providers/JmapProtocol.js
@@ -469,16 +469,19 @@ function messagesFrom(list, rolesById) {
 function actionPlan(action, roles) {
   var verb = String(action || "")
   var map = roles && typeof roles === "object" ? roles : {}
-  var plan = { keywords: {}, moveTo: "", removeFrom: "" }
+  // `moveRole` is what the caller asked for; `moveTo` is what this account
+  // could resolve it to. They differ exactly when the server has no mailbox
+  // for that role — which must not read as "nothing to do".
+  var plan = { keywords: {}, moveTo: "", removeFrom: "", moveRole: "" }
 
   if (verb === "read") { plan.keywords["$seen"] = true; return plan }
   if (verb === "unread") { plan.keywords["$seen"] = null; return plan }
   if (verb === "star") { plan.keywords["$flagged"] = true; return plan }
   if (verb === "unstar") { plan.keywords["$flagged"] = null; return plan }
-  if (verb === "archive") { plan.moveTo = trimmed(map.archive); plan.removeFrom = trimmed(map.inbox); return plan }
-  if (verb === "trash") { plan.moveTo = trimmed(map.trash); return plan }
-  if (verb === "untrash") { plan.moveTo = trimmed(map.inbox); return plan }
-  if (verb === "spam") { plan.moveTo = trimmed(map.junk); return plan }
+  if (verb === "archive") { plan.moveRole = "archive"; plan.moveTo = trimmed(map.archive); plan.removeFrom = trimmed(map.inbox); return plan }
+  if (verb === "trash") { plan.moveRole = "trash"; plan.moveTo = trimmed(map.trash); return plan }
+  if (verb === "untrash") { plan.moveRole = "inbox"; plan.moveTo = trimmed(map.inbox); return plan }
+  if (verb === "spam") { plan.moveRole = "junk"; plan.moveTo = trimmed(map.junk); return plan }
   return plan
 }
 
@@ -527,7 +530,7 @@ function planFromLabels(addLabelIds, removeLabelIds, roles) {
   var added = Array.isArray(addLabelIds) ? addLabelIds : []
   var removed = Array.isArray(removeLabelIds) ? removeLabelIds : []
   var map = roles && typeof roles === "object" ? roles : {}
-  var plan = { keywords: {}, moveTo: "", removeFrom: "" }
+  var plan = { keywords: {}, moveTo: "", removeFrom: "", moveRole: "" }
 
   function has(list, name) {
     for (var i = 0; i < list.length; i++) {
@@ -546,13 +549,34 @@ function planFromLabels(addLabelIds, removeLabelIds, roles) {
   // A move is exclusive, so only one destination is honoured. Trash wins over
   // junk and junk over archive: the more destructive reading of an ambiguous
   // request is the one the user is least surprised by, because they can see it.
-  if (has(added, "TRASH")) plan.moveTo = trimmed(map.trash)
-  else if (has(added, "SPAM")) plan.moveTo = trimmed(map.junk)
-  else if (has(removed, "INBOX")) plan.moveTo = trimmed(map.archive)
-  else if (has(removed, "TRASH") || has(removed, "SPAM")) plan.moveTo = trimmed(map.inbox)
-  else if (has(added, "INBOX")) plan.moveTo = trimmed(map.inbox)
+  if (has(added, "TRASH")) plan.moveRole = "trash"
+  else if (has(added, "SPAM")) plan.moveRole = "junk"
+  else if (has(removed, "INBOX")) plan.moveRole = "archive"
+  else if (has(removed, "TRASH") || has(removed, "SPAM")) plan.moveRole = "inbox"
+  else if (has(added, "INBOX")) plan.moveRole = "inbox"
+  if (plan.moveRole !== "") plan.moveTo = trimmed(map[plan.moveRole])
 
   return plan
+}
+
+// A move was asked for and this account has nowhere to put it. Distinct from
+// an empty plan, and the distinction is the whole point: `planIsEmpty` would
+// say true for both, and a caller that treats "nothing to do" as success
+// reports an archive that never happened — the row leaves the list, the note
+// says "Archived", and the server was never asked. That is the fault AGENTS.md
+// records against HEY, and a per-account capability ceiling reintroduces it
+// unless this is checked first.
+function planUnresolved(plan) {
+  var wanted = plan || {}
+  return trimmed(wanted.moveRole) !== "" && trimmed(wanted.moveTo) === ""
+}
+
+// What to call the mailbox that is missing, for the note the user reads.
+var ROLE_NAMES = { archive: "Archive", trash: "Trash", junk: "Junk", inbox: "Inbox", sent: "Sent", drafts: "Drafts" }
+
+function roleName(role) {
+  var key = trimmed(role)
+  return ROLE_NAMES[key] || key
 }
 
 // Whether a plan asks for anything at all. A caller that would otherwise send

--- a/providers/Registry.js
+++ b/providers/Registry.js
@@ -2,6 +2,7 @@
 
 .import "Gmail.js" as Gmail
 .import "Imap.js" as Imap
+.import "Jmap.js" as Jmap
 .import "Hey.js" as Hey
 
 // What kind of mail service an account is, and what the rest of the plugin may
@@ -125,7 +126,7 @@ function define(source) {
 // service of their own first, then the one that is every other mailbox. IMAP is
 // last because it is the answer for a server this list does not name, and a
 // chooser that opened with it would ask the question backwards.
-var ALL = [define(Gmail), define(Hey), define(Imap)]
+var ALL = [define(Gmail), define(Hey), define(Jmap), define(Imap)]
 
 var DEFAULT_ID = "gmail"
 

--- a/scripts/jmap-push.sh
+++ b/scripts/jmap-push.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Holds a JMAP event-source connection open and writes each line it receives to
+# stdout, for a caller reading them one at a time.
+#
+# The URL and the token arrive base64 on stdin, and the token reaches curl in a
+# config on *its* stdin — never on the command line, where /proc would show it
+# to every process on the machine for as long as the stream is open. That is a
+# longer window than any other script here has, which is why it matters more.
+#
+# This exits whenever the stream ends, for any reason. Reconnecting is the
+# caller's business: it is the one that knows how many times it has already
+# tried and how long it should now wait.
+set -u
+
+fail() { printf '%s\n' "$1" >&2; exit 2; }
+decode() { printf '%s' "$1" | base64 -d 2>/dev/null || fail 'jmap-push.sh: bad base64 field'; }
+escape() { printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
+
+. "$(dirname "$0")/curl-config.sh"
+
+IFS= read -r line || fail 'jmap-push.sh: no request on stdin'
+# The two fields are base64 and therefore contain no spaces.
+# shellcheck disable=SC2086
+set -- $line
+[ $# -eq 2 ] || fail 'jmap-push.sh: expected URL and token'
+validate_config_fields "$@"
+
+url=$(decode "$1")
+token=$(decode "$2")
+case "$url" in https://*) ;; *) fail 'jmap-push.sh: the event source must be HTTPS' ;; esac
+
+build_config() {
+  printf 'url = "%s"\n' "$(escape "$url")"
+  printf 'noproxy = "*"\n'
+  printf 'header = "Authorization: Bearer %s"\n' "$(escape "$token")"
+  printf 'header = "Accept: text/event-stream"\n'
+  printf 'proto = "=https"\n'
+  printf 'proto-redir = "=https"\n'
+}
+
+# --no-buffer is the whole point: without it curl holds output in a block buffer
+# and an event that arrived a second ago is not written until enough of them
+# have. No --max-time, because the connection is meant to last; the server's own
+# ping is what proves it is still there.
+build_config | exec curl -q --globoff --config - --silent --show-error \
+  --no-buffer --connect-timeout 20

--- a/tests/test_curl_config.py
+++ b/tests/test_curl_config.py
@@ -31,6 +31,11 @@ with tempfile.TemporaryDirectory(prefix="omamail-config-test-") as directory:
         ("mail-transport.sh", ["smtp"], [b"smtps://example.com/", b"user:secret", b"sender@example.com", b"Subject: Hello\r\n\r\nBody\r\n", b"to@example.com", b"next@example.com"], [0, 1, 2, 4, 5]),
         ("mail-transport.sh", ["imap-append"], [b"imaps://example.com/Drafts", b"user:secret", b"Subject: Draft\r\n\r\nBody\r\n", b"draft"], [0, 1, 3]),
         ("mail-transport.sh", ["imap-append"], [b"imaps://example.com/Sent", b"user:secret", b"Subject: Sent\r\n\r\nBody\r\n", b"seen"], [0, 1, 3]),
+        # The push stream holds its connection open for hours, so its config is
+        # the one that is exposed longest. Both fields are protected: the URL
+        # comes from the server's own session response, the token is a bearer
+        # credential that must never reach an argument or an error.
+        ("jmap-push.sh", [], [b"https://example.com/jmap/event/", b"user:secret"], [0, 1]),
     ]
     count = 0
     for script, prefix, fields, protected in cases:

--- a/tests/test_jmap.js
+++ b/tests/test_jmap.js
@@ -422,4 +422,45 @@ assert.strictEqual(jmap.pushBackoffMs(3), 8000)
 assert.strictEqual(jmap.pushBackoffMs(99), 300000, "capped, so a dead server is not hammered")
 assert.strictEqual(jmap.pushBackoffMs(0), 2000)
 
+
+// --- a move this account cannot make is not "nothing to do" -----------------
+//
+// The fault this guards: an archive on a server with no Archive mailbox left
+// moveTo empty, planIsEmpty said true, and the caller reported success having
+// sent nothing — the row leaves the list and the note says "Archived" for a
+// request no server ever saw. AGENTS.md records the same fault against HEY.
+
+const NO_ARCHIVE = { inbox: "m1", trash: "m9" }
+
+const stranded = jmap.planFromLabels([], ["INBOX"], NO_ARCHIVE)
+assert.strictEqual(stranded.moveRole, "archive", "the role asked for is recorded")
+assert.strictEqual(stranded.moveTo, "", "and could not be resolved")
+assert.ok(jmap.planIsEmpty(stranded), "it still looks empty, which is the trap")
+assert.ok(jmap.planUnresolved(stranded), "so this is what callers must check first")
+
+const landed = jmap.planFromLabels([], ["INBOX"], R)
+assert.strictEqual(landed.moveTo, "m2")
+assert.ok(!jmap.planUnresolved(landed), "a move that resolved is not unresolved")
+
+// A keyword-only change asks for no move at all, so it is neither.
+const starOnly = jmap.planFromLabels(["STARRED"], [], NO_ARCHIVE)
+assert.strictEqual(starOnly.moveRole, "")
+assert.ok(!jmap.planUnresolved(starOnly))
+assert.ok(!jmap.planIsEmpty(starOnly))
+
+// Every verb that moves records which role it wanted, resolvable or not.
+assert.strictEqual(jmap.actionPlan("archive", NO_ARCHIVE).moveRole, "archive")
+assert.strictEqual(jmap.actionPlan("trash", NO_ARCHIVE).moveRole, "trash")
+assert.strictEqual(jmap.actionPlan("spam", NO_ARCHIVE).moveRole, "junk")
+assert.strictEqual(jmap.actionPlan("untrash", NO_ARCHIVE).moveRole, "inbox")
+assert.strictEqual(jmap.actionPlan("star", NO_ARCHIVE).moveRole, "", "a keyword is not a move")
+assert.ok(jmap.planUnresolved(jmap.actionPlan("spam", NO_ARCHIVE)), "no Junk mailbox, no junk verb")
+assert.ok(!jmap.planUnresolved(jmap.actionPlan("trash", NO_ARCHIVE)), "this server does have Trash")
+
+// The note the user reads names the mailbox they have not got.
+assert.strictEqual(jmap.roleName("archive"), "Archive")
+assert.strictEqual(jmap.roleName("junk"), "Junk")
+assert.strictEqual(jmap.roleName("whatever"), "whatever")
+assert.strictEqual(jmap.roleName(""), "")
+
 console.log("test_jmap.js: ok")

--- a/tests/test_jmap.js
+++ b/tests/test_jmap.js
@@ -1,0 +1,425 @@
+const assert = require("assert")
+const { load, deepEqual } = require("./load")
+
+const jmap = load("providers/JmapProtocol.js")
+
+// -------------------------------------------------------------------- hosts
+
+assert.strictEqual(jmap.normalizeHost("Fastmail.com"), "fastmail.com")
+assert.strictEqual(jmap.normalizeHost("https://api.fastmail.com/jmap/session"), "api.fastmail.com",
+  "a pasted session URL is the same server as the bare host")
+assert.strictEqual(jmap.normalizeHost("mail.example.net:443"), "mail.example.net")
+assert.strictEqual(jmap.normalizeHost("  "), "")
+
+assert.ok(jmap.isValidHost("mail.example.net"))
+assert.ok(!jmap.isValidHost("localhost"), "a name with no dot is not a server we can reach")
+assert.ok(!jmap.isValidHost("not a host"))
+
+assert.strictEqual(jmap.presetFor("fastmail.com").id, "fastmail")
+assert.strictEqual(jmap.presetFor("api.fastmail.com").id, "fastmail", "a subdomain resolves to its parent")
+assert.strictEqual(jmap.presetFor("mail.example.net"), null)
+assert.strictEqual(jmap.presetFor("notfastmail.com"), null,
+  "a suffix match must not swallow a different domain")
+
+// Mail arrives at fastmail.com; the API does not live there.
+assert.strictEqual(jmap.sessionUrl("fastmail.com"), "https://api.fastmail.com/jmap/session")
+assert.strictEqual(jmap.sessionUrl("mail.example.net"), "https://mail.example.net/jmap/session")
+assert.strictEqual(jmap.sessionUrl(""), "")
+
+// ------------------------------------------------------------------ session
+
+const CORE = "urn:ietf:params:jmap:core"
+const MAIL = "urn:ietf:params:jmap:mail"
+const SUBMISSION = "urn:ietf:params:jmap:submission"
+
+function session(extra) {
+  const base = {
+    capabilities: { [CORE]: { maxCallsInRequest: 32 }, [MAIL]: {} },
+    primaryAccounts: { [MAIL]: "u123" },
+    apiUrl: "https://api.fastmail.com/jmap/api/",
+    eventSourceUrl: "https://api.fastmail.com/jmap/event/",
+    username: "lee@example.com",
+    state: "abc"
+  }
+  return Object.assign(base, extra || {})
+}
+
+const good = jmap.parseSession(session(), "api.fastmail.com")
+assert.ok(good.ok)
+assert.strictEqual(good.accountId, "u123")
+assert.strictEqual(good.maxCallsInRequest, 32)
+assert.strictEqual(good.canPush, true)
+assert.strictEqual(good.junkTrains, true, "Fastmail learns from its Junk mailbox")
+
+// A token without the submission scope must not leave a Send button on screen.
+assert.strictEqual(good.canSend, false)
+assert.strictEqual(jmap.parseSession(session({
+  capabilities: { [CORE]: {}, [MAIL]: {}, [SUBMISSION]: {} }
+}), "api.fastmail.com").canSend, true)
+
+// A server with no push at all is why the polling path stays.
+assert.strictEqual(jmap.parseSession(session({ eventSourceUrl: "" }), "x.example").canPush, false)
+assert.strictEqual(jmap.parseSession(session(), "mail.example.net").junkTrains, false,
+  "a verb is only offered on a host known to honour it")
+
+// Failures name the missing thing rather than reporting a generic error.
+assert.strictEqual(jmap.parseSession(null, "x").ok, false)
+assert.ok(/no access to mail/i.test(jmap.parseSession(session({
+  capabilities: { [CORE]: {} }
+}), "x").error))
+assert.ok(/names no mail account/i.test(jmap.parseSession(session({
+  primaryAccounts: {}
+}), "x").error))
+
+assert.strictEqual(jmap.parseSession(session(), "x").maxCallsInRequest, 32)
+assert.strictEqual(jmap.parseSession(session({ capabilities: { [CORE]: {}, [MAIL]: {} } }), "x").maxCallsInRequest, 16,
+  "a server that states no ceiling gets a conservative one")
+
+// ------------------------------------------------------------------ queries
+
+deepEqual(jmap.parseQuery("role:inbox"),
+  { role: "inbox", mailbox: "", unread: false, flagged: false, text: "" })
+deepEqual(jmap.parseQuery("role:inbox unread"),
+  { role: "inbox", mailbox: "", unread: true, flagged: false, text: "" })
+deepEqual(jmap.parseQuery("role:inbox flagged"),
+  { role: "inbox", mailbox: "", unread: false, flagged: true, text: "" })
+deepEqual(jmap.parseQuery("role:trash"),
+  { role: "trash", mailbox: "", unread: false, flagged: false, text: "" })
+
+// A mailbox chosen in the sidebar is not a search for its name.
+deepEqual(jmap.parseQuery('mailbox:"Receipts 2026"'),
+  { role: "", mailbox: "Receipts 2026", unread: false, flagged: false, text: "" })
+deepEqual(jmap.parseQuery('mailbox:"say \\"what\\""').mailbox, 'say "what"',
+  "an escaped quote inside a mailbox name survives")
+
+deepEqual(jmap.parseQuery('role:inbox text "quarterly report"'),
+  { role: "inbox", mailbox: "", unread: false, flagged: false, text: "quarterly report" })
+deepEqual(jmap.parseQuery('role:inbox unread text "invoice"'),
+  { role: "inbox", mailbox: "", unread: true, flagged: false, text: "invoice" })
+
+// An empty query is the inbox, which is where a list with nothing selected goes.
+deepEqual(jmap.parseQuery(""),
+  { role: "inbox", mailbox: "", unread: false, flagged: false, text: "" })
+
+// ------------------------------------------------------------------ filters
+
+const boxes = { roles: { inbox: "m1", trash: "m9" }, names: { "Receipts 2026": "m4" } }
+
+deepEqual(jmap.filterFor(jmap.parseQuery("role:inbox"), boxes), { inMailbox: "m1" })
+deepEqual(jmap.filterFor(jmap.parseQuery('mailbox:"Receipts 2026"'), boxes), { inMailbox: "m4" })
+
+// Unread is the absence of a keyword, not a field.
+deepEqual(jmap.filterFor(jmap.parseQuery("role:inbox unread"), boxes),
+  { operator: "AND", conditions: [{ inMailbox: "m1" }, { notKeyword: "$seen" }] })
+deepEqual(jmap.filterFor(jmap.parseQuery("role:inbox flagged"), boxes),
+  { operator: "AND", conditions: [{ inMailbox: "m1" }, { hasKeyword: "$flagged" }] })
+deepEqual(jmap.filterFor(jmap.parseQuery('role:inbox text "hello"'), boxes),
+  { operator: "AND", conditions: [{ inMailbox: "m1" }, { text: "hello" }] })
+
+// A mailbox this account does not have is an empty list, not a rejected filter.
+assert.strictEqual(jmap.filterFor(jmap.parseQuery("role:archive"), boxes), null)
+assert.strictEqual(jmap.filterFor(jmap.parseQuery('mailbox:"Nope"'), boxes), null)
+
+// "all" is every mailbox, so it constrains nothing.
+deepEqual(jmap.filterFor(jmap.parseQuery("role:all"), boxes), {})
+
+// ------------------------------------------------------------ method calls
+
+const page = jmap.pageRequest("u123", { inMailbox: "m1" }, 25, 0)
+assert.strictEqual(page.methodCalls.length, 3)
+assert.strictEqual(page.methodCalls[0][0], "Mailbox/get")
+assert.strictEqual(page.methodCalls[1][0], "Email/query")
+assert.strictEqual(page.methodCalls[2][0], "Email/get")
+
+// The point of the provider: the fetch names the query's result instead of
+// waiting for it, so a page is one round trip.
+deepEqual(page.methodCalls[2][1]["#ids"],
+  { resultOf: "query", name: "Email/query", path: "/ids" })
+assert.ok(page.using.indexOf(MAIL) >= 0)
+assert.strictEqual(page.methodCalls[1][1].limit, 25)
+assert.strictEqual(page.methodCalls[1][1].sort[0].property, "receivedAt")
+assert.strictEqual(page.methodCalls[1][1].sort[0].isAscending, false)
+
+// Headers only. A get with no properties returns every body structure too.
+assert.ok(page.methodCalls[2][1].properties.indexOf("preview") >= 0)
+assert.ok(page.methodCalls[2][1].properties.indexOf("threadId") >= 0,
+  "threads are the reason this provider exists")
+assert.strictEqual(page.methodCalls[2][1].properties.indexOf("bodyValues"), -1)
+
+assert.strictEqual(jmap.pageRequest("u1", {}, 0, -5).methodCalls[1][1].limit, 25,
+  "a nonsense limit falls back rather than asking for none")
+
+// A cold client must learn the mailbox ids before a role can become a filter.
+const boxesOnly = jmap.mailboxesRequest("u123")
+assert.strictEqual(boxesOnly.methodCalls.length, 1)
+assert.strictEqual(boxesOnly.methodCalls[0][0], "Mailbox/get")
+assert.strictEqual(boxesOnly.methodCalls[0][1].ids, null, "every mailbox, not a subset")
+assert.strictEqual(boxesOnly.methodCalls[0][2], "mailboxes",
+  "the same call id the page request uses, so one reader serves both")
+
+const changes = jmap.changesRequest("u123", "s1")
+assert.strictEqual(changes.methodCalls[0][0], "Email/changes")
+assert.strictEqual(changes.methodCalls[0][1].sinceState, "s1")
+deepEqual(changes.methodCalls[1][1]["#ids"],
+  { resultOf: "changes", name: "Email/changes", path: "/created" })
+
+// ---------------------------------------------------------------- responses
+
+const body = {
+  methodResponses: [
+    ["Email/get", { list: [{ id: "e1" }] }, "messages"],
+    ["Mailbox/get", { list: [] }, "mailboxes"]
+  ]
+}
+assert.strictEqual(jmap.responseFor(body, "messages").payload.list[0].id, "e1")
+assert.strictEqual(jmap.responseFor(body, "mailboxes").name, "Mailbox/get",
+  "responses are found by call id, because order is not promised")
+assert.strictEqual(jmap.responseFor(body, "absent"), null)
+assert.strictEqual(jmap.responseFor(null, "messages"), null)
+
+// A 200 whose body contains a failed call is a failure.
+assert.strictEqual(jmap.methodError(body), "")
+assert.ok(/does not support/i.test(jmap.methodError({
+  methodResponses: [["error", { type: "unknownMethod" }, "c0"]]
+})))
+assert.ok(/rate limiting/i.test(jmap.methodError({
+  methodResponses: [["error", { type: "rateLimit" }, "c0"]]
+})))
+assert.strictEqual(jmap.methodError({
+  methodResponses: [["error", { type: "weird", description: "Bad in a new way" }, "c0"]]
+}), "Bad in a new way")
+
+// A batch can half succeed, and the list has to know which half.
+deepEqual(jmap.setFailures({ notUpdated: { e2: { type: "forbidden", description: "no" } } }),
+  [{ id: "e2", type: "forbidden", description: "no" }])
+deepEqual(jmap.setFailures({}), [])
+
+assert.ok(/revoked/i.test(jmap.responseError(401, {}, "")))
+assert.ok(/scope/i.test(jmap.responseError(403, {}, "")))
+assert.ok(/No JMAP service/i.test(jmap.responseError(404, {}, "")))
+assert.ok(/rate limiting/i.test(jmap.responseError(429, {}, "")))
+assert.strictEqual(jmap.responseError(0, {}, "Timed out"), "Timed out",
+  "an aborted request reports what the client knows, since there is no status")
+assert.ok(/500/.test(jmap.responseError(500, {}, "")))
+
+
+// ----------------------------------------------------------------- messages
+
+const roles = { m1: "inbox", m9: "trash", m7: "junk", m5: "sent", m3: "drafts" }
+
+const email = {
+  id: "e1", blobId: "b1", threadId: "t1", size: 4096,
+  receivedAt: "2026-09-05T10:00:00Z",
+  mailboxIds: { m1: true },
+  keywords: { "$flagged": true },
+  from: [{ name: "Jane Roe", email: "jane@example.com" }],
+  to: [{ email: "lee@example.com" }],
+  subject: "Quarterly report",
+  preview: "Here is the report you asked for",
+  messageId: ["abc@example.com"],
+  hasAttachment: true
+}
+
+const m = jmap.messageFrom(email, roles)
+assert.strictEqual(m.id, "e1")
+assert.strictEqual(m.threadId, "t1", "the server's own conversation id")
+assert.strictEqual(m.sizeEstimate, 4096)
+assert.strictEqual(m.snippet, "Here is the report you asked for",
+  "JMAP sends a preview, so nothing has to be built from a body that was not fetched")
+assert.strictEqual(m.internalDate, Date.parse("2026-09-05T10:00:00Z"))
+assert.strictEqual(m.hasAttachment, true)
+
+// Unread is the ABSENCE of $seen — the one inversion in the mapping.
+deepEqual(m.labelIds.sort(), ["INBOX", "STARRED", "UNREAD"])
+deepEqual(jmap.labelIdsFor({ keywords: { "$seen": true }, mailboxIds: { m1: true } }, roles).sort(),
+  ["INBOX"])
+deepEqual(jmap.labelIdsFor({ keywords: { "$seen": true }, mailboxIds: { m9: true } }, roles).sort(),
+  ["TRASH"])
+deepEqual(jmap.labelIdsFor({ keywords: { "$seen": true }, mailboxIds: { m7: true } }, roles).sort(),
+  ["SPAM"])
+deepEqual(jmap.labelIdsFor({ keywords: {}, mailboxIds: {} }, roles), ["UNREAD"])
+
+// Headers are synthesised so Message.js reads them exactly as it reads IMAP's.
+function header(msg, name) {
+  const hit = msg.payload.headers.filter(function (h) { return h.name === name })[0]
+  return hit ? hit.value : ""
+}
+assert.strictEqual(header(m, "From"), '"Jane Roe" <jane@example.com>')
+assert.strictEqual(header(m, "To"), "lee@example.com", "no display name, no quoting")
+assert.strictEqual(header(m, "Subject"), "Quarterly report")
+assert.strictEqual(header(m, "Message-ID"), "<abc@example.com>")
+assert.strictEqual(header(m, "Cc"), "", "an absent header is omitted, not empty")
+
+assert.strictEqual(jmap.addressText([{ name: 'Say "what"', email: "a@b.c" }]),
+  '"Say \\"what\\"" <a@b.c>', "a quote in a display name is escaped")
+assert.strictEqual(jmap.addressText([{ email: "a@b.c" }, { email: "d@e.f" }]), "a@b.c, d@e.f")
+assert.strictEqual(jmap.addressText(null), "")
+
+// A message with no threadId is its own thread rather than an empty one.
+assert.strictEqual(jmap.messageFrom({ id: "x" }, roles).threadId, "x")
+assert.strictEqual(jmap.messagesFrom([email, email], roles).length, 2)
+
+// ------------------------------------------------------------------ actions
+
+const R = { inbox: "m1", archive: "m2", trash: "m9", junk: "m7" }
+
+deepEqual(jmap.actionPlan("read", R).keywords, { "$seen": true })
+deepEqual(jmap.actionPlan("unread", R).keywords, { "$seen": null })
+deepEqual(jmap.actionPlan("star", R).keywords, { "$flagged": true })
+deepEqual(jmap.actionPlan("unstar", R).keywords, { "$flagged": null })
+assert.strictEqual(jmap.actionPlan("archive", R).moveTo, "m2")
+assert.strictEqual(jmap.actionPlan("trash", R).moveTo, "m9")
+assert.strictEqual(jmap.actionPlan("spam", R).moveTo, "m7")
+assert.strictEqual(jmap.actionPlan("nonsense", R).moveTo, "", "an unknown verb changes nothing")
+
+// A keyword patch is a JSON pointer, so one keyword changes without the rest
+// being sent back.
+const starred = jmap.updateRequest("u1", ["e1", "e2"], jmap.actionPlan("star", R))
+assert.strictEqual(starred.methodCalls[0][0], "Email/set")
+deepEqual(starred.methodCalls[0][1].update.e1, { "keywords/$flagged": true })
+deepEqual(starred.methodCalls[0][1].update.e2, { "keywords/$flagged": true })
+
+// A move replaces mailboxIds outright: a patch that only added Archive would
+// leave the message in the inbox too.
+const archived = jmap.updateRequest("u1", ["e1"], jmap.actionPlan("archive", R))
+deepEqual(archived.methodCalls[0][1].update.e1, { mailboxIds: { m2: true } })
+
+deepEqual(jmap.updateRequest("u1", [], jmap.actionPlan("star", R)).methodCalls[0][1].update, {})
+
+
+// Gmail's vocabulary, which MailAccount speaks to every client, translated.
+deepEqual(jmap.planFromLabels([], ["UNREAD"], R).keywords, { "$seen": true },
+  "marking read removes the UNREAD label, which sets $seen")
+deepEqual(jmap.planFromLabels(["UNREAD"], [], R).keywords, { "$seen": null })
+deepEqual(jmap.planFromLabels(["STARRED"], [], R).keywords, { "$flagged": true })
+assert.strictEqual(jmap.planFromLabels([], ["INBOX"], R).moveTo, "m2", "leaving the inbox is archiving")
+assert.strictEqual(jmap.planFromLabels(["TRASH"], [], R).moveTo, "m9")
+assert.strictEqual(jmap.planFromLabels(["SPAM"], [], R).moveTo, "m7")
+assert.strictEqual(jmap.planFromLabels([], ["TRASH"], R).moveTo, "m1", "untrashing returns to the inbox")
+// A move is exclusive, so an ambiguous request resolves the visible way.
+assert.strictEqual(jmap.planFromLabels(["TRASH", "SPAM"], ["INBOX"], R).moveTo, "m9")
+
+assert.ok(jmap.planIsEmpty({ keywords: {}, moveTo: "" }))
+assert.ok(jmap.planIsEmpty(jmap.planFromLabels([], [], R)))
+assert.ok(!jmap.planIsEmpty(jmap.actionPlan("star", R)))
+assert.ok(!jmap.planIsEmpty(jmap.actionPlan("archive", R)))
+
+
+// The download URL is a template, so every value has to be put in and escaped.
+const sess = {
+  accountId: "u 1", downloadUrl:
+    "https://x.example/jmap/download/{accountId}/{blobId}/{name}?type={type}"
+}
+assert.strictEqual(jmap.downloadUrlFor(sess, "b/1", "text/plain", "a b.txt"),
+  "https://x.example/jmap/download/u%201/b%2F1/a%20b.txt?type=text%2Fplain")
+assert.strictEqual(jmap.downloadUrlFor(sess, "", "", ""), "", "no blob, no URL")
+assert.strictEqual(jmap.downloadUrlFor({}, "b1", "", ""), "")
+
+const got = jmap.getRequest("u1", ["e1", "e2"])
+assert.strictEqual(got.methodCalls[0][0], "Email/get")
+deepEqual(got.methodCalls[0][1].ids, ["e1", "e2"])
+assert.ok(got.methodCalls[0][1].properties.indexOf("threadId") >= 0)
+deepEqual(jmap.getRequest("u1", ["e1"], ["id", "blobId"]).methodCalls[0][1].properties,
+  ["id", "blobId"])
+
+
+// ------------------------------------------------------------------ sending
+
+assert.strictEqual(jmap.uploadUrlFor({ accountId: "u 1",
+  uploadUrl: "https://x.example/jmap/upload/{accountId}/" }),
+  "https://x.example/jmap/upload/u%201/")
+assert.strictEqual(jmap.uploadUrlFor({}), "")
+
+const ids = jmap.identitiesRequest("u1")
+assert.strictEqual(ids.methodCalls[0][0], "Identity/get")
+assert.ok(ids.using.indexOf("urn:ietf:params:jmap:submission") >= 0,
+  "Identity is a submission method, so the capability has to be asked for")
+
+const idents = [{ id: "i1", email: "other@example.com" }, { id: "i2", email: "you@example.com" }]
+assert.strictEqual(jmap.pickIdentity(idents, "you@example.com").id, "i2",
+  "the mailbox's own address wins")
+assert.strictEqual(jmap.pickIdentity(idents, "nobody@example.com").id, "i1", "else the first that can send")
+assert.strictEqual(jmap.pickIdentity([], "a@b.c"), null)
+deepEqual(jmap.identitiesFrom(idents)[0], { id: "i1", email: "other@example.com", name: "", isDefault: true, isPrimary: true })
+deepEqual(jmap.identitiesFrom([{ id: "x", email: "" }]), [], "an identity with no address is not one")
+
+// A draft keeps $draft; something about to be sent does not, so a failed send
+// is not left looking like a message that was never written.
+const asDraft = jmap.importRequest("u1", "b1", "mDrafts", true)
+assert.strictEqual(asDraft.methodCalls[0][0], "Email/import")
+deepEqual(asDraft.methodCalls[0][1].emails.draft.keywords, { "$seen": true, "$draft": true })
+deepEqual(asDraft.methodCalls[0][1].emails.draft.mailboxIds, { mDrafts: true })
+deepEqual(jmap.importRequest("u1", "b1", "mDrafts", false).methodCalls[0][1].emails.draft.keywords,
+  { "$seen": true })
+
+// The submission files the sent copy and clears $draft in the same request, so
+// there is no window where a sent message is still in Drafts.
+const sub = jmap.submitRequest("u1", "i2", "e9", "mSent")
+assert.strictEqual(sub.methodCalls[0][0], "EmailSubmission/set")
+assert.strictEqual(sub.methodCalls[0][1].create.send.emailId, "e9")
+assert.strictEqual(sub.methodCalls[0][1].create.send.identityId, "i2")
+deepEqual(sub.methodCalls[0][1].onSuccessUpdateEmail["#send"],
+  { "keywords/$draft": null, "keywords/$seen": true, mailboxIds: { mSent: true } })
+assert.ok(sub.using.indexOf("urn:ietf:params:jmap:submission") >= 0)
+// A server with no Sent mailbox still sends; it just files nothing.
+assert.strictEqual(sub.methodCalls[0][1].onSuccessUpdateEmail["#send"].mailboxIds.mSent, true)
+deepEqual(jmap.submitRequest("u1", "i2", "e9", "").methodCalls[0][1].onSuccessUpdateEmail["#send"],
+  { "keywords/$draft": null, "keywords/$seen": true })
+
+deepEqual(jmap.destroyRequest("u1", ["e1"]).methodCalls[0][1].destroy, ["e1"])
+
+assert.strictEqual(jmap.createdId({ created: { draft: { id: "e5" } } }, "draft"), "e5")
+assert.strictEqual(jmap.createdId({}, "draft"), "")
+
+assert.ok(/may send from/i.test(jmap.createError({ notCreated: { send: { type: "forbiddenFrom" } } }, "send")))
+assert.ok(/too large/i.test(jmap.createError({ notCreated: { send: { type: "tooLarge" } } }, "send")))
+assert.strictEqual(jmap.createError({ notCreated: { send: { type: "odd", description: "Nope" } } }, "send"), "Nope")
+assert.strictEqual(jmap.createError({ created: { send: { id: "s1" } } }, "send"), "",
+  "a create that worked has no error")
+
+
+// --------------------------------------------------------------------- push
+
+const pushSession = { eventSourceUrl:
+  "https://x.example/jmap/event/?types={types}&closeafter={closeafter}&ping={ping}" }
+assert.strictEqual(jmap.pushUrlFor(pushSession, 300),
+  "https://x.example/jmap/event/?types=Email%2CMailbox&closeafter=no&ping=300")
+assert.ok(/ping=300/.test(jmap.pushUrlFor(pushSession, 5)), "a nonsense ping falls back")
+assert.strictEqual(jmap.pushUrlFor({}, 300), "", "a server with no event source has no URL")
+
+// Only data lines carry anything; the rest is framing.
+assert.strictEqual(jmap.pushChange("event: state", "u1").isData, false)
+assert.strictEqual(jmap.pushChange(": keepalive", "u1").isData, false)
+assert.strictEqual(jmap.pushChange("", "u1").isData, false)
+
+const change = jmap.pushChange(
+  'data:{"@type":"StateChange","changed":{"u1":{"Email":"s99","Mailbox":"s98"}}}', "u1")
+assert.ok(change.isData)
+assert.ok(change.changed)
+assert.strictEqual(change.state, "s99")
+
+// A ping is a data line too, and carries no changed at all.
+assert.strictEqual(jmap.pushChange('data:{"@type":"ping","interval":300}', "u1").changed, false)
+// Another account on the same connection is not this mailbox's business.
+assert.strictEqual(jmap.pushChange(
+  'data:{"changed":{"other":{"Email":"s1"}}}', "u1").changed, false)
+// A type we did not ask to be woken for does not wake us.
+assert.strictEqual(jmap.pushChange(
+  'data:{"changed":{"u1":{"CalendarEvent":"s1"}}}', "u1").changed, false)
+assert.strictEqual(jmap.pushChange("data:not json", "u1").changed, false)
+
+// The real wire format has a space after the colon, which JSON.parse tolerates
+// as leading whitespace. Measured against Fastmail's own stream.
+const real = 'data: {"@type":"StateChange","type":"connect","changed":' +
+  '{"u1234abcd":{"AddressBook":"53","Mailbox":"J5832","Email":"J5832","Thread":"J5832"}}}'
+assert.ok(jmap.pushChange(real, "u1234abcd").changed, "the space after data: must not break it")
+assert.strictEqual(jmap.pushChange(real, "u1234abcd").state, "J5832")
+assert.strictEqual(jmap.pushChange(real, "someoneelse").changed, false)
+
+assert.strictEqual(jmap.pushBackoffMs(1), 2000)
+assert.strictEqual(jmap.pushBackoffMs(2), 4000)
+assert.strictEqual(jmap.pushBackoffMs(3), 8000)
+assert.strictEqual(jmap.pushBackoffMs(99), 300000, "capped, so a dead server is not hammered")
+assert.strictEqual(jmap.pushBackoffMs(0), 2000)
+
+console.log("test_jmap.js: ok")

--- a/tests/test_provider.js
+++ b/tests/test_provider.js
@@ -10,7 +10,7 @@ const provider = load("providers/Registry.js")
 //
 // The order is the order the chooser lists them in: the two hosted mailboxes
 // with a service of their own, then the one that is every other mailbox.
-deepEqual(provider.ids(), ["gmail", "hey", "imap"])
+deepEqual(provider.ids(), ["gmail", "hey", "jmap", "imap"])
 assert.strictEqual(provider.get("gmail").name, "Gmail")
 assert.strictEqual(provider.get("imap").name, "IMAP")
 assert.strictEqual(provider.get("hey").name, "HEY")
@@ -277,5 +277,57 @@ assert.strictEqual(provider.badge("imap"), "IMAP")
 assert.ok(provider.summary("imap").length > 0)
 assert.strictEqual(provider.DEFAULT_ID, "gmail",
   "an account written before providers existed is a Gmail account")
+
+
+// -------------------------------------------------------------------- jmap
+
+assert.ok(provider.ids().indexOf("jmap") >= 0, "the registry knows the provider")
+assert.strictEqual(provider.authKind("jmap"), "password")
+assert.ok(provider.usesPassword("jmap"))
+assert.ok(provider.isConnectable("jmap"))
+
+// The reason the provider exists: what IMAP has to fake, JMAP has.
+assert.strictEqual(provider.can("jmap", "threads"), true, "a server-side threadId")
+assert.strictEqual(provider.can("imap", "threads"), false)
+assert.strictEqual(provider.can("jmap", "search"), true)
+assert.strictEqual(provider.can("jmap", "batch"), true)
+assert.strictEqual(provider.can("jmap", "send"), true)
+assert.strictEqual(provider.can("jmap", "star"), true, "$flagged is a star")
+assert.strictEqual(provider.can("jmap", "move"), true)
+
+// A ceiling, not a guarantee. The provider says a JMAP mailbox *can* have a
+// junk verb; the client withdraws it for an account whose server does not
+// learn from its Junk mailbox, through `unsupported`. Same shape as
+// `Imap.js` declaring archive true and letting the client find out.
+assert.strictEqual(provider.can("jmap", "spam"), true)
+assert.strictEqual(provider.can("imap", "spam"), false,
+  "IMAP refuses outright: it has no host it could know this of")
+
+// Still false, and not for want of knowing the address: Registry.webMessageUrl
+// takes a provider id and a message id, with no account and so no host in
+// scope, so a generic provider cannot answer it for one host and not another.
+assert.strictEqual(provider.can("jmap", "web"), false,
+  "no web UI this provider can know the address of through this seam")
+assert.strictEqual(provider.can("jmap", "webBox"), false)
+assert.strictEqual(provider.can("jmap", "labels"), false)
+
+// Mailboxes are roles, so nothing here is a folder name a server may translate.
+assert.strictEqual(provider.mailboxes("jmap").length, 8)
+assert.strictEqual(provider.query("jmap", "inbox", "", ""), "role:inbox")
+assert.strictEqual(provider.unreadQuery("jmap"), "role:inbox unread")
+assert.strictEqual(provider.mailboxFor("jmap", "trash").query, "role:trash")
+
+// The inherited Gmail default must not reach a provider that cannot read it.
+assert.strictEqual(provider.query("jmap", "inbox", "", "in:inbox"), "role:inbox",
+  "the shipped Gmail default gives way to the provider's own inbox")
+
+assert.strictEqual(provider.query("jmap", "inbox", "quarterly report", ""),
+  'role:inbox text "quarterly report"')
+assert.strictEqual(provider.labelQuery("jmap", "Receipts 2026"), 'mailbox:"Receipts 2026"')
+assert.strictEqual(provider.labelQuery("jmap", ""), "")
+
+// It is listed before imap, which the registry reserves for last as the answer
+// for a server the list does not name.
+assert.ok(provider.ids().indexOf("jmap") < provider.ids().indexOf("imap"))
 
 console.log("Provider.js ok")


### PR DESCRIPTION
Fastmail already worked here through the `imap` provider, so this is not about
reaching it. It is about three things `Imap.js` documents that IMAP cannot do,
each of which JMAP answers directly.

`Imap.js` declares `threads: false` and falls back to `References`, which is what
every IMAP client has to do. Its search is a `TEXT` criterion the file itself
calls only "the closest standard equivalent". And it refuses `spam` on principle,
because moving a message to a folder teaches a generic server nothing and "a
'Report spam' button that quietly means 'move' is a promise the provider cannot
keep". JMAP gives every message a server-side `threadId`, filters `Email/query`
on the server, and — on a host known to learn from its Junk mailbox — makes that
button honest.

It is also faster in a way that is structural rather than tuned.
`GmailApiClient.qml` records the cost of the alternative: a list call plus one
metadata call per message, where "25 sequential round trips to Google is most of
a second of staring at an empty panel". A JMAP request is a list of method calls
in which a later call may name an earlier one's result, so a page is one round
trip — `Mailbox/get`, `Email/query`, and an `Email/get` that names the query's
ids. Measured against a real 2,171-message inbox: 25 rows with headers in 203 ms.

**The decision worth arguing about, made three times.** Everything above a
provider reads the shape Gmail's API returns, so a JMAP message is adapted into
it, with headers synthesised from the structured fields JMAP already sends. But
wherever actual MIME is needed, this uses the raw message rather than mapping
JMAP's `bodyStructure`: a body is downloaded by `blobId` and handed to
`Message.parseRfc822`, and an outgoing message is the one
`Message.buildRawMessage` already produced, uploaded as a blob and imported.
The alternative was building structured `Email` objects in both directions —
a second implementation of MIME that could disagree with the first. This costs
a round trip when opening a message, which is what IMAP costs too.

Sending is therefore upload → `Email/import` → `EmailSubmission/set`. The
message is imported *without* `$draft`, because a send that fails should not
leave something behind that looks like a draft nobody wrote, and
`onSuccessUpdateEmail` files the sent copy and clears `$draft` in the same
request, so there is no window where a sent message is still in Drafts.

**Push.** The session's `eventSourceUrl` is held open by `scripts/jmap-push.sh`
through curl, read a line at a time by `Process` + `SplitParser`. It does not
replace the poll: a server may expose no event source and a held connection
drops, so `pollTimer` is untouched and this only makes its work happen sooner.
`MailAccount` connects with `ignoreUnknownSignals`, so nothing asks which
provider it holds — the clients that cannot push simply never emit.

**The one change to a shared contract**, and the part most likely to be wrong.
`Registry.can()` answers per provider, but two of these answers are per
*account*: only the session knows whether a token was scoped to send, and only
the server knows whether it has an Archive mailbox or a Junk one that learns. So
the provider states a ceiling and the client withdraws what an account cannot do,
in `unsupported`, read by `MailAccount.accountRefuses()`. A client without that
property refuses nothing, so gmail, hey and imap are unaffected. If you would
rather that seam looked different, say so — it is the piece I am least sure of.

`web`/`webBox` stay false even for a known host: `Registry.webMessageUrl` takes a
provider id and a message id, with no account and therefore no host in scope, so
a generic provider cannot answer it for one host and not another.

Secrets follow the existing rule. The token lives in GNOME Keyring under
`kind=jmap-token`, `accounts.json` holds only host and username, and every curl
invocation takes its config on curl's own stdin through `scripts/curl-config.sh`
— which matters more here than elsewhere, because the push process lives for
hours.

## Verification

`make validate` green on d724154, run on Arch with Qt 6.11.2.

`tests/test_jmap.js` is new — 182 assertions over session parsing, the query
grammar, filter building, the message adapter, action plans, the send requests
and the push stream. Run against unmodified fd713ad it fails immediately
(`ENOENT: providers/JmapProtocol.js`), and `tests/test_provider.js` fails there
too on the provider list (`['gmail','hey','imap']` vs the expected four).

Live, against a real Fastmail account: a 2,171-message inbox paged in one
request in 203 ms with 23 distinct threads across 25 rows; a message body
downloaded raw and parsed to 835 chars of text and 12,339 of HTML with its
`List-Unsubscribe` found; a message sent end to end (upload → import → submit,
`undoStatus: final`) landing in Sent with `$draft` cleared; and a server-side
change producing a push wake in the same second, against a 120 s poll.

Driven by hand on an Omarchy 4.0.2 desktop: the whole add flow, from the
provider picker through JMAP to the address, server and token fields, to
Connect the mailbox — in a light theme and in a dark one, at three columns and
at mini. In each combination the setup page took the address, the server and
the token, and the mailbox connected and listed on the first attempt.

No screenshot is attached to this body. Say if you want one and I will add it.

A fresh agent reviewed the diff against `AGENTS.md` with no context from the
work. It found one high-severity fault and four smaller ones, all fixed in
0555e24:

- **The capability ceiling had a hole in it.** `Jmap.js` declares `archive`,
  `spam` and `send` as a ceiling and lets the client withdraw them per account,
  but `refuseUnavailableAction` — the guard `act()` runs *before* the optimistic
  update — consulted only `Provider.can`. For a JMAP account it could never
  refuse anything, so `e` and `s`, bound in every mail context, did what the
  hidden button would not have. Downstream it was worse: archiving on a server
  with no Archive mailbox left `moveTo` empty, `planIsEmpty` said true, and
  `applyPlan` reported success having sent nothing — the row left the list and
  the note said "Archived" for a request no server saw. That is the fault
  `AGENTS.md` records against HEY, reintroduced through the ceiling. Fixed in
  both places: a plan now records the role it asked for, so an unresolvable move
  is distinguishable from an empty one and is refused with a note naming the
  missing mailbox; and the guard consults `accountRefuses` as well. Both are
  covered by tests that fail without the change.
- `getAttachment` created a handle for its own callback guard but never threaded
  it into the fetch, so aborting suppressed the answer while the message
  download and blob fetch ran on. It now drives the real request, as
  `ImapClient.getAttachment` does.
- `scripts/jmap-push.sh` had no test. It is now a case in
  `tests/test_curl_config.py`; removing its `validate_config_fields` call makes
  that test fail on an accepted config injection.
- The token field set `echoMode` directly, overriding the `TextField`
  component's own `password` binding, and its `tokenVisible` property was never
  wired to anything. It now uses the component's `password` property and has the
  reveal control `ImapSetupPage` has.
- A `children` list on the request handle was never populated — every chain here
  is sequential — so it implied a cancellation shape this client does not have.
  Removed.

It also reported that the commit message carries no `## Verification` or
`## Release Notes` sections. Those belong in this body, which is where they are;
the reviewer had the diff but not this text.

What it checked and found sound, stated because a reviewer will ask: the
`inFlight` bookkeeping and the timeout-versus-abort race in `send()`; that the
token reaches no argv, log or error string; and that none of the seven shared
files regress gmail, hey or imap — `accountRefuses` is a no-op for clients that
declare no `unsupported`, and the new `Connections` block is
`ignoreUnknownSignals`.

## Release Notes

- A mailbox that speaks JMAP can now be added directly, instead of over IMAP.
  Fastmail is the one this was built and tested against.
- Conversations on such a mailbox come from the server rather than being
  reconstructed from `References`, and search runs on the server.
- New mail appears as it arrives rather than at the next poll, where the server
  offers a push connection.

