### PR TITLE
Draw the rail's labels and folders A to Z

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ test-qml:
 	QT_QPA_PLATFORM=offscreen QT_QUICK_BACKEND=software \
 		$(QMLTESTRUNNER) -import $(CURDIR)/tests/qml/imports -input tests/qml
 	python3 tests/test_outlook_http.py "$(QMLTESTRUNNER)"
+	python3 tests/test_sidebar_text.py "$(QMLTESTRUNNER)"
 
 # Both engines on the same fixtures. The QML column is the one that decides
 # anything — the shell runs that engine, not node's — so run it on the machine

--- a/account/Model.js
+++ b/account/Model.js
@@ -419,12 +419,41 @@ function movableLabels(labels, query, currentLabelId) {
     if (typed !== "" && labelName.toLowerCase().indexOf(typed) < 0) continue
     destinations.push(label)
   }
-  destinations.sort(function(left, right) {
-    var leftName = String(left.name || "").toLowerCase()
-    var rightName = String(right.name || "").toLowerCase()
-    return leftName < rightName ? -1 : (leftName > rightName ? 1 : 0)
-  })
+  destinations.sort(compareLabelNames)
   return destinations
+}
+
+// A to Z by the name on screen, case folded so "bills" does not sort after
+// "Work". Shared by the rail and the move picker, so a label sits in the same
+// place in both lists. Two labels that print the same — "Work" and "work" on a
+// case-sensitive IMAP server — fall back to the id, because Qt's sort is not
+// stable and without a total order the pair swapped rows whenever an unrelated
+// label came or went.
+function compareLabelNames(left, right) {
+  var leftName = String(left && left.name || "").toLowerCase()
+  var rightName = String(right && right.name || "").toLowerCase()
+  if (leftName !== rightName) return leftName < rightName ? -1 : 1
+  var leftId = String(left && left.id || "")
+  var rightId = String(right && right.id || "")
+  return leftId < rightId ? -1 : (leftId > rightId ? 1 : 0)
+}
+
+// The labels or folders the rail draws under the provider's mailboxes: the
+// user's own, sorted by name. Providers hand them over in whatever order the
+// server keeps them — Gmail in creation order, IMAP as LIST answered, JMAP by
+// a sortOrder the server may or may not have set — which is no order a person
+// scanning a column can use. A path such as "Work/Invoices" sorts after "Work",
+// so a nested folder follows its parent, though a sibling such as "Work (old)"
+// can sit between them: this is one alphabet, not a tree.
+function railLabels(labels) {
+  var all = Array.isArray(labels) ? labels : []
+  var out = []
+  for (var i = 0; i < all.length; i++) {
+    if (!all[i] || all[i].system === true) continue
+    out.push(all[i])
+  }
+  out.sort(compareLabelNames)
+  return out
 }
 
 // Which capability an action needs, or "" for the ones every provider has.
@@ -738,10 +767,10 @@ function messageById(primary, fallback, id) {
 }
 
 // The rail as one numbered list, in the order it is drawn: the provider's
-// mailboxes first, then the labels or folders the server reported. Both the
-// sidebar's badges and the keys that jump read this, so the number beside a row
-// and the row a number opens cannot disagree — describing the order twice is
-// how they would.
+// mailboxes first, then the user's labels or folders as `railLabels` orders
+// them. Both the sidebar's badges and the keys that jump read this, so the
+// number beside a row and the row a number opens cannot disagree — describing
+// the order twice is how they would.
 //
 // Ten because the keys are digits. Past that a row simply has no number: a
 // mailbox nobody can reach by keyboard is honest, and renumbering the rail
@@ -754,9 +783,8 @@ function sidebarSlots(mailboxes, labels, limit) {
     if (!boxes[i] || !boxes[i].key) continue
     out.push({ kind: "mailbox", key: String(boxes[i].key), name: String(boxes[i].label || "") })
   }
-  var all = Array.isArray(labels) ? labels : []
+  var all = railLabels(labels)
   for (var j = 0; j < all.length && out.length < max; j++) {
-    if (!all[j] || all[j].system) continue
     out.push({ kind: "label", id: String(all[j].id || ""),
       name: String(all[j].rawName || all[j].name || "") })
   }

--- a/components/MailboxSidebar.qml
+++ b/components/MailboxSidebar.qml
@@ -222,6 +222,7 @@ Item {
         : (badge.visible ? badge.left : parent.right)
       anchors.rightMargin: Style.space(6)
       anchors.verticalCenter: parent.verticalCenter
+      textFormat: Text.PlainText
       text: entry.label
       color: entry.selected ? root.textColor : root.dimColor
       font.family: root.panelFontFamily

--- a/components/MailboxSidebar.qml
+++ b/components/MailboxSidebar.qml
@@ -6,7 +6,7 @@ import "../account/Model.js" as Model
 import "../providers/Registry.js" as Provider
 
 // The left column: the mailboxes this account's provider has, then whatever
-// labels or folders the server reported.
+// labels or folders the server reported, A to Z.
 //
 // Icon-first, and narrow enough to leave open: the longest mailbox name is
 // "All mail". Collapsing it to a strip of icons is one click away, and the
@@ -31,14 +31,7 @@ Item {
   property var slots: []
   property bool numbersVisible: false
 
-  readonly property var userLabels: {
-    var all = root.service ? root.service.labels : []
-    var out = []
-    for (var i = 0; i < all.length; i++) {
-      if (!all[i].system) out.push(all[i])
-    }
-    return out
-  }
+  readonly property var userLabels: Model.railLabels(root.service ? root.service.labels : [])
 
   // The rail's own edge. The list already draws one on its far side, so
   // without this the icons sit on the same surface as the messages.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -100,7 +100,7 @@ The sidebar is a compound component with four roles:
 
 - application identity and collapse trigger;
 - primary mailboxes;
-- provider labels or folders;
+- provider labels or folders, A to Z;
 - account identity and account menu trigger.
 
 Expanded rows contain an icon, label, and optional suffix such as an unread count or visible key. Collapsed rows keep the icon and active state, while the label moves to a tooltip. The active mailbox uses fill plus persistent shape and text/icon treatment; unread additionally uses a dot and stronger weight.

--- a/providers/JmapProtocol.js
+++ b/providers/JmapProtocol.js
@@ -1618,9 +1618,10 @@ function mailboxPath(box, byId) {
 // is what goes back in a filter, and only the printed name is a path — which is
 // why nothing here has to be taken apart again on the way out.
 //
-// Ordered by the server's own `sortOrder` and then by the printed path, which
-// puts a parent's children directly under it while a server that sorts nothing
-// still comes back in a stable order rather than in hash order.
+// Ordered by the server's own `sortOrder` and then by the printed path, so a
+// server that sorts nothing still comes back in a stable order rather than in
+// hash order. This is the order the list is cached in, not the order it is
+// drawn in: the rail and the move picker sort by name in `Model.railLabels`.
 function mailboxLabels(mailboxes, roles) {
   var list = mailboxArray(mailboxes)
   var map = roles || {}

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -577,8 +577,37 @@ assert.strictEqual(model.pluralize(0, "message"), "0 messages")
     "an empty mailbox has no row to sit on")
 }
 
-// One numbered list over the rail: mailboxes first, then the labels the server
-// reported, and no number at all past the tenth row.
+// ------------------------------------------------------------- rail labels
+//
+// The rail draws the user's labels A to Z, whatever order the server keeps them
+// in: Gmail answers in creation order, and a column in creation order can only
+// be read by somebody who remembers when each label was made.
+{
+  const reported = [
+    { id: "L2", name: "zebra", rawName: "zebra" },
+    { id: "S1", name: "Inbox", rawName: "INBOX", system: true },
+    { id: "L4", name: "Work/Invoices", rawName: "Work/Invoices" },
+    { id: "L1", name: "Bills", rawName: "Bills" },
+    { id: "L3", name: "Work", rawName: "Work" },
+    { id: "L5", name: "archive notes", rawName: "archive notes" }
+  ]
+  deepEqual(model.railLabels(reported).map(l => l.id), ["L5", "L1", "L3", "L4", "L2"],
+    "A to Z, case folded, a nested folder under its parent, and no system label")
+  const twins = [
+    { id: "b", name: "Work" }, { id: "c", name: "Bills" }, { id: "a", name: "work" }
+  ]
+  deepEqual(model.railLabels(twins).map(l => l.id), ["c", "a", "b"],
+    "two labels that print the same are ordered by id, so the pair never swaps")
+  deepEqual(model.railLabels(twins.slice().reverse()).map(l => l.id), ["c", "a", "b"],
+    "whatever order the server handed them over in")
+  deepEqual(reported.map(l => l.id), ["L2", "S1", "L4", "L1", "L3", "L5"],
+    "the provider's own list is not reordered underneath it")
+  deepEqual(model.railLabels(null), [])
+  deepEqual(model.railLabels([null, { id: "L9", name: "x" }]).map(l => l.id), ["L9"])
+}
+
+// One numbered list over the rail: mailboxes first, then the labels A to Z,
+// and no number at all past the tenth row.
 {
   const boxes = [
     { key: "inbox", label: "Inbox" },
@@ -595,12 +624,13 @@ assert.strictEqual(model.pluralize(0, "message"), "0 messages")
   assert.strictEqual(slots[0].kind, "mailbox")
   assert.strictEqual(slots[0].key, "inbox")
   assert.strictEqual(slots[3].kind, "label")
-  assert.strictEqual(slots[3].id, "L1")
-  assert.strictEqual(slots[3].name, "Work", "the name a provider selects a label by")
+  assert.strictEqual(slots[3].id, "L2",
+    "Bills is numbered before Work: the digits follow the rail, and the rail is A to Z")
+  assert.strictEqual(slots[3].name, "Bills", "the name a provider selects a label by")
 
   assert.strictEqual(model.slotNumberOf(slots, "mailbox", "inbox"), 1)
   assert.strictEqual(model.slotNumberOf(slots, "mailbox", "sent"), 3)
-  assert.strictEqual(model.slotNumberOf(slots, "label", "L2"), 5)
+  assert.strictEqual(model.slotNumberOf(slots, "label", "L1"), 5)
   assert.strictEqual(model.slotNumberOf(slots, "label", "SYS"), 0)
   assert.strictEqual(model.slotNumberOf(slots, "mailbox", "L1"), 0,
     "a key and an id are not the same handle")

--- a/tests/test_qml_text_format.py
+++ b/tests/test_qml_text_format.py
@@ -27,6 +27,8 @@ UNTRUSTED = re.compile(
     # name, a caption and a count all written by the server or the message,
     # and the mailbox row's detail line, which names the server.
     r"|\.sender\b|\.mailbox\b|\.caption\b|\.detail\b|threadCount\b"
+    # Sidebar Entry forwards the server's label name through a local alias.
+    r"|entry\s*\.\s*label\b"
     # A row that works out its own two lines and hands them over as strings.
     # The address goes in there, so the guard has to follow the value: read
     # from the element, the reference to `.email` is no longer visible and

--- a/tests/test_sidebar_text.py
+++ b/tests/test_sidebar_text.py
@@ -1,0 +1,151 @@
+"""Server label names remain text in the real sidebar, without image requests.
+
+Uses synthetic provider data and shell styling stubs; Qt's Text/image loader is
+real. A positive control proves that the loopback observer sees native image
+requests. This does not claim any public provider delivers these label names.
+"""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+ROOT = Path(__file__).resolve().parents[1]
+requests = []
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_):
+        pass
+
+    def do_GET(self):
+        requests.append(self.path)
+        self.send_response(404)
+        self.end_headers()
+
+
+QML = r'''
+import QtQuick
+import QtTest
+import @COMPONENTS@ as Mail
+import @GMAIL@ as Gmail
+import @JMAP@ as Jmap
+import @IMAP@ as Imap
+import @HEY@ as Hey
+
+Item {
+  id: host
+  width: 400; height: 400
+  property string endpoint: @ENDPOINT@
+  Component {
+    id: sidebarFactory
+    Mail.MailboxSidebar {
+      width: 400; height: 400
+      service: null
+      textColor: "black"; accentColor: "blue"; dimColor: "gray"
+      panelFontFamily: "monospace"
+    }
+  }
+  Component { id: controlFactory; Text { textFormat: Text.AutoText } }
+  TestCase {
+    name: "SidebarPlainText"
+    when: windowShown
+    function textItem(item, value) {
+      if (item.text === value && item.textFormat !== undefined) return item
+      var children = item.children || []
+      for (var i = 0; i < children.length; i++) {
+        var found = textItem(children[i], value)
+        if (found) return found
+      }
+      return null
+    }
+    function test_1_observer_positive_control() {
+      var item = createTemporaryObject(controlFactory, host, {
+        text: '<img src="' + endpoint + '/control">'
+      })
+      verify(item !== null)
+      wait(300)
+    }
+    function test_2_labels_data() {
+      var names = [
+        '<img src="' + endpoint + '/label">',
+        '<b>Invoices</b><img src="' + endpoint + '/nested">',
+        '<img\nsrc="' + endpoint + '/lf">',
+        '<img\rsrc="' + endpoint + '/cr">',
+        '<img\r\nsrc="' + endpoint + '/crlf">',
+        '<img src="' + endpoint + '/trailing">\n',
+        '<img src="' + endpoint + '/nul">\u0000',
+        'A & B / 中文 / مرحبا / "quotes" / \\backslash',
+        'literal &lt;img&gt; and <b>bold</b>',
+        'one\ntwo\rthree\r\nfour'
+      ]
+      var rows = []
+      for (var i = 0; i < names.length; i++) {
+        var providers = ["raw", "gmail", "jmap", "imap", "hey"]
+        for (var j = 0; j < providers.length; j++)
+          rows.push({tag: providers[j] + "-" + i, provider: providers[j], name: names[i]})
+      }
+      return rows
+    }
+    function test_2_labels(data) {
+      // Construct arrays here: QtTest data rows cross QVariant conversion,
+      // whereas real providers return JavaScript arrays to Model.railLabels.
+      var name = data.name
+      var labels = [{id: "probe", name: name, rawName: name, system: false, unread: 0}]
+      if (data.provider === "gmail")
+        labels = Gmail.parseLabels({labels: [{id: "probe", name: name, type: "user"}]})
+      else if (data.provider === "jmap")
+        labels = Jmap.mailboxLabels([{id: "probe", name: name}], {})
+      else if (data.provider === "imap") labels[0].name = Imap.decodeMailbox(name)
+      else if (data.provider === "hey") labels = Hey.parseLabels([{id: "probe", name: name}])
+      var service = {labels: labels, mailboxes: [], rawQuery: "",
+        mailboxKey: "inbox", searchQuery: "", providerId: "imap"}
+      var sidebar = createTemporaryObject(sidebarFactory, host)
+      verify(sidebar !== null)
+      sidebar.service = service
+      wait(50)
+      compare(sidebar.userLabels.length, 1)
+      var expected = labels[0].name
+      var drawn = textItem(sidebar, expected)
+      verify(drawn !== null, "The provider's name must reach the visible Text unchanged")
+      compare(drawn.textFormat, Text.PlainText, "A mailbox name is never HTML")
+    }
+    function test_3_drain_network() { wait(300) }
+  }
+}
+'''
+
+
+def main():
+    runner = sys.argv[1] if len(sys.argv) > 1 else "/usr/lib/qt6/bin/qmltestrunner"
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        with tempfile.TemporaryDirectory(prefix="omamail-sidebar-text-") as directory:
+            source = QML
+            for key, path in {
+                "COMPONENTS": "components", "GMAIL": "providers/GmailApi.js",
+                "JMAP": "providers/JmapProtocol.js", "IMAP": "providers/ImapProtocol.js",
+                "HEY": "providers/HeyCli.js",
+            }.items():
+                source = source.replace("@" + key + "@", json.dumps((ROOT / path).as_uri()))
+            source = source.replace("@ENDPOINT@", json.dumps(f"http://127.0.0.1:{server.server_port}"))
+            fixture = Path(directory) / "tst_sidebar_text.qml"
+            fixture.write_text(source)
+            env = dict(os.environ, QT_QPA_PLATFORM="offscreen", QT_QUICK_BACKEND="software",
+                       QT_QPA_PLATFORMTHEME="", NO_PROXY="127.0.0.1,localhost", no_proxy="127.0.0.1,localhost")
+            result = subprocess.run([runner, "-import", str(ROOT / "tests/qml/imports"),
+                                     "-input", str(fixture)], env=env, timeout=30)
+        assert requests == ["/control"], f"Unexpected label network requests: {requests}"
+        result.check_returncode()
+        print("Sidebar text: native image control observed; no label initiated a request")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The labels under the mailboxes on the rail came in whatever order the provider keeps them: Gmail answers its labels list in creation order, IMAP in the order LIST returned, JMAP by a `sortOrder` the server may never have set. A column in creation order can only be scanned by somebody who remembers when each label was made, and the number beside a row moved whenever a server changed its mind.

`Model.railLabels` is now the one place that decides what the rail draws under the mailboxes: the user's own labels, sorted by the name on screen, case folded, so "bills" does not land after "Work". A path such as "Work/Invoices" sorts after "Work", which keeps a nested folder after its parent; this is one alphabet rather than a tree, so a sibling like "Work (old)" can sit between them. Two labels that print the same fall back to their id, because Qt's array sort is not stable and without a total order the pair swapped rows whenever an unrelated label came or went.

The sidebar reads `railLabels` for its rows and `sidebarSlots` reads it for the digits, so the badge and the key that opens the row cannot disagree. The move picker already sorted by name; it now shares the comparator, so a label sits in the same place in both lists. The provider's own array is left in the order it came, since the cache and the providers own that. One user-visible consequence: a JMAP server's `sortOrder`, which Fastmail exposes as the user's drag order, no longer decides what the rail shows.

## Verification

`make validate` green on the pushed commit (node, shell, QML tests, qmllint, manifest, `git diff --check`).

`tests/test_model.js` gains a `railLabels` block: A to Z, case folded, system labels dropped, a nested path after its parent, equal names ordered by id from either input order, and the provider's array left untouched. The `sidebarSlots` test now expects Bills numbered before Work. Against `origin/main`'s `Model.js` the file fails at the first `railLabels` call, and the slots assertion fails on its own with `L2 !== L1`; on this branch it passes.

By hand, in the installed plugin on a Gmail account and an IMAP account behind Proton Bridge: the rail's labels read A to Z, Alt+N opens the row whose badge shows N, and `v` offers the same order the rail does. No screenshot, because the mailboxes on screen are private accounts.

A fresh agent reviewed the diff against `AGENTS.md`. It confirmed nothing else reads the rail by provider index (Alt+N resolves through `sidebarSlots`, unread counts key by id, the picker goes through `movableLabels`), that the sidebar binding re-evaluates when the labels change, and that `name` is the right sort key for every provider. It measured that Qt 6.11's sort scrambles equal keys, which is why the id tiebreak and its test exist, and asked for the JMAP `mailboxLabels` comment to say its order is the cache's, not the screen's. Security verdict: PASS.

## Release Notes

- Labels and folders on the rail are listed A to Z instead of in the order the server keeps them. The number keys follow the new order.


