### PR TITLE
Copy an event's location, and open a place on a map

### DIFF
--- a/components/CalendarEventDetail.qml
+++ b/components/CalendarEventDetail.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import Quickshell
 import qs.Commons
 import qs.Ui
 import "../calendar/Calendar.js" as Calendar
@@ -48,6 +49,12 @@ Rectangle {
     source ? source.colorKey : "accent")
   readonly property string meetingLink: httpLink(event ? event.meetLink : "")
   readonly property string locationLink: httpLink(event ? event.location : "")
+  // The location as written. One that is not a link is a place, and a place
+  // is something to copy into a message or to look up on a map.
+  readonly property string locationText: String(event && event.location || "").trim()
+  readonly property bool locationIsPlace: locationText !== "" && locationLink === ""
+  readonly property string mapLink: locationIsPlace
+    ? "https://www.google.com/maps/search/?api=1&query=" + encodeURIComponent(locationText) : ""
   readonly property string providerLink: httpLink(event ? event.href : "")
 
   color: root.backgroundColor
@@ -187,7 +194,7 @@ Rectangle {
 
       Flow {
         visible: root.meetingLink !== "" || root.locationLink !== ""
-          || root.providerLink !== "" || root.canWrite
+          || root.providerLink !== "" || root.canWrite || root.locationText !== ""
         width: parent.width
         spacing: Style.space(7)
 
@@ -229,6 +236,29 @@ Rectangle {
           accent: root.eventColor
           fontFamily: root.panelFontFamily
           onClicked: Qt.openUrlExternally(root.locationLink)
+        }
+
+        IconTextButton {
+          objectName: "event-open-map"
+          visible: root.locationIsPlace
+          text: "Open in Google Maps"
+          iconName: "pin"
+          foreground: root.textColor
+          accent: root.eventColor
+          fontFamily: root.panelFontFamily
+          onClicked: Qt.openUrlExternally(root.mapLink)
+        }
+
+        IconTextButton {
+          objectName: "event-copy-location"
+          visible: root.locationText !== ""
+          text: "Copy location"
+          iconName: "pin"
+          foreground: root.textColor
+          accent: root.eventColor
+          fontFamily: root.panelFontFamily
+          // Straight to wl-copy as one argument: no shell in between.
+          onClicked: Quickshell.execDetached(["wl-copy", root.locationText])
         }
 
         IconTextButton {


### PR DESCRIPTION
## What changes

An event's location was shown and, when it was a link, opened. A place — a street address, a venue name — could only be read off the screen. The event detail gains two buttons beside the existing ones:

- **Copy location**, for any location: the text as written goes to the clipboard through `wl-copy` as one argument, with no shell in between, the way the address menu already copies an address.
- **Open in Google Maps**, for a location that is not a link: a maps search for the text as written, opened in the browser. A link keeps "Open location" and does not get this one.

## Verification

`make test-qml` and `make test-shell` pass on this branch alone. Exercised live on a fork carrying this branch, on iCloud events: a street address copies to the clipboard and opens as a Google Maps search; an event whose location is a link keeps Open location and gains only the copy.

## Security

The location text is user data from the calendar. It reaches the clipboard as a single argv entry and the browser as a URL-encoded query on a fixed host; neither passes through a shell.

## Release Notes

- The event detail can copy a location, and open a place on Google Maps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8PEgfKnNP3iPhiDZGSbx6

