### PR TITLE
Show and hide a calendar from the calendar itself

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -1684,6 +1684,8 @@ Item {
             dimColor: root.dim
             calendarBorderColor: root.calendarBorder
             calendarTodayBackgroundColor: root.calendarTodayBackground
+            popupBackgroundColor: root.popupBackground
+            popupBorderColor: root.popupBorder
             calendarBorderWidth: root.calendarBorderWidth
             panelFontFamily: root.fontFamily
             // An event opened for reading is a place, so Back closes it before

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/SettingsPage.qml \
 	components/SettingsSidebar.qml \
 	components/CalendarSettings.qml \
+	components/CalendarFilterMenu.qml \
 	components/CalendarEventComposer.qml \
 	components/CalendarEventDetail.qml \
 	components/CalendarPalette.qml \

--- a/calendar/CalendarController.qml
+++ b/calendar/CalendarController.qml
@@ -416,6 +416,31 @@ Item {
     sourceWriter.running = true
   }
 
+  // Every hidden calendar in the current scope shown again, in one write.
+  // A row at a time would only ever bring the first one back: `savingSource`
+  // turns the next call away while the first is still in flight.
+  function showAllSources() {
+    if (savingSource) return
+    var values = contextSources && Array.isArray(contextSources.sources)
+      ? contextSources.sources : []
+    var next = sourceList
+    var changed = false
+    for (var i = 0; i < values.length; i++) {
+      var source = values[i]
+      if (!source || source.enabled !== false) continue
+      next = Sources.setEnabled(Sources.add(next, source), source.id, true)
+      changed = true
+    }
+    if (!changed) return
+    sourceBeingSaved = null
+    sourceSecret = ""
+    sourceWritePayload = Sources.serialize(next)
+    refreshAfterSourceWrite = true
+    savingSource = true
+    sourceWriter.command = [pluginDir + "/scripts/config-store.sh", "calendars.json"]
+    sourceWriter.running = true
+  }
+
   function colorKeyFor(sourceId) {
     var values = availableSources && Array.isArray(availableSources.sources)
       ? availableSources.sources : []

--- a/components/CalendarFilterMenu.qml
+++ b/components/CalendarFilterMenu.qml
@@ -1,0 +1,356 @@
+import QtQuick
+import QtQuick.Controls as QQC
+import qs.Commons
+import qs.Ui
+import "Menu.js" as Menu
+
+// Which calendars the grid is drawing, asked where the grid is.
+//
+// `CalendarController.setSourceEnabled` has been able to hide a calendar's
+// events for as long as it has existed, and nothing has ever called it. This
+// is that call: a calendar is shown or hidden over the grid it changes,
+// because it is the question asked several times a day — this week's work
+// calendar off, next week's on — and the settings page is where you go to
+// give a calendar a password, not to answer that.
+//
+// Rows read from `controller.sourceGroups`, which is the current scope rather
+// than every account — the unified view lists them all, a per-mailbox view
+// lists that mailbox's. A calendar the grid could not draw is not one this
+// menu can hide.
+Item {
+  id: root
+
+  required property var controller
+  required property color textColor
+  required property color dimColor
+  required property color accentColor
+  required property color urgentColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
+  required property string panelFontFamily
+
+  readonly property var groups: controller && Array.isArray(controller.sourceGroups)
+    ? controller.sourceGroups : []
+  readonly property var sources: {
+    var out = []
+    for (var i = 0; i < groups.length; i++) {
+      var calendars = groups[i] && Array.isArray(groups[i].calendars) ? groups[i].calendars : []
+      for (var c = 0; c < calendars.length; c++) out.push(calendars[c])
+    }
+    return out
+  }
+  readonly property int shownCount: {
+    var count = 0
+    for (var i = 0; i < sources.length; i++) if (sources[i] && sources[i].enabled !== false) count++
+    return count
+  }
+  readonly property bool filtered: shownCount < sources.length
+  // A write is refused while another is in flight, so the rows say so rather
+  // than dropping a tap on the floor.
+  readonly property bool busy: !!controller && controller.savingSource === true
+  readonly property bool opened: menu.opened
+
+  // A popup that closes on a press outside itself is already closed by the
+  // press that reaches the trigger, so by the time the release becomes a
+  // click `opened` reads false and a plain toggle opens it straight back up:
+  // the button can never put its own menu away. The moment it closed is what
+  // tells "the user wants this open" apart from "this just closed under the
+  // same press". `ComposeView` carries the same guard for the same reason.
+  property double closedAt: 0
+
+  // Where the keyboard is standing, as an index into `sources` — or the
+  // length of it, which is the Show all row. -1 is nowhere, which is where it
+  // starts: opening with a row lit reads as "this is the one you are on".
+  property int cursorIndex: -1
+  readonly property int rowCount: root.sources.length + (root.filtered ? 1 : 0)
+
+  // The label carries the count, not just the colour of a dot: a theme can put
+  // a calendar's colour close to the foreground, and "some of your calendars
+  // are hidden" is exactly the state you forget you left the app in.
+  //
+  // The word goes before the count does. This sits in a header row that is
+  // already tight at the mini size, and of the two halves the count is the
+  // one saying something the icon beside it does not.
+  readonly property real windowWidth: root.Window.window ? root.Window.window.width : 0
+  readonly property bool roomForTheWord: root.windowWidth === 0 || root.windowWidth >= Style.space(700)
+  readonly property string countLabel: root.shownCount + "/" + root.sources.length
+  readonly property string summary: root.roomForTheWord
+    ? (root.filtered ? "Calendars " + root.countLabel : "Calendars")
+    : (root.filtered ? root.countLabel : "")
+
+  implicitWidth: trigger.implicitWidth
+  implicitHeight: trigger.implicitHeight
+
+  function toggle() {
+    if (menu.opened) { menu.close(); return }
+    if (Date.now() - root.closedAt < 250) return
+    menu.open()
+    root.place()
+  }
+
+  function indexOfSource(sourceId) {
+    for (var i = 0; i < root.sources.length; i++) {
+      if (root.sources[i] && String(root.sources[i].id) === String(sourceId)) return i
+    }
+    return -1
+  }
+
+  function moveCursor(step) {
+    if (root.rowCount === 0) { root.cursorIndex = -1; return }
+    var at = root.cursorIndex
+    if (at < 0 || at >= root.rowCount) at = Number(step) < 0 ? root.rowCount : -1
+    root.cursorIndex = (at + Number(step) + root.rowCount) % root.rowCount
+  }
+
+  function activateCursor() {
+    if (root.busy || root.cursorIndex < 0 || root.cursorIndex >= root.rowCount) return
+    if (root.cursorIndex === root.sources.length) { root.showAll(); return }
+    var source = root.sources[root.cursorIndex]
+    if (source) root.setEnabled(source.id, source.enabled === false)
+  }
+
+  function setEnabled(sourceId, enabled) {
+    if (!controller || typeof controller.setSourceEnabled !== "function") return
+    controller.setSourceEnabled(String(sourceId), enabled === true)
+  }
+
+  function showAll() {
+    if (!controller || typeof controller.showAllSources !== "function") return
+    controller.showAllSources()
+  }
+
+  IconTextButton {
+    id: trigger
+    objectName: "calendarFilterTrigger"
+    anchors.fill: parent
+    iconName: "calendar"
+    text: root.summary
+    tooltipText: "Choose which calendars are drawn"
+    foreground: root.filtered ? root.textColor : root.dimColor
+    hoverColor: root.textColor
+    accent: root.accentColor
+    ghost: true
+    fontFamily: root.panelFontFamily
+    fontSize: Style.font.caption
+    selected: menu.opened
+    onClicked: root.toggle()
+  }
+
+  // Under the trigger, right edges aligned, and above it when there is no
+  // room below. The flip is around the trigger rather than around the point
+  // below it: reflecting around the lower point lands the menu back on top of
+  // the trigger and the heading beside it, which is what a short window did.
+  //
+  // A Popup has no height until it has been opened once, so placing again on
+  // every height change is what puts the first open where the later ones go.
+  function place() {
+    if (!menu.visible) return
+    var window = root.Window.window
+    var windowWidth = window ? window.width : root.width
+    var windowHeight = window ? window.height : root.height
+    var gap = Style.space(4)
+    var tall = menu.height > 0 ? menu.height : menu.implicitHeight
+    var top = root.mapToItem(null, 0, 0)
+
+    var y = top.y + root.height + gap
+    if (y + tall > windowHeight) y = top.y - gap - tall
+    y = Math.max(0, Math.min(y, Math.max(0, windowHeight - tall)))
+
+    var x = top.x + root.width - menu.width
+    x = Math.max(0, Math.min(x, Math.max(0, windowWidth - menu.width)))
+
+    var origin = root.mapFromItem(null, x, y)
+    menu.x = origin.x
+    menu.y = origin.y
+  }
+
+  QQC.Popup {
+    id: menu
+    // Never wider than the window: at the mini size a fixed width runs off
+    // the edge with nothing to scroll it back.
+    width: Math.min(Style.space(280),
+      Math.max(Style.space(180), (root.Window.window ? root.Window.window.width : Style.space(280))
+        - Style.space(24)))
+    implicitHeight: rows.implicitHeight + Style.space(8)
+    padding: Style.space(4)
+    modal: false
+    focus: true
+    closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
+    onHeightChanged: root.place()
+    onOpened: {
+      root.cursorIndex = -1
+      root.place()
+    }
+    onClosed: root.closedAt = Date.now()
+
+    background: Rectangle {
+      radius: Style.cornerRadius
+      color: root.popupBackgroundColor
+      border.width: 1
+      border.color: root.popupBorderColor
+    }
+
+    contentItem: Column {
+      id: rows
+      spacing: Style.space(2)
+
+      // An open popup takes every key before the window's shortcut map, so a
+      // menu that answers none of them silently disables the whole calendar
+      // keymap until it is dismissed. `tests/qml/tst_popup_keys.qml` is why
+      // this is a rule rather than a nicety.
+      focus: true
+      Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_J || event.key === Qt.Key_Down) {
+          root.moveCursor(1); event.accepted = true
+        } else if (event.key === Qt.Key_K || event.key === Qt.Key_Up) {
+          root.moveCursor(-1); event.accepted = true
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter
+            || event.key === Qt.Key_Space) {
+          root.activateCursor(); event.accepted = true
+        }
+      }
+
+      Repeater {
+        model: root.groups
+
+        Column {
+          id: group
+          required property var modelData
+          width: menu.width - menu.leftPadding - menu.rightPadding
+          spacing: Style.space(2)
+
+          // The account only needs naming when there is more than one to
+          // tell apart; one mailbox's calendars are already its own.
+          Text {
+            visible: root.groups.length > 1
+            width: parent.width
+            height: visible ? implicitHeight + Style.space(6) : 0
+            verticalAlignment: Text.AlignBottom
+            leftPadding: Style.space(9)
+            text: group.modelData.accountLabel
+            color: root.dimColor
+            font.family: root.panelFontFamily
+            font.pixelSize: Style.font.caption
+            elide: Text.ElideMiddle
+            textFormat: Text.PlainText
+          }
+
+          Repeater {
+            model: group.modelData.calendars
+
+            Rectangle {
+              id: calendarRow
+              required property var modelData
+              readonly property string sourceId: String(modelData.id || "")
+              readonly property bool shown: modelData.enabled !== false
+              readonly property int rowIndex: root.indexOfSource(calendarRow.sourceId)
+              readonly property color sourceColor: calendarPalette.colorFor(modelData.colorKey)
+
+              objectName: "calendarFilter:" + calendarRow.sourceId
+              width: parent.width
+              implicitHeight: Style.spacing.popupRowHeight
+              radius: Style.cornerRadius
+              // A write already in flight is refused by the controller, so a
+              // row that still took the tap would swallow it and say nothing.
+              enabled: !root.busy
+              opacity: enabled ? 1 : 0.4
+              color: rowHover.hovered || root.cursorIndex === calendarRow.rowIndex
+                ? Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b, 0.08)
+                : "transparent"
+
+              function toggle() { root.setEnabled(calendarRow.sourceId, !calendarRow.shown) }
+
+              // A filled dot for shown, a ring for hidden. The check beside the
+              // name says the same thing again in a second way, because a
+              // calendar's colour is chosen from a palette that a theme can put
+              // close to the ground it sits on.
+              Rectangle {
+                id: rowDot
+                anchors.left: parent.left
+                anchors.leftMargin: Style.space(9)
+                anchors.verticalCenter: parent.verticalCenter
+                width: Style.space(10)
+                height: width
+                radius: width / 2
+                color: calendarRow.shown ? calendarRow.sourceColor : "transparent"
+                border.width: calendarRow.shown ? 0 : Math.max(1, Style.normalBorderWidth)
+                border.color: calendarRow.sourceColor
+              }
+
+              Text {
+                anchors.left: rowDot.right
+                anchors.leftMargin: Style.space(8)
+                anchors.right: rowCheck.left
+                anchors.rightMargin: Style.space(6)
+                anchors.verticalCenter: parent.verticalCenter
+                text: String(calendarRow.modelData.name || calendarRow.modelData.id || "Calendar")
+                color: calendarRow.shown ? root.textColor : root.dimColor
+                font.family: root.panelFontFamily
+                font.pixelSize: Style.font.bodySmall
+                elide: Text.ElideRight
+                textFormat: Text.PlainText
+              }
+
+              ActionIcon {
+                id: rowCheck
+                anchors.right: parent.right
+                anchors.rightMargin: Style.space(9)
+                anchors.verticalCenter: parent.verticalCenter
+                visible: calendarRow.shown
+                name: "check"
+                iconSize: Style.font.iconSmall
+                color: root.accentColor
+              }
+
+              HoverHandler { id: rowHover }
+              TapHandler { onTapped: calendarRow.toggle() }
+            }
+          }
+        }
+      }
+
+      MenuSeparatorLine {
+        visible: root.filtered
+        width: menu.width - menu.leftPadding - menu.rightPadding
+        lineColor: root.textColor
+      }
+
+      // The row names its own collection, and is not in it. A MenuActionRow
+      // left with the default empty one answers `indexOf(this) === cursorIndex`
+      // with `-1 === -1` and draws itself lit from the moment it appears.
+      MenuActionRow {
+        id: showAllRow
+        objectName: "calendarFilterShowAll"
+        visible: root.filtered
+        width: menu.width - menu.leftPadding - menu.rightPadding
+        text: "Show all"
+        textColor: root.textColor
+        panelFontFamily: root.panelFontFamily
+        collection: [showAllRow]
+        cursorIndex: root.cursorIndex === root.sources.length ? 0 : -1
+        enabled: !root.busy
+        onActivated: root.showAll()
+      }
+
+      Text {
+        visible: root.sources.length === 0
+        width: menu.width - menu.leftPadding - menu.rightPadding
+        padding: Style.space(9)
+        text: "No calendars yet. Add one in Settings."
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+        textFormat: Text.PlainText
+      }
+    }
+  }
+
+  CalendarPalette {
+    id: calendarPalette
+    textColor: root.textColor
+    accentColor: root.accentColor
+    urgentColor: root.urgentColor
+    dimColor: root.dimColor
+  }
+}

--- a/components/CalendarSettings.qml
+++ b/components/CalendarSettings.qml
@@ -175,7 +175,10 @@ Column {
           foreground: root.textColor
           fontFamily: root.panelFontFamily
           enabled: existingPassword.text !== "" && !root.controller.savingSource
-          onClicked: root.controller.updateCalendarPassword(modelData, existingPassword.text)
+          onClicked: {
+            root.awaitingSave = true
+            root.controller.updateCalendarPassword(modelData, existingPassword.text)
+          }
         }
         IconTextButton {
           id: cancelExisting
@@ -271,6 +274,7 @@ Column {
 
   function saveCalendar() {
     resultText.text = ""
+    root.awaitingSave = true
     root.controller.addCalDavCalendar({
       name: calendarName.text,
       url: calendarUrl.text,
@@ -278,9 +282,18 @@ Column {
     }, calendarPassword.text)
   }
 
+  // `calendarSaved` is the controller's, not this page's, and every write to
+  // `calendars.json` raises it — including one started from the calendar
+  // header, which this page can now be sitting behind. Answering those too
+  // stamped "Calendar saved" over a half-typed form and threw the fields
+  // away. This answers only a save it asked for.
+  property bool awaitingSave: false
+
   Connections {
     target: root.controller
     function onCalendarSaved(ok, error) {
+      if (!root.awaitingSave) return
+      root.awaitingSave = false
       if (!ok) { resultText.text = error; return }
       resultText.text = "Calendar saved"
       calendarName.text = ""

--- a/components/CalendarView.qml
+++ b/components/CalendarView.qml
@@ -14,6 +14,8 @@ Item {
   required property color dimColor
   required property color calendarBorderColor
   required property color calendarTodayBackgroundColor
+  required property color popupBackgroundColor
+  required property color popupBorderColor
   required property int calendarBorderWidth
   required property string panelFontFamily
 
@@ -214,6 +216,19 @@ Item {
               running: calendarLoading.visible
             }
           }
+        }
+
+        CalendarFilterMenu {
+          objectName: "calendarFilterMenu"
+          anchors.verticalCenter: parent.verticalCenter
+          controller: root.controller
+          textColor: root.textColor
+          dimColor: root.dimColor
+          accentColor: root.accentColor
+          urgentColor: root.urgentColor
+          popupBackgroundColor: root.popupBackgroundColor
+          popupBorderColor: root.popupBorderColor
+          panelFontFamily: root.panelFontFamily
         }
 
         IconTextButton {

--- a/tests/qml/tst_calendar_controller.qml
+++ b/tests/qml/tst_calendar_controller.qml
@@ -47,6 +47,16 @@ Item {
       // the function, so a restore on its last line does not run and one real
       // failure becomes a cascade that hides it.
       mailService.unifiedCalendarView = false
+      controller.sourceList = ({
+        version: 1,
+        sources: [{
+          id: "caldav:team", kind: "caldav", name: "Team",
+          url: "https://calendar.example/team/", username: "work@example.com",
+          enabled: true, readOnly: false, colorKey: "accent"
+        }]
+      })
+      controller.savingSource = false
+      controller.sourceWritePayload = ""
       controller.accountId = "imap:work@example.com"
       controller.refreshScope = ""
       controller.refreshAccountId = ""
@@ -133,6 +143,42 @@ Item {
 
       compare(controller.pendingRangeStart, 1000)
       compare(controller.pendingRangeEnd, 2000)
+    }
+
+    // Bringing hidden calendars back is one write, not one per calendar: a
+    // second call is refused while the first is still saving, so a loop over
+    // `setSourceEnabled` would only ever restore the first of them.
+    function test_show_all_calendars_is_a_single_write() {
+      controller.sourceList = ({
+        version: 1,
+        sources: [
+          { id: "caldav:team", kind: "caldav", name: "Team",
+            url: "https://calendar.example/team/", username: "work@example.com",
+            enabled: false, readOnly: false, colorKey: "accent" },
+          { id: "caldav:oncall", kind: "caldav", name: "On call",
+            url: "https://calendar.example/oncall/", username: "work@example.com",
+            enabled: false, readOnly: false, colorKey: "cyan" }
+        ]
+      })
+      controller.savingSource = false
+      controller.sourceWritePayload = ""
+
+      controller.showAllSources()
+
+      compare(controller.savingSource, true, "one write started")
+      var written = JSON.parse(controller.sourceWritePayload)
+      compare(written.sources.length, 2)
+      compare(written.sources[0].enabled, true)
+      compare(written.sources[1].enabled, true)
+
+      // Nothing hidden, nothing to write: a second press does not queue a
+      // save that would change nothing.
+      controller.savingSource = false
+      controller.sourceList = ({ version: 1, sources: written.sources })
+      controller.sourceWritePayload = ""
+      controller.showAllSources()
+      compare(controller.savingSource, false)
+      compare(controller.sourceWritePayload, "")
     }
   }
 }

--- a/tests/qml/tst_calendar_filter_menu.qml
+++ b/tests/qml/tst_calendar_filter_menu.qml
@@ -1,0 +1,218 @@
+import QtQuick 2.15
+import QtTest 1.3
+import qs.Commons
+import "../../components" as Omamail
+
+// Showing and hiding a calendar from the view that draws it.
+//
+// The pointer and the keyboard are driven here rather than the signals behind
+// them: a menu that cannot be clicked shut, or that eats every key while it is
+// open, passes every test that calls `clicked()` directly and fails the first
+// time somebody uses it.
+Item {
+  id: shell
+  width: 900
+  height: 700
+
+  QtObject {
+    id: calendarController
+
+    property var events: []
+    property bool loading: false
+    property bool sourcesLoaded: true
+    property bool savingSource: false
+    property string lastError: ""
+    property string lastErrorKind: ""
+    property double nowMs: 0
+    property bool clockRunning: false
+    property var visibilityChanges: []
+    property int showAllCalls: 0
+    property var sourceGroups: [{
+      id: "account:me@example.com",
+      providerLabel: "Google",
+      accountLabel: "me@example.com",
+      calendars: [
+        { id: "google:me@example.com", kind: "google", name: "me@example.com",
+          enabled: true, colorKey: "accent" },
+        { id: "google:me@example.com:team", kind: "google", name: "Team",
+          enabled: false, colorKey: "cyan" }
+      ]
+    }]
+
+    function refresh(_startMs, _endMs) {}
+    function colorKeyFor(_sourceId) { return "accent" }
+    // The real controller refuses a write while another is in flight. The
+    // stub does too, or a test cannot see a refusal being avoided.
+    function setSourceEnabled(sourceId, enabled) {
+      if (savingSource) return
+      visibilityChanges = visibilityChanges.concat([[String(sourceId), enabled === true]])
+    }
+    function showAllSources() {
+      if (savingSource) return
+      showAllCalls = showAllCalls + 1
+    }
+  }
+
+  Omamail.CalendarView {
+    id: calendarView
+    anchors.fill: parent
+    controller: calendarController
+    textColor: Color.foreground
+    backgroundColor: Color.background
+    accentColor: Color.accent
+    urgentColor: Color.accent
+    dimColor: Color.foreground
+    calendarBorderColor: Color.foreground
+    calendarTodayBackgroundColor: Color.accent
+    popupBackgroundColor: Color.background
+    popupBorderColor: Color.foreground
+    calendarBorderWidth: 1
+    panelFontFamily: "monospace"
+  }
+
+  TestCase {
+    name: "CalendarFilterMenu"
+    when: windowShown
+
+    // `findChild` follows the object tree, and a Repeater parents its
+    // delegates visually rather than owning them — inside a popup that is
+    // enough to hide every row it built. This walks what is drawn instead,
+    // from the window down, which is also where a popup's contents live.
+    function drawn(name) { return drawnUnder(shell.Window.window.contentItem, name) }
+
+    function drawnUnder(item, name) {
+      if (!item) return null
+      if (String(item.objectName) === name) return item
+      for (var i = 0; i < item.children.length; i++) {
+        var found = drawnUnder(item.children[i], name)
+        if (found !== null) return found
+      }
+      return null
+    }
+
+    function trigger() { return findChild(calendarView, "calendarFilterTrigger") }
+
+    function menu() { return findChild(calendarView, "calendarFilterMenu") }
+
+    // Opening and closing go through the pointer, and the guard that stops a
+    // press outside re-opening the menu is waited out between cases.
+    function openMenu() {
+      if (!menu().opened) mouseClick(trigger())
+      verify(menu().opened, "the menu opened")
+    }
+
+    function init() {
+      calendarController.savingSource = false
+      calendarController.visibilityChanges = []
+      calendarController.showAllCalls = 0
+      if (menu().opened) mouseClick(trigger())
+      wait(300)
+    }
+
+    // The count is in the label, not only in the colour of a dot: some of
+    // your calendars being hidden is exactly the state you forget you left
+    // the app in, and a theme can put a calendar's colour near the ground.
+    function test_the_trigger_says_how_many_calendars_are_drawn() {
+      compare(trigger().text, "Calendars 1/2")
+    }
+
+    // The button that opened the menu can put it away. A popup closing on a
+    // press outside itself is already shut by the press that reaches its own
+    // trigger, so a plain toggle re-opens it on the release and the control
+    // never works.
+    function test_the_trigger_closes_the_menu_it_opened() {
+      mouseClick(trigger())
+      compare(menu().opened, true)
+
+      mouseClick(trigger())
+      compare(menu().opened, false, "a second click puts it away")
+    }
+
+    function test_a_calendar_is_shown_and_hidden_from_the_view() {
+      openMenu()
+
+      var primary = drawn("calendarFilter:google:me@example.com")
+      var team = drawn("calendarFilter:google:me@example.com:team")
+      verify(primary !== null)
+      verify(team !== null)
+      compare(primary.shown, true)
+      compare(team.shown, false)
+
+      mouseClick(primary)
+      mouseClick(team)
+      compare(JSON.stringify(calendarController.visibilityChanges), JSON.stringify([
+        ["google:me@example.com", false],
+        ["google:me@example.com:team", true]
+      ]))
+    }
+
+    // Every hidden calendar comes back in one write, because a second call
+    // would be refused while the first is still saving.
+    function test_show_all_asks_the_controller_once() {
+      openMenu()
+      var showAll = drawn("calendarFilterShowAll")
+      verify(showAll !== null)
+      verify(showAll.visible, "offered while something is hidden")
+
+      mouseClick(showAll)
+      compare(calendarController.showAllCalls, 1)
+    }
+
+    // A write already in flight is refused by the controller, so the rows say
+    // so and take no tap, rather than swallowing one and changing nothing.
+    function test_a_save_in_flight_stops_the_rows_taking_a_tap() {
+      openMenu()
+      var primary = drawn("calendarFilter:google:me@example.com")
+      var showAll = drawn("calendarFilterShowAll")
+      compare(primary.enabled, true)
+      compare(showAll.enabled, true)
+
+      calendarController.savingSource = true
+      compare(primary.enabled, false, "a calendar row refuses while saving")
+      compare(showAll.enabled, false)
+
+      mouseClick(primary)
+      compare(JSON.stringify(calendarController.visibilityChanges), "[]",
+        "and the tap changed nothing rather than being dropped silently")
+    }
+
+    // An open popup takes every key before the window's shortcut map, so it
+    // has to answer the ones it takes. j/k walk the rows, Return toggles the
+    // one they are standing on.
+    function test_the_keyboard_walks_the_rows_and_toggles_one() {
+      openMenu()
+
+      keyClick(Qt.Key_J)
+      compare(menu().cursorIndex, 0)
+      keyClick(Qt.Key_J)
+      compare(menu().cursorIndex, 1)
+      keyClick(Qt.Key_K)
+      compare(menu().cursorIndex, 0)
+
+      keyClick(Qt.Key_Return)
+      compare(JSON.stringify(calendarController.visibilityChanges),
+        JSON.stringify([["google:me@example.com", false]]))
+    }
+
+    // The cursor wraps past the last row onto Show all, which is a row like
+    // any other as far as the keyboard is concerned.
+    function test_the_keyboard_reaches_show_all() {
+      openMenu()
+      compare(menu().rowCount, 3, "two calendars and Show all")
+
+      keyClick(Qt.Key_K)
+      compare(menu().cursorIndex, 2, "up from nowhere lands on the last row")
+
+      keyClick(Qt.Key_Return)
+      compare(calendarController.showAllCalls, 1)
+    }
+
+    // Escape is the popup's own, and it must leave the calendar's keys behind
+    // it: the window's shortcut map is dead while this is open.
+    function test_escape_closes_the_menu() {
+      openMenu()
+      keyClick(Qt.Key_Escape)
+      compare(menu().opened, false)
+    }
+  }
+}


### PR DESCRIPTION
`CalendarController.setSourceEnabled` has no caller. `git grep setSourceEnabled -- '*.qml'` on `main` returns the definition and nothing else. The controller can hide a calendar's events, `Sources` can persist the flag, `Sources.setEnabled` is tested, and every source carries `enabled` through the whole read path — but nothing in the interface asks for any of it. On a machine with a work calendar, a family calendar and a feed of public holidays in the same grid, all three are drawn and there is no way to say otherwise.

This is the control that was missing, put over the grid it changes. It lists the calendars in the current scope — every account under the unified view, one mailbox's under the default — as a colour dot, the name, and a check for the ones being drawn. A calendar the grid could not draw is not one this can hide. Both the dot and the check carry the state, because a calendar's colour comes from a palette a theme can put close to the ground it sits on, and the trigger reads `Calendars 2/3` rather than leaving "you have hidden something" to be noticed: it is the state you forget you left the app in. The word drops before the count does when the window is narrow, because that header row is already tight at the mini size and the count is the half saying something the icon does not.

`showAllSources` is one write rather than a loop over `setSourceEnabled`, which would restore only the first calendar — the second call is refused while the first is still in flight. The rows disable while a write runs rather than taking a tap the controller will refuse.

Three things a popup owes the window it opens in, all three of which I had wrong first time and all three of which fall out of clicking it once:

- An open `QQC.Popup` takes every key before the shortcut map, so a menu answering none of them silently disables the whole calendar keymap until it is dismissed. This one answers `j`/`k` and `Return`. `tests/qml/tst_popup_keys.qml` is why that is a rule here rather than a nicety.
- It closes on a press outside itself, which means the press reaching its own trigger has already closed it — so a plain `opened ? close() : open()` re-opens on the release and the button can never put its own menu away. The trigger keeps the moment it shut and refuses to re-open inside it, the guard `ComposeView` already carries for the same reason.
- It flips *above its trigger* rather than around the point below it. Reflecting around the lower point lands the menu back on top of the trigger and the heading beside it, which is what a short window did.

One thing outside the new file. `CalendarSettings` answered `calendarSaved` whoever raised it, which was harmless while it was the only thing writing `calendars.json`. Now that a second place writes it, hiding a calendar from the header stamped "Calendar saved" over a half-typed *Add a calendar* form and threw the fields away, so it answers only a save it asked for.

Known and not fixed here: a failed write is still reported only on the settings page, so a row that snaps back in this menu does so without saying why. That is a pre-existing gap in `calendarSaved` handling rather than something this introduces, and fixing it properly means giving the menu somewhere to put an error — worth its own change.

Note this touches the same header row as the working-week PR alongside it; whichever lands second will want a trivial rebase.

## Verification

`make validate` green on `6ee5166`: 376 QML tests, node/shell/python suites, `qmllint` clean, `omarchy plugin validate .` clean, `git diff --check` clean.

New tests: `tests/qml/tst_calendar_filter_menu.qml` (10 cases) and a `showAllSources` case in `tests/qml/tst_calendar_controller.qml`. Watched both fail against unfixed code — the controller test on `showAllSources` not being a function, the menu test failing to compile for want of `popupBorderColor`.

The tests drive the pointer and the keyboard rather than calling the signals behind them, which is the whole reason the three popup defects above were found at all: an earlier version called `trigger.clicked()` and `row.toggle()` directly and passed 372 tests with a menu that could not be clicked shut, ate every calendar key, and took taps it would silently refuse. Re-ran the specific mutation: removing the re-open guard makes `test_the_trigger_closes_the_menu_it_opened` fail on the second `mouseClick`.

**Hand test: not done, and this is the gap in this PR.** What exists is offscreen renders — light, dark, and a 420px window — and they are not attached, because a render is not the screenshot CONTRIBUTING asks for. The narrow one shows the popup staying inside the window after the width clamp, and also shows the header row itself already over-full at that size before this control is added to it, which is worth an eye during the hand pass. Not marked ready, and no screenshot attached, until someone has driven it on a screen at both sizes.

A fresh agent with no context reviewed the diff and found the keyboard, the toggle, the flip anchor, the un-disabled rows, the fixed width, the settings cross-talk, an unreachable empty state, and a header comment claiming a symmetry with a settings control that does not exist. All acted on except the error-reporting gap noted above.

## Release Notes

- Calendars can be shown and hidden from the calendar itself. The new **Calendars** button above the grid lists them with their colours, and the label shows how many are drawn when any are hidden.
