### PR TITLE
Read the IMAP search ceiling with a FETCH curl passes through, and take from:, to: and subject:

### DIFF
--- a/providers/Imap.js
+++ b/providers/Imap.js
@@ -59,12 +59,37 @@ var MAILBOXES = [
 ]
 
 // IMAP SEARCH has no free-text operator that means what a user means by typing
-// words into a search box, so the text becomes a TEXT criterion — headers and
-// body, the closest standard equivalent. JSON.stringify is used for the quoting
-// because it escapes exactly the two characters IMAP escapes.
+// words into a search box, so plain words become a TEXT criterion — headers and
+// body, the closest standard equivalent. The three operators people bring from
+// webmail, from: to: and subject:, become the IMAP criteria of the same name;
+// a space after the colon is allowed because that is how they get typed, and a
+// quoted value keeps its spaces. IMAP matches a criterion as a substring, so a
+// `*` wildcard is dropped rather than searched for. An operator with nothing
+// after it, or nothing but wildcards, is searched for as typed — which
+// matches nothing — rather than dropped, which would either list the whole
+// inbox as if it were a result or quietly widen the search.
+// JSON.stringify is used for the quoting because it escapes exactly the two
+// characters IMAP escapes.
 function searchQuery(text) {
   var value = String(text === undefined || text === null ? "" : text).trim()
-  return value === "" ? "" : "folder:INBOX TEXT " + JSON.stringify(value)
+  if (value === "") return ""
+  var pattern = /(from|to|subject):\s*(?:"([^"]*)"|(\S*))|(\S+)/gi
+  var words = []
+  var parts = []
+  var match
+  while ((match = pattern.exec(value)) !== null) {
+    if (match[1] === undefined) {
+      words.push(match[4])
+      continue
+    }
+    var term = (match[2] !== undefined ? match[2] : match[3]).replace(/\*/g, "")
+    if (term !== "") parts.push(match[1].toUpperCase() + " " + JSON.stringify(term))
+    else words.push(match[0])
+  }
+  var plain = words.join(" ").trim()
+  if (plain !== "") parts.push("TEXT " + JSON.stringify(plain))
+  if (parts.length === 0) parts.push("TEXT " + JSON.stringify(value))
+  return "folder:INBOX " + parts.join(" ")
 }
 
 // Standard IMAP SEARCH has one selected folder. A typed search selects INBOX,

--- a/providers/ImapClient.qml
+++ b/providers/ImapClient.qml
@@ -299,57 +299,54 @@ Item {
       // times, though, so an under-filled first range falls back to one snapshot
       // and one multi-command connection for everything older.
       if (typeof progress === "function" && criteria !== "") {
-        root.run(folder, [Imap.uidCeilingCommand()], function(ceilingText, ceilingError) {
+        var found = []
+        var emitted = {}
+        var nextUid = 0
+
+        function report(hasUnscanned) {
+          var partial = pageOf(found, hasUnscanned)
+          var ids = []
+          for (var i = 0; i < partial.ids.length; i++) {
+            if (emitted[partial.ids[i]]) continue
+            emitted[partial.ids[i]] = true
+            ids.push(partial.ids[i])
+          }
+          if (ids.length > 0) progress({
+            ids: ids,
+            threadIds: [],
+            nextPageToken: partial.nextPageToken,
+            estimate: partial.estimate
+          })
+          return partial
+        }
+
+        // `settled` says whether a first window has already answered: an
+        // error after one still leaves an authoritative prefix, an error
+        // before one says nothing about the cached preview.
+        function searchSnapshotRemainder(settled) {
           if (handle.aborted) return
-          if (ceilingError) {
-            finish([], ceilingError, false, false)
-            return
-          }
-          var ceiling = Imap.parseUidList(ceilingText)
-          var nextUid = ceiling.length > 0 ? ceiling[ceiling.length - 1] : 0
-          var found = []
-          var emitted = {}
-
-          function report(hasUnscanned) {
-            var partial = pageOf(found, hasUnscanned)
-            var ids = []
-            for (var i = 0; i < partial.ids.length; i++) {
-              if (emitted[partial.ids[i]]) continue
-              emitted[partial.ids[i]] = true
-              ids.push(partial.ids[i])
-            }
-            if (ids.length > 0) progress({
-              ids: ids,
-              threadIds: [],
-              nextPageToken: partial.nextPageToken,
-              estimate: partial.estimate
-            })
-            return partial
-          }
-
-          function searchSnapshotRemainder() {
+          root.run(folder, [Imap.uidListCommand()], function(snapshotText, snapshotError) {
             if (handle.aborted) return
-            root.run(folder, [Imap.uidListCommand()], function(snapshotText, snapshotError) {
+            if (snapshotError) {
+              finish(found, snapshotError, false, settled)
+              return
+            }
+            var snapshot = Imap.parseUidList(snapshotText)
+            var commands = Imap.searchCommands(criteria, snapshot, nextUid)
+            if (commands.length === 0) {
+              finish(found, "", false)
+              return
+            }
+            root.run(folder, commands, function(searchText, searchError) {
               if (handle.aborted) return
-              if (snapshotError) {
-                finish(found, snapshotError, false, true)
-                return
-              }
-              var snapshot = Imap.parseUidList(snapshotText)
-              var commands = Imap.searchCommands(criteria, snapshot, nextUid)
-              if (commands.length === 0) {
-                finish(found, "", false)
-                return
-              }
-              root.run(folder, commands, function(searchText, searchError) {
-                if (handle.aborted) return
-                if (!searchError) found = found.concat(Imap.parseSearch(searchText))
-                finish(found, searchError, false, true)
-              }, handle)
+              if (!searchError) found = found.concat(Imap.parseSearch(searchText))
+              finish(found, searchError, false, settled)
             }, handle)
-          }
+          }, handle)
+        }
 
-          var window = Imap.searchWindow(criteria, nextUid)
+        function searchBelow(ceiling) {
+          var window = Imap.searchWindow(criteria, ceiling)
           if (window.command === "") {
             finish(found, "", false)
             return
@@ -366,7 +363,45 @@ Item {
             if (partial.ids.length >= limit || nextUid === 0)
               finish(found, "", nextUid > 0)
             else
-              searchSnapshotRemainder()
+              searchSnapshotRemainder(true)
+          }, handle)
+        }
+
+        // The ceiling is the UID of the last message by sequence number,
+        // asked for in two short steps: the count from STATUS on an
+        // unselected connection, as the unread counts are, then one numeric
+        // FETCH. A FETCH that comes back empty — the last message expunged
+        // between the two — falls back to the complete snapshot rather than
+        // answering "nothing".
+        root.run("", [Imap.statusCommand(folder)], function(statusText, statusError) {
+          if (handle.aborted) return
+          if (statusError) {
+            finish([], statusError, false, false)
+            return
+          }
+          // A STATUS with no count is an odd server, not an empty mailbox:
+          // the complete snapshot answers instead of an authoritative nothing.
+          if (!/MESSAGES\s+\d+/i.test(String(statusText || ""))) {
+            searchSnapshotRemainder(false)
+            return
+          }
+          var count = Imap.parseStatus(statusText).messages
+          if (count < 1) {
+            finish([], "", false)
+            return
+          }
+          root.run(folder, [Imap.topUidCommand(count)], function(ceilingText, ceilingError) {
+            if (handle.aborted) return
+            // Some servers answer BAD to a range that starts past the end,
+            // which an expunge between STATUS and this FETCH can produce.
+            // The snapshot is the authoritative answer either way.
+            if (ceilingError) {
+              searchSnapshotRemainder(false)
+              return
+            }
+            var ceiling = Imap.parseUidList(ceilingText)
+            if (ceiling.length === 0) searchSnapshotRemainder(false)
+            else searchBelow(Math.max.apply(null, ceiling))
           }, handle)
         }, handle)
         return

--- a/providers/ImapProtocol.js
+++ b/providers/ImapProtocol.js
@@ -479,11 +479,17 @@ function uidListCommand() {
   return "UID FETCH 1:* (UID)"
 }
 
-// An interactive search does not need every UID before it can begin. This one
-// short FETCH learns the immutable upper boundary of the mailbox; an empty
-// mailbox answers with no FETCH row at all.
-function uidCeilingCommand() {
-  return "UID FETCH *:* (UID)"
+// An interactive search does not need every UID before it can begin: the UID
+// of the last message by sequence number is the mailbox's upper boundary. The
+// obvious `UID FETCH *:*` cannot be used through curl, which takes a FETCH of
+// one message for a body fetch and routes its untagged answer where the
+// transport never sees it. A range that starts with a number passes through
+// intact; the count it starts from comes from STATUS on an earlier connection,
+// and running the range up to `*` rather than back to the count keeps a
+// message delivered between the two from sitting above the ceiling unseen.
+function topUidCommand(count) {
+  var n = Math.floor(Number(count))
+  return isFinite(n) && n >= 1 ? "FETCH " + n + ":* (UID)" : ""
 }
 
 // A SEARCH over a known UID snapshot can be split without using message

--- a/tests/test_imap.js
+++ b/tests/test_imap.js
@@ -284,8 +284,9 @@ assert.strictEqual(imap.sequenceSet(null), "")
 
 assert.strictEqual(imap.uidListCommand(), "UID FETCH 1:* (UID)",
   "a UID snapshot is one bounded FETCH response line per message")
-assert.strictEqual(imap.uidCeilingCommand(), "UID FETCH *:* (UID)",
-  "an interactive search learns its stable ceiling without reading every UID")
+assert.strictEqual(imap.topUidCommand(1397), "FETCH 1397:* (UID)",
+  "an interactive search learns its ceiling from a numeric range curl passes through")
+assert.strictEqual(imap.topUidCommand(0), "", "an empty mailbox has no ceiling to fetch")
 deepEqual(imap.searchWindow("TEXT \"invoice\"", 9000), {
   command: "UID SEARCH UID 4905:9000 TEXT \"invoice\"", nextUid: 4904
 }, "the first interactive SEARCH window starts at the newest UID")

--- a/tests/test_provider.js
+++ b/tests/test_provider.js
@@ -37,6 +37,22 @@ assert.strictEqual(provider.exists("imap"), true)
 assert.strictEqual(provider.can("gmail", "labels"), true)
 assert.strictEqual(provider.can("imap", "labels"), false)
 assert.strictEqual(provider.can("outlook", "labels"), false)
+
+// The operators people bring from webmail, in IMAP's words.
+assert.strictEqual(provider.query("imap", "inbox", "from: ada@example.com", ""),
+  'folder:INBOX FROM "ada@example.com"', "a webmail from: operator, space and all, becomes the IMAP criterion")
+assert.strictEqual(provider.query("imap", "inbox", "to:*@example.com invoice", ""),
+  'folder:INBOX TO "@example.com" TEXT "invoice"', "wildcards go: IMAP criteria already match substrings")
+assert.strictEqual(provider.query("imap", "inbox", "plain words", ""),
+  'folder:INBOX TEXT "plain words"', "words without an operator stay one TEXT criterion")
+assert.strictEqual(provider.query("imap", "inbox", 'from:"Jane Doe" report', ""),
+  'folder:INBOX FROM "Jane Doe" TEXT "report"', "a quoted operator value keeps its spaces")
+assert.strictEqual(provider.query("imap", "inbox", "from:", ""),
+  'folder:INBOX TEXT "from:"', "an operator with no value searches for what was typed, not for everything")
+assert.strictEqual(provider.query("imap", "inbox", "from:*", ""),
+  'folder:INBOX TEXT "from:*"', "a wildcard alone is not a criterion either")
+assert.strictEqual(provider.query("imap", "inbox", "from:*** invoice", ""),
+  'folder:INBOX TEXT "from:*** invoice"', "an operator that strips to nothing is not quietly dropped")
 // Separate questions. `labels` is whether a message can carry several at once,
 // which is what the reader's strip draws; `move` is whether the user gets to
 // say where it goes. IMAP answers no and yes -- one folder per message is the

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -664,8 +664,10 @@ awk '
   || fail "a conversation member must not be given the row's thread block"
 grep -q 'if (ids.length > 0) progress({' providers/ImapClient.qml \
   || fail "IMAP search windows must report ids before the final page"
-grep -q 'Imap\.uidCeilingCommand()' providers/ImapClient.qml \
+grep -q 'Imap\.topUidCommand(count)' providers/ImapClient.qml \
   || fail "interactive IMAP search must not wait for the complete UID snapshot"
+! grep -q '"[A-Z ]*FETCH \*:\*' providers/ImapProtocol.js providers/ImapClient.qml \
+  || fail "curl drops the untagged answer to a one-message FETCH: read the ceiling numerically"
 grep -q 'Imap\.searchCommands(criteria, snapshot, nextUid)' providers/ImapClient.qml \
   || fail "a sparse interactive search must reuse a UID snapshot after its first window"
 grep -q 'streamedSummaryBatch' providers/ImapClient.qml \


### PR DESCRIPTION
## What changes

**Every search on an IMAP account answered nothing.** The interactive search opened with `UID FETCH *:* (UID)` to learn the newest UID before searching its first window. curl treats a FETCH of one message as a body fetch and delivers its untagged answer through the protocol-header callback, where the transport never looks, so the ceiling came back empty and the search never got a range. Verified against iCloud through `mail-transport.sh`: that one command returns only the greeting, while a numeric range returns the row.

The ceiling is now read in two short steps — the message count from STATUS on an unselected connection, as the unread badge already does, then `FETCH n:* (UID)`, which curl returns intact and which a message delivered between the two commands raises rather than escapes. The client takes the highest UID it returns. A STATUS with no count, a FETCH with no row, or a BAD to a range past the end (an expunge between the two) each fall back to the complete snapshot rather than answering "nothing" or raising a search error that would discard the cached preview.

**The typed search takes `from:`, `to:` and `subject:`.** With or without a space after the colon, with a quoted value keeping its spaces; other words stay one TEXT criterion. A `*` wildcard is dropped, since IMAP criteria already match substrings. An operator with no value is searched for as typed — which matches nothing — rather than dropped, which would have listed the whole inbox as a result and put Ctrl+A one keystroke from acting on it.

## Verification

- `make test-js`, `make test-shell` and `make test-qml` pass on this branch alone. New cases in `tests/test_imap.js` (`topUidCommand`) and `tests/test_provider.js` (the operators, quoting, wildcards, and empty values); `tests/test_source.sh` now refuses any `*:*` FETCH literal in the IMAP client and protocol.
- Exercised live against iCloud and an Office 365 mailbox over IMAP: a plain word, `from: name@example.com`, `from:*@example.com`, and `subject:` phrases all return rows; each was returning nothing before.

## Security

No new inputs reach the transport. The typed text is still quoted with `JSON.stringify`, which escapes exactly the two characters IMAP escapes, and `normalizeCriteria` folds the control characters it always did; an operator value is quoted the same way. Non-ASCII search terms still go as a quoted string, which is the pre-existing limit of this path and unchanged here.

## Release Notes

- Search works again on IMAP accounts; it had been answering nothing.
- `from:`, `to:` and `subject:` work in the search box on IMAP accounts, with or without a space after the colon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8PEgfKnNP3iPhiDZGSbx6