### PR TITLE
Mark today on the date rather than by washing the whole cell

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -164,7 +164,14 @@ Item {
   readonly property color popupBackground: Color.popups.background
   readonly property color popupBorder: Color.popups.border
   readonly property color calendarBorder: Style.normalBorderColor
-  readonly property color calendarTodayBackground: Style.selectedAccentFill
+  // A wash across a whole day is the wrong thing to carry "today" on. At the
+  // selected alpha it is a field of accent behind the event chips, which are
+  // what the cell is for; quieter, it is a wash a theme could turn off
+  // entirely. So the weight moves off the wash and onto the date: the month
+  // grid's number is bold and accent-coloured, and the fill drops to the
+  // hover alpha. Two marks, and the one that survives a theme with no fills
+  // is not the one lying over the events.
+  readonly property color calendarTodayBackground: Util.alpha(accent, Style.hoverFillAlpha)
   readonly property int calendarBorderWidth: Style.normalBorderWidth
   // Mixed toward the ground rather than Qt.darker: on a light theme darkening
   // an almost-black foreground makes secondary text heavier than body text.

--- a/components/CalendarView.qml
+++ b/components/CalendarView.qml
@@ -373,6 +373,7 @@ Item {
         delegate: Rectangle {
           id: dayCell
           required property var modelData
+          objectName: "calendarDayCell:" + modelData.isoDate
           readonly property var dayEvents: Calendar.eventsOnDay(
             root.controller ? root.controller.events : [], modelData)
           width: monthGrid.width / 7
@@ -395,8 +396,13 @@ Item {
             anchors.top: parent.top
             anchors.left: parent.left
             anchors.margins: Style.space(6)
+            objectName: "calendarDayNumber:" + dayCell.modelData.isoDate
             text: dayCell.modelData.day
-            color: dayCell.modelData.inMonth ? root.textColor : root.dimColor
+            // Today is named twice over, and neither sign is the cell's fill:
+            // weight carries it where a theme's accent sits close to the
+            // foreground, colour where the grid is scanned rather than read.
+            color: dayCell.modelData.isoDate === root.todayIso ? root.accentColor
+              : dayCell.modelData.inMonth ? root.textColor : root.dimColor
             opacity: dayCell.modelData.inMonth ? 1 : 0.55
             font.family: root.panelFontFamily
             font.pixelSize: Style.font.caption

--- a/tests/qml/tst_calendar_today.qml
+++ b/tests/qml/tst_calendar_today.qml
@@ -1,0 +1,119 @@
+import QtQuick 2.15
+import QtTest 1.3
+import qs.Commons
+import "../../components" as Omamail
+import "../../calendar/Calendar.js" as Calendar
+
+// How today is marked in the month grid, and how many ways at once.
+//
+// The fill is the mark that a theme can take away — every fill alpha in the
+// kit is a theme token and zero is a legal value — and it is also the one
+// laid over the events. So what is asserted here is that it is never the
+// only mark: the date carries weight and colour of its own.
+Item {
+  id: shell
+  width: 900
+  height: 700
+
+  // A palette with a deliberately quiet accent, so nothing here passes only
+  // because the test theme happens to be loud.
+  readonly property color fg: Qt.rgba(0.9, 0.9, 0.9, 1)
+  readonly property color bg: Qt.rgba(0.1, 0.1, 0.1, 1)
+  readonly property color acc: Qt.rgba(0.45, 0.6, 0.8, 1)
+
+  readonly property string todayIso: Calendar.isoDate(new Date())
+  readonly property string otherIso: {
+    var now = new Date()
+    var other = new Date(now.getFullYear(), now.getMonth(), now.getDate() + (now.getDate() > 15 ? -5 : 5))
+    return Calendar.isoDate(other)
+  }
+
+  QtObject {
+    id: calendarController
+    property var events: []
+    property bool loading: false
+    property bool sourcesLoaded: true
+    property string lastError: ""
+    property string lastErrorKind: ""
+    property double nowMs: Date.now()
+    property bool clockRunning: false
+    function refresh(_a, _b) {}
+    function colorKeyFor(_sourceId) { return "accent" }
+  }
+
+  Omamail.CalendarView {
+    id: calendarView
+    anchors.fill: parent
+    controller: calendarController
+    textColor: shell.fg
+    backgroundColor: shell.bg
+    accentColor: shell.acc
+    urgentColor: shell.acc
+    dimColor: Qt.rgba(0.6, 0.6, 0.6, 1)
+    calendarBorderColor: shell.fg
+    // What App.qml composes: the theme accent at one of the kit's alphas.
+    calendarTodayBackgroundColor: Qt.rgba(shell.acc.r, shell.acc.g, shell.acc.b, Style.hoverFillAlpha)
+    calendarBorderWidth: 1
+    panelFontFamily: "monospace"
+  }
+
+  TestCase {
+    name: "CalendarToday"
+    when: windowShown
+
+    // Reset here rather than at the end of a case: a failed compare aborts the
+    // function, so a restore on its last line does not run and one real
+    // failure becomes a cascade that hides it.
+    function init() {
+      calendarView.setView("month")
+      calendarView.calendarTodayBackgroundColor = Qt.rgba(
+        shell.acc.r, shell.acc.g, shell.acc.b, Style.hoverFillAlpha)
+    }
+
+    // The date itself says "today" in two ways that do not depend on the
+    // cell's fill, so a theme that draws no fills still marks the day.
+    function test_todays_date_is_marked_without_the_fill() {
+      var today = findChild(calendarView, "calendarDayNumber:" + shell.todayIso)
+      var other = findChild(calendarView, "calendarDayNumber:" + shell.otherIso)
+      verify(today !== null, "today is drawn in the month grid")
+      verify(other !== null, "and so is a day that is not today")
+
+      compare(today.font.bold, true)
+      compare(other.font.bold, false, "weight is a mark, not the default")
+
+      compare(String(today.color), String(shell.acc))
+      verify(String(other.color) !== String(today.color),
+        "colour is a second mark, and only today wears it")
+    }
+
+    // And the fill is still a mark: quiet, but not nothing, and not the same
+    // as the cell beside it.
+    function test_todays_cell_is_tinted_and_the_others_are_not() {
+      var today = findChild(calendarView, "calendarDayCell:" + shell.todayIso)
+      var other = findChild(calendarView, "calendarDayCell:" + shell.otherIso)
+      verify(today !== null)
+      verify(other !== null)
+
+      verify(today.color.a > 0, "today is tinted")
+      compare(other.color.a, 0, "and nothing else is")
+      verify(String(today.color) !== String(other.color))
+    }
+
+    // The point of the weight and the colour: strip the fill entirely, the
+    // way a theme with `hover-cursor-fill-alpha = 0` does, and today is still
+    // findable. This is the case the fill alone cannot survive.
+    function test_today_survives_a_theme_that_draws_no_fill() {
+      calendarView.calendarTodayBackgroundColor = "transparent"
+
+      var todayCell = findChild(calendarView, "calendarDayCell:" + shell.todayIso)
+      compare(todayCell.color.a, 0, "the fill is gone")
+
+      var today = findChild(calendarView, "calendarDayNumber:" + shell.todayIso)
+      var other = findChild(calendarView, "calendarDayNumber:" + shell.otherIso)
+      compare(today.font.bold, true)
+      compare(String(today.color), String(shell.acc))
+      verify(String(other.color) !== String(today.color),
+        "today is still told apart with no fill at all")
+    }
+  }
+}

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -415,6 +415,7 @@ for name in ("create-event-button", "compose-button"):
         raise SystemExit("test_source.sh: " + name + " must not carry an icon")
 PY
 python3 - <<'PY'
+import re
 from pathlib import Path
 
 sidebar = Path("components/MailboxSidebar.qml").read_text()
@@ -450,8 +451,19 @@ if "calendarTodayBackgroundColor: root.calendarTodayBackground" not in app:
     raise SystemExit("test_source.sh: App must pass the system Today background token")
 if "readonly property color calendarBorder: Style.normalBorderColor" not in app:
     raise SystemExit("test_source.sh: calendar borders must originate from the system border token")
-if "readonly property color calendarTodayBackground: Style.selectedAccentFill" not in app:
-    raise SystemExit("test_source.sh: Today must use the quieter system accent fill token")
+# The theme's accent at one of the kit's own alphas, composed by the kit's own
+# helper. What this catches is a hand-picked number: the literal-colour greps
+# above only see quoted hex and named colours, so an alpha typed into a
+# `Qt.rgba` here would pass everything else.
+today_fill = re.search(
+    r"readonly property color calendarTodayBackground:\s*(.+)", app)
+if today_fill is None:
+    raise SystemExit("test_source.sh: App must define calendarTodayBackground")
+if not re.fullmatch(r"Util\.alpha\(\s*accent\s*,\s*Style\.[A-Za-z]+Alpha\s*\)",
+                    today_fill.group(1).strip()):
+    raise SystemExit(
+        "test_source.sh: Today's fill must be Util.alpha(accent, Style.<name>Alpha), "
+        "not a hand-picked alpha")
 if "calendarBorderWidth: root.calendarBorderWidth" not in app:
     raise SystemExit("test_source.sh: App must pass the system calendar border width")
 if "border.color: root.calendarBorderColor" not in calendar or "border.width: root.calendarBorderWidth" not in calendar:


### PR DESCRIPTION
Today is marked by filling its cell with `Style.selectedAccentFill` — the theme accent at the kit's selected alpha. In the month grid that is a field of accent sitting behind the day's event chips, which are what the cell is for, and it is the one cell whose events you are most likely to be reading. The chips are not lost in it — each carries its own fill, a full-opacity border and a solid stripe — but the busiest cell in the grid is the one that did not need help being busy.

Quieting the wash on its own would not be right either, and that is the part worth spending words on. Every fill alpha in the kit is a theme token and zero is a legal value; a theme that prefers hover borders to hover fills sets `hover-cursor-fill-alpha` to `0` without expecting to delete a date from a calendar. Whatever the fill's weight, resting "today" on it alone is resting it on something a theme can take away.

So the mark moves rather than shrinking. The month grid's date is now accent-coloured as well as bold, and the fill drops to the hover alpha. Today is stated twice, neither statement is colour alone (the weight is the one that survives an accent sitting close to the foreground), and the statement that survives a theme with no fills at all is not the one lying over the events.

`Util.alpha(accent, Style.hoverFillAlpha)` is the kit's own composition, so no alpha is chosen here. The rule in `test_source.sh` that pinned the old token now pins that *shape* rather than an exact string — it accepts any of the kit's alphas and rejects a hand-picked one, which the literal-colour greps above it cannot see inside a `Qt.rgba`.

I am not attached to the hover alpha specifically; `normalFillAlpha` would also be defensible. The part I would argue for is that the date carries the mark and the wash is not alone.

## Verification

`make validate` green on `10bc9d9`: 370 QML tests, node/shell/python suites, `qmllint` clean, `omarchy plugin validate .` clean, `git diff --check` clean.

New test `tests/qml/tst_calendar_today.qml` (5 cases). Watched it fail against the unfixed code two ways: against `origin/main`'s `CalendarView.qml` it fails on the missing marks, and — the useful mutation — with the new objectNames left in place but today's date colour reverted to the old `inMonth ? textColor : dimColor`, it fails 3 of 5 on the assertions themselves, including `test_today_survives_a_theme_that_draws_no_fill`.

The `test_source.sh` rule was mutation-tested rather than assumed. It rejects `Qt.rgba(accent.r, accent.g, accent.b, 0.42)` (a hand-picked alpha) and rejects a revert to `Style.selectedAccentFill`, while accepting `Util.alpha(accent, Style.normalFillAlpha)` — any kit alpha passes, a number does not.

**Hand test: not done, and this is the gap in this PR.** What exists is offscreen renders of the month grid before and after, in a light and a dark palette. They are not attached, because CONTRIBUTING asks for a screenshot of the change driven on a screen and a render is not that; a draft claiming evidence it does not have is worse than one saying the evidence is still owed. This is a purely visual change, so it stays a draft until someone has driven it — in particular on a low-contrast theme, which is where the trade between a weaker wash and a stronger date is actually decided. The screenshot goes on with that pass.

A fresh agent with no context reviewed the diff against `AGENTS.md`. It found four things I acted on: the alpha should be composed with `Util.alpha` rather than a bare `Qt.rgba` (every other fill in the repo goes through a kit helper); the `selected` token's documented meaning is "persistent chosen/current state", which does cover today, so the original commit's "today is marked, not selected" framing was wrong and is gone; the claim that 18% was "brighter than most of what is drawn on top of it" was not supported once the chips' borders and stripes are counted, and is gone; and the first version of the `test_source.sh` rule was a restatement of the diff that passed on a wrong value and failed on a correct reformat. Its remaining objection I did not fully resolve: it argues the whole change may be unnecessary and that a theme could lower `selected-fill-alpha` instead. That is true but global — it would quiet every selected row in the shell — which is why I think the calendar's own mark is the right place to fix it. Worth your call.

## Release Notes

- Today is easier to read in the calendar: its date is picked out in the accent colour, and the tint behind it is lighter so events on today stand out as clearly as events on any other day.
