### PR TITLE
Let a calendar be given a colour from Settings

### DIFF
--- a/components/CalendarSettings.qml
+++ b/components/CalendarSettings.qml
@@ -15,8 +15,27 @@ Column {
   property bool adding: false
   property string passwordEditingId: ""
 
+  // Every calendar the app offers, not only the ones written to disk. A
+  // discovered Google calendar is persisted the first time it is toggled or
+  // coloured, and it has to be listed before either can happen — so a list of
+  // what is already on disk is a list that cannot reach a new calendar.
+  readonly property var offeredSources: {
+    var available = root.controller ? root.controller.availableSources : null
+    if (available && Array.isArray(available.sources)) return available.sources
+    var stored = root.controller ? root.controller.sourceList : null
+    return stored && Array.isArray(stored.sources) ? stored.sources : []
+  }
+
   width: parent ? parent.width : implicitWidth
   spacing: Style.space(8)
+
+  CalendarPalette {
+    id: calendarPalette
+    textColor: root.textColor
+    accentColor: root.accentColor
+    urgentColor: root.urgentColor
+    dimColor: root.dimColor
+  }
 
   Text {
     text: "CALENDARS"
@@ -86,22 +105,36 @@ Column {
   }
 
   Repeater {
-    model: root.controller && root.controller.sourceList
-      ? root.controller.sourceList.sources : []
+    model: root.offeredSources
 
     Item {
+      id: sourceItem
+      required property var modelData
+      readonly property string sourceId: String(modelData.id || "")
+      readonly property color sourceColor: calendarPalette.colorFor(modelData.colorKey)
       width: root.width
-      implicitHeight: sourceRow.height + (passwordRow.visible
-        ? passwordRow.implicitHeight + Style.space(6) : 0)
+      implicitHeight: sourceRow.height + Style.space(6) + swatchRow.implicitHeight
+        + (passwordRow.visible ? passwordRow.implicitHeight + Style.space(6) : 0)
 
       Item {
         id: sourceRow
         width: parent.width
         height: Math.max(sourceText.implicitHeight, sourceActions.implicitHeight)
 
+      Rectangle {
+        id: colorDot
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        width: Style.space(10)
+        height: width
+        radius: width / 2
+        color: sourceItem.sourceColor
+      }
+
       Column {
         id: sourceText
-        anchors.left: parent.left
+        anchors.left: colorDot.right
+        anchors.leftMargin: Style.space(8)
         anchors.right: sourceActions.left
         anchors.rightMargin: Style.space(8)
         anchors.verticalCenter: parent.verticalCenter
@@ -109,7 +142,7 @@ Column {
 
         Text {
           width: parent.width
-          text: String(modelData.name || modelData.id || "Calendar")
+          text: String(sourceItem.modelData.name || sourceItem.modelData.id || "Calendar")
           color: root.textColor
           font.family: root.panelFontFamily
           font.pixelSize: Style.font.bodySmall
@@ -117,7 +150,8 @@ Column {
         }
         Text {
           width: parent.width
-          text: modelData.kind === "google" ? "Google Calendar" : String(modelData.url || "CalDAV")
+          text: sourceItem.modelData.kind === "google"
+            ? "Google Calendar" : String(sourceItem.modelData.url || "CalDAV")
           color: root.dimColor
           font.family: root.panelFontFamily
           font.pixelSize: Style.font.caption
@@ -131,31 +165,78 @@ Column {
         anchors.verticalCenter: parent.verticalCenter
         spacing: Style.space(4)
         IconTextButton {
-          visible: modelData.kind === "caldav"
+          visible: sourceItem.modelData.kind === "caldav"
           text: "Set password"
           bordered: false
           foreground: root.textColor
           fontFamily: root.panelFontFamily
-          onClicked: root.passwordEditingId = String(modelData.id)
+          onClicked: root.passwordEditingId = sourceItem.sourceId
         }
         IconTextButton {
-          visible: modelData.kind !== "google"
+          visible: sourceItem.modelData.kind !== "google"
           text: "Remove"
           bordered: false
           foreground: root.urgentColor
           fontFamily: root.panelFontFamily
-          onClicked: root.controller.removeCalendar(modelData.id)
+          onClicked: root.controller.removeCalendar(sourceItem.sourceId)
         }
       }
       }
 
+      // The palette a calendar can wear, as the colours themselves. A name
+      // ("cyan") is not what you are choosing between when four calendars are
+      // drawn over one another in a week; the swatch is.
+      Row {
+        id: swatchRow
+        anchors.top: sourceRow.bottom
+        anchors.topMargin: Style.space(6)
+        anchors.left: parent.left
+        anchors.leftMargin: Style.space(18)
+        spacing: Style.space(6)
+
+        Repeater {
+          model: calendarPalette.slots
+
+          Rectangle {
+            id: swatch
+            required property string modelData
+            readonly property bool current: modelData === String(sourceItem.modelData.colorKey || "")
+
+            objectName: "calendarColor:" + sourceItem.sourceId + ":" + modelData
+            width: Style.space(14)
+            height: width
+            radius: width / 2
+            color: calendarPalette.colorFor(swatch.modelData)
+            // The chosen one wears a ring rather than only being brighter: a
+            // theme can put two palette slots close together, and "which of
+            // these seven am I on" is the whole question this row answers.
+            border.width: swatch.current ? 2 : 0
+            border.color: root.textColor
+            opacity: swatch.current || swatchHover.containsMouse ? 1 : 0.6
+
+            function choose() {
+              if (root.controller && typeof root.controller.setSourceColor === "function")
+                root.controller.setSourceColor(sourceItem.sourceId, swatch.modelData)
+            }
+
+            MouseArea {
+              id: swatchHover
+              anchors.fill: parent
+              hoverEnabled: true
+              cursorShape: Qt.PointingHandCursor
+              onClicked: swatch.choose()
+            }
+          }
+        }
+      }
+
       Row {
         id: passwordRow
-        anchors.top: sourceRow.bottom
+        anchors.top: swatchRow.bottom
         anchors.topMargin: visible ? Style.space(6) : 0
         width: parent.width
-        visible: modelData.kind === "caldav"
-          && root.passwordEditingId === String(modelData.id)
+        visible: sourceItem.modelData.kind === "caldav"
+          && root.passwordEditingId === sourceItem.sourceId
         spacing: Style.space(6)
 
         TextField {
@@ -175,7 +256,7 @@ Column {
           foreground: root.textColor
           fontFamily: root.panelFontFamily
           enabled: existingPassword.text !== "" && !root.controller.savingSource
-          onClicked: root.controller.updateCalendarPassword(modelData, existingPassword.text)
+          onClicked: root.controller.updateCalendarPassword(sourceItem.modelData, existingPassword.text)
         }
         IconTextButton {
           id: cancelExisting

--- a/tests/qml/tst_calendar_settings.qml
+++ b/tests/qml/tst_calendar_settings.qml
@@ -28,12 +28,26 @@ Item {
     id: calendarController
 
     property var sourceList: ({ version: 1, sources: [] })
+    // What the app offers, persisted or not: a discovered Google calendar is
+    // listed here before anything has been written for it.
+    property var availableSources: ({ version: 1, sources: [
+      { id: "google:me@example.com", kind: "google", name: "me@example.com",
+        accountId: "me@example.com", calendarId: "primary", enabled: true,
+        readOnly: false, colorKey: "accent" },
+      { id: "google:me@example.com:team", kind: "google", name: "Team",
+        accountId: "me@example.com", calendarId: "team@group.calendar.google.com",
+        enabled: true, readOnly: true, colorKey: "cyan" }
+    ] })
     property bool savingSource: false
+    property var colorChanges: []
     signal calendarSaved(bool ok, string error)
 
     function addCalDavCalendar(_source, _password) {}
     function removeCalendar(_sourceId) {}
     function updateCalendarPassword(_source, _password) {}
+    function setSourceColor(sourceId, colorKey) {
+      colorChanges = colorChanges.concat([[String(sourceId), String(colorKey)]])
+    }
   }
 
   Omamail.SettingsPage {
@@ -66,6 +80,34 @@ Item {
       compare(mailService.unifiedCalendarView, false)
       compare(mailService.settingChanges, 2)
       compare(toggle.checked, false)
+    }
+
+    // Every offered calendar can be given a colour, including a discovered
+    // Google calendar that nothing has been written for yet — which is the
+    // one a fresh sign-in leaves you with.
+    function test_each_offered_calendar_can_be_coloured() {
+      var primary = findChild(settings, "calendarColor:google:me@example.com:red")
+      var team = findChild(settings, "calendarColor:google:me@example.com:team:magenta")
+      verify(primary !== null, "the account's own calendar offers the palette")
+      verify(team !== null, "and so does a discovered one")
+
+      primary.choose()
+      team.choose()
+      compare(JSON.stringify(calendarController.colorChanges), JSON.stringify([
+        ["google:me@example.com", "red"],
+        ["google:me@example.com:team", "magenta"]
+      ]))
+    }
+
+    // The colour a calendar already wears is the one wearing the ring, so the
+    // row says which of the seven you are on without relying on brightness.
+    function test_the_current_colour_is_marked() {
+      var chosen = findChild(settings, "calendarColor:google:me@example.com:accent")
+      var other = findChild(settings, "calendarColor:google:me@example.com:red")
+      compare(chosen.current, true)
+      compare(other.current, false)
+      verify(chosen.border.width > 0)
+      compare(other.border.width, 0)
     }
   }
 }


### PR DESCRIPTION
`CalendarController.setSourceColor` has no caller. `git grep setSourceColor -- '*.qml'` on `main` returns the definition and nothing else — the same shape as `setSourceEnabled` in the calendar-filter PR alongside this one. Every calendar is already drawn in the colour its `colorKey` names, `Sources.setColor` persists one, and `Palette` resolves the seven slots against the active theme. Nothing asks.

So the colour a calendar wears is whatever `Palette.defaultKey` hashed out of its id. That is fine until two calendars land on the same slot, which with seven slots is not rare, and then they are drawn identically in the same week with nothing to separate them. There is currently no answer to that at all.

Settings is the right home for it rather than the calendar header. It owns a calendar's whole life — its password, whether it exists — and a colour is set once and then left. Which calendars are *drawn* is the question asked several times a day, and that one belongs over the grid it changes.

Two small decisions in the row. The palette is listed as the colours themselves rather than as their names, because a name is not what you are choosing between when four calendars are stacked in a week — you are picking the one that is not the other three. And the slot in use wears a ring rather than only being brighter: a theme can put two slots close together, and "which of these seven am I on" is the only question this row exists to answer, so it is not left to a 0.6 opacity difference.

The list is now what the app offers rather than what is on disk. A discovered Google calendar is written the first time it is toggled or coloured, so a list of the already-persisted could never reach a newly signed-in account's calendars — which is precisely the set that still has hashed colours and most needs this. `availableSources` is what `colorKeyFor` already reads, so the page and the grid now agree on what exists.

## Verification

`make validate` green on `329c49a`: 367 QML tests, node/shell/python suites, `qmllint` clean, `omarchy plugin validate .` clean, `git diff --check` clean.

Two new cases in `tests/qml/tst_calendar_settings.qml`, and the controller stub gained the `availableSources` and `setSourceColor` the real one has. Watched both fail against the unfixed code: `test_each_offered_calendar_can_be_coloured` fails on the swatch not existing, and `test_the_current_colour_is_marked` throws reading `current` of null.

The first of those covers the discovered-calendar case specifically — the stub's second calendar is a Google one with nothing persisted for it — so the "offered, not stored" half of the change is asserted rather than just described.

**Hand test: not done, and this is the gap in this PR**, as with the others in this series. No screenshot is attached, because what exists is an offscreen render and that is not what CONTRIBUTING asks for. This one wants a real eye more than most: seven swatches in a row is a size-and-spacing decision, and whether the ring reads as "chosen" at 14px is exactly the kind of thing an offscreen run cannot tell you. Not marked ready until someone has driven it in a light theme and a dark one.

Note this touches `components/CalendarSettings.qml`, which the calendar-filter PR also changes (it scopes that page's `calendarSaved` handler to saves it started). Whichever lands second will want a small rebase there; the two changes are independent in intent.

## Release Notes

- A calendar's colour can be chosen in Settings. Every calendar the app offers now lists the theme's palette, including calendars discovered from a newly connected Google account, so two calendars no longer have to share a colour by accident.
