### PR TITLE
Draw the week five days wide as well as seven

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -1686,6 +1686,10 @@ Item {
             calendarTodayBackgroundColor: root.calendarTodayBackground
             calendarBorderWidth: root.calendarBorderWidth
             panelFontFamily: root.fontFamily
+            weekDayCount: root.service ? root.service.calendarWeekDays : 7
+            onWeekDayCountRequested: function(count) {
+              if (root.service) root.service.setCalendarWeekDays(count)
+            }
             // An event opened for reading is a place, so Back closes it before
             // it leaves the calendar. The view owns the open state; the stack
             // follows it.

--- a/Service.qml
+++ b/Service.qml
@@ -11,6 +11,7 @@ import "compose/Senders.js" as Senders
 import "providers/Registry.js" as Provider
 import "bar/Preview.js" as Preview
 import "calendar/Sources.js" as CalendarSources
+import "calendar/Calendar.js" as Calendar
 import "message/Outbox.js" as Outbox
 import "message/Html.js" as Html
 import "message/Direction.js" as Direction
@@ -65,6 +66,7 @@ Item {
     oauthPort: 9481,
     undoSendSeconds: 10,
     unifiedCalendarView: false,
+    calendarWeekDays: 7,
     showBarIcon: true
   })
   property var settings: defaultSettingValues
@@ -80,6 +82,13 @@ Item {
     settings ? settings.contentDirection : null)
   readonly property bool unifiedCalendarView: !!settings
     && settings.unifiedCalendarView === true
+
+  // How wide a week is: five days for the working week, seven for all of it.
+  // Kept here rather than on the view so it outlasts the window, and
+  // normalised on the way out so a hand-edited `shell.json` cannot ask for a
+  // week of nine days.
+  readonly property int calendarWeekDays: Calendar.weekDayCount(
+    settings ? settings.calendarWeekDays : null)
 
   // Whether the bar draws an envelope for this.
   //
@@ -150,6 +159,10 @@ Item {
 
   function setUnifiedCalendarView(value) {
     persistSetting("unifiedCalendarView", value === true)
+  }
+
+  function setCalendarWeekDays(value) {
+    persistSetting("calendarWeekDays", Calendar.weekDayCount(value))
   }
 
   function setShowBarIcon(value) {

--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -661,7 +661,21 @@ function monthDays(year, monthIndex, weekStart) {
   return out
 }
 
-function weekDays(anchorMs, weekStart) {
+// A week is the seven days from `weekStart`, or the first five of them. It is
+// the same week either way: the anchor resolves before the span is cut, so a
+// Saturday asked for five days answers with that Saturday's own week rather
+// than the next one's. `weekSpan` is the whole seven whatever is drawn,
+// because the range fetched for a week has to stay one cache key across the
+// toggle.
+//
+// The five are the first five from `weekStart`, which is the working week
+// only when the week starts on Monday. Both callers start there; a caller
+// that did not would be asking for a different five days, not for Mon-Fri.
+function weekDays(anchorMs, weekStart, dayCount) {
+  return weekSpan(anchorMs, weekStart).slice(0, weekDayCount(dayCount))
+}
+
+function weekSpan(anchorMs, weekStart) {
   var anchor = new Date(Number(anchorMs) || Date.now())
   var startDay = Math.floor(Number(weekStart))
   if (!isFinite(startDay) || startDay < 0 || startDay > 6) startDay = 1
@@ -679,13 +693,27 @@ function weekDays(anchorMs, weekStart) {
   return out
 }
 
+// How many days a week view draws: the working week, or all of it. Only the
+// two widths the interface offers are answers — a settings file asking for
+// three gets a week rather than a grid `weekTitle` cannot name and no button
+// can get back out of.
+var WORKING_WEEK_DAYS = 5
+var WEEK_DAYS = 7
+
+function weekDayCount(value) {
+  return Math.floor(Number(value)) === WORKING_WEEK_DAYS ? WORKING_WEEK_DAYS : WEEK_DAYS
+}
+
+// Titled for the span it draws, which is no longer always seven days: the last
+// day is read off the end of the list rather than off index 6, or a working
+// week is named for the Sunday it does not show.
 function weekTitle(days) {
   var values = Array.isArray(days) ? days : []
-  if (values.length < 7) return ""
+  if (values.length < 2) return ""
   var months = ["January", "February", "March", "April", "May", "June",
     "July", "August", "September", "October", "November", "December"]
   var first = values[0]
-  var last = values[6]
+  var last = values[values.length - 1]
   if (first.year === last.year && first.month === last.month)
     return first.day + "–" + last.day + " " + months[first.month] + " " + first.year
   if (first.year === last.year)

--- a/components/CalendarView.qml
+++ b/components/CalendarView.qml
@@ -16,6 +16,15 @@ Item {
   required property color calendarTodayBackgroundColor
   required property int calendarBorderWidth
   required property string panelFontFamily
+  // How wide the week view is, and where that answer is kept. The setting
+  // lives on the service so it outlasts the window; the view reads it and
+  // asks for the change rather than holding a second copy of it.
+  property int weekDayCount: 7
+  signal weekDayCountRequested(int count)
+  // Which day a week starts on, said once: the week drawn and the week
+  // fetched are two calls that have to agree, and they did not when each
+  // carried its own literal.
+  readonly property int weekStart: 1
 
   property date visibleMonth: new Date(new Date().getFullYear(), new Date().getMonth(), 1)
   property date visibleWeek: new Date()
@@ -25,7 +34,8 @@ Item {
   readonly property bool detailOpen: detailEvent !== null
   readonly property var days: Calendar.monthDays(
     visibleMonth.getFullYear(), visibleMonth.getMonth(), 1)
-  readonly property var weekDays: Calendar.weekDays(visibleWeek.getTime(), 1)
+  readonly property var weekDays: Calendar.weekDays(
+    visibleWeek.getTime(), root.weekStart, root.weekDayCount)
   readonly property var monthNames: ["January", "February", "March", "April", "May", "June",
     "July", "August", "September", "October", "November", "December"]
   readonly property var weekdayNames: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
@@ -105,8 +115,13 @@ Item {
     moveSelection(1)
   }
 
+  // A week fetches all seven days whichever width is drawn. The range cache is
+  // keyed by range, so a five-day week that asked only for its own five would
+  // open a second entry beside the seven-day one and refetch the same events
+  // every time the toggle moved.
   function refresh() {
-    var range = viewMode === "week" ? weekDays : days
+    var range = viewMode === "week"
+      ? Calendar.weekSpan(visibleWeek.getTime(), root.weekStart) : days
     if (!controller || range.length === 0) return
     controller.refresh(range[0].startMs, range[range.length - 1].endMs)
   }
@@ -129,6 +144,29 @@ Item {
         visibleWeek.getDate() + offset * 7)
       refresh()
     } else moveMonth(offset)
+  }
+
+  // A width, and nothing else. The view mode is not changed here: the buttons
+  // are only drawn in week mode, and a setter named for a day count that also
+  // navigated would be a surprise to the next caller.
+  function setWeekDayCount(count) {
+    var wanted = Calendar.weekDayCount(count)
+    if (wanted === root.weekDayCount) return
+    root.weekDayCountRequested(wanted)
+  }
+
+  // A narrower week takes two days off the end of it, and the selection or
+  // the open event may have been standing on one of them. Dropping both is
+  // what stops the keyboard walking from an event that is no longer drawn
+  // and a detail sheet outliving its day.
+  onWeekDaysChanged: {
+    if (viewMode !== "week" || selectedEventId === "") return
+    var visible = visibleEvents()
+    for (var i = 0; i < visible.length; i++) {
+      if (String(visible[i].uid || "") === selectedEventId) return
+    }
+    selectedEventId = ""
+    detailEvent = null
   }
 
   function setView(mode) {
@@ -217,6 +255,7 @@ Item {
         }
 
         IconTextButton {
+          objectName: "calendarViewWeek"
           text: "Week"
           foreground: root.viewMode === "week" ? root.textColor : root.dimColor
           fontFamily: root.panelFontFamily
@@ -225,6 +264,7 @@ Item {
           onClicked: root.setView("week")
         }
 
+
         IconTextButton {
           text: "Month"
           foreground: root.viewMode === "month" ? root.textColor : root.dimColor
@@ -232,6 +272,35 @@ Item {
           fontSize: Style.font.caption
           selected: root.viewMode === "month"
           onClicked: root.setView("month")
+        }
+
+        // How wide that week is. After Month rather than beside Week: these
+        // appear and disappear with the week view, and between the two mode
+        // buttons they shoved Month sideways by their own width every time —
+        // the control you go back with moving out from under the pointer at
+        // the moment you switch. The numerals are named by their tooltips.
+        IconTextButton {
+          objectName: "calendarWeekDays5"
+          visible: root.viewMode === "week"
+          text: "5"
+          tooltipText: "Show the working week"
+          foreground: root.weekDayCount === 5 ? root.textColor : root.dimColor
+          fontFamily: root.panelFontFamily
+          fontSize: Style.font.caption
+          selected: root.weekDayCount === 5
+          onClicked: root.setWeekDayCount(5)
+        }
+
+        IconTextButton {
+          objectName: "calendarWeekDays7"
+          visible: root.viewMode === "week"
+          text: "7"
+          tooltipText: "Show the whole week"
+          foreground: root.weekDayCount === 7 ? root.textColor : root.dimColor
+          fontFamily: root.panelFontFamily
+          fontSize: Style.font.caption
+          selected: root.weekDayCount === 7
+          onClicked: root.setWeekDayCount(7)
         }
 
         IconButton {
@@ -480,6 +549,7 @@ Item {
     }
 
     WeekCalendarView {
+      objectName: "calendarWeekGrid"
       width: parent.width
       height: parent.height - y
       visible: root.viewMode === "week"

--- a/components/WeekCalendarView.qml
+++ b/components/WeekCalendarView.qml
@@ -24,6 +24,10 @@ Item {
   signal eventActivated(var event)
 
   readonly property real timeRailWidth: Style.space(52)
+  // The columns divide by however many days were handed over, not by seven.
+  // A working week is five of them, and dividing by seven regardless left the
+  // last two columns' worth of grid empty beside them.
+  readonly property int dayCount: Math.max(1, Array.isArray(days) ? days.length : 0)
   readonly property var weekdayNames: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
   readonly property var hourRange: Calendar.weekHourRange(
     controller ? controller.events : [], days, 7, 19)
@@ -57,7 +61,7 @@ Item {
       delegate: Item {
         required property var modelData
         required property int index
-        width: (dayHeaders.width - root.timeRailWidth) / 7
+        width: (dayHeaders.width - root.timeRailWidth) / root.dayCount
         height: parent.height
         Text {
           anchors.centerIn: parent
@@ -110,7 +114,7 @@ Item {
           required property var modelData
           readonly property var events: Calendar.allDayEventsOnDay(
             root.controller ? root.controller.events : [], modelData)
-          width: (allDayLane.width - root.timeRailWidth) / 7
+          width: (allDayLane.width - root.timeRailWidth) / root.dayCount
           height: parent.height
 
           Rectangle {
@@ -250,11 +254,12 @@ Item {
           delegate: Item {
             id: dayColumn
             required property var modelData
+            objectName: "calendarDayColumn:" + modelData.isoDate
             readonly property var dayEvents: Calendar.eventsOnDay(
               root.controller ? root.controller.events : [], modelData).filter(function(event) {
                 return event && event.start && !event.start.allDay
               })
-            width: (timeline.width - root.timeRailWidth) / 7
+            width: (timeline.width - root.timeRailWidth) / root.dayCount
             height: parent.height
 
             Rectangle {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -67,7 +67,7 @@ Outlook.com and Hotmail use Microsoft's OAuth device-code flow for delegated IMA
 - Actions: read/unread, star, archive, trash, untrash, report spam, mark all read
 - Compose, reply, reply-all, forward
 - Calendar invitations: full meeting detail, RSVP, and one-click Meet join
-- Calendar: month and week views over Google Calendar and CalDAV, with event create, edit and delete. Google calendars follow the current mailbox by default. A setting can combine every connected account in one view.
+- Calendar: month and week views over Google Calendar and CalDAV, with event create, edit and delete. The week is drawn five days wide or seven, and the choice is remembered. Google calendars follow the current mailbox by default. A setting can combine every connected account in one view.
 - One-click unsubscribe from mailing lists that support it
 - Search using Gmail's own operator syntax
 - Unread badge in the bar; merged desktop notification for new mail

--- a/manifest.json
+++ b/manifest.json
@@ -46,6 +46,7 @@
       "oauthPort": 9481,
       "undoSendSeconds": 10,
       "unifiedCalendarView": false,
+      "calendarWeekDays": 7,
       "openOnClick": "Window",
       "showBarIcon": true
     },
@@ -136,6 +137,17 @@
         "step": 1,
         "defaultValue": 10,
         "description": "Delays outgoing mail so you can cancel it. Set this to 0 to send immediately."
+      },
+      {
+        "key": "calendarWeekDays",
+        "type": "enum",
+        "label": "Week view shows",
+        "options": [
+          "5 days",
+          "7 days"
+        ],
+        "defaultValue": "7 days",
+        "description": "How wide the week view is. The working week, or all of it. The calendar's own header changes this too."
       },
       {
         "key": "unifiedCalendarView",

--- a/tests/qml/tst_calendar_week_days.qml
+++ b/tests/qml/tst_calendar_week_days.qml
@@ -1,0 +1,181 @@
+import QtQuick 2.15
+import QtTest 1.3
+import qs.Commons
+import "../../components" as Omamail
+import "../../calendar/Calendar.js" as Calendar
+
+// A week drawn five days wide or seven, and the range fetched for either.
+Item {
+  width: 900
+  height: 700
+
+  QtObject {
+    id: calendarController
+
+    property var events: []
+    property bool loading: false
+    property bool sourcesLoaded: true
+    property string lastError: ""
+    property string lastErrorKind: ""
+    property double nowMs: 0
+    property bool clockRunning: false
+    property var refreshRanges: []
+
+    function refresh(startMs, endMs) {
+      refreshRanges = refreshRanges.concat([[Number(startMs), Number(endMs)]])
+    }
+    function colorKeyFor(_sourceId) { return "accent" }
+  }
+
+  Omamail.CalendarView {
+    id: calendarView
+    anchors.fill: parent
+    controller: calendarController
+    textColor: Color.foreground
+    backgroundColor: Color.background
+    accentColor: Color.accent
+    urgentColor: Color.accent
+    dimColor: Color.foreground
+    calendarBorderColor: Color.foreground
+    calendarTodayBackgroundColor: Color.accent
+    calendarBorderWidth: 1
+    panelFontFamily: "monospace"
+    weekDayCount: 7
+    // The service owns the setting, so the view only ever reads back a width
+    // something else agreed to. The test stands in for that.
+    onWeekDayCountRequested: function(count) { calendarView.weekDayCount = count }
+  }
+
+  TestCase {
+    name: "CalendarWeekDays"
+    when: windowShown
+
+    function init() {
+      calendarView.setView("month")
+      calendarView.weekDayCount = 7
+      calendarController.refreshRanges = []
+    }
+
+    function test_a_week_is_drawn_five_days_wide_or_seven() {
+      calendarView.setView("week")
+      compare(calendarView.weekDays.length, 7)
+
+      var five = findChild(calendarView, "calendarWeekDays5")
+      var seven = findChild(calendarView, "calendarWeekDays7")
+      verify(five !== null)
+      verify(seven !== null)
+      verify(five.visible, "the widths are offered in week view")
+      compare(seven.selected, true)
+      compare(five.selected, false)
+
+      five.clicked()
+      compare(calendarView.weekDayCount, 5)
+      compare(calendarView.weekDays.length, 5)
+      compare(five.selected, true)
+      compare(seven.selected, false)
+
+      // Monday to Friday of the week the anchor falls in, whichever day the
+      // anchor is: the five are the front of the same seven.
+      var whole = Calendar.weekSpan(calendarView.visibleWeek.getTime(), 1)
+      compare(calendarView.weekDays[0].isoDate, whole[0].isoDate)
+      compare(calendarView.weekDays[4].isoDate, whole[4].isoDate)
+
+      seven.clicked()
+      compare(calendarView.weekDayCount, 7)
+      compare(calendarView.weekDays.length, 7)
+    }
+
+    // The widths belong to the week, so they are drawn with it and nowhere
+    // else. They do not navigate: a width is not a view.
+    function test_the_widths_are_drawn_only_with_the_week_view() {
+      var five = findChild(calendarView, "calendarWeekDays5")
+      var seven = findChild(calendarView, "calendarWeekDays7")
+      compare(calendarView.viewMode, "month")
+      compare(five.visible, false)
+      compare(seven.visible, false)
+
+      calendarView.setView("week")
+      compare(five.visible, true)
+      compare(seven.visible, true)
+    }
+
+    // Both widths ask for the same seven days, so the toggle reads the week
+    // already fetched instead of opening a second entry in the range cache.
+    function test_both_widths_fetch_the_whole_week() {
+      calendarView.setView("week")
+
+      calendarController.refreshRanges = []
+      calendarView.setWeekDayCount(5)
+      calendarView.refresh()
+      var narrow = calendarController.refreshRanges[calendarController.refreshRanges.length - 1]
+
+      calendarView.setWeekDayCount(7)
+      calendarView.refresh()
+      var wide = calendarController.refreshRanges[calendarController.refreshRanges.length - 1]
+
+      compare(JSON.stringify(narrow), JSON.stringify(wide))
+    }
+
+    // A drawn column, not a property saying how many there ought to be.
+    // `dayCount` can be right while the divisor is still a literal seven,
+    // which draws five columns across five sevenths of the grid and leaves
+    // the rest empty. So what is measured here is a column's width.
+    function test_the_columns_fill_the_width_they_are_given() {
+      calendarView.setView("week")
+      var grid = findChild(calendarView, "calendarWeekGrid")
+      verify(grid !== null)
+
+      var seven = dayColumn()
+      verify(seven !== null, "a day column is drawn")
+      fuzzyCompare(seven.width, (grid.width - grid.timeRailWidth) / 7, 1.5)
+
+      calendarView.setWeekDayCount(5)
+      var five = dayColumn()
+      verify(five !== null)
+      fuzzyCompare(five.width, (grid.width - grid.timeRailWidth) / 5, 1.5)
+      verify(five.width > seven.width, "five columns are wider than seven")
+    }
+
+    // The first day column of the week on screen, by name.
+    function dayColumn() {
+      return findChild(calendarView, "calendarDayColumn:" + calendarView.weekDays[0].isoDate)
+    }
+
+    // The heading names the days on screen, so it ends on the last of them.
+    function test_the_title_ends_on_the_last_day_drawn() {
+      calendarView.setView("week")
+      calendarView.setWeekDayCount(5)
+      var days = calendarView.weekDays
+      var title = Calendar.weekTitle(days)
+      verify(title !== "", "a five-day week has a heading at all")
+      verify(String(title).indexOf(String(days[days.length - 1].day)) >= 0,
+        "the Friday it shows is named in the heading: " + title)
+
+      calendarView.setWeekDayCount(7)
+      var wide = calendarView.weekDays
+      var wideTitle = Calendar.weekTitle(wide)
+      verify(String(wideTitle).indexOf(String(wide[6].day)) >= 0)
+      verify(title !== wideTitle, "five days are not titled as seven")
+    }
+
+    // A selection standing on a day the narrower week drops is let go, so the
+    // keyboard cannot walk from an event that is no longer drawn.
+    function test_narrowing_the_week_drops_a_selection_it_hides() {
+      calendarView.setView("week")
+      calendarView.setWeekDayCount(7)
+      var saturday = calendarView.weekDays[5]
+
+      calendarController.events = [{
+        uid: "weekend", sourceId: "s", summary: "Football",
+        start: { ms: saturday.startMs + 10 * 3600000, allDay: false },
+        end: { ms: saturday.startMs + 11 * 3600000 }
+      }]
+      calendarView.selectedEventId = "weekend"
+      compare(calendarView.selectedEventId, "weekend")
+
+      calendarView.setWeekDayCount(5)
+      compare(calendarView.selectedEventId, "", "Saturday is no longer drawn")
+      calendarController.events = []
+    }
+  }
+}

--- a/tests/qml/tst_service_settings.qml
+++ b/tests/qml/tst_service_settings.qml
@@ -66,5 +66,21 @@ Item {
       verify(shellStore.updatedEntry !== null)
       compare(shellStore.updatedEntry.unifiedCalendarView, true)
     }
+
+    // The week's width outlives the window, and a settings file asking for a
+    // week of nine days still shows a week.
+    function test_the_week_width_defaults_to_seven_and_persists_changes() {
+      mailService.applySettings({})
+      compare(mailService.calendarWeekDays, 7)
+
+      mailService.setCalendarWeekDays(5)
+      compare(mailService.calendarWeekDays, 5)
+      compare(shellStore.updatedEntry.calendarWeekDays, 5)
+
+      mailService.applySettings({ calendarWeekDays: 9 })
+      compare(mailService.calendarWeekDays, 7)
+      mailService.applySettings({ calendarWeekDays: "5" })
+      compare(mailService.calendarWeekDays, 5)
+    }
   }
 }

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -470,4 +470,55 @@ assert.ok(googleUrl.indexOf("singleEvents=true") > 0)
 assert.ok(googleUrl.indexOf("orderBy=startTime") > 0)
 assert.ok(googleUrl.indexOf("timeMin=2026-08-01T00%3A00%3A00.000Z") > 0)
 
+// A week is five days or seven, and it is the same week either way. Saturday
+// 12 September 2026 belongs to the week beginning Monday the 7th, so asking
+// for five days from it answers with that Monday to Friday rather than the
+// next week's — the anchor resolves before the span is cut.
+const saturday = new Date(2026, 8, 12, 15).getTime()
+const wholeWeek = feed.weekDays(saturday, 1)
+assert.strictEqual(wholeWeek.length, 7)
+assert.strictEqual(wholeWeek[0].isoDate, "2026-09-07")
+assert.strictEqual(wholeWeek[6].isoDate, "2026-09-13")
+
+const workingWeek = feed.weekDays(saturday, 1, 5)
+assert.strictEqual(workingWeek.length, 5)
+assert.strictEqual(workingWeek[0].isoDate, "2026-09-07")
+assert.strictEqual(workingWeek[4].isoDate, "2026-09-11")
+assert.strictEqual(JSON.stringify(workingWeek),
+  JSON.stringify(wholeWeek.slice(0, 5)),
+  "the shorter week is the front of the same week, not a different one")
+
+// The span fetched for a week stays seven days whichever is drawn, so the
+// range cache holds one entry across the toggle instead of two.
+assert.strictEqual(JSON.stringify(feed.weekSpan(saturday, 1)),
+  JSON.stringify(wholeWeek))
+
+// Only the two widths the interface offers are answers. Every other value is
+// a whole week — including the ones that would otherwise produce a grid with
+// no heading and no button to get back out of it.
+assert.strictEqual(feed.weekDayCount(5), 5)
+assert.strictEqual(feed.weekDayCount("5"), 5)
+assert.strictEqual(feed.weekDayCount(5.9), 5, "a fractional five is still five")
+assert.strictEqual(feed.weekDayCount(7), 7)
+for (const rejected of [0, 1, 2, 3, 4, 6, 8, 9, -5, null, undefined, true, false, "", "nonsense", NaN]) {
+  assert.strictEqual(feed.weekDayCount(rejected), 7,
+    `weekDayCount(${String(rejected)}) should fall back to a whole week`)
+}
+assert.strictEqual(feed.weekDays(saturday, 1, 0).length, 7)
+assert.strictEqual(feed.weekDays(saturday, 1, 3).length, 7,
+  "a width nothing offers draws the whole week rather than an untitleable one")
+
+// Every width this can return has a heading, which is what the clamp is for.
+assert.notStrictEqual(feed.weekTitle(feed.weekDays(saturday, 1, feed.weekDayCount(3))), "")
+assert.notStrictEqual(feed.weekTitle(feed.weekDays(saturday, 1, feed.weekDayCount(5))), "")
+
+// The title names the span drawn. A working week ends on the Friday it shows,
+// not on the Sunday it does not.
+assert.strictEqual(feed.weekTitle(wholeWeek), "7–13 September 2026")
+assert.strictEqual(feed.weekTitle(workingWeek), "7–11 September 2026")
+
+// A five-day week straddling a month keeps both month names.
+const straddling = feed.weekDays(new Date(2026, 8, 30).getTime(), 1, 5)
+assert.strictEqual(feed.weekTitle(straddling), "28 September–2 October 2026")
+
 console.log("test_calendar_feed.js ok")


### PR DESCRIPTION
The week view is always the whole seven, and for a calendar that is mostly work that spends two columns on days with nothing in them while the five that matter are squeezed into what is left. This offers the working week beside it: the same view, five columns, each that much wider.

A width is a shape of the week rather than a third view, so the two numerals are drawn only while the week view is, and they do not navigate — a setter named for a day count that also changed the view mode would surprise its next caller. They sit after Month rather than between Week and Month, where appearing and disappearing shoved Month sideways by their own width at the moment you were reaching for it.

The part worth explaining is why cutting the span happens *after* the anchor resolves. It is what keeps both widths the same week: a Saturday asked for five days answers with that Saturday's own Monday-to-Friday, not the next week's. `weekSpan` is the whole seven whatever is drawn, and `refresh` fetches that — the range cache is keyed by range, so a five-day week asking only for its own five would open a second entry beside the seven-day one and refetch the same events every time the toggle moved. Which day a week starts on is now stated once on the view, because the week drawn and the week fetched are two calls that have to agree and each was carrying its own literal.

`weekDayCount` answers only the two widths the interface offers. An earlier version accepted anything from one to seven, which meant a hand-edited `shell.json` could ask for three days and get a grid that `weekTitle` refuses to name and no button can get back out of.

Two adjacent fixes the change forced. `WeekCalendarView` divided its width by a literal seven in three places — correct while every week was seven days, wrong the moment one is not — so it divides by the days it is handed. And a selection standing on a day the narrower week drops is now let go, rather than leaving the keyboard walking to an event that is no longer drawn or a detail sheet outliving its day.

Note this touches the same header row as the calendar-filter PR alongside it; whichever lands second will want a trivial rebase.

## Verification

`make validate` green on `1896db3`: 374 QML tests, node/shell/python suites, `qmllint` clean, `omarchy plugin validate .` clean, `git diff --check` clean.

New tests: `tests/qml/tst_calendar_week_days.qml` (8 cases) and additions to `tests/test_calendar_feed.js` and `tests/qml/tst_service_settings.qml`. Watched all three fail against unfixed code — the node test on the day count, the service test on the missing setting, the QML test failing to compile for want of `onWeekDayCountRequested`.

The column-width test earned its keep twice. The first version read `grid.dayCount`, and a fresh-agent review defeated it by reverting the three divisors to `/ 7` while leaving that property correct — 7 passed, 0 failed, with five columns drawn across five sevenths of the grid. It now measures a drawn day column's `width` against `(grid.width - timeRailWidth) / 5`, and I re-ran that same mutation against it: it fails.

**Hand test: not done, and this is the gap in this PR.** What exists is offscreen renders at 1040px and at 620px, in a light and a dark palette; they are not attached, because a render is not the screenshot CONTRIBUTING asks for. They did catch the divisor bug — the empty two-sevenths was visible immediately — which is an argument for the hand pass rather than against it. Not marked ready, and no screenshot attached, until someone has driven the toggle on a screen at both sizes.

A fresh agent with no context reviewed the diff. Acted on: the column test that did not test the divisor; a commit message describing the divisor as a pre-existing bug when it was one this patch introduced; `weekDayCount` accepting widths `weekTitle` cannot title; `refresh()` carrying a second hard-coded `weekStart`; the dead `setView("week")` branch in the setter, kept alive only by its own test; the header jitter; the missing `manifest.json` schema entry for the new setting; and `docs/SPEC.md`. Left as known: the five-day slice is Mon–Fri only because both callers pass `weekStart: 1` — with a Sunday start it would be Sun–Thu, which is latent rather than live, and the tooltip now says "the working week" rather than naming the days.

## Release Notes

- The week view can be shown five days wide as well as seven. Choose 5 or 7 next to Month while the week is on screen, and the choice is remembered.
