### PR TITLE
Lay overlapping events side by side instead of on top of each other

### DIFF
--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -713,12 +713,72 @@ function eventTop(event, day, firstHour, hourHeight) {
   return Math.max(0, minutes / 60 * Number(hourHeight))
 }
 
+// The least a timed block is drawn as, in hours: a five-minute event still
+// needs room for its title. `overlapLayout` measures with the same floor, so
+// two short events drawn touching are also laid side by side.
+var MIN_BLOCK_HOURS = 0.42
+
 function eventHeight(event, day, hourHeight) {
   if (!event || !event.start || event.start.allDay) return 0
   var start = Math.max(Number(event.start.ms), Number(day.startMs))
   var end = event.end ? Math.min(Number(event.end.ms), Number(day.endMs)) : start + 1800000
-  return Math.max(Number(hourHeight) * 0.42,
+  return Math.max(Number(hourHeight) * MIN_BLOCK_HOURS,
     (dayMinutes(end, day) - dayMinutes(start, day)) / 60 * Number(hourHeight))
+}
+
+// Side-by-side columns for the timed events of one day column, so events at
+// the same time sit next to each other instead of on top of one another.
+// Returns one `{ column, columns }` per input event, in input order: the
+// event's column and how many columns its cluster of overlapping events was
+// split into. A cluster is every event joined by a chain of overlaps — an
+// event overlapping only the second of two overlapping events still shares
+// their split, or the three would not line up — and inside it each event
+// takes the first column free by the time it starts.
+//
+// Every span is clipped to the day before it is compared, so an event that
+// began yesterday is measured by the part of it drawn here, and stretched to
+// the minimum block, so two events drawn touching are split rather than
+// overlapping on screen while the clock says they do not.
+function overlapLayout(events, day) {
+  var values = Array.isArray(events) ? events : []
+  var spans = []
+  for (var i = 0; i < values.length; i++) {
+    var event = values[i]
+    if (!event || !event.start || event.start.allDay) continue
+    var start = Math.max(Number(event.start.ms), Number(day.startMs))
+    var end = event.end ? Math.min(Number(event.end.ms), Number(day.endMs)) : start + 1800000
+    end = Math.max(end, start + MIN_BLOCK_HOURS * 3600000)
+    spans.push({ index: i, start: start, end: end })
+  }
+  spans.sort(function(left, right) {
+    return left.start - right.start || right.end - left.end || left.index - right.index
+  })
+  var out = []
+  for (var o = 0; o < values.length; o++) out.push({ column: 0, columns: 1 })
+  var cluster = []
+  var columnEnds = []
+  var clusterEnd = -Infinity
+  function flush() {
+    for (var c = 0; c < cluster.length; c++)
+      out[cluster[c].index] = { column: cluster[c].column, columns: columnEnds.length }
+    cluster = []
+    columnEnds = []
+    clusterEnd = -Infinity
+  }
+  for (var s = 0; s < spans.length; s++) {
+    var span = spans[s]
+    if (cluster.length > 0 && span.start >= clusterEnd) flush()
+    var column = -1
+    for (var k = 0; k < columnEnds.length; k++) {
+      if (columnEnds[k] <= span.start) { column = k; break }
+    }
+    if (column < 0) { column = columnEnds.length; columnEnds.push(0) }
+    columnEnds[column] = span.end
+    cluster.push({ index: span.index, column: column })
+    clusterEnd = Math.max(clusterEnd, span.end)
+  }
+  flush()
+  return out
 }
 
 // Where "now" sits in a day column, or -1 when it does not belong on the grid:

--- a/components/WeekCalendarView.qml
+++ b/components/WeekCalendarView.qml
@@ -254,6 +254,10 @@ Item {
               root.controller ? root.controller.events : [], modelData).filter(function(event) {
                 return event && event.start && !event.start.allDay
               })
+            // Events at the same time share the column's width side by side
+            // rather than being painted over one another.
+            readonly property var layout: Calendar.overlapLayout(dayEvents, modelData)
+            readonly property real lanePadding: Style.space(3)
             width: (timeline.width - root.timeRailWidth) / 7
             height: parent.height
 
@@ -276,10 +280,15 @@ Item {
               delegate: Rectangle {
                 id: eventBlock
                 required property var modelData
+                required property int index
                 readonly property color eventColor: calendarPalette.colorFor(
                   root.controller ? root.controller.colorKeyFor(modelData.sourceId) : "")
-                x: Style.space(3)
-                width: dayColumn.width - Style.space(6)
+                readonly property var slot: dayColumn.layout[index] || ({ column: 0, columns: 1 })
+                readonly property int columns: Math.max(1, Number(slot.columns) || 1)
+                readonly property real laneWidth: (dayColumn.width - dayColumn.lanePadding * 2) / columns
+                x: dayColumn.lanePadding + laneWidth * Number(slot.column)
+                width: Math.max(Style.space(8),
+                  laneWidth - (Number(slot.column) < columns - 1 ? Style.space(2) : 0))
                 y: Calendar.eventTop(modelData, dayColumn.modelData,
                   root.firstHour, timeline.hourHeight)
                 height: Calendar.eventHeight(modelData, dayColumn.modelData, timeline.hourHeight)

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -470,4 +470,61 @@ assert.ok(googleUrl.indexOf("singleEvents=true") > 0)
 assert.ok(googleUrl.indexOf("orderBy=startTime") > 0)
 assert.ok(googleUrl.indexOf("timeMin=2026-08-01T00%3A00%3A00.000Z") > 0)
 
+// Overlapping timed events are laid side by side: every event joined by a
+// chain of overlaps shares one split, and an event takes the first column
+// free by the time it starts.
+const gridDay = feed.weekDays(new Date(2026, 8, 7).getTime(), 1)[0]
+function clock(hour, minute) { return new Date(2026, 8, 7, hour, minute || 0).getTime() }
+function block(uid, startMs, endMs) { return { uid, start: { ms: startMs }, end: { ms: endMs } } }
+
+assert.strictEqual(gridDay.isoDate, "2026-09-07")
+const laid = feed.overlapLayout([
+  block("a", clock(9), clock(10)),
+  block("b", clock(9, 30), clock(10, 30)),
+  block("c", clock(10), clock(11)),
+  block("d", clock(13), clock(14)),
+  block("e", clock(15), clock(16)),
+  block("f", clock(15), clock(16)),
+  block("g", clock(15), clock(16))
+], gridDay)
+assert.strictEqual(JSON.stringify(laid), JSON.stringify([
+  { column: 0, columns: 2 }, { column: 1, columns: 2 }, { column: 0, columns: 2 },
+  { column: 0, columns: 1 },
+  { column: 0, columns: 3 }, { column: 1, columns: 3 }, { column: 2, columns: 3 }
+]), "a chained cluster shares its columns; a lone event keeps the width")
+
+assert.strictEqual(JSON.stringify(feed.overlapLayout([], gridDay)), "[]")
+
+assert.strictEqual(JSON.stringify(feed.overlapLayout([
+  { uid: "all", start: { ms: clock(0), allDay: true }, end: { ms: new Date(2026, 8, 8).getTime() } },
+  block("x", clock(9), clock(10))
+], gridDay)), JSON.stringify([{ column: 0, columns: 1 }, { column: 0, columns: 1 }]),
+  "an all-day event is not part of the timed grid")
+
+assert.strictEqual(JSON.stringify(feed.overlapLayout([
+  block("short", clock(9), clock(9, 5)),
+  block("next", clock(9, 10), clock(9, 15))
+], gridDay)), JSON.stringify([{ column: 0, columns: 2 }, { column: 1, columns: 2 }]),
+  "two events drawn at the minimum block height would touch, so they split too")
+
+assert.strictEqual(JSON.stringify(feed.overlapLayout([
+  block("late", clock(10), clock(11)),
+  block("early", clock(9), clock(10, 30))
+], gridDay)), JSON.stringify([{ column: 1, columns: 2 }, { column: 0, columns: 2 }]),
+  "input order does not decide the column; start time does")
+
+assert.strictEqual(JSON.stringify(feed.overlapLayout([
+  block("overnight", new Date(2026, 8, 6, 23).getTime(), clock(1)),
+  block("morning", clock(0, 30), clock(1, 30))
+], gridDay)), JSON.stringify([{ column: 0, columns: 2 }, { column: 1, columns: 2 }]),
+  "an event that started yesterday is clipped to this day before comparing")
+
+// Back to back is not overlapping: an event starting exactly when the last
+// one ends takes the column that just came free rather than a new one.
+assert.strictEqual(JSON.stringify(feed.overlapLayout([
+  block("first", clock(9), clock(10)),
+  block("second", clock(10), clock(11))
+], gridDay)), JSON.stringify([{ column: 0, columns: 1 }, { column: 0, columns: 1 }]),
+  "consecutive events each keep the full width")
+
 console.log("test_calendar_feed.js ok")


### PR DESCRIPTION
Two events at the same time are drawn at the same `x` and the same width, so the later one covers the earlier one completely. A morning with a standup inside a longer block shows the block and no standup — the event is fetched, laid out and painted, and then hidden by the next one. Nothing in the interface says a second event is there.

`overlapLayout` splits a day column's timed events into side-by-side lanes. It works on clusters rather than on pairs, and that is the part worth spending words on: every event joined by a chain of overlaps shares one split, because an event overlapping only the *second* of two overlapping events still has to line up with both, and splitting pairwise would give the three different widths and leave the middle one straddling a boundary. Inside a cluster each event takes the first lane free by the time it starts, which keeps a long event on the left with the short ones beside it in start order.

Two details the grid forces rather than the clock:

- A span is clipped to the day before it is compared, so an event that began yesterday is measured by the part drawn here rather than by a start time off the top of the column.
- A span is stretched to the minimum block height first. That floor already governs what is drawn, so without it two five-minute events ten minutes apart do not overlap by the clock but *are* drawn overlapping — and would be painted over each other exactly as before. `MIN_BLOCK_HOURS` is now named once and used by both `eventHeight` and the layout, so the two cannot drift.

## Verification

`make validate` green on `22a7336`: 365 QML tests, node/shell/python suites, `qmllint` clean, `omarchy plugin validate .` clean, `git diff --check` clean.

New assertions in `tests/test_calendar_feed.js` covering the chained cluster, a lone event keeping the full width, all-day events staying out of the timed grid, input order not deciding the column, an overnight event clipped to the day, two short events that only overlap once drawn, and back-to-back events reusing the lane that just came free. Watched them fail against the unfixed code: `overlapLayout` does not exist there, and the file aborts.

**Hand test: not done, and this is the gap in this PR.** No screenshot is attached, for the same reason: what exists is an offscreen render, which is not what CONTRIBUTING asks for. This is the least visual change of the set — the layout is arithmetic and the node tests assert the actual column assignments rather than a rendering — but the lane widths and the gutter between them are a drawing decision and want an eye on them. Not marked ready until someone has put a real overlapping morning on screen at both window sizes.

A fresh agent with no context reviewed the diff (its review covered this change as part of a larger branch) and raised nothing against the layout itself.

## Release Notes

- Events at the same time are drawn side by side in the week view instead of on top of one another, so a meeting inside a longer block is no longer hidden by it.
