### PR TITLE
Find a CalDAV server's calendars from its address

### DIFF
--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -121,6 +121,107 @@ function caldavResponses(xml) {
   return out
 }
 
+// ------------------------------------------------------------ discovery
+//
+// A CalDAV server's calendars are found in three steps, each a PROPFIND: the
+// address the user typed says who they are (current-user-principal), the
+// principal says where their calendars live (calendar-home-set), and the home
+// lists them one level down. A typed address that is itself a calendar
+// answers the first step by saying so, and needs no other.
+
+function propfindPrincipalBody() {
+  return '<?xml version="1.0" encoding="utf-8"?>'
+    + '<d:propfind xmlns:d="DAV:"><d:prop>'
+    + '<d:current-user-principal/><d:resourcetype/><d:displayname/>'
+    + '</d:prop></d:propfind>'
+}
+
+function propfindHomeBody() {
+  return '<?xml version="1.0" encoding="utf-8"?>'
+    + '<d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav"><d:prop>'
+    + '<c:calendar-home-set/>'
+    + '</d:prop></d:propfind>'
+}
+
+function propfindCollectionsBody() {
+  return '<?xml version="1.0" encoding="utf-8"?>'
+    + '<d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav"><d:prop>'
+    + '<d:displayname/><d:resourcetype/><c:supported-calendar-component-set/>'
+    + '</d:prop></d:propfind>'
+}
+
+function davResponses(xml) {
+  var input = String(xml || "")
+  var pattern = /<(?:[A-Za-z0-9_-]+:)?response(?:\s[^>]*)?>([\s\S]*?)<\/(?:[A-Za-z0-9_-]+:)?response>/gi
+  var out = []
+  var match
+  while ((match = pattern.exec(input)) !== null) out.push(match[1])
+  return out
+}
+
+// An href the way the server wrote it, made absolute against the address it
+// was asked at: a full URL as it is, a path from that address's origin, and
+// anything else beside it.
+function resolveDavHref(baseUrl, href) {
+  var base = String(baseUrl || "").trim()
+  var value = String(href || "").trim()
+  if (value === "") return ""
+  if (/^https?:\/\//i.test(value)) return value
+  var origin = base.match(/^(https?:\/\/[^\/]+)/i)
+  if (!origin) return ""
+  if (value.charAt(0) === "/") return origin[1] + value
+  return base.replace(/[^\/]*$/, "") + value
+}
+
+// Whether a resourcetype block says "calendar": the CalDAV element, under any
+// prefix, self-closed or not. A subscribed feed or a reminder list is not one.
+function isCalendarResource(block) {
+  return /<(?:[A-Za-z0-9_-]+:)?calendar(?:\s[^>]*)?(?:\/>|>\s*<\/)/i.test(String(block || ""))
+}
+
+function davPrincipal(xml) {
+  return tagText(tagText(xml, "current-user-principal"), "href")
+}
+
+function davHome(xml) {
+  return tagText(tagText(xml, "calendar-home-set"), "href")
+}
+
+// What the typed address itself is: a calendar, in which case its name and no
+// further step; or a place that names a principal to go on from.
+function caldavSelf(xml, url) {
+  var blocks = davResponses(xml)
+  var first = blocks.length > 0 ? blocks[0] : String(xml || "")
+  return {
+    isCalendar: isCalendarResource(tagText(first, "resourcetype")),
+    name: tagText(first, "displayname").trim(),
+    principal: resolveDavHref(url, davPrincipal(first))
+  }
+}
+
+// The calendars a home lists: one entry per collection whose resourcetype is
+// a calendar, that has a name, and that holds events — a collection that
+// says it holds only tasks is a reminder list, and the home itself and the
+// server's own inbox and outbox carry no name.
+function caldavCollections(xml, homeUrl) {
+  var blocks = davResponses(xml)
+  var out = []
+  for (var i = 0; i < blocks.length; i++) {
+    var block = blocks[i]
+    var name = tagText(block, "displayname").trim()
+    if (name === "" || !isCalendarResource(tagText(block, "resourcetype"))) continue
+    var comps = []
+    var pattern = /<(?:[A-Za-z0-9_-]+:)?comp\s+name="([A-Z]+)"/gi
+    var match
+    while ((match = pattern.exec(block)) !== null) comps.push(match[1].toUpperCase())
+    if (comps.length > 0 && comps.indexOf("VEVENT") < 0) continue
+    var url = resolveDavHref(homeUrl, tagText(block, "href"))
+    if (url === "") continue
+    out.push({ name: name, url: url })
+  }
+  return out
+}
+
 function recurrenceParts(value) {
   var out = {}
   var pieces = String(value || "").split(";")

--- a/calendar/CalendarController.qml
+++ b/calendar/CalendarController.qml
@@ -116,6 +116,8 @@ Item {
 
   signal passwordSaved(bool ok, string error)
   signal calendarSaved(bool ok, string error)
+  // The calendars found at an address, or why none were.
+  signal calendarsDiscovered(var calendars, string error)
   signal eventCreated(bool ok, string error)
   signal eventUpdated(bool ok, string error)
   signal eventDeleted(bool ok, string error)
@@ -366,23 +368,84 @@ Item {
   }
 
   function addCalDavCalendar(raw, secret) {
+    addCalDavCalendars([raw], secret)
+  }
+
+  // Several calendars found at one address, saved in one write and given the
+  // one password each, under its own id, one keyring store after another.
+  property var sourcesBeingSaved: []
+
+  function addCalDavCalendars(list, secret) {
     if (savingSource) return
-    var candidate = raw || {}
-    candidate.kind = "caldav"
-    candidate.id = Sources.sourceId(candidate)
-    candidate.enabled = true
-    var checked = Sources.validate(candidate)
-    if (!checked.ok) { calendarSaved(false, checked.error); return }
+    var given = Array.isArray(list) ? list : []
+    if (given.length === 0) { calendarSaved(false, "Choose a calendar to add"); return }
     if (String(secret || "") === "") {
       calendarSaved(false, "Add the calendar password")
       return
     }
-    sourceBeingSaved = checked.source
+    var next = sourceList
+    var accepted = []
+    for (var i = 0; i < given.length; i++) {
+      var candidate = {}
+      for (var key in given[i]) candidate[key] = given[i][key]
+      candidate.kind = "caldav"
+      candidate.id = Sources.sourceId(candidate)
+      candidate.enabled = true
+      var checked = Sources.validate(candidate)
+      if (!checked.ok) { calendarSaved(false, checked.error); return }
+      next = Sources.add(next, checked.source)
+      accepted.push(checked.source)
+    }
+    sourceBeingSaved = null
+    sourcesBeingSaved = accepted
     sourceSecret = String(secret)
-    sourceWritePayload = Sources.serialize(Sources.add(sourceList, checked.source))
+    sourceWritePayload = Sources.serialize(next)
     savingSource = true
     sourceWriter.command = [pluginDir + "/scripts/config-store.sh", "calendars.json"]
     sourceWriter.running = true
+  }
+
+  // ------------------------------------------------------------ discovery
+
+  property bool discovering: false
+  property string discoveryUrl: ""
+  property string discoveryUsername: ""
+  // Held for the three requests and no longer.
+  property string discoveryCredentials: ""
+
+  function discoverCalDav(url, username, secret) {
+    if (discovering || savingSource) return
+    var address = String(url || "").trim()
+    var user = String(username || "").trim()
+    var password = String(secret || "")
+    if (!/^https:\/\//i.test(address)) { calendarsDiscovered([], "Add the calendar's HTTPS address"); return }
+    if (password === "") { calendarsDiscovered([], "Add the calendar password"); return }
+    discovering = true
+    discoveryUrl = address
+    discoveryUsername = user
+    discoveryCredentials = user + ":" + password
+    password = ""
+    discoveryStep("self", address)
+  }
+
+  function discoveryStep(step, url) {
+    var body = step === "self" ? Calendar.propfindPrincipalBody()
+      : step === "home" ? Calendar.propfindHomeBody() : Calendar.propfindCollectionsBody()
+    var method = step === "collections" ? "propfind-1" : "propfind-0"
+    discoveryTransport.step = step
+    discoveryTransport.url = url
+    discoveryTransport.command = [pluginDir + "/scripts/calendar-transport.sh"]
+    discoveryTransport.requestLine = [Mail.encodeBase64(url), Mail.encodeBase64(discoveryCredentials),
+      Mail.encodeBase64(body), Mail.encodeBase64(method)].join(" ") + "\n"
+    discoveryTransport.running = true
+  }
+
+  function finishDiscovery(list, error) {
+    discovering = false
+    discoveryCredentials = ""
+    var found = Array.isArray(list) ? list : []
+    for (var i = 0; i < found.length; i++) found[i].username = discoveryUsername
+    calendarsDiscovered(found, String(error || ""))
   }
 
   function removeCalendar(sourceId) {
@@ -662,7 +725,7 @@ Item {
         return
       }
       root.sourceList = Sources.load(root.sourceWritePayload)
-      if (!root.sourceBeingSaved) {
+      if (!root.sourceBeingSaved && root.sourcesBeingSaved.length === 0) {
         root.savingSource = false
         root.calendarSaved(true, "")
         if (root.refreshAfterSourceWrite && root.rangeStart && root.rangeEnd)
@@ -670,10 +733,24 @@ Item {
         root.refreshAfterSourceWrite = false
         return
       }
-      sourcePasswordStore.command = [root.pluginDir + "/scripts/keyring-store.sh"]
-        .concat(Sources.keyringAttributes(root.sourceBeingSaved.id))
-      sourcePasswordStore.running = true
+      root.storeNextSourcePassword()
     }
+  }
+
+  // One keyring store per calendar saved, the same password each time.
+  function storeNextSourcePassword() {
+    var source = sourceBeingSaved
+    if (!source && sourcesBeingSaved.length > 0) source = sourcesBeingSaved[0]
+    if (!source) {
+      sourceSecret = ""
+      savingSource = false
+      calendarSaved(true, "")
+      if (rangeStart && rangeEnd) refresh(rangeStart, rangeEnd)
+      return
+    }
+    sourcePasswordStore.command = [pluginDir + "/scripts/keyring-store.sh"]
+      .concat(Sources.keyringAttributes(source.id))
+    sourcePasswordStore.running = true
   }
 
   Process {
@@ -682,15 +759,56 @@ Item {
     stderr: StdioCollector { id: sourcePasswordError; waitForEnd: true }
     onStarted: write(root.sourceSecret + "\n")
     onExited: function(exitCode) {
-      root.sourceSecret = ""
-      root.sourceBeingSaved = null
-      root.savingSource = false
       if (exitCode !== 0) {
+        root.sourceSecret = ""
+        root.sourceBeingSaved = null
+        root.sourcesBeingSaved = []
+        root.savingSource = false
         root.calendarSaved(false, String(sourcePasswordError.text || "Could not save the password"))
         return
       }
-      root.calendarSaved(true, "")
-      if (root.rangeStart && root.rangeEnd) root.refresh(root.rangeStart, root.rangeEnd)
+      root.sourceBeingSaved = null
+      if (root.sourcesBeingSaved.length > 0) root.sourcesBeingSaved = root.sourcesBeingSaved.slice(1)
+      root.storeNextSourcePassword()
+    }
+  }
+
+  Process {
+    id: discoveryTransport
+    property string step: ""
+    property string url: ""
+    property string requestLine: ""
+    stdinEnabled: true
+    stdout: StdioCollector { id: discoveryOutput; waitForEnd: true }
+    stderr: StdioCollector { waitForEnd: true }
+    onStarted: {
+      write(requestLine)
+      requestLine = ""
+    }
+    onExited: function(exitCode) {
+      var lines = String(discoveryOutput.text || "").split("\n")
+      var status = Number(lines[0])
+      var body = lines.length > 1 ? Mail.decodeBase64Url(lines[1].replace(/\+/g, "-").replace(/\//g, "_")) : ""
+      if (exitCode !== 0 || status !== 0) { root.finishDiscovery([], "The calendar server could not be reached"); return }
+      if (!/multistatus/i.test(body)) {
+        root.finishDiscovery([], "The calendar server refused the sign-in, or has no calendars at that address")
+        return
+      }
+      if (step === "self") {
+        var self = Calendar.caldavSelf(body, url)
+        if (self.isCalendar) { root.finishDiscovery([{ name: self.name, url: url }], ""); return }
+        if (self.principal === "") { root.finishDiscovery([], "No calendars were found at that address"); return }
+        root.discoveryStep("home", self.principal)
+        return
+      }
+      if (step === "home") {
+        var home = Calendar.resolveDavHref(url, Calendar.davHome(body))
+        if (home === "") { root.finishDiscovery([], "The calendar server did not say where its calendars are"); return }
+        root.discoveryStep("collections", home)
+        return
+      }
+      var found = Calendar.caldavCollections(body, url)
+      root.finishDiscovery(found, found.length > 0 ? "" : "No calendars were found at that address")
     }
   }
 

--- a/components/CalendarSettings.qml
+++ b/components/CalendarSettings.qml
@@ -14,6 +14,9 @@ Column {
   required property string panelFontFamily
   property bool adding: false
   property string passwordEditingId: ""
+  // What the last "Find calendars" turned up, and which of them are ticked.
+  property var found: []
+  property var chosen: ({})
 
   width: parent ? parent.width : implicitWidth
   spacing: Style.space(8)
@@ -209,6 +212,8 @@ Column {
       foreground: root.textColor
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.bodySmall
+      // Used only when the address turns out to be one calendar; a list keeps
+      // the server's own names.
       placeholderText: "Calendar name"
     }
     TextField {
@@ -217,7 +222,9 @@ Column {
       foreground: root.textColor
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.bodySmall
+      // The server is enough; one calendar's own address works as before.
       placeholderText: "CalDAV URL"
+      onTextChanged: root.found = []
     }
     TextField {
       id: calendarUsername
@@ -235,17 +242,76 @@ Column {
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.bodySmall
       placeholderText: "Password or app password"
-      onAccepted: root.saveCalendar()
+      onAccepted: root.findCalendars()
+    }
+
+    // The calendars the address turned out to hold, each with a switch. A
+    // server address is where most people start, and it holds several.
+    Column {
+      width: parent.width
+      spacing: Style.space(4)
+      visible: root.found.length > 0
+
+      Text {
+        width: parent.width
+        text: root.found.length === 1 ? "One calendar found:" : root.found.length + " calendars found:"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+      }
+
+      Repeater {
+        model: root.found
+        delegate: Row {
+          required property var modelData
+          width: parent.width
+          spacing: Style.space(8)
+
+          ToggleSwitch {
+            anchors.verticalCenter: parent.verticalCenter
+            checked: root.chosen[modelData.url] !== false
+            foreground: root.textColor
+            accent: root.accentColor
+            onToggled: {
+              var next = {}
+              for (var key in root.chosen) next[key] = root.chosen[key]
+              next[modelData.url] = root.chosen[modelData.url] === false
+              root.chosen = next
+            }
+          }
+
+          Text {
+            anchors.verticalCenter: parent.verticalCenter
+            text: String(modelData.name || "")
+            color: root.textColor
+            font.family: root.panelFontFamily
+            font.pixelSize: Style.font.bodySmall
+          }
+        }
+      }
     }
 
     Row {
       spacing: Style.space(6)
       IconTextButton {
-        text: root.controller && root.controller.savingSource ? "Adding" : "Add calendar"
+        objectName: "calendar-find"
+        visible: root.found.length === 0
+        text: root.controller && root.controller.discovering ? "Looking" : "Find calendars"
         foreground: root.textColor
         accent: root.accentColor
         fontFamily: root.panelFontFamily
-        enabled: root.controller && !root.controller.savingSource
+        enabled: root.controller && !root.controller.discovering && !root.controller.savingSource
+        onClicked: root.findCalendars()
+      }
+      IconTextButton {
+        objectName: "calendar-add"
+        visible: root.found.length > 0
+        text: root.controller && root.controller.savingSource ? "Adding"
+          : (root.chosenCount() === 1 ? "Add calendar" : "Add " + root.chosenCount() + " calendars")
+        foreground: root.textColor
+        accent: root.accentColor
+        fontFamily: root.panelFontFamily
+        enabled: root.controller && !root.controller.savingSource && root.chosenCount() > 0
         onClicked: root.saveCalendar()
       }
       IconTextButton {
@@ -269,17 +335,42 @@ Column {
     textFormat: Text.PlainText
   }
 
+  function findCalendars() {
+    resultText.text = ""
+    root.found = []
+    root.chosen = ({})
+    root.controller.discoverCalDav(calendarUrl.text, calendarUsername.text, calendarPassword.text)
+  }
+
+  function chosenCount() {
+    var count = 0
+    for (var i = 0; i < root.found.length; i++) {
+      if (root.chosen[root.found[i].url] !== false) count++
+    }
+    return count
+  }
+
   function saveCalendar() {
     resultText.text = ""
-    root.controller.addCalDavCalendar({
-      name: calendarName.text,
-      url: calendarUrl.text,
-      username: calendarUsername.text
-    }, calendarPassword.text)
+    var picked = []
+    for (var i = 0; i < root.found.length; i++) {
+      if (root.chosen[root.found[i].url] === false) continue
+      var entry = { name: root.found[i].name, url: root.found[i].url, username: root.found[i].username }
+      // A typed name wins for a single calendar; a list keeps the server's.
+      if (root.found.length === 1 && String(calendarName.text || "").trim() !== "")
+        entry.name = calendarName.text
+      picked.push(entry)
+    }
+    root.controller.addCalDavCalendars(picked, calendarPassword.text)
   }
 
   Connections {
     target: root.controller
+    function onCalendarsDiscovered(calendars, error) {
+      if (error !== "") { resultText.text = error; return }
+      root.found = calendars
+      root.chosen = ({})
+    }
     function onCalendarSaved(ok, error) {
       if (!ok) { resultText.text = error; return }
       resultText.text = "Calendar saved"
@@ -287,6 +378,8 @@ Column {
       calendarUrl.text = ""
       calendarUsername.text = ""
       calendarPassword.text = ""
+      root.found = []
+      root.chosen = ({})
       root.adding = false
       root.passwordEditingId = ""
     }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -67,7 +67,7 @@ Outlook.com and Hotmail use Microsoft's OAuth device-code flow for delegated IMA
 - Actions: read/unread, star, archive, trash, untrash, report spam, mark all read
 - Compose, reply, reply-all, forward
 - Calendar invitations: full meeting detail, RSVP, and one-click Meet join
-- Calendar: month and week views over Google Calendar and CalDAV, with event create, edit and delete. Google calendars follow the current mailbox by default. A setting can combine every connected account in one view.
+- Calendar: month and week views over Google Calendar and CalDAV, with event create, edit and delete. A CalDAV server address is enough: Omamail finds the calendars it holds and adds the ones you pick. Google calendars follow the current mailbox by default. A setting can combine every connected account in one view.
 - One-click unsubscribe from mailing lists that support it
 - Search using Gmail's own operator syntax
 - Unread badge in the bar; merged desktop notification for new mail

--- a/scripts/calendar-transport.sh
+++ b/scripts/calendar-transport.sh
@@ -12,12 +12,22 @@ IFS= read -r line || fail 'calendar-transport.sh: no request on stdin'
 # The three fields are base64 and therefore contain no spaces.
 # shellcheck disable=SC2086
 set -- $line
-[ $# -eq 3 ] || fail 'calendar-transport.sh: expected URL, credentials and report'
+# Three fields are a REPORT, the calendar query. A fourth names another
+# method — `propfind-0` or `propfind-1`, the steps of finding a server's
+# calendars — and nothing else: the method is one of three words, never a
+# field curl is handed.
+[ $# -eq 3 ] || [ $# -eq 4 ] || fail 'calendar-transport.sh: expected URL, credentials, a body and an optional method'
 validate_config_fields "$@"
 
 url=$(decode "$1")
 credentials=$(decode "$2")
 report=$(decode "$3")
+method=report
+[ $# -eq 3 ] || method=$(decode "$4")
+case "$method" in
+  report|propfind-0|propfind-1) ;;
+  *) fail 'calendar-transport.sh: method must be report, propfind-0 or propfind-1' ;;
+esac
 case "$url" in https://*) ;; *) fail 'calendar-transport.sh: CalDAV requires HTTPS' ;; esac
 
 umask 077
@@ -29,8 +39,11 @@ build_config() {
   printf 'url = "%s"\n' "$(escape "$url")"
   printf 'noproxy = "*"\n'
   printf 'user = "%s"\n' "$(escape "$credentials")"
-  printf 'request = "REPORT"\n'
-  printf 'header = "Depth: 1"\n'
+  case "$method" in
+    report) printf 'request = "REPORT"\n'; printf 'header = "Depth: 1"\n' ;;
+    propfind-0) printf 'request = "PROPFIND"\n'; printf 'header = "Depth: 0"\n' ;;
+    propfind-1) printf 'request = "PROPFIND"\n'; printf 'header = "Depth: 1"\n' ;;
+  esac
   printf 'header = "Content-Type: application/xml; charset=utf-8"\n'
   printf 'data = "%s"\n' "$(escape "$report")"
   printf 'proto = "=https"\n'

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -471,3 +471,58 @@ assert.ok(googleUrl.indexOf("orderBy=startTime") > 0)
 assert.ok(googleUrl.indexOf("timeMin=2026-08-01T00%3A00%3A00.000Z") > 0)
 
 console.log("test_calendar_feed.js ok")
+
+// ------------------------------------------------------------ discovery
+//
+// iCloud's answers, as it spells them: prefixed elements, a relative
+// principal, an absolute home on a per-user host, and a home listing that
+// mixes calendars with the reminder lists, the server's own boxes, and the
+// home itself.
+{
+  const principal = '<?xml version="1.0" encoding="UTF-8"?><multistatus xmlns="DAV:"><response><href>/</href>'
+    + '<propstat><prop><current-user-principal><href>/123456789/principal/</href></current-user-principal>'
+    + '<resourcetype><collection/></resourcetype></prop><status>HTTP/1.1 200 OK</status></propstat></response></multistatus>'
+  const self = feed.caldavSelf(principal, "https://caldav.icloud.com/")
+  assert.strictEqual(self.isCalendar, false)
+  assert.strictEqual(self.principal, "https://caldav.icloud.com/123456789/principal/", "a path is resolved against the origin")
+
+  const home = '<multistatus xmlns="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav"><response><href>/123456789/principal/</href>'
+    + '<propstat><prop><C:calendar-home-set><href>https://p42-caldav.icloud.com:443/123456789/calendars/</href></C:calendar-home-set>'
+    + '</prop></propstat></response></multistatus>'
+  assert.strictEqual(feed.resolveDavHref("https://caldav.icloud.com/123456789/principal/", feed.davHome(home)),
+    "https://p42-caldav.icloud.com:443/123456789/calendars/", "an absolute home is kept as it is")
+
+  const listing = '<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav" xmlns:CS="http://calendarserver.org/ns/">'
+    + '<D:response><D:href>/123456789/calendars/</D:href><D:propstat><D:prop><D:displayname>Jack</D:displayname>'
+    + '<D:resourcetype><D:collection/></D:resourcetype></D:prop></D:propstat></D:response>'
+    + '<D:response><D:href>/123456789/calendars/home/</D:href><D:propstat><D:prop><D:displayname>Home</D:displayname>'
+    + '<D:resourcetype><D:collection/><C:calendar/></D:resourcetype>'
+    + '<C:supported-calendar-component-set><C:comp name="VEVENT"/></C:supported-calendar-component-set></D:prop></D:propstat></D:response>'
+    + '<D:response><D:href>/123456789/calendars/ABCD-EF/</D:href><D:propstat><D:prop><D:displayname>Reminders</D:displayname>'
+    + '<D:resourcetype><D:collection/><C:calendar/></D:resourcetype>'
+    + '<C:supported-calendar-component-set><C:comp name="VTODO"/></C:supported-calendar-component-set></D:prop></D:propstat></D:response>'
+    + '<D:response><D:href>/123456789/calendars/inbox/</D:href><D:propstat><D:prop><D:displayname/>'
+    + '<D:resourcetype><D:collection/><C:schedule-inbox/></D:resourcetype></D:prop></D:propstat></D:response>'
+    + '<D:response><D:href>/123456789/calendars/feed/</D:href><D:propstat><D:prop><D:displayname>School</D:displayname>'
+    + '<D:resourcetype><D:collection/><CS:subscribed/></D:resourcetype></D:prop></D:propstat></D:response>'
+    + '<D:response><D:href>/123456789/calendars/work/</D:href><D:propstat><D:prop><D:displayname>Work &amp; Travel</D:displayname>'
+    + '<D:resourcetype><D:collection/><C:calendar></C:calendar></D:resourcetype></D:prop></D:propstat></D:response>'
+    + '</D:multistatus>'
+  const found = feed.caldavCollections(listing, "https://p42-caldav.icloud.com:443/123456789/calendars/")
+  assert.strictEqual(JSON.stringify(found), JSON.stringify([
+    { name: "Home", url: "https://p42-caldav.icloud.com:443/123456789/calendars/home/" },
+    { name: "Work & Travel", url: "https://p42-caldav.icloud.com:443/123456789/calendars/work/" }
+  ]), "the home itself, a reminder list, the inbox and a subscribed feed are not calendars")
+
+  // An address that is one calendar answers the first step by saying so.
+  const one = '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav"><d:response><d:href>/cal/home/</d:href>'
+    + '<d:propstat><d:prop><d:displayname>Home</d:displayname><d:resourcetype><d:collection/><c:calendar/></d:resourcetype>'
+    + '</d:prop></d:propstat></d:response></d:multistatus>'
+  const single = feed.caldavSelf(one, "https://dav.example/cal/home/")
+  assert.strictEqual(single.isCalendar, true)
+  assert.strictEqual(single.name, "Home")
+
+  assert.strictEqual(feed.resolveDavHref("https://dav.example/a/b/", "c/"), "https://dav.example/a/b/c/")
+  assert.strictEqual(feed.resolveDavHref("not a url", "/x/"), "", "no origin, no address")
+  assert.ok(feed.propfindCollectionsBody().indexOf("supported-calendar-component-set") >= 0)
+}

--- a/tests/test_calendar_transport.sh
+++ b/tests/test_calendar_transport.sh
@@ -36,4 +36,19 @@ if printf '%s\n' "$(b64 'http://calendar.example/') $(b64 'me:secret') $(b64 '<q
   exit 1
 fi
 
+# Finding a server's calendars is a PROPFIND at depth 0 or 1, named by a
+# fourth field that is one of three words and nothing curl is handed.
+request="$(b64 'https://calendar.example/') $(b64 'me:secret') $(b64 '<propfind/>') $(b64 'propfind-1')"
+reply=$(printf '%s\n' "$request" | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-transport.sh")
+grep -q 'request = "PROPFIND"' "$work/config"
+grep -q 'header = "Depth: 1"' "$work/config"
+test "$(printf '%s\n' "$reply" | sed -n '1p')" = 0
+request="$(b64 'https://calendar.example/') $(b64 'me:secret') $(b64 '<propfind/>') $(b64 'propfind-0')"
+printf '%s\n' "$request" | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-transport.sh" >/dev/null
+grep -q 'header = "Depth: 0"' "$work/config"
+if printf '%s\n' "$(b64 'https://calendar.example/') $(b64 'me:secret') $(b64 '<x/>') $(b64 'DELETE')" \
+  | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-transport.sh" >/dev/null 2>&1; then
+  echo 'an unknown method was accepted' >&2
+  exit 1
+fi
 echo 'calendar-transport.sh ok'


### PR DESCRIPTION
## What changes

**A CalDAV server address is enough to add its calendars.** A calendar could only be added by its exact collection address, and the calendar query runs against whatever address a source holds. Typing the server — `https://caldav.icloud.com/`, the address every provider's help page gives — saved a source that asked the server's root for events, got none, and left the calendar empty with nothing to say why.

Adding a calendar now starts with **Find calendars**: a PROPFIND at the typed address for `current-user-principal`, one at the principal for `calendar-home-set`, and one at depth 1 on the home for what it holds. A typed address that is itself a calendar answers the first step by saying so and is added as it is, under the typed name if one was given. The page lists what was found, a switch beside each, and adds the ticked ones in one write with the one password stored under each calendar's own id. Left out, because none of them answers a calendar query with events: a subscribed feed (`CS:subscribed`), a collection whose component set holds only tasks (a reminder list), the server's inbox and outbox, and the home itself.

## How

- `scripts/calendar-transport.sh` takes an optional fourth field naming the method: `report` (the default, unchanged), `propfind-0` or `propfind-1`. It is one of three words, never a field curl is handed; anything else is refused.
- `calendar/Calendar.js`: the three request bodies, `davResponses`, `resolveDavHref` (absolute as given, a path from the asked address's origin, anything else beside it), `isCalendarResource` (the CalDAV element under any prefix, self-closed or not), `caldavSelf`, `davHome`, `caldavCollections`. All pure and covered in `tests/test_calendar_feed.js` with iCloud's own shapes: prefixed elements, a relative principal, an absolute home on a per-user host, and a listing that mixes the home, a reminder list, the inbox, a subscribed feed and two calendars.
- `CalendarController`: `discoverCalDav(url, username, password)` runs the steps through a process of its own and answers with `calendarsDiscovered(list, error)`; the credentials are held for those requests and no longer. `addCalDavCalendars(list, password)` saves several sources in one write and stores the password under each id in turn; `addCalDavCalendar` is now the one-item case of it.
- `CalendarSettings`: the add form's button is **Find calendars**; the found list appears with a switch each and an **Add N calendars** button. The existing single-address path still works: an address that is one calendar is added the way it always was.

## Verification

- `make test-js`, `make test-shell` and `make test-qml` pass on this branch alone. New coverage in `tests/test_calendar_feed.js` (the parsers, against iCloud-shaped answers) and `tests/test_calendar_transport.sh` (the PROPFIND methods and the refusal of any other).
- Exercised live against iCloud: `https://caldav.icloud.com/` with an app password finds the principal, the per-user home on `pNN-caldav.icloud.com`, and the calendars; the five real ones were added and answer this week's events, the reminder lists and subscribed feeds were left out.

The maintainer also ran `QT_QPA_PLATFORMTHEME= make validate` on cbc1c69: 445 main QML tests and four native HTTP tests passed, alongside JS/shell checks, qmllint and plugin validation. These general checks do not cover all discovery and save-failure boundaries. Comparable before/after screenshots and a visible-difference explanation are still missing.

## Security

The typed address still has to be HTTPS. The three PROPFIND bodies are fixed strings; the method is one of three words checked before anything is written to curl's config. Every field still passes `validate_config_fields` as before. Credential-destination and server-provided display-content handling still require corrections and verification; this revision does not have a passing security review. The password is held for the discovery requests and cleared when they answer.

## Release Notes

- Adding a CalDAV calendar takes the server address: Omamail finds the calendars it holds and adds the ones you pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8PEgfKnNP3iPhiDZGSbx6