### PR TITLE
Improve mail pane controls and navigation

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -184,6 +184,14 @@ Item {
     Math.min(accent.hslSaturation, 0.55),
     accent.hslLightness, 1.0)
 
+  MailPalette {
+    id: mailPalette
+    enabled: root.systemThemeStyling
+    baseBackground: root.background
+    baseText: root.foreground
+    baseUrgent: root.urgent
+  }
+
   readonly property string fontFamily: Style.font.family
 
   function copyText(text) {
@@ -215,8 +223,24 @@ Item {
   // service holds it because it is written to disk: a size somebody reached for
   // is theirs until they change it, not until they close the window.
   readonly property real bodyZoom: service ? service.bodyZoom : 1.0
-  // 0 means "proportional"; anything else is a width somebody dragged to.
-  property real listWidth: 0
+  // Read the setting itself. Keeping an intermediate multiplier on a service
+  // made the control look updated while a long-lived pane could retain the old
+  // derived value.
+  readonly property real scrollSpeedMultiplier: service
+    && Number(service.scrollSpeedPercent) > 0
+    ? Number(service.scrollSpeedPercent) / 100 : 1.6
+  readonly property bool systemThemeStyling: !!service
+    && service.systemThemeStyling === true
+  // Zero means "responsive default"; a positive value is the last grip
+  // position and is clamped again against the live window below.
+  readonly property real sidebarWidth: service && Number(service.sidebarWidth) > 0
+    ? Number(service.sidebarWidth) : 0
+  readonly property real listWidth: service && Number(service.listWidth) > 0
+    ? Number(service.listWidth) : 0
+
+  readonly property color labelsPaneBackground: mailPalette.sidebarSurface
+  readonly property color inboxPaneBackground: mailPalette.listSurface
+  readonly property color readerPaneBackground: mailPalette.readerSurface
 
   function zoomBy(step) {
     if (service) service.setBodyZoom(Model.zoomAfterStep(service.bodyZoom, step))
@@ -387,9 +411,15 @@ Item {
   // Mailboxes lands in.
   function openSettings() {
     dismissHelp()
-    if (page === "settings") return
     settingsScroll.stop()
     settingsFlick.contentY = 0
+    // A second request is useful recovery, not a no-op: if the page was
+    // already selected while its popup was still relinquishing focus, bring
+    // its viewport home and focus it again.
+    if (page === "settings") {
+      Qt.callLater(function() { focusScope.applyContextFocus() })
+      return
+    }
     pushEntry("settings")
   }
 
@@ -1443,6 +1473,7 @@ Item {
           // same place however the control was pressed.
           IconButton {
             id: menuButton
+            objectName: "menu-button"
             anchors.verticalCenter: parent.verticalCenter
             iconName: "menu"
             tooltipText: "Menu"
@@ -1453,6 +1484,41 @@ Item {
             onClicked: {
               var scene = mapToGlobal(0, height)
               appMenu.openAt(scene.x, scene.y)
+            }
+          }
+
+          IconButton {
+            id: mailViewButton
+            objectName: "mail-view-button"
+            anchors.verticalCenter: parent.verticalCenter
+            visible: !root.composing
+            iconName: "mail"
+            tooltipText: "Mail · Ctrl+Shift+M"
+            foreground: root.systemThemeStyling && !root.showPage
+              && !root.calendarVisible ? mailPalette.unread : root.dim
+            hoverColor: root.systemThemeStyling ? mailPalette.unread : root.foreground
+            fontFamily: root.fontFamily
+            selected: !root.showPage && !root.calendarVisible
+            enabled: root.ready
+            onClicked: root.backToList()
+          }
+
+          IconButton {
+            id: calendarViewButton
+            objectName: "calendar-view-button"
+            anchors.verticalCenter: parent.verticalCenter
+            visible: !root.composing
+            iconName: "calendar"
+            tooltipText: "Calendar · Ctrl+Shift+C"
+            foreground: root.systemThemeStyling && !root.showPage
+              && root.calendarVisible ? mailPalette.calendar : root.dim
+            hoverColor: root.systemThemeStyling ? mailPalette.calendar : root.foreground
+            fontFamily: root.fontFamily
+            selected: !root.showPage && root.calendarVisible
+            enabled: root.ready
+            onClicked: {
+              root.showCalendar()
+              calendarView.refresh()
             }
           }
         }
@@ -1593,7 +1659,9 @@ Item {
           anchors.left: parent.left
           anchors.top: parent.top
           anchors.bottom: parent.bottom
-          width: root.sidebarCollapsed ? Style.space(44) : Style.space(148)
+          width: root.sidebarCollapsed ? Style.space(44)
+            : Math.max(Style.space(100), Math.min(parent.width - Style.space(480),
+                root.sidebarWidth > 0 ? root.sidebarWidth : Style.space(148)))
           visible: !root.compact && !root.showPage && !root.composing
           collapsed: root.sidebarCollapsed
           calendarSelected: root.calendarVisible
@@ -1601,6 +1669,20 @@ Item {
           textColor: root.foreground
           accentColor: root.accent
           dimColor: root.dim
+          backgroundColor: root.labelsPaneBackground
+          systemThemeStyling: root.systemThemeStyling
+          selectedSurfaceColor: mailPalette.selectedSurface
+          hoverSurfaceColor: mailPalette.hoverSurface
+          activeTextColor: mailPalette.activeText
+          unreadColor: mailPalette.unread
+          starColor: mailPalette.starred
+          sentColor: mailPalette.sent
+          draftColor: mailPalette.drafts
+          labelColor: mailPalette.labels
+          calendarColor: mailPalette.calendar
+          dangerColor: mailPalette.danger
+          scrollSpeedMultiplier: root.scrollSpeedMultiplier
+          showTrailingSeparator: root.sidebarCollapsed || root.calendarVisible
           panelFontFamily: root.fontFamily
           slots: root.sidebarSlots
           numbersVisible: focusScope.ctrlHeld
@@ -1617,6 +1699,50 @@ Item {
           }
         }
 
+
+        // Labels/inbox grip. It draws the same one-pixel rule as the
+        // inbox/reader divider; the remaining width is only a transparent hit
+        // target, so both dividers look alike without becoming hard to catch.
+        Item {
+          id: sidebarSplitter
+          objectName: "labels-inbox-splitter"
+          anchors.left: sidebar.right
+          anchors.top: parent.top
+          anchors.bottom: parent.bottom
+          width: Style.space(5)
+          visible: sidebar.visible && !root.sidebarCollapsed
+            && !root.calendarVisible
+          z: 5
+
+          PanelSeparator {
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            width: 1
+            foreground: root.foreground
+          }
+
+          MouseArea {
+            id: sidebarGrip
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.SplitHCursor
+            property real grabbedAt: 0
+            property real grabbedWidth: 0
+
+            onPressed: function(mouse) {
+              grabbedAt = mapToItem(body, mouse.x, mouse.y).x
+              grabbedWidth = sidebar.width
+            }
+            onPositionChanged: function(mouse) {
+              if (!pressed || !root.service) return
+              var moved = mapToItem(body, mouse.x, mouse.y).x - grabbedAt
+              root.service.setSidebarWidth(grabbedWidth + moved)
+            }
+            onDoubleClicked: if (root.service) root.service.setSidebarWidth(0)
+          }
+        }
+
         // Narrow windows lose the sidebar; the same mailboxes come back as a
         // scrolling strip above the list.
         MailboxTabs {
@@ -1628,6 +1754,12 @@ Item {
           visible: root.compact && !root.showPage && !root.composing && root.currentView === "list"
           textColor: root.foreground
           accentColor: root.accent
+          systemThemeStyling: root.systemThemeStyling
+          unreadColor: mailPalette.unread
+          starColor: mailPalette.starred
+          sentColor: mailPalette.sent
+          draftColor: mailPalette.drafts
+          dangerColor: mailPalette.danger
           panelFontFamily: root.fontFamily
           // The account's own mailboxes, not a fixed set: this row and the
           // sidebar it replaces on a narrow window must offer the same ones.
@@ -1639,7 +1771,8 @@ Item {
 
         Item {
           id: listColumn
-          anchors.left: sidebar.visible ? sidebar.right : parent.left
+          anchors.left: sidebarSplitter.visible ? sidebarSplitter.right
+            : (sidebar.visible ? sidebar.right : parent.left)
           anchors.top: tabs.visible ? tabs.bottom : parent.top
           anchors.bottom: parent.bottom
           anchors.topMargin: tabs.visible ? Style.space(8) : 0
@@ -1651,11 +1784,17 @@ Item {
           width: root.compact
             ? (root.currentView === "list" ? parent.width : 0)
             : Math.max(Style.space(100),
-                Math.min(parent.width - Style.space(360),
+                Math.min(parent.width - x - Style.space(280),
                   root.listWidth > 0 ? root.listWidth
-                    : Math.min(Style.space(460), Math.round(parent.width * 0.34))))
+                    : Math.min(Style.space(460),
+                        Math.round((parent.width - x) * 0.34))))
           visible: width > 0 && !root.showPage && !root.composing
             && !root.calendarVisible
+
+          Rectangle {
+            anchors.fill: parent
+            color: root.inboxPaneBackground
+          }
 
           // The scroller fills the column so its bar sits on the column edge;
           // the breathing room is padding on the content, not a margin on the
@@ -1663,7 +1802,10 @@ Item {
           Flickable {
             id: listFlick
 
-            WheelScroller { view: listFlick }
+            WheelScroller {
+              view: listFlick
+              speedMultiplier: root.scrollSpeedMultiplier
+            }
             anchors.fill: parent
             contentWidth: width
             contentHeight: list.implicitHeight + Style.space(16)
@@ -1682,6 +1824,12 @@ Item {
               textColor: root.foreground
               accentColor: root.accent
               dimColor: root.dim
+              systemThemeStyling: root.systemThemeStyling
+              selectedSurfaceColor: mailPalette.selectedSurface
+              hoverSurfaceColor: mailPalette.hoverSurface
+              unreadColor: mailPalette.unread
+              starColor: mailPalette.starred
+              sourceColor: mailPalette.labels
               panelFontFamily: root.fontFamily
               cursorId: root.cursorId
               onMessageActivated: function(id) { root.openMessage(id) }
@@ -1729,11 +1877,11 @@ Item {
             onPositionChanged: function(mouse) {
               if (!pressed) return
               var moved = mapToItem(body, mouse.x, mouse.y).x - grabbedAt
-              root.listWidth = grabbedWidth + moved
+              if (root.service) root.service.setListWidth(grabbedWidth + moved)
             }
             // Back to the proportional default, which is what most people
             // want after one bad drag.
-            onDoubleClicked: root.listWidth = 0
+            onDoubleClicked: if (root.service) root.service.setListWidth(0)
           }
         }
 
@@ -1747,16 +1895,19 @@ Item {
             && (!root.compact || root.currentView === "reader")
           service: root.service
           textColor: root.foreground
-          backgroundColor: root.background
+          backgroundColor: root.readerPaneBackground
           accentColor: root.accent
           linkColor: root.link
           dimColor: root.dim
           dimmerColor: root.dimmer
+          systemThemeStyling: root.systemThemeStyling
+          starColor: mailPalette.starred
           popupBackgroundColor: root.popupBackground
           popupBorderColor: root.popupBorder
           leadingBoundaryOverlap: listSplitter.visible ? listSplitter.width : 0
           panelFontFamily: root.fontFamily
           zoom: root.bodyZoom
+          scrollSpeedMultiplier: root.scrollSpeedMultiplier
           showBack: root.compact
           bodyMode: root.bodyMode
           alwaysRenderHeavyMessages: !!root.service && root.service.alwaysRenderHeavyMessages
@@ -1810,6 +1961,7 @@ Item {
           popupBackgroundColor: root.popupBackground
           popupBorderColor: root.popupBorder
           panelFontFamily: root.fontFamily
+          scrollSpeedMultiplier: root.scrollSpeedMultiplier
           contentDirection: root.service ? root.service.contentDirection : ""
           // The stack follows the view: opening pushes, closing pops — and
           // the pop is here rather than on `closed`, because a draft parked
@@ -1845,6 +1997,7 @@ Item {
           urgentColor: root.urgent
           dimColor: root.dim
           panelFontFamily: root.fontFamily
+          scrollSpeedMultiplier: root.scrollSpeedMultiplier
         }
 
         Rectangle {
@@ -1869,6 +2022,7 @@ Item {
             calendarTodayBackgroundColor: root.calendarTodayBackground
             calendarBorderWidth: root.calendarBorderWidth
             panelFontFamily: root.fontFamily
+            scrollSpeedMultiplier: root.scrollSpeedMultiplier
             // An event opened for reading is a place, so Back closes it before
             // it leaves the calendar. The view owns the open state; the stack
             // follows it.
@@ -1912,7 +2066,10 @@ Item {
         Flickable {
           id: setupFlick
 
-          WheelScroller { view: setupFlick }
+            WheelScroller {
+              view: setupFlick
+              speedMultiplier: root.scrollSpeedMultiplier
+            }
           anchors.fill: parent
           anchors.margins: Style.space(18)
           anchors.topMargin: parent.pageTop
@@ -2017,7 +2174,10 @@ Item {
         Flickable {
           id: settingsFlick
 
-          WheelScroller { view: settingsFlick }
+          WheelScroller {
+            view: settingsFlick
+            speedMultiplier: root.scrollSpeedMultiplier
+          }
           // The whole width, rail included: the wheel scrolls the page from
           // anywhere in the block, and the scrollbar keeps the window's edge.
           anchors.left: parent.left
@@ -2049,6 +2209,11 @@ Item {
               dimColor: root.dim
               accentColor: root.accent
               urgentColor: root.urgent
+              unreadColor: mailPalette.unread
+              starColor: mailPalette.starred
+              draftColor: mailPalette.drafts
+              labelColor: mailPalette.labels
+              calendarColor: mailPalette.calendar
               panelFontFamily: root.fontFamily
               onClientSetupRequested: root.openClientSetup()
               // Which kind first, then the form for it.
@@ -2294,7 +2459,10 @@ Item {
           root.showCalendar()
           calendarView.refresh()
         }
-        onSetupRequested: root.openSettings()
+        // Let the Popup finish closing before replacing everything below it.
+        // On the live shell, doing both in the row's release handler could
+        // restore the old focus/navigation state over the newly opened page.
+        onSetupRequested: Qt.callLater(root.openSettings)
         onSwitchAccountRequested: accountSwitcher.openCentered()
         onProjectRequested: if (root.service) root.service.openProjectPage()
         onAuthorRequested: if (root.service) root.service.openAuthorPage()
@@ -2339,6 +2507,7 @@ Item {
         popupBackgroundColor: root.popupBackground
         popupBorderColor: root.popupBorder
         panelFontFamily: root.fontFamily
+        scrollSpeedMultiplier: root.scrollSpeedMultiplier
         labels: root.service ? root.service.labels : []
         currentLabelId: root.service ? String(root.service.rawLabelId || "") : ""
         onLabelChosen: function(labelId) {
@@ -2407,6 +2576,7 @@ Item {
         backgroundColor: root.background
         dimColor: root.dim
         panelFontFamily: root.fontFamily
+        scrollSpeedMultiplier: root.scrollSpeedMultiplier
         onDismissed: root.dismissHelp()
       }
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/MenuActionRow.qml components/MenuSeparatorLine.qml \
 	components/KeyRouter.qml \
 	components/WheelScroller.qml \
+	components/MailPalette.qml \
 	components/ActionIcon.qml \
 	components/IconButton.qml \
 	components/IconTextButton.qml \

--- a/Service.qml
+++ b/Service.qml
@@ -62,6 +62,8 @@ Item {
     maxMessages: 25,
     heavyMessageRendering: Html.HEAVY_MESSAGE_RENDERING_DEFAULT,
     contentDirection: Direction.MODE_DEFAULT,
+    scrollSpeedPercent: Model.WHEEL_SPEED_DEFAULT_PERCENT,
+    systemThemeStyling: false,
     defaultQuery: "in:inbox",
     notifyNewMail: "On",
     oauthPort: 9481,
@@ -87,6 +89,11 @@ Item {
     && settings.unifiedCalendarView === true
   readonly property bool unifiedMailboxes: !!settings
     && settings.unifiedMailboxes === true
+  readonly property int scrollSpeedPercent: Model.scrollSpeedPercent(
+    settings ? settings.scrollSpeedPercent : null)
+  readonly property real scrollSpeedMultiplier: scrollSpeedPercent / 100
+  readonly property bool systemThemeStyling: !!settings
+    && settings.systemThemeStyling === true
 
   // Whether the bar draws an envelope for this.
   //
@@ -173,6 +180,14 @@ Item {
 
   function setContentDirection(value) {
     persistSetting("contentDirection", Direction.normalizeMode(value))
+  }
+
+  function setScrollSpeedPercent(value) {
+    persistSetting("scrollSpeedPercent", Model.scrollSpeedPercent(value))
+  }
+
+  function setSystemThemeStyling(value) {
+    persistSetting("systemThemeStyling", value === true)
   }
 
   function setUnifiedCalendarView(value) {
@@ -587,6 +602,8 @@ Item {
   // the window cannot recompute lives here.
 
   property bool sidebarCollapsed: false
+  property real sidebarWidth: 0
+  property real listWidth: 0
   // Somebody who needed the text bigger needs it bigger for their mail, not for
   // the message that made them reach for it. The same goes for `bodyMode`:
   // both of these are ways of reading mail, not ways of reading one message.
@@ -615,6 +632,8 @@ Item {
     bodyZoom = prefs.bodyZoom
     bodyMode = prefs.bodyMode
     alwaysShowImages = prefs.alwaysShowImages
+    sidebarWidth = prefs.sidebarWidth
+    listWidth = prefs.listWidth
     restoreWindow = prefs.windowOpen
     restoreAttempts = 0
     windowPrefsLoaded = true
@@ -651,6 +670,8 @@ Item {
       bodyZoom: bodyZoom,
       bodyMode: bodyMode,
       alwaysShowImages: alwaysShowImages,
+      sidebarWidth: sidebarWidth,
+      listWidth: listWidth,
       windowOpen: windowOpen || restoreWindow
     })
     windowWriter.command = [pluginDir + "/scripts/config-store.sh", "window.json"]
@@ -661,6 +682,20 @@ Item {
     var next = value === true
     if (next === sidebarCollapsed) return
     sidebarCollapsed = next
+    saveWindowPrefs()
+  }
+
+  function setSidebarWidth(value) {
+    var next = Model.paneWidth(value)
+    if (next === sidebarWidth) return
+    sidebarWidth = next
+    saveWindowPrefs()
+  }
+
+  function setListWidth(value) {
+    var next = Model.paneWidth(value)
+    if (next === listWidth) return
+    listWidth = next
     saveWindowPrefs()
   }
 

--- a/account/Model.js
+++ b/account/Model.js
@@ -562,6 +562,18 @@ var ZOOM_MIN = 0.6
 var ZOOM_MAX = 2.5
 var ZOOM_STEPS_PER_UNIT = 20
 
+// Pane widths are saved as physical pixels because the window itself is saved
+// in physical pixels. Zero means "use the responsive default"; positive
+// values are still clamped against the live window by App.qml.
+var PANE_WIDTH_MAX = 1600
+
+function paneWidth(value) {
+  if (value === null || value === undefined || value === "") return 0
+  var width = Number(value)
+  if (!isFinite(width) || width <= 0) return 0
+  return Math.min(PANE_WIDTH_MAX, Math.round(width))
+}
+
 // What a zoom read back off disk means. Anything that is not a number is a
 // file that was hand-edited or never written, and the answer to both is the
 // size it shipped at.
@@ -582,6 +594,8 @@ function windowPrefs(raw) {
       bodyZoom: 1,
       bodyMode: "reader",
       alwaysShowImages: false,
+      sidebarWidth: 0,
+      listWidth: 0,
       windowOpen: false
     }
   }
@@ -593,6 +607,8 @@ function windowPrefs(raw) {
     bodyZoom: clampZoom(parsed.bodyZoom),
     bodyMode: bodyMode,
     alwaysShowImages: parsed.alwaysShowImages === true,
+    sidebarWidth: paneWidth(parsed.sidebarWidth),
+    listWidth: paneWidth(parsed.listWidth),
     windowOpen: parsed.windowOpen === true
   }
 }
@@ -1240,21 +1256,71 @@ var WHEEL_PIXELS_PER_NOTCH = 120
 // stays 120 so the arithmetic is still "a notch is a notch"; the gain is how
 // far that notch moves on screen.
 var WHEEL_GAIN = 2
+var WHEEL_SPEED_DEFAULT_PERCENT = 160
+// Five deliberate stops keep the control legible: the setting describes how
+// scrolling feels rather than exposing an implementation percentage. The
+// stored number stays compatible with settings written by older builds.
+var WHEEL_SPEED_PRESETS = [75, 100, 160, 250, 400]
+var WHEEL_SPEED_LABELS = ["Gentle", "Standard", "Quick", "Fast", "Rapid"]
+var WHEEL_SPEED_MIN_PERCENT = WHEEL_SPEED_PRESETS[0]
+var WHEEL_SPEED_MAX_PERCENT = WHEEL_SPEED_PRESETS[WHEEL_SPEED_PRESETS.length - 1]
+
+function scrollSpeedLevel(value) {
+  var speed = Number(value)
+  if (!isFinite(speed)) speed = WHEEL_SPEED_DEFAULT_PERCENT
+  var closest = 0
+  for (var i = 1; i < WHEEL_SPEED_PRESETS.length; i++) {
+    if (Math.abs(WHEEL_SPEED_PRESETS[i] - speed)
+        < Math.abs(WHEEL_SPEED_PRESETS[closest] - speed)) closest = i
+  }
+  return closest
+}
+
+function scrollSpeedPercentForLevel(level) {
+  var index = Math.max(0, Math.min(WHEEL_SPEED_PRESETS.length - 1,
+    Math.round(Number(level) || 0)))
+  return WHEEL_SPEED_PRESETS[index]
+}
+
+function scrollSpeedLabel(value) {
+  return WHEEL_SPEED_LABELS[scrollSpeedLevel(value)]
+}
+
+function scrollSpeedPercent(value) {
+  if (value === null || value === undefined || value === "")
+    return WHEEL_SPEED_DEFAULT_PERCENT
+  var speed = Number(value)
+  if (!isFinite(speed)) return WHEEL_SPEED_DEFAULT_PERCENT
+  return scrollSpeedPercentForLevel(scrollSpeedLevel(speed))
+}
+
+function scrollSpeedMultiplier(value) {
+  return scrollSpeedPercent(value) / 100
+}
 
 // Numerically the identity at these two values, and written as a ratio anyway:
 // the constant that matters is "a notch moves 120 pixels", and it is the one a
 // reader changes.
-function wheelDistance(angleDelta) {
-  return (Number(angleDelta) || 0) / WHEEL_UNITS_PER_NOTCH * WHEEL_PIXELS_PER_NOTCH
+function wheelDistance(angleDelta, speedMultiplier) {
+  var speed = Number(speedMultiplier)
+  if (!isFinite(speed) || speed <= 0) speed = 1
+  return (Number(angleDelta) || 0) / WHEEL_UNITS_PER_NOTCH
+    * WHEEL_PIXELS_PER_NOTCH * speed
+}
+
+function wheelDistanceForDeltas(pixelDelta, angleDelta, speedMultiplier) {
+  var pixels = Number(pixelDelta) || 0
+  var speed = Number(speedMultiplier)
+  if (!isFinite(speed) || speed <= 0) speed = 1
+  return pixels !== 0 ? pixels * speed : wheelDistance(angleDelta, speed)
 }
 
 // Pixels to move the view. `pixelDelta` wins when the device reports it
 // (touchpad, high-res wheel); otherwise the notch mapping. The gain is
 // applied here so QML cannot forget it.
-function wheelPixels(angleDelta, pixelDelta) {
-  var pixels = Number(pixelDelta) || 0
-  if (pixels === 0) pixels = wheelDistance(angleDelta)
-  return pixels * WHEEL_GAIN
+function wheelPixels(angleDelta, pixelDelta, speedMultiplier) {
+  return wheelDistanceForDeltas(pixelDelta, angleDelta, speedMultiplier)
+    * WHEEL_GAIN
 }
 
 // Where the view lands after a movement already expressed in pixels —
@@ -1268,8 +1334,16 @@ function wheelScrollByPixels(contentY, pixels, contentHeight, viewportHeight,
 
 // Where the view lands, inside what it can actually reach.
 function wheelScrollTarget(contentY, angleDelta, contentHeight, viewportHeight,
-                           originY, topMargin, bottomMargin) {
-  return wheelScrollByPixels(contentY, wheelDistance(angleDelta), contentHeight,
+                           originY, topMargin, bottomMargin, speedMultiplier) {
+  return wheelScrollByPixels(contentY, wheelPixels(angleDelta, 0, speedMultiplier), contentHeight,
+    viewportHeight, originY, topMargin, bottomMargin)
+}
+
+function wheelScrollTargetForDeltas(contentY, pixelDelta, angleDelta,
+                                    contentHeight, viewportHeight, originY,
+                                    topMargin, bottomMargin, speedMultiplier) {
+  return wheelScrollByPixels(contentY,
+    wheelPixels(angleDelta, pixelDelta, speedMultiplier), contentHeight,
     viewportHeight, originY, topMargin, bottomMargin)
 }
 

--- a/calendar/Palette.js
+++ b/calendar/Palette.js
@@ -33,5 +33,9 @@ function parse(raw) {
     var value = values[key] || values[ANSI_KEYS[key]] || ""
     if (value !== "") result[key] = value
   }
+  // Mail chrome uses terminal orange for labels. It is intentionally not a
+  // calendar slot, so this exposes the value without changing that UI's
+  // stable choices or ordering.
+  if (values.orange) result.orange = values.orange
   return result
 }

--- a/components/AppMenu.qml
+++ b/components/AppMenu.qml
@@ -7,6 +7,7 @@ import "Menu.js" as Menu
 // Links out, plus the handful of actions that have no natural home on screen.
 Item {
   id: root
+  objectName: "app-menu"
 
   required property color textColor
   required property color popupBackgroundColor
@@ -79,6 +80,11 @@ Item {
   signal switchAccountRequested()
   signal projectRequested()
   signal authorRequested()
+
+  // Exposed for the window's integration test. Popup content lives in its own
+  // visual hierarchy, so walking down from App cannot otherwise reach the row
+  // a real pointer clicks.
+  readonly property alias settingsAction: settingsRow
 
   anchors.fill: root.showTrigger ? undefined : parent
   implicitWidth: root.showTrigger ? Style.space(24) : 0
@@ -174,6 +180,7 @@ Item {
       }
       MenuRow {
         id: settingsRow
+        objectName: "app-menu-settings"
         text: "Settings..."
         onActivated: { menu.close(); root.setupRequested() }
       }

--- a/components/CalendarEventComposer.qml
+++ b/components/CalendarEventComposer.qml
@@ -14,6 +14,7 @@ Rectangle {
   required property color urgentColor
   required property color dimColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   property bool opened: false
   property string selectedSourceId: ""
@@ -171,7 +172,10 @@ Rectangle {
   Flickable {
     id: composerFlick
 
-    WheelScroller { view: composerFlick }
+    WheelScroller {
+      view: composerFlick
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
 
     anchors.fill: parent
     anchors.margins: Style.space(18)

--- a/components/CalendarEventDetail.qml
+++ b/components/CalendarEventDetail.qml
@@ -15,6 +15,7 @@ Rectangle {
   required property color urgentColor
   required property color dimColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   signal closed()
   signal editRequested(string sourceId, var event)
@@ -87,7 +88,10 @@ Rectangle {
   Flickable {
     id: detailFlick
 
-    WheelScroller { view: detailFlick }
+    WheelScroller {
+      view: detailFlick
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
 
     anchors.fill: parent
     anchors.margins: Style.space(18)

--- a/components/CalendarView.qml
+++ b/components/CalendarView.qml
@@ -16,6 +16,7 @@ Item {
   required property color calendarTodayBackgroundColor
   required property int calendarBorderWidth
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   property date visibleMonth: new Date(new Date().getFullYear(), new Date().getMonth(), 1)
   property date visibleWeek: new Date()
@@ -495,6 +496,7 @@ Item {
       calendarTodayBackgroundColor: root.calendarTodayBackgroundColor
       calendarBorderWidth: root.calendarBorderWidth
       panelFontFamily: root.panelFontFamily
+      scrollSpeedMultiplier: root.scrollSpeedMultiplier
       selectedEventId: root.selectedEventId
       onCreateAt: function(startMs) { root.createAt(startMs) }
       onEventActivated: function(event) { root.activateEvent(event) }
@@ -516,6 +518,7 @@ Item {
     urgentColor: root.urgentColor
     dimColor: root.dimColor
     panelFontFamily: root.panelFontFamily
+    scrollSpeedMultiplier: root.scrollSpeedMultiplier
     onClosed: root.closeDetail()
     // Editing replaces the detail: the composer covers the view, and the
     // event it rewrites is not the one these labels would go on showing.

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -30,6 +30,7 @@ DropArea {
   required property color popupBackgroundColor
   required property color popupBorderColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   readonly property int formInset: Style.space(18)
   readonly property int formLabelWidth: Style.space(52)
@@ -1142,6 +1143,7 @@ DropArea {
         popupBackgroundColor: root.popupBackgroundColor
         popupBorderColor: root.popupBorderColor
         panelFontFamily: root.panelFontFamily
+        scrollSpeedMultiplier: root.scrollSpeedMultiplier
         onChosen: function(contact) { root.acceptTo(contact) }
       }
 
@@ -1224,6 +1226,7 @@ DropArea {
         popupBackgroundColor: root.popupBackgroundColor
         popupBorderColor: root.popupBorderColor
         panelFontFamily: root.panelFontFamily
+        scrollSpeedMultiplier: root.scrollSpeedMultiplier
         onChosen: function(contact) { root.acceptCc(contact) }
       }
 
@@ -1302,6 +1305,7 @@ DropArea {
         accentColor: root.accentColor
         popupBackgroundColor: root.popupBackgroundColor
         popupBorderColor: root.popupBorderColor
+        scrollSpeedMultiplier: root.scrollSpeedMultiplier
         panelFontFamily: root.panelFontFamily
         onChosen: function(contact) { root.acceptBcc(contact) }
       }
@@ -1477,7 +1481,10 @@ DropArea {
     contentItem: ListView {
       id: fromRows
 
-      WheelScroller { view: fromRows }
+      WheelScroller {
+        view: fromRows
+        speedMultiplier: root.scrollSpeedMultiplier
+      }
       implicitHeight: contentHeight
       clip: true
       model: root.fromIdentities
@@ -1542,6 +1549,7 @@ DropArea {
     popupBackgroundColor: root.popupBackgroundColor
     popupBorderColor: root.popupBorderColor
     panelFontFamily: root.panelFontFamily
+    scrollSpeedMultiplier: root.scrollSpeedMultiplier
     onContactChosen: function(contact, target) {
       if (target === "cc") {
         root.ccVisible = true
@@ -1565,7 +1573,10 @@ DropArea {
   Flickable {
     id: bodyFlick
 
-    WheelScroller { view: bodyFlick }
+    WheelScroller {
+      view: bodyFlick
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
     objectName: "compose-body"
     anchors.top: fields.bottom
     anchors.left: parent.left
@@ -1627,7 +1638,10 @@ DropArea {
     Flickable {
       id: attachFlick
 
-      WheelScroller { view: attachFlick }
+      WheelScroller {
+        view: attachFlick
+        speedMultiplier: root.scrollSpeedMultiplier
+      }
       anchors.fill: parent
       anchors.leftMargin: Style.space(18)
       anchors.rightMargin: Style.space(18)

--- a/components/ContactsPicker.qml
+++ b/components/ContactsPicker.qml
@@ -14,6 +14,7 @@ Item {
   required property color popupBackgroundColor
   required property color popupBorderColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   readonly property bool opened: menu.opened
   property string searchQuery: ""
@@ -139,7 +140,10 @@ Item {
       ListView {
         id: contactsList
 
-        WheelScroller { view: contactsList }
+        WheelScroller {
+          view: contactsList
+          speedMultiplier: root.scrollSpeedMultiplier
+        }
         width: parent.width
         implicitHeight: Math.min(contentHeight, Style.space(280))
         clip: true

--- a/components/LabelPicker.qml
+++ b/components/LabelPicker.qml
@@ -20,6 +20,7 @@ Item {
   required property color popupBackgroundColor
   required property color popupBorderColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   // [{ id, name, system, unread, total }], as the provider reported them.
   property var labels: []
@@ -157,7 +158,10 @@ Item {
       ListView {
         id: labelList
 
-        WheelScroller { view: labelList }
+        WheelScroller {
+          view: labelList
+          speedMultiplier: root.scrollSpeedMultiplier
+        }
         width: parent.width
         implicitHeight: Math.min(contentHeight, Style.space(280))
         clip: true

--- a/components/MailPalette.qml
+++ b/components/MailPalette.qml
@@ -1,0 +1,71 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import "../calendar/Palette.js" as Palette
+
+// Theme-reactive mail roles. Like the weather palette, color is selective:
+// neutral/muted structure for large surfaces and the terminal accent only for
+// state that deserves attention. Optional `omamail.*` shell.toml roles let a
+// theme override the defaults without teaching this view about that theme.
+QtObject {
+  id: root
+
+  property bool enabled: false
+  property color baseBackground: Color.background
+  property color baseText: Color.foreground
+  property color baseUrgent: Color.urgent
+  property var terminalValues: ({})
+  readonly property string palettePath: Quickshell.env("HOME")
+    + "/.local/state/omarchy/current/theme/colors.toml"
+
+  function role(name, fallbackColor) {
+    if (typeof Color.pick !== "function" || typeof Color.flatColor !== "function")
+      return fallbackColor
+    var configured = Color.pick("omamail." + name, "")
+    return configured === "" ? fallbackColor
+      : Color.flatColor(configured, fallbackColor)
+  }
+
+  function terminal(name, fallbackColor) {
+    var value = terminalValues[String(name || "").toLowerCase()]
+    return typeof value === "string" && value !== "" ? value : fallbackColor
+  }
+
+  function alpha(color, amount) {
+    return Qt.rgba(color.r, color.g, color.b, amount)
+  }
+
+  readonly property color primary: role("accent", Color.accent)
+  readonly property color muted: role("muted",
+    typeof Color.muted !== "undefined" ? Color.muted : baseText)
+  readonly property color unread: role("unread", terminal("cyan", primary))
+  readonly property color starred: role("starred", terminal("yellow", primary))
+  readonly property color sent: role("sent", terminal("green", primary))
+  readonly property color drafts: role("drafts", terminal("magenta", primary))
+  readonly property color labels: role("labels", terminal("orange", starred))
+  readonly property color calendar: role("calendar", terminal("green", primary))
+  readonly property color danger: role("danger", terminal("red", baseUrgent))
+
+  // Large areas stay close to the terminal background. The accent is reserved
+  // for selection, matching the weather plugin's cards instead of washing an
+  // entire pane with one saturated hue.
+  readonly property color sidebarSurface: enabled
+    ? alpha(muted, 0.10) : baseBackground
+  readonly property color listSurface: enabled
+    ? alpha(unread, 0.03) : baseBackground
+  readonly property color readerSurface: enabled
+    ? alpha(drafts, 0.018) : baseBackground
+  readonly property color selectedSurface: alpha(primary, 0.15)
+  readonly property color hoverSurface: alpha(primary, 0.065)
+  readonly property color activeText: primary
+
+  property FileView paletteFile: FileView {
+    path: root.palettePath
+    watchChanges: true
+    printErrors: false
+    onLoaded: root.terminalValues = Palette.parse(text())
+    onFileChanged: reload()
+    onLoadFailed: root.terminalValues = ({})
+  }
+}

--- a/components/MailboxSidebar.qml
+++ b/components/MailboxSidebar.qml
@@ -19,6 +19,20 @@ Item {
   required property color accentColor
   required property color dimColor
   required property string panelFontFamily
+  property color backgroundColor: "transparent"
+  property bool systemThemeStyling: false
+  property color selectedSurfaceColor: Style.selectedFillFor(textColor, accentColor)
+  property color hoverSurfaceColor: Style.hoverFillFor(textColor, accentColor)
+  property color activeTextColor: accentColor
+  property color unreadColor: accentColor
+  property color starColor: accentColor
+  property color sentColor: accentColor
+  property color draftColor: accentColor
+  property color labelColor: accentColor
+  property color calendarColor: accentColor
+  property color dangerColor: accentColor
+  property real scrollSpeedMultiplier: 1
+  property bool showTrailingSeparator: true
   property bool collapsed: false
   property bool calendarSelected: false
 
@@ -31,12 +45,31 @@ Item {
   property var slots: []
   property bool numbersVisible: false
 
+  function mailboxColor(key) {
+    if (key === "inbox" || key === "unread") return root.unreadColor
+    if (key === "starred" || key === "flagged") return root.starColor
+    if (key === "sent") return root.sentColor
+    if (key === "drafts") return root.draftColor
+    if (key === "trash" || key === "spam") return root.dangerColor
+    return root.activeTextColor
+  }
+
+  function stateSurface(color, amount) {
+    return Qt.rgba(color.r, color.g, color.b, amount)
+  }
+
   readonly property var userLabels: Model.railLabels(root.service ? root.service.labels : [])
+
+  Rectangle {
+    anchors.fill: parent
+    color: root.backgroundColor
+  }
 
   // The rail's own edge. The list already draws one on its far side, so
   // without this the icons sit on the same surface as the messages.
   PanelSeparator {
     id: edge
+    visible: root.showTrailingSeparator
     anchors.right: parent.right
     anchors.top: parent.top
     anchors.bottom: parent.bottom
@@ -47,7 +80,10 @@ Item {
   Flickable {
     id: flick
 
-    WheelScroller { view: flick }
+    WheelScroller {
+      view: flick
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
     anchors.left: parent.left
     anchors.right: edge.left
     anchors.top: parent.top
@@ -84,6 +120,7 @@ Item {
             && root.service.mailboxKey === modelData.key
             && root.service.searchQuery === "" && root.service.rawQuery === ""
           slotNumber: Model.slotNumberOf(root.slots, "mailbox", modelData.key)
+          semanticColor: root.mailboxColor(modelData.key)
           onActivated: root.mailboxSelected(modelData.key)
         }
       }
@@ -122,6 +159,7 @@ Item {
           icon: "label"
           slotNumber: Model.slotNumberOf(root.slots, "label", modelData.id)
           count: modelData.unread
+          semanticColor: root.labelColor
           selected: !root.calendarSelected && !!root.service && root.service.rawQuery !== ""
             && root.service.rawQuery
               === Provider.labelQuery(root.service.providerId, modelData.rawName)
@@ -143,6 +181,7 @@ Item {
       label: "Calendar"
       icon: "calendar"
       selected: root.calendarSelected
+      semanticColor: root.calendarColor
       onActivated: root.calendarRequested()
     }
 
@@ -162,6 +201,7 @@ Item {
     property int count: 0
     property bool selected: false
     property int slotNumber: 0
+    property color semanticColor: root.activeTextColor
     signal activated()
 
     // The badge names the key, not the position: the tenth row is opened by
@@ -173,8 +213,12 @@ Item {
     implicitHeight: Style.space(28)
     radius: Style.cornerRadius
     color: entry.selected
-      ? Style.selectedFillFor(root.textColor, root.accentColor)
-      : (hover.hovered ? Style.hoverFillFor(root.textColor, root.accentColor) : "transparent")
+      ? (root.systemThemeStyling ? root.stateSurface(entry.semanticColor, 0.15)
+        : Style.selectedFillFor(root.textColor, root.accentColor))
+      : (hover.hovered
+        ? (root.systemThemeStyling ? root.hoverSurfaceColor
+          : Style.hoverFillFor(root.textColor, root.accentColor))
+        : "transparent")
 
     ActionIcon {
       id: glyph
@@ -184,7 +228,8 @@ Item {
       anchors.verticalCenter: parent.verticalCenter
       name: entry.icon
       iconSize: Style.font.icon
-      color: entry.selected ? root.textColor : root.dimColor
+      color: entry.selected && root.systemThemeStyling
+        ? entry.semanticColor : (entry.selected ? root.textColor : root.dimColor)
       visible: !(entry.showsNumber && root.collapsed)
     }
 
@@ -224,7 +269,8 @@ Item {
       anchors.verticalCenter: parent.verticalCenter
       textFormat: Text.PlainText
       text: entry.label
-      color: entry.selected ? root.textColor : root.dimColor
+      color: entry.selected && root.systemThemeStyling
+        ? entry.semanticColor : (entry.selected ? root.textColor : root.dimColor)
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.bodySmall
       font.bold: entry.selected
@@ -238,7 +284,7 @@ Item {
       anchors.rightMargin: Style.space(8)
       anchors.verticalCenter: parent.verticalCenter
       text: Model.badgeText(entry.count, 999)
-      color: root.accentColor
+      color: root.systemThemeStyling ? entry.semanticColor : root.accentColor
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.caption
       font.bold: true
@@ -253,7 +299,7 @@ Item {
       width: Style.space(5)
       height: width
       radius: width / 2
-      color: root.accentColor
+      color: root.systemThemeStyling ? entry.semanticColor : root.accentColor
     }
 
     HoverHandler { id: hover }

--- a/components/MailboxTabs.qml
+++ b/components/MailboxTabs.qml
@@ -13,6 +13,12 @@ Flickable {
   required property color textColor
   required property color accentColor
   required property string panelFontFamily
+  property bool systemThemeStyling: false
+  property color unreadColor: accentColor
+  property color starColor: accentColor
+  property color sentColor: accentColor
+  property color draftColor: accentColor
+  property color dangerColor: accentColor
   property string current: "inbox"
   // Provider-specific, and handed down rather than looked up: this row must
   // never offer a mailbox the account on screen does not have.
@@ -22,6 +28,15 @@ Flickable {
 
   signal selected(string key)
   signal chipHovered(int index, bool isHovered)
+
+  function mailboxColor(key) {
+    if (key === "inbox" || key === "unread") return root.unreadColor
+    if (key === "starred" || key === "flagged") return root.starColor
+    if (key === "sent") return root.sentColor
+    if (key === "drafts") return root.draftColor
+    if (key === "trash" || key === "spam") return root.dangerColor
+    return root.accentColor
+  }
 
   // Scrolling a six-segment control in a narrow window is worse than not
   // offering two of the segments: All mail and Trash are places you go looking
@@ -114,7 +129,9 @@ Flickable {
             text: segment.modelData.key === "unread" && root.unread > 0
               ? segment.modelData.label + " " + root.unread
               : segment.modelData.label
-            foreground: root.textColor
+            foreground: root.systemThemeStyling
+              && root.current === segment.modelData.key
+              ? root.mailboxColor(segment.modelData.key) : root.textColor
             bordered: false
             selected: root.current === segment.modelData.key
             hasCursor: root.cursorIndex === segment.index

--- a/components/MessageList.qml
+++ b/components/MessageList.qml
@@ -23,6 +23,12 @@ Column {
   required property color dimColor
   required property string panelFontFamily
   property string cursorId: ""
+  property bool systemThemeStyling: false
+  property color selectedSurfaceColor: Style.selectedFillFor(textColor, accentColor)
+  property color hoverSurfaceColor: Style.hoverFillFor(textColor, accentColor)
+  property color unreadColor: accentColor
+  property color starColor: accentColor
+  property color sourceColor: accentColor
 
   signal messageActivated(string id)
   signal menuRequested(string id, real sceneX, real sceneY)
@@ -53,6 +59,12 @@ Column {
       textColor: root.textColor
       accentColor: root.accentColor
       dimColor: root.dimColor
+      systemThemeStyling: root.systemThemeStyling
+      selectedSurfaceColor: root.selectedSurfaceColor
+      hoverSurfaceColor: root.hoverSurfaceColor
+      unreadColor: root.unreadColor
+      starColor: root.starColor
+      sourceColor: root.sourceColor
       panelFontFamily: root.panelFontFamily
       hasCursor: root.cursorId === modelData.id
       selected: root.service.selectedId === modelData.id

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -25,6 +25,9 @@ Item {
   required property color popupBorderColor
   required property real leadingBoundaryOverlap
   required property color dimmerColor
+  property bool systemThemeStyling: false
+  property color starColor: accentColor
+  property real scrollSpeedMultiplier: 1
   required property string panelFontFamily
   // Which of the three ways of reading a message this window is set to. The
   // window's preference, not this message's: it may not be the one on screen,
@@ -52,6 +55,11 @@ Item {
   signal composeRequested(string mode)
   signal mailtoRequested(string url)
   signal actionRequested(string action)
+
+  Rectangle {
+    anchors.fill: parent
+    color: root.backgroundColor
+  }
 
   // ------------------------------------------------------- the conversation
 
@@ -307,8 +315,10 @@ Item {
       iconName: "star"
       filled: !!root.summary && root.summary.starred
       tooltipText: (root.summary && root.summary.starred ? "Unstar" : "Star") + " · s"
-      foreground: root.summary && root.summary.starred ? root.accentColor : root.dimColor
-      hoverColor: root.accentColor
+      foreground: root.summary && root.summary.starred
+        ? (root.systemThemeStyling ? root.starColor : root.accentColor)
+        : root.dimColor
+      hoverColor: root.systemThemeStyling ? root.starColor : root.accentColor
       fontFamily: root.panelFontFamily
       onClicked: if (root.service && root.summary) root.service.toggleStar(root.selectedId)
     }
@@ -514,7 +524,10 @@ Item {
   Flickable {
     id: bodyFlick
 
-    WheelScroller { view: bodyFlick }
+    WheelScroller {
+      view: bodyFlick
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
     anchors.top: notices.bottom
     anchors.left: parent.left
     // The rail takes its width out of the body's, which is what keeps the

--- a/components/MessageRow.qml
+++ b/components/MessageRow.qml
@@ -28,6 +28,12 @@ Rectangle {
   property bool conversations: false
   property bool hasCursor: false
   property bool selected: false
+  property bool systemThemeStyling: false
+  property color selectedSurfaceColor: Style.selectedFillFor(textColor, accentColor)
+  property color hoverSurfaceColor: Style.hoverFillFor(textColor, accentColor)
+  property color unreadColor: accentColor
+  property color starColor: accentColor
+  property color sourceColor: accentColor
   // How the direction of this message's own text is arrived at. Passed down
   // like every other fact a row draws, because a row decides nothing.
   property string contentDirection: Direction.MODE_DEFAULT
@@ -70,8 +76,10 @@ Rectangle {
   implicitHeight: body.implicitHeight + Style.space(14)
   radius: Style.cornerRadius
   color: selected
-    ? Style.selectedFillFor(textColor, accentColor)
-    : (hot ? Style.hoverFillFor(textColor, accentColor) : "transparent")
+    ? (systemThemeStyling ? selectedSurfaceColor
+      : Style.selectedFillFor(textColor, accentColor))
+    : (hot ? (systemThemeStyling ? hoverSurfaceColor
+      : Style.hoverFillFor(textColor, accentColor)) : "transparent")
 
   MouseArea {
     id: mouse
@@ -102,7 +110,7 @@ Rectangle {
     height: width
     radius: width / 2
     visible: root.summary.unread
-    color: root.accentColor
+    color: root.systemThemeStyling ? root.unreadColor : root.accentColor
   }
 
   Column {
@@ -197,7 +205,7 @@ Rectangle {
         width: Math.min(implicitWidth, Math.floor(parent.width / 3))
         textFormat: Text.PlainText
         text: root.sourceLabel
-        color: root.accentColor
+        color: root.systemThemeStyling ? root.sourceColor : root.accentColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.caption
         elide: Text.ElideRight
@@ -252,8 +260,10 @@ Rectangle {
       iconName: "star"
       filled: root.summary.starred
       tooltipText: (root.summary.starred ? "Unstar" : "Star") + " · s"
-      foreground: root.summary.starred ? root.accentColor : root.dimColor
-      hoverColor: root.accentColor
+      foreground: root.summary.starred
+        ? (root.systemThemeStyling ? root.starColor : root.accentColor)
+        : root.dimColor
+      hoverColor: root.systemThemeStyling ? root.starColor : root.accentColor
       iconSize: Style.font.iconSmall
       size: Style.space(24)
       fontFamily: root.panelFontFamily

--- a/components/RecipientSuggestions.qml
+++ b/components/RecipientSuggestions.qml
@@ -11,6 +11,7 @@ Rectangle {
   required property color popupBackgroundColor
   required property color popupBorderColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   property int currentIndex: -1
 
@@ -50,7 +51,10 @@ Rectangle {
   ListView {
     id: suggestions
 
-    WheelScroller { view: suggestions }
+    WheelScroller {
+      view: suggestions
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
     anchors.fill: parent
     anchors.margins: Style.space(2)
     clip: true

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -2,6 +2,7 @@ import QtQuick
 import qs.Commons
 import qs.Ui
 import "../message/Direction.js" as Direction
+import "../account/Model.js" as Model
 
 // Where mailboxes are managed.
 //
@@ -21,6 +22,11 @@ Column {
   required property color accentColor
   required property color urgentColor
   required property string panelFontFamily
+  property color unreadColor: accentColor
+  property color starColor: accentColor
+  property color draftColor: accentColor
+  property color labelColor: accentColor
+  property color calendarColor: accentColor
 
   signal clientSetupRequested()
   signal addRequested()
@@ -38,8 +44,9 @@ Column {
   // below it in the rail's map as well as on screen. The calendars section
   // is a component with its own heading, so its top stands in.
   readonly property var sections: [
-    { key: "bar", title: "Bar", y: barHeading.y },
+    { key: "appearance", title: "Appearance", y: appearanceHeading.y },
     { key: "reading", title: "Reading", y: readingHeading.y },
+    { key: "bar", title: "Bar", y: barHeading.y },
     { key: "notifications", title: "Notifications", y: notificationsHeading.y },
     { key: "writing", title: "Writing", y: writingHeading.y },
     { key: "mailboxes", title: "Mailboxes", y: mailboxesHeading.y },
@@ -53,6 +60,33 @@ Column {
       if (String(signatureAccounts[i].id || "") === String(id || ""))
         return signatureAccounts[i]
     return null
+  }
+
+  readonly property int scrollSpeedPercent: root.service
+    && Number(root.service.scrollSpeedPercent) > 0
+    ? Number(root.service.scrollSpeedPercent) : 160
+  readonly property int scrollSpeedLevel: Model.scrollSpeedLevel(scrollSpeedPercent)
+  readonly property bool colorful: !!root.service
+    && root.service.systemThemeStyling === true
+
+  function adjustPaneWidth(pane, direction) {
+    if (!root.service) return
+    var step = Style.space(20) * (direction < 0 ? -1 : 1)
+    if (pane === "labels") {
+      var labels = Number(root.service.sidebarWidth) > 0
+        ? Number(root.service.sidebarWidth) : Style.space(148)
+      root.service.setSidebarWidth(labels + step)
+    } else {
+      var inbox = Number(root.service.listWidth) > 0
+        ? Number(root.service.listWidth) : Style.space(460)
+      root.service.setListWidth(inbox + step)
+    }
+  }
+
+  function resetPaneWidths() {
+    if (!root.service) return
+    root.service.setSidebarWidth(0)
+    root.service.setListWidth(0)
   }
 
   function signatureOptions() {
@@ -142,12 +176,12 @@ Column {
     font.bold: true
   }
 
-  // ------------------------------------------------------------------- bar
+  // ------------------------------------------------------------ appearance
 
   Text {
-    id: barHeading
-    text: "BAR"
-    color: root.dimColor
+    id: appearanceHeading
+    text: "APPEARANCE"
+    color: root.colorful ? root.draftColor : root.dimColor
     font.family: root.panelFontFamily
     font.pixelSize: Style.font.caption
     font.letterSpacing: 1
@@ -155,67 +189,148 @@ Column {
 
   Rectangle {
     width: parent.width
-    implicitHeight: Math.max(barIconText.implicitHeight, barIconSwitch.implicitHeight)
+    implicitHeight: Math.max(themeText.implicitHeight, themeSwitch.implicitHeight)
       + Style.space(16)
     radius: Style.cornerRadius
     color: Style.normalFillFor(root.textColor, root.accentColor)
 
     Column {
-      id: barIconText
+      id: themeText
       anchors.left: parent.left
       anchors.leftMargin: Style.space(12)
-      anchors.right: barIconSwitch.left
+      anchors.right: themeSwitch.left
       anchors.rightMargin: Style.space(10)
       anchors.verticalCenter: parent.verticalCenter
       spacing: Style.space(2)
 
       Text {
         width: parent.width
-        text: "Show the icon in the bar"
+        text: "System theme styling"
         color: root.textColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.bodySmall
-        textFormat: Text.PlainText
       }
 
-      // Says what turning it off costs, and what it does not: mail is still
-      // checked and still notifies. The keybinding is the part worth naming,
-      // because without one the window is only reachable from a terminal —
-      // which is true, and is why this does not claim there is no way back.
       Text {
         width: parent.width
-        text: "Mail is still checked and still notifies; only the envelope goes. "
-          + "With it off the window opens from a keybinding or a terminal and "
-          + "nowhere else, so bind a key before turning this off:"
+        text: "Use the terminal palette for subtle surfaces and accent selected mail"
         color: root.dimColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.caption
         wrapMode: Text.WordWrap
-        textFormat: Text.PlainText
-      }
-
-      Text {
-        width: parent.width
-        text: "o.bind(\"SUPER + SHIFT + G\", \"Omamail\", "
-          + "\"omarchy shell shell toggle omamail '\{}'\")"
-        color: root.dimColor
-        font.family: root.panelFontFamily
-        font.pixelSize: Style.font.caption
-        wrapMode: Text.WrapAnywhere
-        textFormat: Text.PlainText
       }
     }
 
     ToggleSwitch {
-      id: barIconSwitch
-      objectName: "showBarIconSwitch"
+      id: themeSwitch
+      objectName: "systemThemeStylingSwitch"
       anchors.right: parent.right
       anchors.rightMargin: Style.space(10)
       anchors.verticalCenter: parent.verticalCenter
-      checked: !root.service || root.service.showBarIcon !== false
+      checked: !!root.service && root.service.systemThemeStyling === true
       foreground: root.textColor
       accent: root.accentColor
-      onToggled: if (root.service) root.service.setShowBarIcon(!root.service.showBarIcon)
+      onToggled: if (root.service)
+        root.service.setSystemThemeStyling(!root.service.systemThemeStyling)
+    }
+  }
+
+  Rectangle {
+    width: parent.width
+    implicitHeight: Math.max(paneWidthText.implicitHeight,
+      paneWidthControls.implicitHeight) + Style.space(16)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+
+    Column {
+      id: paneWidthText
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(12)
+      anchors.right: paneWidthControls.left
+      anchors.rightMargin: Style.space(12)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(2)
+
+      Text {
+        width: parent.width
+        text: "Pane widths"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+      }
+
+      Text {
+        width: parent.width
+        text: "Resize the labels and inbox panes without a pointer"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+      }
+    }
+
+    Row {
+      id: paneWidthControls
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(12)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(6)
+
+      Button {
+        objectName: "labelsPaneNarrower"
+        text: "Labels −"
+        tooltipText: "Narrower labels pane"
+        foreground: root.dimColor
+        bordered: true
+        focusable: true
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.caption
+        onClicked: root.adjustPaneWidth("labels", -1)
+      }
+      Button {
+        objectName: "labelsPaneWider"
+        text: "Labels +"
+        tooltipText: "Wider labels pane"
+        foreground: root.dimColor
+        bordered: true
+        focusable: true
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.caption
+        onClicked: root.adjustPaneWidth("labels", 1)
+      }
+      Button {
+        objectName: "inboxPaneNarrower"
+        text: "Inbox −"
+        tooltipText: "Narrower inbox pane"
+        foreground: root.dimColor
+        bordered: true
+        focusable: true
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.caption
+        onClicked: root.adjustPaneWidth("inbox", -1)
+      }
+      Button {
+        objectName: "inboxPaneWider"
+        text: "Inbox +"
+        tooltipText: "Wider inbox pane"
+        foreground: root.dimColor
+        bordered: true
+        focusable: true
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.caption
+        onClicked: root.adjustPaneWidth("inbox", 1)
+      }
+      Button {
+        objectName: "paneWidthsReset"
+        text: "Reset"
+        tooltipText: "Reset pane widths"
+        foreground: root.dimColor
+        bordered: true
+        focusable: true
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.caption
+        onClicked: root.resetPaneWidths()
+      }
     }
   }
 
@@ -224,10 +339,120 @@ Column {
   Text {
     id: readingHeading
     text: "READING"
-    color: root.dimColor
+    color: root.colorful ? root.unreadColor : root.dimColor
     font.family: root.panelFontFamily
     font.pixelSize: Style.font.caption
     font.letterSpacing: 1
+  }
+
+  Rectangle {
+    width: parent.width
+    implicitHeight: Math.max(scrollText.implicitHeight, scrollControls.implicitHeight)
+      + Style.space(16)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+
+    Column {
+      id: scrollText
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(12)
+      anchors.right: scrollControls.left
+      anchors.rightMargin: Style.space(12)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(2)
+
+      Text {
+        width: parent.width
+        text: "Pane scroll speed"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+      }
+
+      Text {
+        width: parent.width
+        text: "Applies to mouse wheels and touchpad scrolling"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+      }
+    }
+
+    Row {
+      id: scrollControls
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(12)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(8)
+
+      Button {
+        objectName: "scrollSpeedSlower"
+        anchors.verticalCenter: parent.verticalCenter
+        text: "−"
+        tooltipText: "Slower scrolling"
+        foreground: root.dimColor
+        bordered: true
+        focusable: true
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.bodySmall
+        enabled: root.scrollSpeedLevel > 0
+        onClicked: if (root.service)
+          root.service.setScrollSpeedPercent(
+            Model.scrollSpeedPercentForLevel(root.scrollSpeedLevel - 1))
+      }
+
+      PanelSlider {
+        id: scrollSlider
+        objectName: "scrollSpeedSlider"
+        anchors.verticalCenter: parent.verticalCenter
+        width: Style.space(150)
+        minimum: 0
+        maximum: 4
+        step: 1
+        tickCount: 5
+        integer: true
+        value: root.scrollSpeedLevel
+        trackColor: Style.normalFillFor(root.textColor, root.accentColor)
+        fillColor: root.accentColor
+        knobColor: root.textColor
+        tickColor: root.dimColor
+        function chooseLevel(next) {
+          if (root.service)
+            root.service.setScrollSpeedPercent(Model.scrollSpeedPercentForLevel(next))
+        }
+        onReleased: function(next) {
+          chooseLevel(next)
+        }
+      }
+
+      Button {
+        objectName: "scrollSpeedFaster"
+        anchors.verticalCenter: parent.verticalCenter
+        text: "+"
+        tooltipText: "Faster scrolling"
+        foreground: root.dimColor
+        bordered: true
+        focusable: true
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.bodySmall
+        enabled: root.scrollSpeedLevel < 4
+        onClicked: if (root.service)
+          root.service.setScrollSpeedPercent(
+            Model.scrollSpeedPercentForLevel(root.scrollSpeedLevel + 1))
+      }
+
+      Text {
+        anchors.verticalCenter: parent.verticalCenter
+        width: Style.space(62)
+        horizontalAlignment: Text.AlignRight
+        text: Model.WHEEL_SPEED_LABELS[Math.round(scrollSlider.dragging
+          ? scrollSlider.liveValue : root.scrollSpeedLevel)]
+        color: root.colorful ? root.unreadColor : root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+      }
+    }
   }
 
   Rectangle {
@@ -508,12 +733,85 @@ Column {
     }
   }
 
+  // ------------------------------------------------------------------- bar
+
+  Text {
+    id: barHeading
+    text: "BAR"
+    color: root.colorful ? root.starColor : root.dimColor
+    font.family: root.panelFontFamily
+    font.pixelSize: Style.font.caption
+    font.letterSpacing: 1
+  }
+
+  Rectangle {
+    width: parent.width
+    implicitHeight: Math.max(barIconText.implicitHeight, barIconSwitch.implicitHeight)
+      + Style.space(16)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+
+    Column {
+      id: barIconText
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(12)
+      anchors.right: barIconSwitch.left
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(2)
+
+      Text {
+        width: parent.width
+        text: "Show the icon in the bar"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        textFormat: Text.PlainText
+      }
+
+      Text {
+        width: parent.width
+        text: "Mail is still checked and still notifies; only the envelope goes. "
+          + "With it off the window opens from a keybinding or a terminal and "
+          + "nowhere else, so bind a key before turning this off:"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+        textFormat: Text.PlainText
+      }
+
+      Text {
+        width: parent.width
+        text: "o.bind(\"SUPER + SHIFT + G\", \"Omamail\", "
+          + "\"omarchy shell shell toggle omamail '\{}'\")"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WrapAnywhere
+        textFormat: Text.PlainText
+      }
+    }
+
+    ToggleSwitch {
+      id: barIconSwitch
+      objectName: "showBarIconSwitch"
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      checked: !root.service || root.service.showBarIcon !== false
+      foreground: root.textColor
+      accent: root.accentColor
+      onToggled: if (root.service) root.service.setShowBarIcon(!root.service.showBarIcon)
+    }
+  }
+
   // -------------------------------------------------------- notifications
 
   Text {
     id: notificationsHeading
     text: "NOTIFICATIONS"
-    color: root.dimColor
+    color: root.colorful ? root.unreadColor : root.dimColor
     font.family: root.panelFontFamily
     font.pixelSize: Style.font.caption
     font.letterSpacing: 1
@@ -571,7 +869,7 @@ Column {
   Text {
     id: writingHeading
     text: "WRITING"
-    color: root.dimColor
+    color: root.colorful ? root.draftColor : root.dimColor
     font.family: root.panelFontFamily
     font.pixelSize: Style.font.caption
     font.letterSpacing: 1
@@ -729,7 +1027,7 @@ Column {
   Text {
     id: mailboxesHeading
     text: "MAILBOXES"
-    color: root.dimColor
+    color: root.colorful ? root.labelColor : root.dimColor
     font.family: root.panelFontFamily
     font.pixelSize: Style.font.caption
     font.letterSpacing: 1
@@ -954,7 +1252,7 @@ Column {
     controller: root.calendarController
     textColor: root.textColor
     dimColor: root.dimColor
-    accentColor: root.accentColor
+    accentColor: root.colorful ? root.calendarColor : root.accentColor
     urgentColor: root.urgentColor
     panelFontFamily: root.panelFontFamily
   }
@@ -969,7 +1267,7 @@ Column {
   Text {
     id: oauthHeading
     text: "GOOGLE OAUTH CLIENT"
-    color: root.dimColor
+    color: root.colorful ? root.calendarColor : root.dimColor
     font.family: root.panelFontFamily
     font.pixelSize: Style.font.caption
     font.letterSpacing: 1

--- a/components/ShortcutHelp.qml
+++ b/components/ShortcutHelp.qml
@@ -24,6 +24,7 @@ Rectangle {
   required property color backgroundColor
   required property color dimColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   signal dismissed()
 
@@ -68,7 +69,10 @@ Rectangle {
   Flickable {
     id: scroller
 
-    WheelScroller { view: scroller }
+    WheelScroller {
+      view: scroller
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
     // Filling the sheet rather than hugging the content is the whole of the
     // scrollbar fix: a Flickable sized to its column puts the bar at that
     // column's edge, which on a wide window is the middle of the screen.

--- a/components/WeekCalendarView.qml
+++ b/components/WeekCalendarView.qml
@@ -19,6 +19,7 @@ Item {
   required property int calendarBorderWidth
   required property string panelFontFamily
   required property string selectedEventId
+  property real scrollSpeedMultiplier: 1
 
   signal createAt(double startMs)
   signal eventActivated(var event)
@@ -168,7 +169,10 @@ Item {
   Flickable {
     id: timeline
 
-    WheelScroller { view: timeline }
+    WheelScroller {
+      view: timeline
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
     anchors.left: parent.left
     anchors.right: parent.right
     anchors.top: root.allDayCount > 0 ? allDayLane.bottom : dayHeaders.bottom

--- a/components/WheelScroller.qml
+++ b/components/WheelScroller.qml
@@ -23,6 +23,9 @@ WheelHandler {
   id: root
 
   required property Flickable view
+  // One keeps the upstream Chromium-like distance; the mail window defaults
+  // to the Quick preset and updates this binding live from Settings.
+  property real speedMultiplier: 1
 
   blocking: true
   grabPermissions: PointerHandler.CanTakeOverFromAnything
@@ -31,12 +34,15 @@ WheelHandler {
 
   onWheel: function(event) {
     if (!root.view) return
+    var previous = root.view.contentY
     root.view.contentY = Model.wheelScrollByPixels(root.view.contentY,
-      Model.wheelPixels(event.angleDelta.y, event.pixelDelta.y),
+      Model.wheelPixels(event.angleDelta.y, event.pixelDelta.y,
+        root.speedMultiplier),
       root.view.contentHeight, root.view.height,
       root.view.originY, root.view.topMargin, root.view.bottomMargin)
     // Not dead despite `blocking`: a flick already in flight from a drag
     // goes on decelerating from where it was and fights every turn after.
     root.view.cancelFlick()
+    event.accepted = Math.abs(root.view.contentY - previous) > 0.01
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,8 @@
       "maxMessages": 25,
       "heavyMessageRendering": "Show plain text first",
       "contentDirection": "Auto",
+      "scrollSpeedPercent": 160,
+      "systemThemeStyling": false,
       "defaultQuery": "in:inbox",
       "notifyNewMail": "On",
       "oauthPort": 9481,
@@ -58,6 +60,13 @@
         "label": "Show the icon in the bar",
         "defaultValue": true,
         "description": "Turn this off to run Omamail with no envelope in the bar. Mail is still checked and still notifies; only the icon goes. With it off the window opens from a keybinding or a terminal and nowhere else, so bind a key first: o.bind(\"SUPER + SHIFT + G\", \"Omamail\", \"omarchy shell shell toggle omamail '{}'\")"
+      },
+      {
+        "key": "systemThemeStyling",
+        "type": "boolean",
+        "label": "System theme styling",
+        "defaultValue": false,
+        "description": "Use the terminal palette for subtle pane structure and accent selected folders and mail. Colors update automatically when the system theme changes."
       },
       {
         "key": "refreshIntervalSec",

--- a/tests/qml/imports/qs/Ui/PanelSlider.qml
+++ b/tests/qml/imports/qs/Ui/PanelSlider.qml
@@ -1,0 +1,20 @@
+import QtQuick
+
+Item {
+  property real value: 0
+  property real minimum: 0
+  property real maximum: 1
+  property real step: 0.05
+  property bool integer: false
+  property color trackColor: "transparent"
+  property color fillColor: "transparent"
+  property color knobColor: "transparent"
+  property color tickColor: "transparent"
+  property int tickCount: 0
+  property bool dragging: false
+  property real liveValue: value
+  signal moved(real value)
+  signal released(real value)
+  implicitWidth: 200
+  implicitHeight: 24
+}

--- a/tests/qml/imports/qs/Ui/qmldir
+++ b/tests/qml/imports/qs/Ui/qmldir
@@ -7,6 +7,7 @@ PanelActionButton 1.0 PanelActionButton.qml
 PanelSeparator 1.0 PanelSeparator.qml
 PanelSectionHeader 1.0 PanelSectionHeader.qml
 PanelToolTip 1.0 PanelToolTip.qml
+PanelSlider 1.0 PanelSlider.qml
 ToggleSwitch 1.0 ToggleSwitch.qml
 Dropdown 1.0 Dropdown.qml
 BarWidget 1.0 BarWidget.qml

--- a/tests/qml/tst_service_settings.qml
+++ b/tests/qml/tst_service_settings.qml
@@ -68,6 +68,25 @@ Item {
       compare(shellStore.updatedEntry.unifiedCalendarView, true)
     }
 
+    function test_scroll_speed_defaults_faster_and_persists_a_clamped_value() {
+      mailService.applySettings({})
+      compare(mailService.scrollSpeedPercent, 160)
+      compare(mailService.scrollSpeedMultiplier, 1.6)
+
+      mailService.setScrollSpeedPercent(237)
+      compare(mailService.scrollSpeedPercent, 250)
+      compare(shellStore.updatedEntry.scrollSpeedPercent, 250)
+    }
+
+    function test_system_theme_styling_defaults_off_and_persists() {
+      mailService.applySettings({})
+      compare(mailService.systemThemeStyling, false)
+
+      mailService.setSystemThemeStyling(true)
+      compare(mailService.systemThemeStyling, true)
+      compare(shellStore.updatedEntry.systemThemeStyling, true)
+    }
+
     function test_unified_mailboxes_setting_defaults_off_and_persists_changes() {
       mailService.applySettings({})
       compare(mailService.unifiedMailboxes, false)

--- a/tests/qml/tst_settings_sidebar.qml
+++ b/tests/qml/tst_settings_sidebar.qml
@@ -77,6 +77,11 @@ Item {
     property int accountCount: 1
     property int inboxUnread: 0
     property real bodyZoom: 1
+    property real scrollSpeedMultiplier: 1.6
+    property int scrollSpeedPercent: 160
+    property bool systemThemeStyling: false
+    property real sidebarWidth: 0
+    property real listWidth: 0
     property string bodyMode: "reader"
     property string providerId: "imap"
     property string pluginDir: ""
@@ -147,6 +152,10 @@ Item {
     }
     function preferredSendAs(_recipients) { return null }
     function refreshRecipientContacts() {}
+    function setScrollSpeedPercent(value) { scrollSpeedPercent = Math.round(value) }
+    function setSystemThemeStyling(value) { systemThemeStyling = value === true }
+    function setSidebarWidth(value) { sidebarWidth = Number(value) || 0 }
+    function setListWidth(value) { listWidth = Number(value) || 0 }
     function cursorOffset(_id, _delta) { return "" }
     function clearSelection() {
       selectedId = ""
@@ -237,6 +246,9 @@ Item {
     function init() {
       mailService.anyAccountReady = true
       mailService.hasSavedAccounts = true
+      mailService.scrollSpeedPercent = 160
+      mailService.scrollSpeedMultiplier = 1.6
+      mailService.systemThemeStyling = false
       app.opened = true
       window().width = 980
       app.backToList()
@@ -267,10 +279,61 @@ Item {
       view.contentY = 0
 
       mouseWheel(view, view.width / 2, view.height / 2, 0, -120)
-      compare(view.contentY, 240, "one notch, in the real hierarchy")
+      compare(view.contentY, 384, "the Quick preset, in the real hierarchy")
 
       mouseWheel(view, view.width / 2, view.height / 2, 0, 120)
       compare(view.contentY, 0)
+    }
+
+    function test_appearance_and_scroll_controls_reach_the_service() {
+      var slider = named(app, "scrollSpeedSlider")
+      verify(slider, "the settings page exposes the pane-speed slider")
+      var view = flick()
+      verify(slider.mapToItem(view, 0, 0).y < view.height,
+        "the speed control is in the initial settings viewport")
+      compare(slider.value, 2)
+      var faster = named(app, "scrollSpeedFaster")
+      var slower = named(app, "scrollSpeedSlower")
+      verify(faster && slower, "keyboard-reachable step buttons flank the slider")
+      faster.clicked()
+      compare(mailService.scrollSpeedPercent, 250,
+        "the faster button chooses the next named speed preset")
+      slower.clicked()
+      compare(mailService.scrollSpeedPercent, 160)
+      slider.released(4)
+      compare(mailService.scrollSpeedPercent, 400)
+      view.contentY = 0
+      mouseWheel(view, view.width / 2, view.height / 2, 0, -120)
+      compare(view.contentY, 960,
+        "the changed setting immediately changes this pane's distance")
+
+      var theme = named(app, "systemThemeStylingSwitch")
+      verify(theme, "the settings page exposes system theme styling")
+      theme.toggled()
+      compare(mailService.systemThemeStyling, true)
+      verify(String(app.labelsPaneBackground) !== String(app.background),
+        "turning styling on adds a muted labels surface")
+      verify(String(app.inboxPaneBackground) !== String(app.background),
+        "and a restrained accent surface behind the list")
+
+      var labelsWider = named(app, "labelsPaneWider")
+      var inboxWider = named(app, "inboxPaneWider")
+      var resetWidths = named(app, "paneWidthsReset")
+      verify(labelsWider && inboxWider && resetWidths,
+        "keyboard-reachable controls provide a splitter alternative")
+      verify(labelsWider.focusable,
+        "labels width controls participate in keyboard traversal")
+      verify(inboxWider.focusable,
+        "inbox width controls participate in keyboard traversal")
+      verify(resetWidths.focusable,
+        "reset participates in keyboard traversal")
+      labelsWider.clicked()
+      inboxWider.clicked()
+      verify(mailService.sidebarWidth > 0)
+      verify(mailService.listWidth > 0)
+      resetWidths.clicked()
+      compare(mailService.sidebarWidth, 0)
+      compare(mailService.listWidth, 0)
     }
 
     function test_the_rail_lists_the_pages_sections_in_order() {
@@ -278,7 +341,7 @@ Item {
       verify(rail && rail.visible, "a wide window has a rail")
       var page = named(app, "settings-page")
       var keys = page.sections.map(function(s) { return s.key })
-      compare(keys.join(","), "bar,reading,notifications,writing,mailboxes,calendars,oauth")
+      compare(keys.join(","), "appearance,reading,bar,notifications,writing,mailboxes,calendars,oauth")
       for (var i = 1; i < page.sections.length; i++)
         verify(page.sections[i].y > page.sections[i - 1].y, "sections are laid out top to bottom")
       for (var j = 0; j < keys.length; j++)
@@ -293,7 +356,7 @@ Item {
       var view = flick()
       verify(view, "the page scrolls inside a Flickable")
       compare(view.contentY, 0)
-      compare(rail.activeKey, "bar",
+      compare(rail.activeKey, "appearance",
         "the top of the page is the first section, whichever that is")
       compare(app.navKinds.join(","), "list,settings")
 
@@ -324,9 +387,48 @@ Item {
       // Scrolled by other means — the wheel, say — the highlight still
       // follows the page, because the page is what it describes.
       view.contentY = 0
-      tryCompare(rail, "activeKey", "bar")
+      tryCompare(rail, "activeKey", "appearance")
       view.contentY = sectionY(page, "mailboxes") + 5
       tryCompare(rail, "activeKey", "mailboxes")
+    }
+
+    function test_header_buttons_switch_directly_between_mail_and_calendar() {
+      var mail = named(app, "mail-view-button")
+      var calendar = named(app, "calendar-view-button")
+      verify(mail && calendar, "the header exposes both direct view buttons")
+      mouseClick(calendar)
+      compare(app.currentView, "calendar")
+      compare(calendar.selected, true)
+      mouseClick(mail)
+      compare(app.currentView, "list")
+      compare(mail.selected, true)
+    }
+
+    function test_hamburger_settings_row_opens_settings() {
+      app.backToList()
+      waitForRendering(app)
+      var menu = named(app, "menu-button")
+      var appMenu = named(app, "app-menu")
+      verify(menu && appMenu, "the hamburger and its menu exist")
+      var settingsRow = appMenu.settingsAction
+      verify(settingsRow, "the menu exposes its Settings row")
+      mouseClick(menu)
+      tryVerify(function() { return settingsRow.visible }, 1000,
+        "the Settings row is visible in the open menu")
+      mouseClick(settingsRow)
+      tryCompare(app, "showSettings", true)
+      compare(app.currentView, "list", "Settings is a page over mail")
+    }
+
+    function test_labels_inbox_divider_has_a_working_drag_target() {
+      app.backToList()
+      waitForRendering(app)
+      var divider = named(app, "labels-inbox-splitter")
+      verify(divider && divider.visible, "the labels divider is visible in mail")
+      var before = mailService.sidebarWidth
+      mouseDrag(divider, divider.width / 2, divider.height / 2, 60, 0)
+      verify(mailService.sidebarWidth > before,
+        "dragging right expands the labels pane")
     }
 
     // Narrow, the rail has no room; the page keeps the whole width and its

--- a/tests/qml/tst_wheel_scroll.qml
+++ b/tests/qml/tst_wheel_scroll.qml
@@ -23,7 +23,7 @@ Item {
     contentHeight: 5000
     boundsBehavior: Flickable.StopAtBounds
 
-    Omamail.WheelScroller { view: view }
+    Omamail.WheelScroller { id: speedHandler; view: view; speedMultiplier: 1.6 }
   }
 
   Flickable {
@@ -65,6 +65,7 @@ Item {
 
     function init() {
       view.contentY = 0
+      speedHandler.speedMultiplier = 1.6
       margined.contentY = -margined.topMargin
       headed.contentY = headed.originY
       bare.contentY = 0
@@ -74,7 +75,7 @@ Item {
 
     function test_one_notch_moves_three_lines_worth() {
       mouseWheel(view, 200, 150, 0, -120)
-      compare(view.contentY, 240)
+      compare(view.contentY, 384)
     }
 
     // The whole point. A high-resolution wheel reports one notch as many
@@ -82,7 +83,7 @@ Item {
     // where a bare Flickable is eight times short.
     function test_a_finely_reporting_wheel_moves_the_same_distance() {
       for (var i = 0; i < 8; i++) mouseWheel(view, 200, 150, 0, -15)
-      compare(view.contentY, 240, "eight fractions of a notch are still one notch")
+      compare(view.contentY, 384, "eight fractions of a notch are still one notch")
 
       for (var j = 0; j < 8; j++) mouseWheel(bare, 200, 150, 0, -15)
       wait(400)
@@ -92,24 +93,30 @@ Item {
 
     function test_three_notches_move_three_notches() {
       mouseWheel(view, 200, 150, 0, -360)
-      compare(view.contentY, 720)
+      compare(view.contentY, 1152)
+    }
+
+    function test_a_live_speed_change_reaches_the_same_pane() {
+      speedHandler.speedMultiplier = 2.4
+      mouseWheel(view, 200, 150, 0, -120)
+      compare(view.contentY, 576)
     }
 
     // Uncapped: ten notches as one event and as ten events agree. A per-event
     // cap put the chunking dependence back at the coarse end.
     function test_a_free_spinning_wheel_is_not_capped() {
       mouseWheel(view, 200, 150, 0, -1200)
-      compare(view.contentY, 2400)
+      compare(view.contentY, 3840)
 
       view.contentY = 0
       for (var i = 0; i < 10; i++) mouseWheel(view, 200, 150, 0, -120)
-      compare(view.contentY, 2400, "however the ten notches arrive")
+      compare(view.contentY, 3840, "however the ten notches arrive")
     }
 
     function test_it_scrolls_back_up() {
       view.contentY = 500
       mouseWheel(view, 200, 150, 0, 120)
-      compare(view.contentY, 260)
+      compare(view.contentY, 116)
     }
 
     // ------------------------------------------------------- the bounds

--- a/tests/test_calendar_palette.js
+++ b/tests/test_calendar_palette.js
@@ -11,11 +11,13 @@ const parsed = palette.parse([
   'yellow = "#c9b26d"',
   'color4 = "#5fa2d5"',
   'magenta = "#b07aa1"',
-  'color6 = "#7ec0ae"'
+  'color6 = "#7ec0ae"',
+  'orange = "#de8f67"'
 ].join("\n"))
 deepEqual(parsed, {
   accent: "#ff7a00", red: "#d45941", green: "#578c60",
-  yellow: "#c9b26d", blue: "#5fa2d5", magenta: "#b07aa1", cyan: "#7ec0ae"
+  yellow: "#c9b26d", blue: "#5fa2d5", magenta: "#b07aa1", cyan: "#7ec0ae",
+  orange: "#de8f67"
 })
 
 assert.strictEqual(palette.normalizeKey("blue"), "blue")

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -719,7 +719,7 @@ assert.strictEqual(model.clampZoom("1.5"), 1.5, "including one written as text")
 
 deepEqual(model.windowPrefs(""), {
   sidebarCollapsed: false, bodyZoom: 1, bodyMode: "reader",
-  alwaysShowImages: false, windowOpen: false
+  alwaysShowImages: false, sidebarWidth: 0, listWidth: 0, windowOpen: false
 })
 assert.strictEqual(model.windowPrefs('{"plainTextForced":true}').bodyMode, "plain",
   "the old two-mode preference migrates to the three-mode setting")
@@ -727,6 +727,10 @@ assert.strictEqual(model.windowPrefs('{"bodyMode":"original"}').bodyMode, "origi
 assert.strictEqual(model.windowPrefs('{"bodyMode":"unknown"}').bodyMode, "reader")
 assert.strictEqual(model.windowPrefs('{"windowOpen":true}').windowOpen, true)
 assert.strictEqual(model.windowPrefs('{"windowOpen":"yes"}').windowOpen, false)
+assert.strictEqual(model.windowPrefs('{"sidebarWidth":222.4}').sidebarWidth, 222)
+assert.strictEqual(model.windowPrefs('{"listWidth":481}').listWidth, 481)
+assert.strictEqual(model.windowPrefs('{"sidebarWidth":-5,"listWidth":"bad"}').sidebarWidth, 0)
+assert.strictEqual(model.windowPrefs('{"sidebarWidth":-5,"listWidth":"bad"}').listWidth, 0)
 
 // ------------------------------------------------- what a detail read carries
 //
@@ -926,8 +930,26 @@ for (let i = 0; i < 8; i++) fine += model.wheelDistance(-NOTCH / 8)
 assert.strictEqual(fine, -120, "eight fractions of a notch are still one notch")
 
 assert.strictEqual(model.wheelDistance(-3 * NOTCH), -360, "three notches")
+assert.strictEqual(model.wheelDistance(-NOTCH, 1.6), -192,
+  "the configured multiplier changes the distance")
+assert.strictEqual(model.wheelDistanceForDeltas(-24, -NOTCH, 2), -48,
+  "a physical pixel delta wins and follows the configured multiplier")
+assert.strictEqual(model.wheelDistanceForDeltas(0, -NOTCH, 2), -240,
+  "an angle delta remains the fallback")
 assert.strictEqual(model.wheelDistance(0), 0)
 assert.strictEqual(model.wheelDistance(null), 0)
+
+assert.strictEqual(model.scrollSpeedPercent(undefined), 160)
+assert.strictEqual(model.scrollSpeedPercent(237), 250)
+assert.strictEqual(model.scrollSpeedPercent(10), 75)
+assert.strictEqual(model.scrollSpeedPercent(900), 400)
+assert.strictEqual(model.scrollSpeedMultiplier(160), 1.6)
+assert.strictEqual(model.scrollSpeedLevel(75), 0)
+assert.strictEqual(model.scrollSpeedLevel(160), 2)
+assert.strictEqual(model.scrollSpeedLevel(400), 4)
+assert.strictEqual(model.scrollSpeedPercentForLevel(4), 400)
+assert.strictEqual(model.scrollSpeedLabel(75), "Gentle")
+assert.strictEqual(model.scrollSpeedLabel(400), "Rapid")
 
 // Nothing is capped. A cap on one event would put the chunking dependence
 // straight back at the coarse end: a free-spinning wheel delivers ten notches
@@ -940,8 +962,12 @@ assert.strictEqual(asTen, model.wheelDistance(-10 * NOTCH),
   "ten notches move the same distance however they arrive")
 
 // Where the view lands, inside what it can actually reach.
-assert.strictEqual(model.wheelScrollTarget(0, -NOTCH, 5000, 300), 120)
-assert.strictEqual(model.wheelScrollTarget(500, NOTCH, 5000, 300), 380)
+assert.strictEqual(model.wheelScrollTarget(0, -NOTCH, 5000, 300), 240)
+assert.strictEqual(model.wheelScrollTarget(500, NOTCH, 5000, 300), 260)
+assert.strictEqual(model.wheelScrollTarget(0, -NOTCH, 5000, 300,
+  0, 0, 0, 1.6), 384)
+assert.strictEqual(model.wheelScrollTargetForDeltas(0, -30, -NOTCH,
+  5000, 300, 0, 0, 0, 2), 120)
 assert.strictEqual(model.wheelScrollTarget(0, 2 * NOTCH, 5000, 300), 0,
   "there is nothing above the first row")
 assert.strictEqual(model.wheelScrollTarget(4700, -2 * NOTCH, 5000, 300), 4700)
@@ -951,12 +977,12 @@ assert.strictEqual(model.wheelScrollTarget(0, -2 * NOTCH, 100, 300), 0,
 // A margined view scrolled up at the top stays in its margin. With a floor of
 // 0 this moved *down* to 0 in answer to a scroll up.
 assert.strictEqual(model.wheelScrollTarget(-50, NOTCH, 5000, 300, 0, 50, 70), -50)
-assert.strictEqual(model.wheelScrollTarget(-50, -NOTCH, 5000, 300, 0, 50, 70), 70)
+assert.strictEqual(model.wheelScrollTarget(-50, -NOTCH, 5000, 300, 0, 50, 70), 190)
 assert.strictEqual(model.wheelScrollTarget(4770, -NOTCH, 5000, 300, 0, 50, 70), 4770,
   "and the bottom margin is reachable rather than cut off")
 
 // A ListView with a header: one notch is one notch, not a jump to 0.
-assert.strictEqual(model.wheelScrollTarget(-200, -NOTCH, 4200, 300, -200, 0, 0), -80)
+assert.strictEqual(model.wheelScrollTarget(-200, -NOTCH, 4200, 300, -200, 0, 0), 40)
 assert.strictEqual(model.wheelScrollTarget(-200, NOTCH, 4200, 300, -200, 0, 0), -200,
   "and the header stays reachable")
 
@@ -967,7 +993,7 @@ assert.strictEqual(model.wheelScrollByPixels(500, 40, 5000, 300), 460)
 assert.strictEqual(model.wheelScrollByPixels(0, 40, 5000, 300), 0,
   "there is nothing above the first row")
 assert.strictEqual(model.wheelScrollTarget(0, -NOTCH, 5000, 300),
-  model.wheelScrollByPixels(0, model.wheelDistance(-NOTCH), 5000, 300),
+  model.wheelScrollByPixels(0, model.wheelPixels(-NOTCH, 0), 5000, 300),
   "a notch is the pixel helper fed a notch's worth")
 
 assert.strictEqual(model.WHEEL_GAIN, 2)

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -434,7 +434,7 @@ if "Style.space(6)" not in footer[calendar:]:
     raise SystemExit("test_source.sh: Calendar must keep breathing room at the sidebar foot")
 
 app = Path("App.qml").read_text()
-sidebar_use = app[app.index("id: sidebar"):app.index("MailboxTabs {")]
+sidebar_use = app[app.index("id: sidebar"):app.index("// Labels/inbox grip")]
 if "!root.calendarVisible" in sidebar_use or "calendarSelected: root.calendarVisible" not in sidebar_use:
     raise SystemExit("test_source.sh: the mailbox sidebar must remain visible and select Calendar")
 header = app[app.index("id: headerRight"):app.index("// mailbox as a whole")]


### PR DESCRIPTION
Omamail's three-column layout was fixed in place, wheel behavior had no user-facing tuning, and the settings route could lose its click while the hamburger popup was closing. The mail and calendar roots also required an extra menu trip, while the existing theme integration left most mail surfaces using one accent.

This change makes both column boundaries adjustable and persists the chosen labels and inbox widths. The visible dividers stay one-pixel hairlines with wider transparent drag targets, double-click resets them, and Settings provides keyboard-reachable narrower, wider, and reset controls for both panes.

Pane scrolling now has five named levels—Gentle, Standard, Quick, Fast, and Rapid—with Rapid reaching 4x the normal setting. The selected level updates existing views immediately and is shared by mail, reader, settings, compose, calendar, pickers, setup, and shortcut-help scrollers. Pixel-delta touchpads and angle-delta wheels both retain the upstream Chromium-like platform compensation.

An optional System theme styling switch reads the active Omarchy terminal palette and assigns semantic colors to unread mail, stars, sent mail, drafts, labels, calendar items, selected rows, and the three pane surfaces. Palette changes are watched live, while turning the option off preserves the original restrained styling.

The header now includes direct mail and calendar buttons beside the hamburger menu. Settings opening is deferred until the popup has closed, and reopening Settings restores the page and focus instead of silently doing nothing.

## Verification

`QT_QPA_PLATFORMTHEME= XDG_RUNTIME_DIR=/tmp make validate` is green on commit `ed762f9`. The final run reported 452 QML tests, 4 Outlook native HTTP tests, and 54 sidebar text/safety tests passing, along with the JavaScript, Python, shell, qmllint, plugin manifest, and diff checks.

The live-speed QML assertion stayed at the old scroll position before the direct setting binding was added; it now observes the configured distance immediately. Additional QML coverage exercises the five-level control, keyboard-operable step buttons, theme state, settings-menu routing, direct mail/calendar navigation, draggable labels divider, and persistent pane widths. Model tests cover preset normalization, pixel and angle deltas, bounds, and the 4x maximum.

Live review was performed in the Tokyo Night system theme at 1896×1146 in the three-column layout on workspace 3. The draggable labels and reader dividers, settings dialog, named speed levels, theme colors, and direct mail/calendar buttons were exercised iteratively. A fresh-context agent reviewed the complete diff and its security boundary; its release-version, shortcut-label, scroll propagation, reader backdrop, duplicate-divider, manifest-schema, and keyboard-accessibility findings were addressed before the final validation run.

## Release Notes

- Resize the labels, inbox, and reader panes, with widths remembered between sessions and keyboard-accessible controls in Settings.
- Choose from five pane-scrolling speeds, from Gentle through Rapid, across mail, reader, settings, compose, calendar, and auxiliary views.
- Opt into richer mail colors derived from the active Omarchy terminal theme.
- Switch directly between mail and calendar from new header buttons.
- Open Settings reliably from the hamburger menu, including repeated visits.
