### PR TITLE
Check for mail on Ctrl+R as well as F5

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -1522,9 +1522,9 @@ Item {
             iconName: "refresh"
             tooltipText: root.calendarVisible
               ? (root.service && root.service.calendarController.loading
-                ? "Loading calendars" : "Refresh calendars · F5")
+                ? "Loading calendars" : "Refresh calendars · F5 / Ctrl+R")
               : (root.service && root.service.listLoading
-                ? "Checking for mail" : "Check mail · F5")
+                ? "Checking for mail" : "Check mail · F5 / Ctrl+R")
             foreground: root.dim
             hoverColor: root.foreground
             fontFamily: root.fontFamily

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ and the client itself are console-only; there is no CLI for them.
 | `Alt+1` … `Alt+0` | The mailbox with that number on the rail |
 | `Alt+A` | Switch account |
 | `Ctrl+=` / `Ctrl+-` / `Ctrl+0` | Zoom the message body, or reset it |
-| `F5` | Check for mail |
+| `F5` / `Ctrl+R` | Check for mail |
 | `?` | Every shortcut |
 
 Search paints matching cached rows first and adds server results as they arrive. It takes Gmail's own operator syntax straight through — `from:jane`, `has:attachment`, `older_than:7d`. The Unread mailbox leaves Promotions, Social and Forums out rather than asking for Primary: Gmail's categories do not remove the `INBOX` label, so an unread filter without that exclusion comes back as the whole promotional backlog rather than the mail you have not read — while one that asks for Primary comes back empty on any account where Gmail is not applying the category labels, which is unread mail with nothing left to say so. Updates stays in, because receipts, deliveries and notifications land there. Right-click any row in the list for archive, trash, spam, star and read/unread without leaving the keyboard cursor behind.

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -123,7 +123,7 @@ used to exist, and they had.
 | `zoomIn` | `Ctrl++`, `Ctrl+=` | reader | Zoom the message body in |
 | `zoomOut` | `Ctrl+-` | reader | Zoom the message body out |
 | `zoomReset` | `Ctrl+Shift+0` | reader | Reset the zoom |
-| `refresh` | `F5` | all | Check for mail |
+| `refresh` | `F5`, `Ctrl+R` | all | Check for mail |
 | `settings` | `Ctrl+,` | all | Open settings |
 | `help` | `?` | mail | Toggle all keybindings |
 | `back` | `Escape` | all | Back, or close the window |

--- a/docs/index.html
+++ b/docs/index.html
@@ -889,7 +889,7 @@ footer p:last-child { margin-bottom: 0; }
           <tr><td class="keycell"><kbd>Alt</kbd> + <kbd>1</kbd> … <kbd>Alt</kbd> + <kbd>0</kbd></td><td data-zh="导航栏上对应编号的邮箱——按住 Alt，导航栏会说明哪个是哪个">The mailbox with that number on the rail — hold Alt and the rail says which is which</td></tr>
           <tr><td class="keycell"><kbd>Alt</kbd> + <kbd>A</kbd></td><td data-zh="切换账号">Switch account</td></tr>
           <tr><td class="keycell"><kbd>Ctrl</kbd> + <kbd>=</kbd><span class="sep">/</span><kbd>Ctrl</kbd> + <kbd>-</kbd><span class="sep">/</span><kbd>Ctrl</kbd> + <kbd>0</kbd></td><td data-zh="缩放正文，或复位">Zoom the message body, or reset it</td></tr>
-          <tr><td class="keycell"><kbd>F5</kbd></td><td data-zh="收信">Check for mail</td></tr>
+          <tr><td class="keycell"><kbd>F5</kbd><span class="sep">/</span><kbd>Ctrl</kbd> + <kbd>R</kbd></td><td data-zh="收信">Check for mail</td></tr>
           <tr><td class="keycell"><kbd>?</kbd></td><td data-zh="其余全部快捷键">Every shortcut</td></tr>
         </tbody>
       </table>

--- a/keys/Keymap.js
+++ b/keys/Keymap.js
@@ -174,7 +174,7 @@ var BINDINGS = [
   { id: "zoomReset", keys: ["Ctrl+Shift+0"], contexts: ["reader"],
     group: "Reading", label: "Reset the zoom" },
 
-  { id: "refresh", keys: ["F5"], contexts: ANY,
+  { id: "refresh", keys: ["F5", "Ctrl+R"], contexts: ANY,
     group: "Mailbox", label: "Check for mail" },
   { id: "settings", keys: ["Ctrl+,"], contexts: ANY,
     group: "Mailbox", label: "Open settings" },

--- a/tests/test_keymap.js
+++ b/tests/test_keymap.js
@@ -111,6 +111,20 @@ assert.strictEqual(keymap.isEnabled(settings, "calendar", false), true,
 assert.strictEqual(keymap.isEnabled(settings, "page", false), true,
   "the settings route is available from every screen")
 
+// Checking for mail answers to the browser's reload chord as well as its key.
+// Ctrl+R is a modified sequence, so it is live while a query or a draft is
+// being typed, where a bare `r` is a letter and stays reply's.
+deepEqual(byId("refresh").keys, ["F5", "Ctrl+R"],
+  "F5 and Ctrl+R both check for mail")
+// Through the table the router instantiates from, not `isSequenceEnabled`,
+// which answers for any sequence whether or not the row binds it.
+keymap.CONTEXTS.forEach(function (context) {
+  var live = keymap.sequencesFor(context).some(function (entry) {
+    return entry.id === "refresh" && entry.sequence === "Ctrl+R"
+  })
+  assert.strictEqual(live, true, "Ctrl+R must check for mail from " + context)
+})
+
 const zoomIn = byId("zoomIn")
 assert.strictEqual(keymap.isEnabled(zoomIn, "reader", false), true)
 assert.strictEqual(keymap.isEnabled(zoomIn, "page", false), false,


### PR DESCRIPTION
F5 was the only key that checked for mail. Ctrl+R is the reload chord in every browser and in most desktop mail clients, so it is the key people reach for first, and finding it dead sends them to the mouse. Both keys now fire the same refresh action, in every context.

Ctrl+R can be live everywhere because it is a modified sequence: in the search, compose and settings contexts it passes the same rule that already lets `Ctrl+,` and `Ctrl+Return` through, while a bare `r` stays a letter in a draft and reply's key in the list. Qt's text controls do not claim Ctrl+R as a standard key on Linux, so the window shortcut reaches the router even while a field has focus.

The key table in `keys/Keymap.js` is the one source for the live shortcuts, the help sheet and the status hints, so the binding is added there and nowhere else has to be kept in step by hand. The refresh button tooltips, README, `docs/KEYS.md` and the site's key table are updated to say the same.

## Verification

`make validate` green on 2be81a9 (node, shell, QML tests, qmllint, manifest, `git diff --check`).

`tests/test_keymap.js` asserts that the refresh row binds both keys and that `sequencesFor(context)`, the table `KeyRouter` instantiates from, offers Ctrl+R for refresh in every context. Run against `origin/main`'s `keys/Keymap.js` it fails with `F5 and Ctrl+R both check for mail`; on this branch it passes.

By hand, in the installed plugin: Ctrl+R from the list and from the reader runs the same spinner as the header button, and F5 still does. No screenshot, because the mailbox on screen is a private account; the change to the interface is two tooltip strings and one row on the help sheet.

A fresh agent reviewed the diff against `AGENTS.md`. It found no collisions with Ctrl+R anywhere in the tree, no `Keys.onPressed` handler that consumes it, and no text control that would claim it. Its one finding was that the first version of the test checked `isSequenceEnabled`, which answers for any sequence whether or not the row binds it; the test now reads `sequencesFor` instead. Security verdict: PASS, the change touches only the key table, labels and docs.

## Release Notes

- Ctrl+R checks for mail, alongside F5.

