### PR TITLE
Take two-finger scroll from the Flickable

### DIFF
--- a/account/Model.js
+++ b/account/Model.js
@@ -960,6 +960,10 @@ function clampContentY(value, bounds) {
 // turned that far.
 var WHEEL_UNITS_PER_NOTCH = 120
 var WHEEL_PIXELS_PER_NOTCH = 120
+// Chromium on a 2x laptop travels further than GTK's three lines. The notch
+// stays 120 so the arithmetic is still "a notch is a notch"; the gain is how
+// far that notch moves on screen.
+var WHEEL_GAIN = 2
 
 // Numerically the identity at these two values, and written as a ratio anyway:
 // the constant that matters is "a notch moves 120 pixels", and it is the one a
@@ -968,12 +972,29 @@ function wheelDistance(angleDelta) {
   return (Number(angleDelta) || 0) / WHEEL_UNITS_PER_NOTCH * WHEEL_PIXELS_PER_NOTCH
 }
 
+// Pixels to move the view. `pixelDelta` wins when the device reports it
+// (touchpad, high-res wheel); otherwise the notch mapping. The gain is
+// applied here so QML cannot forget it.
+function wheelPixels(angleDelta, pixelDelta) {
+  var pixels = Number(pixelDelta) || 0
+  if (pixels === 0) pixels = wheelDistance(angleDelta)
+  return pixels * WHEEL_GAIN
+}
+
+// Where the view lands after a movement already expressed in pixels —
+// `pixelDelta` from a touchpad, or `wheelDistance` from a mouse notch.
+function wheelScrollByPixels(contentY, pixels, contentHeight, viewportHeight,
+                             originY, topMargin, bottomMargin) {
+  var bounds = contentYBounds(originY, contentHeight, viewportHeight,
+    topMargin, bottomMargin)
+  return clampContentY((Number(contentY) || 0) - (Number(pixels) || 0), bounds)
+}
+
 // Where the view lands, inside what it can actually reach.
 function wheelScrollTarget(contentY, angleDelta, contentHeight, viewportHeight,
                            originY, topMargin, bottomMargin) {
-  var bounds = contentYBounds(originY, contentHeight, viewportHeight,
-    topMargin, bottomMargin)
-  return clampContentY((Number(contentY) || 0) - wheelDistance(angleDelta), bounds)
+  return wheelScrollByPixels(contentY, wheelDistance(angleDelta), contentHeight,
+    viewportHeight, originY, topMargin, bottomMargin)
 }
 
 // Where a click on a section name scrolls to: its heading, clamped into the

--- a/components/MessageRow.qml
+++ b/components/MessageRow.qml
@@ -63,6 +63,7 @@ Rectangle {
     anchors.fill: parent
     hoverEnabled: true
     acceptedButtons: Qt.LeftButton | Qt.MiddleButton | Qt.RightButton
+    onWheel: function(wheel) { wheel.accepted = false }
     onClicked: function(event) {
       if (event.button === Qt.RightButton) {
         var scene = mapToGlobal(event.x, event.y)

--- a/components/WheelScroller.qml
+++ b/components/WheelScroller.qml
@@ -2,14 +2,17 @@ import QtQuick
 import "../account/Model.js" as Model
 
 // Wheel scrolling for a Flickable, because the Flickable's own is wrong on a
-// mouse that reports finely.
+// mouse that reports finely — and, on a laptop, on two-finger scroll too.
 //
 // A Flickable answers each wheel event with a flick it then decelerates, so
 // the distance depends on how the turn was chopped up rather than on how far
-// the wheel went: one notch as a single delta moves about 72 pixels, and the
-// same notch reported as eight fractions by a high-resolution wheel moves
-// about 9. `Model.wheelScrollTarget` reads the rotation instead, which is the
-// part that does not change.
+// the fingers or the wheel went. Chromium and the terminal compensate;
+// this window did not, and crawled. The handler takes the event from
+// anything under the pointer (`CanTakeOverFromAnything`) and moves
+// `contentY` on the same frame by `Model.wheelPixels`.
+//
+// `pixelDelta` wins when the device reports it. Otherwise the notch mapping
+// still applies, doubled so a 2x panel travels about as far as Chromium.
 //
 // A handler rather than an Item wrapping one. A Flickable reparents its
 // visual children into its content, so an Item dropped inside would be a
@@ -21,30 +24,19 @@ WheelHandler {
 
   required property Flickable view
 
-  // A mouse only, said out loud rather than left to the default.
-  //
-  // A touchpad reports `pixelDelta` and its own momentum, and a Flickable
-  // tracks fingers with it properly. Driving one from a derived `angleDelta`
-  // at a fixed distance per notch would replace a gesture that follows the
-  // hand with a series of jumps, so where Qt can tell a touchpad apart this
-  // stays out of the way and the native behaviour survives.
-  acceptedDevices: PointerDevice.Mouse
-
-  // Vertical only, which is also why there is no `angleDelta.y === 0` guard in
-  // here: Qt filters a horizontal-only wheel before the signal fires, so such
-  // a guard is unreachable and a test for it passes with this whole component
-  // removed.
+  blocking: true
+  grabPermissions: PointerHandler.CanTakeOverFromAnything
+  acceptedDevices: PointerDevice.AllDevices
   orientation: Qt.Vertical
 
   onWheel: function(event) {
     if (!root.view) return
-    root.view.contentY = Model.wheelScrollTarget(root.view.contentY,
-      event.angleDelta.y, root.view.contentHeight, root.view.height,
+    root.view.contentY = Model.wheelScrollByPixels(root.view.contentY,
+      Model.wheelPixels(event.angleDelta.y, event.pixelDelta.y),
+      root.view.contentHeight, root.view.height,
       root.view.originY, root.view.topMargin, root.view.bottomMargin)
-    // Not dead despite `blocking` defaulting true, which stops the Flickable
-    // starting a flick from *this* event: a flick already in flight from a
-    // drag goes on decelerating from where it was and fights every turn
-    // after this one.
+    // Not dead despite `blocking`: a flick already in flight from a drag
+    // goes on decelerating from where it was and fights every turn after.
     root.view.cancelFlick()
   }
 }

--- a/tests/qml/tst_settings_sidebar.qml
+++ b/tests/qml/tst_settings_sidebar.qml
@@ -267,7 +267,7 @@ Item {
       view.contentY = 0
 
       mouseWheel(view, view.width / 2, view.height / 2, 0, -120)
-      compare(view.contentY, 120, "one notch, in the real hierarchy")
+      compare(view.contentY, 240, "one notch, in the real hierarchy")
 
       mouseWheel(view, view.width / 2, view.height / 2, 0, 120)
       compare(view.contentY, 0)

--- a/tests/qml/tst_wheel_scroll.qml
+++ b/tests/qml/tst_wheel_scroll.qml
@@ -74,7 +74,7 @@ Item {
 
     function test_one_notch_moves_three_lines_worth() {
       mouseWheel(view, 200, 150, 0, -120)
-      compare(view.contentY, 120)
+      compare(view.contentY, 240)
     }
 
     // The whole point. A high-resolution wheel reports one notch as many
@@ -82,7 +82,7 @@ Item {
     // where a bare Flickable is eight times short.
     function test_a_finely_reporting_wheel_moves_the_same_distance() {
       for (var i = 0; i < 8; i++) mouseWheel(view, 200, 150, 0, -15)
-      compare(view.contentY, 120, "eight fractions of a notch are still one notch")
+      compare(view.contentY, 240, "eight fractions of a notch are still one notch")
 
       for (var j = 0; j < 8; j++) mouseWheel(bare, 200, 150, 0, -15)
       wait(400)
@@ -92,24 +92,24 @@ Item {
 
     function test_three_notches_move_three_notches() {
       mouseWheel(view, 200, 150, 0, -360)
-      compare(view.contentY, 360)
+      compare(view.contentY, 720)
     }
 
     // Uncapped: ten notches as one event and as ten events agree. A per-event
     // cap put the chunking dependence back at the coarse end.
     function test_a_free_spinning_wheel_is_not_capped() {
       mouseWheel(view, 200, 150, 0, -1200)
-      compare(view.contentY, 1200)
+      compare(view.contentY, 2400)
 
       view.contentY = 0
       for (var i = 0; i < 10; i++) mouseWheel(view, 200, 150, 0, -120)
-      compare(view.contentY, 1200, "however the ten notches arrive")
+      compare(view.contentY, 2400, "however the ten notches arrive")
     }
 
     function test_it_scrolls_back_up() {
       view.contentY = 500
       mouseWheel(view, 200, 150, 0, 120)
-      compare(view.contentY, 380)
+      compare(view.contentY, 260)
     }
 
     // ------------------------------------------------------- the bounds
@@ -138,7 +138,7 @@ Item {
       compare(headed.contentY, -200)
 
       mouseWheel(headed, 200, 150, 0, -120)
-      compare(headed.contentY, -80, "one notch, not two hundred pixels")
+      compare(headed.contentY, 40, "one notch, not two hundred pixels")
 
       mouseWheel(headed, 200, 150, 0, 120)
       compare(headed.contentY, -200, "and the header comes back")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -717,6 +717,24 @@ assert.strictEqual(model.wheelScrollTarget(4770, -NOTCH, 5000, 300, 0, 50, 70), 
 assert.strictEqual(model.wheelScrollTarget(-200, -NOTCH, 4200, 300, -200, 0, 0), -80)
 assert.strictEqual(model.wheelScrollTarget(-200, NOTCH, 4200, 300, -200, 0, 0), -200,
   "and the header stays reachable")
+
+// A touchpad reports pixels, not notches. The same clamp, the same sign:
+// positive pixels are a scroll up, so contentY decreases.
+assert.strictEqual(model.wheelScrollByPixels(0, -40, 5000, 300), 40)
+assert.strictEqual(model.wheelScrollByPixels(500, 40, 5000, 300), 460)
+assert.strictEqual(model.wheelScrollByPixels(0, 40, 5000, 300), 0,
+  "there is nothing above the first row")
+assert.strictEqual(model.wheelScrollTarget(0, -NOTCH, 5000, 300),
+  model.wheelScrollByPixels(0, model.wheelDistance(-NOTCH), 5000, 300),
+  "a notch is the pixel helper fed a notch's worth")
+
+assert.strictEqual(model.WHEEL_GAIN, 2)
+assert.strictEqual(model.wheelPixels(-NOTCH, 0), -240,
+  "a notch on screen is two GTK notches, which is what Chromium travels")
+assert.strictEqual(model.wheelPixels(0, -40), -80,
+  "a touchpad's pixels get the same gain")
+assert.strictEqual(model.wheelPixels(-NOTCH, -40), -80,
+  "pixelDelta wins when the device reports both")
 // ------------------------------------------- moving back into the inbox
 
 // The same pattern a `label:` move already writes: a message filed under a


### PR DESCRIPTION
A `Flickable` answers each wheel event with a flick it then decelerates. Two-finger scroll on a laptop — and a high-resolution mouse — therefore moved a fraction of what Chromium and the terminal move for the same gesture. #89 already mapped mouse notches to 120px, but it left the touchpad to the Flickable and did not take the event from the rows under the pointer, so on Wayland the slow flick stayed in charge.

The handler now takes the wheel from anything under the pointer (`CanTakeOverFromAnything`), reads `pixelDelta` when the device reports it, and assigns `contentY` on the same frame. List rows pass the event through instead of keeping it. Distance is doubled so a 2x panel travels about as far as Chromium.

## Verification

`node tests/test_model.js` and `tst_wheel_scroll.qml` / `tst_settings_sidebar.qml` green. A notch is 240px (`WHEEL_GAIN` 2); eight fractions of a notch still add up to one; bounds still hold.

Live on an Omarchy ThinkPad at scale 2, two-finger scroll through the message list and a long reader now matches Chromium and foot. An ease-out was tried first and sat behind the fingers; taking the event and applying it immediately is what actually fixed it.

## Release Notes

- Two-finger scroll and the mouse wheel in the list, the reader, and the other panes now travel as far as Chromium, instead of crawling a fraction of a flick at a time.
