### PR TITLE
Add resizable mail panes

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -215,8 +215,12 @@ Item {
   // service holds it because it is written to disk: a size somebody reached for
   // is theirs until they change it, not until they close the window.
   readonly property real bodyZoom: service ? service.bodyZoom : 1.0
-  // 0 means "proportional"; anything else is a width somebody dragged to.
-  property real listWidth: 0
+  // Zero means "responsive default"; a positive value is the last grip
+  // position and is clamped again against the live window below.
+  readonly property real sidebarWidth: service && Number(service.sidebarWidth) > 0
+    ? Number(service.sidebarWidth) : 0
+  readonly property real listWidth: service && Number(service.listWidth) > 0
+    ? Number(service.listWidth) : 0
 
   function zoomBy(step) {
     if (service) service.setBodyZoom(Model.zoomAfterStep(service.bodyZoom, step))
@@ -1593,7 +1597,9 @@ Item {
           anchors.left: parent.left
           anchors.top: parent.top
           anchors.bottom: parent.bottom
-          width: root.sidebarCollapsed ? Style.space(44) : Style.space(148)
+          width: root.sidebarCollapsed ? Style.space(44)
+            : Math.max(Style.space(100), Math.min(parent.width - Style.space(480),
+                root.sidebarWidth > 0 ? root.sidebarWidth : Style.space(148)))
           visible: !root.compact && !root.showPage && !root.composing
           collapsed: root.sidebarCollapsed
           calendarSelected: root.calendarVisible
@@ -1601,6 +1607,7 @@ Item {
           textColor: root.foreground
           accentColor: root.accent
           dimColor: root.dim
+          showTrailingSeparator: root.sidebarCollapsed || root.calendarVisible
           panelFontFamily: root.fontFamily
           slots: root.sidebarSlots
           numbersVisible: focusScope.ctrlHeld
@@ -1614,6 +1621,48 @@ Item {
           onLabelSelected: function(labelId, name) {
             root.service.selectLabel(name, labelId)
             root.backToList()
+          }
+        }
+
+        // Labels/inbox grip. It draws the same one-pixel rule as the
+        // inbox/reader divider; the remaining width is only a transparent hit
+        // target, so both dividers look alike without becoming hard to catch.
+        Item {
+          id: sidebarSplitter
+          objectName: "labels-inbox-splitter"
+          anchors.left: sidebar.right
+          anchors.top: parent.top
+          anchors.bottom: parent.bottom
+          width: Style.space(5)
+          visible: sidebar.visible && !root.sidebarCollapsed
+            && !root.calendarVisible
+          z: 5
+
+          PanelSeparator {
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            width: 1
+            foreground: root.foreground
+          }
+
+          MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.SplitHCursor
+            property real grabbedAt: 0
+            property real grabbedWidth: 0
+
+            onPressed: function(mouse) {
+              grabbedAt = mapToItem(body, mouse.x, mouse.y).x
+              grabbedWidth = sidebar.width
+            }
+            onPositionChanged: function(mouse) {
+              if (!pressed || !root.service) return
+              var moved = mapToItem(body, mouse.x, mouse.y).x - grabbedAt
+              root.service.setSidebarWidth(grabbedWidth + moved)
+            }
+            onDoubleClicked: if (root.service) root.service.setSidebarWidth(0)
           }
         }
 
@@ -1639,7 +1688,8 @@ Item {
 
         Item {
           id: listColumn
-          anchors.left: sidebar.visible ? sidebar.right : parent.left
+          anchors.left: sidebarSplitter.visible ? sidebarSplitter.right
+            : (sidebar.visible ? sidebar.right : parent.left)
           anchors.top: tabs.visible ? tabs.bottom : parent.top
           anchors.bottom: parent.bottom
           anchors.topMargin: tabs.visible ? Style.space(8) : 0
@@ -1651,9 +1701,10 @@ Item {
           width: root.compact
             ? (root.currentView === "list" ? parent.width : 0)
             : Math.max(Style.space(100),
-                Math.min(parent.width - Style.space(360),
+                Math.min(parent.width - x - Style.space(280),
                   root.listWidth > 0 ? root.listWidth
-                    : Math.min(Style.space(460), Math.round(parent.width * 0.34))))
+                    : Math.min(Style.space(460),
+                        Math.round((parent.width - x) * 0.34))))
           visible: width > 0 && !root.showPage && !root.composing
             && !root.calendarVisible
 
@@ -1729,11 +1780,11 @@ Item {
             onPositionChanged: function(mouse) {
               if (!pressed) return
               var moved = mapToItem(body, mouse.x, mouse.y).x - grabbedAt
-              root.listWidth = grabbedWidth + moved
+              if (root.service) root.service.setListWidth(grabbedWidth + moved)
             }
             // Back to the proportional default, which is what most people
             // want after one bad drag.
-            onDoubleClicked: root.listWidth = 0
+            onDoubleClicked: if (root.service) root.service.setListWidth(0)
           }
         }
 

--- a/Service.qml
+++ b/Service.qml
@@ -587,6 +587,8 @@ Item {
   // the window cannot recompute lives here.
 
   property bool sidebarCollapsed: false
+  property real sidebarWidth: 0
+  property real listWidth: 0
   // Somebody who needed the text bigger needs it bigger for their mail, not for
   // the message that made them reach for it. The same goes for `bodyMode`:
   // both of these are ways of reading mail, not ways of reading one message.
@@ -615,6 +617,8 @@ Item {
     bodyZoom = prefs.bodyZoom
     bodyMode = prefs.bodyMode
     alwaysShowImages = prefs.alwaysShowImages
+    sidebarWidth = prefs.sidebarWidth
+    listWidth = prefs.listWidth
     restoreWindow = prefs.windowOpen
     restoreAttempts = 0
     windowPrefsLoaded = true
@@ -651,6 +655,8 @@ Item {
       bodyZoom: bodyZoom,
       bodyMode: bodyMode,
       alwaysShowImages: alwaysShowImages,
+      sidebarWidth: sidebarWidth,
+      listWidth: listWidth,
       windowOpen: windowOpen || restoreWindow
     })
     windowWriter.command = [pluginDir + "/scripts/config-store.sh", "window.json"]
@@ -661,6 +667,20 @@ Item {
     var next = value === true
     if (next === sidebarCollapsed) return
     sidebarCollapsed = next
+    saveWindowPrefs()
+  }
+
+  function setSidebarWidth(value) {
+    var next = Model.paneWidth(value)
+    if (next === sidebarWidth) return
+    sidebarWidth = next
+    saveWindowPrefs()
+  }
+
+  function setListWidth(value) {
+    var next = Model.paneWidth(value)
+    if (next === listWidth) return
+    listWidth = next
     saveWindowPrefs()
   }
 

--- a/account/Model.js
+++ b/account/Model.js
@@ -562,6 +562,18 @@ var ZOOM_MIN = 0.6
 var ZOOM_MAX = 2.5
 var ZOOM_STEPS_PER_UNIT = 20
 
+// Pane widths are saved as physical pixels because the window itself is saved
+// in physical pixels. Zero means "use the responsive default"; positive
+// values are still clamped against the live window by App.qml.
+var PANE_WIDTH_MAX = 1600
+
+function paneWidth(value) {
+  if (value === null || value === undefined || value === "") return 0
+  var width = Number(value)
+  if (!isFinite(width) || width <= 0) return 0
+  return Math.min(PANE_WIDTH_MAX, Math.round(width))
+}
+
 // What a zoom read back off disk means. Anything that is not a number is a
 // file that was hand-edited or never written, and the answer to both is the
 // size it shipped at.
@@ -582,6 +594,8 @@ function windowPrefs(raw) {
       bodyZoom: 1,
       bodyMode: "reader",
       alwaysShowImages: false,
+      sidebarWidth: 0,
+      listWidth: 0,
       windowOpen: false
     }
   }
@@ -593,6 +607,8 @@ function windowPrefs(raw) {
     bodyZoom: clampZoom(parsed.bodyZoom),
     bodyMode: bodyMode,
     alwaysShowImages: parsed.alwaysShowImages === true,
+    sidebarWidth: paneWidth(parsed.sidebarWidth),
+    listWidth: paneWidth(parsed.listWidth),
     windowOpen: parsed.windowOpen === true
   }
 }

--- a/components/MailboxSidebar.qml
+++ b/components/MailboxSidebar.qml
@@ -21,6 +21,7 @@ Item {
   required property string panelFontFamily
   property bool collapsed: false
   property bool calendarSelected: false
+  property bool showTrailingSeparator: true
 
   signal mailboxSelected(string key)
   signal labelSelected(string labelId, string name)
@@ -37,6 +38,7 @@ Item {
   // without this the icons sit on the same surface as the messages.
   PanelSeparator {
     id: edge
+    visible: root.showTrailingSeparator
     anchors.right: parent.right
     anchors.top: parent.top
     anchors.bottom: parent.bottom

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -55,6 +55,26 @@ Column {
     return null
   }
 
+  function adjustPaneWidth(pane, direction) {
+    if (!root.service) return
+    var step = Style.space(20) * (direction < 0 ? -1 : 1)
+    if (pane === "labels") {
+      var labels = Number(root.service.sidebarWidth) > 0
+        ? Number(root.service.sidebarWidth) : Style.space(148)
+      root.service.setSidebarWidth(labels + step)
+    } else {
+      var inbox = Number(root.service.listWidth) > 0
+        ? Number(root.service.listWidth) : Style.space(460)
+      root.service.setListWidth(inbox + step)
+    }
+  }
+
+  function resetPaneWidths() {
+    if (!root.service) return
+    root.service.setSidebarWidth(0)
+    root.service.setListWidth(0)
+  }
+
   function signatureOptions() {
     var out = []
     for (var i = 0; i < signatureAccounts.length; i++)
@@ -228,6 +248,105 @@ Column {
     font.family: root.panelFontFamily
     font.pixelSize: Style.font.caption
     font.letterSpacing: 1
+  }
+
+  Rectangle {
+    width: parent.width
+    implicitHeight: Math.max(paneWidthText.implicitHeight,
+      paneWidthControls.implicitHeight) + Style.space(16)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+
+    Column {
+      id: paneWidthText
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(12)
+      anchors.right: paneWidthControls.left
+      anchors.rightMargin: Style.space(12)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(2)
+
+      Text {
+        width: parent.width
+        text: "Pane widths"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+      }
+
+      Text {
+        width: parent.width
+        text: "Resize the labels and inbox panes without a pointer"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+      }
+    }
+
+    Row {
+      id: paneWidthControls
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(12)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(6)
+
+      Button {
+        objectName: "labelsPaneNarrower"
+        text: "Labels −"
+        tooltipText: "Narrower labels pane"
+        foreground: root.dimColor
+        bordered: true
+        focusable: true
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.caption
+        onClicked: root.adjustPaneWidth("labels", -1)
+      }
+      Button {
+        objectName: "labelsPaneWider"
+        text: "Labels +"
+        tooltipText: "Wider labels pane"
+        foreground: root.dimColor
+        bordered: true
+        focusable: true
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.caption
+        onClicked: root.adjustPaneWidth("labels", 1)
+      }
+      Button {
+        objectName: "inboxPaneNarrower"
+        text: "Inbox −"
+        tooltipText: "Narrower inbox pane"
+        foreground: root.dimColor
+        bordered: true
+        focusable: true
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.caption
+        onClicked: root.adjustPaneWidth("inbox", -1)
+      }
+      Button {
+        objectName: "inboxPaneWider"
+        text: "Inbox +"
+        tooltipText: "Wider inbox pane"
+        foreground: root.dimColor
+        bordered: true
+        focusable: true
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.caption
+        onClicked: root.adjustPaneWidth("inbox", 1)
+      }
+      Button {
+        objectName: "paneWidthsReset"
+        text: "Reset"
+        tooltipText: "Reset pane widths"
+        foreground: root.dimColor
+        bordered: true
+        focusable: true
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.caption
+        onClicked: root.resetPaneWidths()
+      }
+    }
   }
 
   Rectangle {

--- a/tests/qml/tst_settings_sidebar.qml
+++ b/tests/qml/tst_settings_sidebar.qml
@@ -77,6 +77,8 @@ Item {
     property int accountCount: 1
     property int inboxUnread: 0
     property real bodyZoom: 1
+    property real sidebarWidth: 0
+    property real listWidth: 0
     property string bodyMode: "reader"
     property string providerId: "imap"
     property string pluginDir: ""
@@ -147,6 +149,8 @@ Item {
     }
     function preferredSendAs(_recipients) { return null }
     function refreshRecipientContacts() {}
+    function setSidebarWidth(value) { sidebarWidth = Number(value) || 0 }
+    function setListWidth(value) { listWidth = Number(value) || 0 }
     function cursorOffset(_id, _delta) { return "" }
     function clearSelection() {
       selectedId = ""
@@ -237,6 +241,8 @@ Item {
     function init() {
       mailService.anyAccountReady = true
       mailService.hasSavedAccounts = true
+      mailService.sidebarWidth = 0
+      mailService.listWidth = 0
       app.opened = true
       window().width = 980
       app.backToList()
@@ -283,6 +289,35 @@ Item {
         verify(page.sections[i].y > page.sections[i - 1].y, "sections are laid out top to bottom")
       for (var j = 0; j < keys.length; j++)
         verify(named(rail, "settings-section-" + keys[j]), "the rail has a row for " + keys[j])
+    }
+
+    function test_pane_width_controls_reach_the_service() {
+      var labelsWider = named(app, "labelsPaneWider")
+      var inboxWider = named(app, "inboxPaneWider")
+      var resetWidths = named(app, "paneWidthsReset")
+      verify(labelsWider && inboxWider && resetWidths,
+        "keyboard-reachable controls provide a splitter alternative")
+      verify(labelsWider.focusable)
+      verify(inboxWider.focusable)
+      verify(resetWidths.focusable)
+      labelsWider.clicked()
+      inboxWider.clicked()
+      verify(mailService.sidebarWidth > 0)
+      verify(mailService.listWidth > 0)
+      resetWidths.clicked()
+      compare(mailService.sidebarWidth, 0)
+      compare(mailService.listWidth, 0)
+    }
+
+    function test_labels_inbox_divider_has_a_working_drag_target() {
+      app.backToList()
+      waitForRendering(app)
+      var divider = named(app, "labels-inbox-splitter")
+      verify(divider && divider.visible, "the labels divider is visible in mail")
+      var before = mailService.sidebarWidth
+      mouseDrag(divider, divider.width / 2, divider.height / 2, 60, 0)
+      verify(mailService.sidebarWidth > before,
+        "dragging right expands the labels pane")
     }
 
     // A click scrolls the page to the section rather than opening another

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -719,7 +719,7 @@ assert.strictEqual(model.clampZoom("1.5"), 1.5, "including one written as text")
 
 deepEqual(model.windowPrefs(""), {
   sidebarCollapsed: false, bodyZoom: 1, bodyMode: "reader",
-  alwaysShowImages: false, windowOpen: false
+  alwaysShowImages: false, sidebarWidth: 0, listWidth: 0, windowOpen: false
 })
 assert.strictEqual(model.windowPrefs('{"plainTextForced":true}').bodyMode, "plain",
   "the old two-mode preference migrates to the three-mode setting")
@@ -727,6 +727,10 @@ assert.strictEqual(model.windowPrefs('{"bodyMode":"original"}').bodyMode, "origi
 assert.strictEqual(model.windowPrefs('{"bodyMode":"unknown"}').bodyMode, "reader")
 assert.strictEqual(model.windowPrefs('{"windowOpen":true}').windowOpen, true)
 assert.strictEqual(model.windowPrefs('{"windowOpen":"yes"}').windowOpen, false)
+assert.strictEqual(model.windowPrefs('{"sidebarWidth":222.4}').sidebarWidth, 222)
+assert.strictEqual(model.windowPrefs('{"listWidth":481}').listWidth, 481)
+assert.strictEqual(model.windowPrefs('{"sidebarWidth":-5,"listWidth":"bad"}').sidebarWidth, 0)
+assert.strictEqual(model.windowPrefs('{"sidebarWidth":-5,"listWidth":"bad"}').listWidth, 0)
 
 // ------------------------------------------------- what a detail read carries
 //

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -434,7 +434,7 @@ if "Style.space(6)" not in footer[calendar:]:
     raise SystemExit("test_source.sh: Calendar must keep breathing room at the sidebar foot")
 
 app = Path("App.qml").read_text()
-sidebar_use = app[app.index("id: sidebar"):app.index("MailboxTabs {")]
+sidebar_use = app[app.index("id: sidebar"):app.index("// Labels/inbox grip")]
 if "!root.calendarVisible" in sidebar_use or "calendarSelected: root.calendarVisible" not in sidebar_use:
     raise SystemExit("test_source.sh: the mailbox sidebar must remain visible and select Calendar")
 header = app[app.index("id: headerRight"):app.index("// mailbox as a whole")]


### PR DESCRIPTION
Split from #137 so pane sizing can be reviewed and adopted independently.

## Summary

- Add draggable labels/inbox and inbox/reader boundaries.
- Persist labels and inbox widths across window sessions.
- Double-click a divider to restore its responsive default.
- Add keyboard-accessible narrower, wider, and reset controls in Settings.

## Visual evidence

The composite below uses the same synthetic mailbox and shows both dividers at their defaults and after resizing, the narrow-window limits, and the keyboard-accessible Settings controls.

![Before and after evidence for resizable mail panes](https://raw.githubusercontent.com/tumbleweedlabs/omamail/pr-evidence/pr-142-resizable-mail-panes.png)

## Verification

- Complete JavaScript and shell/source suites pass.
- Complete QML suite, native Outlook HTTP harness, and sidebar safety harness pass.
- QML lint, plugin manifest validation, and diff checks pass.
