### PR TITLE
Add configurable pane scroll speed

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -215,6 +215,12 @@ Item {
   // service holds it because it is written to disk: a size somebody reached for
   // is theirs until they change it, not until they close the window.
   readonly property real bodyZoom: service ? service.bodyZoom : 1.0
+  // Read the setting itself. Keeping an intermediate multiplier on a service
+  // made the control look updated while a long-lived pane could retain the old
+  // derived value.
+  readonly property real scrollSpeedMultiplier: service
+    && Number(service.scrollSpeedPercent) > 0
+    ? Number(service.scrollSpeedPercent) / 100 : 1.6
   // 0 means "proportional"; anything else is a width somebody dragged to.
   property real listWidth: 0
 
@@ -1601,6 +1607,7 @@ Item {
           textColor: root.foreground
           accentColor: root.accent
           dimColor: root.dim
+          scrollSpeedMultiplier: root.scrollSpeedMultiplier
           panelFontFamily: root.fontFamily
           slots: root.sidebarSlots
           numbersVisible: focusScope.ctrlHeld
@@ -1663,7 +1670,10 @@ Item {
           Flickable {
             id: listFlick
 
-            WheelScroller { view: listFlick }
+            WheelScroller {
+              view: listFlick
+              speedMultiplier: root.scrollSpeedMultiplier
+            }
             anchors.fill: parent
             contentWidth: width
             contentHeight: list.implicitHeight + Style.space(16)
@@ -1757,6 +1767,7 @@ Item {
           leadingBoundaryOverlap: listSplitter.visible ? listSplitter.width : 0
           panelFontFamily: root.fontFamily
           zoom: root.bodyZoom
+          scrollSpeedMultiplier: root.scrollSpeedMultiplier
           showBack: root.compact
           bodyMode: root.bodyMode
           alwaysRenderHeavyMessages: !!root.service && root.service.alwaysRenderHeavyMessages
@@ -1810,6 +1821,7 @@ Item {
           popupBackgroundColor: root.popupBackground
           popupBorderColor: root.popupBorder
           panelFontFamily: root.fontFamily
+          scrollSpeedMultiplier: root.scrollSpeedMultiplier
           contentDirection: root.service ? root.service.contentDirection : ""
           // The stack follows the view: opening pushes, closing pops — and
           // the pop is here rather than on `closed`, because a draft parked
@@ -1845,6 +1857,7 @@ Item {
           urgentColor: root.urgent
           dimColor: root.dim
           panelFontFamily: root.fontFamily
+          scrollSpeedMultiplier: root.scrollSpeedMultiplier
         }
 
         Rectangle {
@@ -1869,6 +1882,7 @@ Item {
             calendarTodayBackgroundColor: root.calendarTodayBackground
             calendarBorderWidth: root.calendarBorderWidth
             panelFontFamily: root.fontFamily
+            scrollSpeedMultiplier: root.scrollSpeedMultiplier
             // An event opened for reading is a place, so Back closes it before
             // it leaves the calendar. The view owns the open state; the stack
             // follows it.
@@ -1912,7 +1926,10 @@ Item {
         Flickable {
           id: setupFlick
 
-          WheelScroller { view: setupFlick }
+          WheelScroller {
+            view: setupFlick
+            speedMultiplier: root.scrollSpeedMultiplier
+          }
           anchors.fill: parent
           anchors.margins: Style.space(18)
           anchors.topMargin: parent.pageTop
@@ -2017,7 +2034,10 @@ Item {
         Flickable {
           id: settingsFlick
 
-          WheelScroller { view: settingsFlick }
+          WheelScroller {
+            view: settingsFlick
+            speedMultiplier: root.scrollSpeedMultiplier
+          }
           // The whole width, rail included: the wheel scrolls the page from
           // anywhere in the block, and the scrollbar keeps the window's edge.
           anchors.left: parent.left
@@ -2339,6 +2359,7 @@ Item {
         popupBackgroundColor: root.popupBackground
         popupBorderColor: root.popupBorder
         panelFontFamily: root.fontFamily
+        scrollSpeedMultiplier: root.scrollSpeedMultiplier
         labels: root.service ? root.service.labels : []
         currentLabelId: root.service ? String(root.service.rawLabelId || "") : ""
         onLabelChosen: function(labelId) {
@@ -2407,6 +2428,7 @@ Item {
         backgroundColor: root.background
         dimColor: root.dim
         panelFontFamily: root.fontFamily
+        scrollSpeedMultiplier: root.scrollSpeedMultiplier
         onDismissed: root.dismissHelp()
       }
 

--- a/Service.qml
+++ b/Service.qml
@@ -62,6 +62,7 @@ Item {
     maxMessages: 25,
     heavyMessageRendering: Html.HEAVY_MESSAGE_RENDERING_DEFAULT,
     contentDirection: Direction.MODE_DEFAULT,
+    scrollSpeedPercent: Model.WHEEL_SPEED_DEFAULT_PERCENT,
     defaultQuery: "in:inbox",
     notifyNewMail: "On",
     oauthPort: 9481,
@@ -87,6 +88,9 @@ Item {
     && settings.unifiedCalendarView === true
   readonly property bool unifiedMailboxes: !!settings
     && settings.unifiedMailboxes === true
+  readonly property int scrollSpeedPercent: Model.scrollSpeedPercent(
+    settings ? settings.scrollSpeedPercent : null)
+  readonly property real scrollSpeedMultiplier: scrollSpeedPercent / 100
 
   // Whether the bar draws an envelope for this.
   //
@@ -173,6 +177,10 @@ Item {
 
   function setContentDirection(value) {
     persistSetting("contentDirection", Direction.normalizeMode(value))
+  }
+
+  function setScrollSpeedPercent(value) {
+    persistSetting("scrollSpeedPercent", Model.scrollSpeedPercent(value))
   }
 
   function setUnifiedCalendarView(value) {

--- a/account/Model.js
+++ b/account/Model.js
@@ -1240,21 +1240,71 @@ var WHEEL_PIXELS_PER_NOTCH = 120
 // stays 120 so the arithmetic is still "a notch is a notch"; the gain is how
 // far that notch moves on screen.
 var WHEEL_GAIN = 2
+var WHEEL_SPEED_DEFAULT_PERCENT = 160
+// Five deliberate stops keep the control legible: the setting describes how
+// scrolling feels rather than exposing an implementation percentage. The
+// stored number stays compatible with settings written by older builds.
+var WHEEL_SPEED_PRESETS = [75, 100, 160, 250, 400]
+var WHEEL_SPEED_LABELS = ["Gentle", "Standard", "Quick", "Fast", "Rapid"]
+var WHEEL_SPEED_MIN_PERCENT = WHEEL_SPEED_PRESETS[0]
+var WHEEL_SPEED_MAX_PERCENT = WHEEL_SPEED_PRESETS[WHEEL_SPEED_PRESETS.length - 1]
+
+function scrollSpeedLevel(value) {
+  var speed = Number(value)
+  if (!isFinite(speed)) speed = WHEEL_SPEED_DEFAULT_PERCENT
+  var closest = 0
+  for (var i = 1; i < WHEEL_SPEED_PRESETS.length; i++) {
+    if (Math.abs(WHEEL_SPEED_PRESETS[i] - speed)
+        < Math.abs(WHEEL_SPEED_PRESETS[closest] - speed)) closest = i
+  }
+  return closest
+}
+
+function scrollSpeedPercentForLevel(level) {
+  var index = Math.max(0, Math.min(WHEEL_SPEED_PRESETS.length - 1,
+    Math.round(Number(level) || 0)))
+  return WHEEL_SPEED_PRESETS[index]
+}
+
+function scrollSpeedLabel(value) {
+  return WHEEL_SPEED_LABELS[scrollSpeedLevel(value)]
+}
+
+function scrollSpeedPercent(value) {
+  if (value === null || value === undefined || value === "")
+    return WHEEL_SPEED_DEFAULT_PERCENT
+  var speed = Number(value)
+  if (!isFinite(speed)) return WHEEL_SPEED_DEFAULT_PERCENT
+  return scrollSpeedPercentForLevel(scrollSpeedLevel(speed))
+}
+
+function scrollSpeedMultiplier(value) {
+  return scrollSpeedPercent(value) / 100
+}
 
 // Numerically the identity at these two values, and written as a ratio anyway:
 // the constant that matters is "a notch moves 120 pixels", and it is the one a
 // reader changes.
-function wheelDistance(angleDelta) {
-  return (Number(angleDelta) || 0) / WHEEL_UNITS_PER_NOTCH * WHEEL_PIXELS_PER_NOTCH
+function wheelDistance(angleDelta, speedMultiplier) {
+  var speed = Number(speedMultiplier)
+  if (!isFinite(speed) || speed <= 0) speed = 1
+  return (Number(angleDelta) || 0) / WHEEL_UNITS_PER_NOTCH
+    * WHEEL_PIXELS_PER_NOTCH * speed
+}
+
+function wheelDistanceForDeltas(pixelDelta, angleDelta, speedMultiplier) {
+  var pixels = Number(pixelDelta) || 0
+  var speed = Number(speedMultiplier)
+  if (!isFinite(speed) || speed <= 0) speed = 1
+  return pixels !== 0 ? pixels * speed : wheelDistance(angleDelta, speed)
 }
 
 // Pixels to move the view. `pixelDelta` wins when the device reports it
 // (touchpad, high-res wheel); otherwise the notch mapping. The gain is
 // applied here so QML cannot forget it.
-function wheelPixels(angleDelta, pixelDelta) {
-  var pixels = Number(pixelDelta) || 0
-  if (pixels === 0) pixels = wheelDistance(angleDelta)
-  return pixels * WHEEL_GAIN
+function wheelPixels(angleDelta, pixelDelta, speedMultiplier) {
+  return wheelDistanceForDeltas(pixelDelta, angleDelta, speedMultiplier)
+    * WHEEL_GAIN
 }
 
 // Where the view lands after a movement already expressed in pixels —
@@ -1268,8 +1318,16 @@ function wheelScrollByPixels(contentY, pixels, contentHeight, viewportHeight,
 
 // Where the view lands, inside what it can actually reach.
 function wheelScrollTarget(contentY, angleDelta, contentHeight, viewportHeight,
-                           originY, topMargin, bottomMargin) {
-  return wheelScrollByPixels(contentY, wheelDistance(angleDelta), contentHeight,
+                           originY, topMargin, bottomMargin, speedMultiplier) {
+  return wheelScrollByPixels(contentY, wheelPixels(angleDelta, 0, speedMultiplier), contentHeight,
+    viewportHeight, originY, topMargin, bottomMargin)
+}
+
+function wheelScrollTargetForDeltas(contentY, pixelDelta, angleDelta,
+                                    contentHeight, viewportHeight, originY,
+                                    topMargin, bottomMargin, speedMultiplier) {
+  return wheelScrollByPixels(contentY,
+    wheelPixels(angleDelta, pixelDelta, speedMultiplier), contentHeight,
     viewportHeight, originY, topMargin, bottomMargin)
 }
 

--- a/components/CalendarEventComposer.qml
+++ b/components/CalendarEventComposer.qml
@@ -14,6 +14,7 @@ Rectangle {
   required property color urgentColor
   required property color dimColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   property bool opened: false
   property string selectedSourceId: ""
@@ -171,7 +172,10 @@ Rectangle {
   Flickable {
     id: composerFlick
 
-    WheelScroller { view: composerFlick }
+    WheelScroller {
+      view: composerFlick
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
 
     anchors.fill: parent
     anchors.margins: Style.space(18)

--- a/components/CalendarEventDetail.qml
+++ b/components/CalendarEventDetail.qml
@@ -15,6 +15,7 @@ Rectangle {
   required property color urgentColor
   required property color dimColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   signal closed()
   signal editRequested(string sourceId, var event)
@@ -87,7 +88,10 @@ Rectangle {
   Flickable {
     id: detailFlick
 
-    WheelScroller { view: detailFlick }
+    WheelScroller {
+      view: detailFlick
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
 
     anchors.fill: parent
     anchors.margins: Style.space(18)

--- a/components/CalendarView.qml
+++ b/components/CalendarView.qml
@@ -16,6 +16,7 @@ Item {
   required property color calendarTodayBackgroundColor
   required property int calendarBorderWidth
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   property date visibleMonth: new Date(new Date().getFullYear(), new Date().getMonth(), 1)
   property date visibleWeek: new Date()
@@ -495,6 +496,7 @@ Item {
       calendarTodayBackgroundColor: root.calendarTodayBackgroundColor
       calendarBorderWidth: root.calendarBorderWidth
       panelFontFamily: root.panelFontFamily
+      scrollSpeedMultiplier: root.scrollSpeedMultiplier
       selectedEventId: root.selectedEventId
       onCreateAt: function(startMs) { root.createAt(startMs) }
       onEventActivated: function(event) { root.activateEvent(event) }
@@ -516,6 +518,7 @@ Item {
     urgentColor: root.urgentColor
     dimColor: root.dimColor
     panelFontFamily: root.panelFontFamily
+    scrollSpeedMultiplier: root.scrollSpeedMultiplier
     onClosed: root.closeDetail()
     // Editing replaces the detail: the composer covers the view, and the
     // event it rewrites is not the one these labels would go on showing.

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -30,6 +30,7 @@ DropArea {
   required property color popupBackgroundColor
   required property color popupBorderColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   readonly property int formInset: Style.space(18)
   readonly property int formLabelWidth: Style.space(52)
@@ -1142,6 +1143,7 @@ DropArea {
         popupBackgroundColor: root.popupBackgroundColor
         popupBorderColor: root.popupBorderColor
         panelFontFamily: root.panelFontFamily
+        scrollSpeedMultiplier: root.scrollSpeedMultiplier
         onChosen: function(contact) { root.acceptTo(contact) }
       }
 
@@ -1224,6 +1226,7 @@ DropArea {
         popupBackgroundColor: root.popupBackgroundColor
         popupBorderColor: root.popupBorderColor
         panelFontFamily: root.panelFontFamily
+        scrollSpeedMultiplier: root.scrollSpeedMultiplier
         onChosen: function(contact) { root.acceptCc(contact) }
       }
 
@@ -1302,6 +1305,7 @@ DropArea {
         accentColor: root.accentColor
         popupBackgroundColor: root.popupBackgroundColor
         popupBorderColor: root.popupBorderColor
+        scrollSpeedMultiplier: root.scrollSpeedMultiplier
         panelFontFamily: root.panelFontFamily
         onChosen: function(contact) { root.acceptBcc(contact) }
       }
@@ -1477,7 +1481,10 @@ DropArea {
     contentItem: ListView {
       id: fromRows
 
-      WheelScroller { view: fromRows }
+      WheelScroller {
+        view: fromRows
+        speedMultiplier: root.scrollSpeedMultiplier
+      }
       implicitHeight: contentHeight
       clip: true
       model: root.fromIdentities
@@ -1542,6 +1549,7 @@ DropArea {
     popupBackgroundColor: root.popupBackgroundColor
     popupBorderColor: root.popupBorderColor
     panelFontFamily: root.panelFontFamily
+    scrollSpeedMultiplier: root.scrollSpeedMultiplier
     onContactChosen: function(contact, target) {
       if (target === "cc") {
         root.ccVisible = true
@@ -1565,7 +1573,10 @@ DropArea {
   Flickable {
     id: bodyFlick
 
-    WheelScroller { view: bodyFlick }
+    WheelScroller {
+      view: bodyFlick
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
     objectName: "compose-body"
     anchors.top: fields.bottom
     anchors.left: parent.left
@@ -1627,7 +1638,10 @@ DropArea {
     Flickable {
       id: attachFlick
 
-      WheelScroller { view: attachFlick }
+      WheelScroller {
+        view: attachFlick
+        speedMultiplier: root.scrollSpeedMultiplier
+      }
       anchors.fill: parent
       anchors.leftMargin: Style.space(18)
       anchors.rightMargin: Style.space(18)

--- a/components/ContactsPicker.qml
+++ b/components/ContactsPicker.qml
@@ -14,6 +14,7 @@ Item {
   required property color popupBackgroundColor
   required property color popupBorderColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   readonly property bool opened: menu.opened
   property string searchQuery: ""
@@ -139,7 +140,10 @@ Item {
       ListView {
         id: contactsList
 
-        WheelScroller { view: contactsList }
+        WheelScroller {
+          view: contactsList
+          speedMultiplier: root.scrollSpeedMultiplier
+        }
         width: parent.width
         implicitHeight: Math.min(contentHeight, Style.space(280))
         clip: true

--- a/components/LabelPicker.qml
+++ b/components/LabelPicker.qml
@@ -20,6 +20,7 @@ Item {
   required property color popupBackgroundColor
   required property color popupBorderColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   // [{ id, name, system, unread, total }], as the provider reported them.
   property var labels: []
@@ -157,7 +158,10 @@ Item {
       ListView {
         id: labelList
 
-        WheelScroller { view: labelList }
+        WheelScroller {
+          view: labelList
+          speedMultiplier: root.scrollSpeedMultiplier
+        }
         width: parent.width
         implicitHeight: Math.min(contentHeight, Style.space(280))
         clip: true

--- a/components/MailboxSidebar.qml
+++ b/components/MailboxSidebar.qml
@@ -19,6 +19,7 @@ Item {
   required property color accentColor
   required property color dimColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
   property bool collapsed: false
   property bool calendarSelected: false
 
@@ -47,7 +48,10 @@ Item {
   Flickable {
     id: flick
 
-    WheelScroller { view: flick }
+    WheelScroller {
+      view: flick
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
     anchors.left: parent.left
     anchors.right: edge.left
     anchors.top: parent.top

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -25,6 +25,7 @@ Item {
   required property color popupBorderColor
   required property real leadingBoundaryOverlap
   required property color dimmerColor
+  property real scrollSpeedMultiplier: 1
   required property string panelFontFamily
   // Which of the three ways of reading a message this window is set to. The
   // window's preference, not this message's: it may not be the one on screen,
@@ -514,7 +515,10 @@ Item {
   Flickable {
     id: bodyFlick
 
-    WheelScroller { view: bodyFlick }
+    WheelScroller {
+      view: bodyFlick
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
     anchors.top: notices.bottom
     anchors.left: parent.left
     // The rail takes its width out of the body's, which is what keeps the

--- a/components/RecipientSuggestions.qml
+++ b/components/RecipientSuggestions.qml
@@ -11,6 +11,7 @@ Rectangle {
   required property color popupBackgroundColor
   required property color popupBorderColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   property int currentIndex: -1
 
@@ -50,7 +51,10 @@ Rectangle {
   ListView {
     id: suggestions
 
-    WheelScroller { view: suggestions }
+    WheelScroller {
+      view: suggestions
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
     anchors.fill: parent
     anchors.margins: Style.space(2)
     clip: true

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -2,6 +2,7 @@ import QtQuick
 import qs.Commons
 import qs.Ui
 import "../message/Direction.js" as Direction
+import "../account/Model.js" as Model
 
 // Where mailboxes are managed.
 //
@@ -47,6 +48,10 @@ Column {
     { key: "oauth", title: "Google OAuth client", y: oauthHeading.y }
   ]
   readonly property var auth: service ? service.auth : null
+  readonly property int scrollSpeedPercent: root.service
+    && Number(root.service.scrollSpeedPercent) > 0
+    ? Number(root.service.scrollSpeedPercent) : 160
+  readonly property int scrollSpeedLevel: Model.scrollSpeedLevel(scrollSpeedPercent)
 
   function signatureAccount(id) {
     for (var i = 0; i < signatureAccounts.length; i++)
@@ -228,6 +233,114 @@ Column {
     font.family: root.panelFontFamily
     font.pixelSize: Style.font.caption
     font.letterSpacing: 1
+  }
+
+  Rectangle {
+    width: parent.width
+    implicitHeight: Math.max(scrollText.implicitHeight, scrollControls.implicitHeight)
+      + Style.space(16)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+
+    Column {
+      id: scrollText
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(12)
+      anchors.right: scrollControls.left
+      anchors.rightMargin: Style.space(12)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(2)
+
+      Text {
+        width: parent.width
+        text: "Pane scroll speed"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+      }
+
+      Text {
+        width: parent.width
+        text: "Applies to mouse wheels and touchpad scrolling"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+      }
+    }
+
+    Row {
+      id: scrollControls
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(12)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(8)
+
+      Button {
+        objectName: "scrollSpeedSlower"
+        anchors.verticalCenter: parent.verticalCenter
+        text: "−"
+        tooltipText: "Slower scrolling"
+        foreground: root.dimColor
+        bordered: true
+        focusable: true
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.bodySmall
+        enabled: root.scrollSpeedLevel > 0
+        onClicked: if (root.service)
+          root.service.setScrollSpeedPercent(
+            Model.scrollSpeedPercentForLevel(root.scrollSpeedLevel - 1))
+      }
+
+      PanelSlider {
+        id: scrollSlider
+        objectName: "scrollSpeedSlider"
+        anchors.verticalCenter: parent.verticalCenter
+        width: Style.space(150)
+        minimum: 0
+        maximum: 4
+        step: 1
+        tickCount: 5
+        integer: true
+        value: root.scrollSpeedLevel
+        trackColor: Style.normalFillFor(root.textColor, root.accentColor)
+        fillColor: root.accentColor
+        knobColor: root.textColor
+        tickColor: root.dimColor
+        function chooseLevel(next) {
+          if (root.service)
+            root.service.setScrollSpeedPercent(Model.scrollSpeedPercentForLevel(next))
+        }
+        onReleased: function(next) { chooseLevel(next) }
+      }
+
+      Button {
+        objectName: "scrollSpeedFaster"
+        anchors.verticalCenter: parent.verticalCenter
+        text: "+"
+        tooltipText: "Faster scrolling"
+        foreground: root.dimColor
+        bordered: true
+        focusable: true
+        fontFamily: root.panelFontFamily
+        fontSize: Style.font.bodySmall
+        enabled: root.scrollSpeedLevel < 4
+        onClicked: if (root.service)
+          root.service.setScrollSpeedPercent(
+            Model.scrollSpeedPercentForLevel(root.scrollSpeedLevel + 1))
+      }
+
+      Text {
+        anchors.verticalCenter: parent.verticalCenter
+        width: Style.space(62)
+        horizontalAlignment: Text.AlignRight
+        text: Model.WHEEL_SPEED_LABELS[Math.round(scrollSlider.dragging
+          ? scrollSlider.liveValue : root.scrollSpeedLevel)]
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+      }
+    }
   }
 
   Rectangle {

--- a/components/ShortcutHelp.qml
+++ b/components/ShortcutHelp.qml
@@ -24,6 +24,7 @@ Rectangle {
   required property color backgroundColor
   required property color dimColor
   required property string panelFontFamily
+  property real scrollSpeedMultiplier: 1
 
   signal dismissed()
 
@@ -68,7 +69,10 @@ Rectangle {
   Flickable {
     id: scroller
 
-    WheelScroller { view: scroller }
+    WheelScroller {
+      view: scroller
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
     // Filling the sheet rather than hugging the content is the whole of the
     // scrollbar fix: a Flickable sized to its column puts the bar at that
     // column's edge, which on a wide window is the middle of the screen.

--- a/components/WeekCalendarView.qml
+++ b/components/WeekCalendarView.qml
@@ -19,6 +19,7 @@ Item {
   required property int calendarBorderWidth
   required property string panelFontFamily
   required property string selectedEventId
+  property real scrollSpeedMultiplier: 1
 
   signal createAt(double startMs)
   signal eventActivated(var event)
@@ -168,7 +169,10 @@ Item {
   Flickable {
     id: timeline
 
-    WheelScroller { view: timeline }
+    WheelScroller {
+      view: timeline
+      speedMultiplier: root.scrollSpeedMultiplier
+    }
     anchors.left: parent.left
     anchors.right: parent.right
     anchors.top: root.allDayCount > 0 ? allDayLane.bottom : dayHeaders.bottom

--- a/components/WheelScroller.qml
+++ b/components/WheelScroller.qml
@@ -23,6 +23,9 @@ WheelHandler {
   id: root
 
   required property Flickable view
+  // One keeps the upstream Chromium-like distance; the mail window defaults
+  // to the Quick preset and updates this binding live from Settings.
+  property real speedMultiplier: 1
 
   blocking: true
   grabPermissions: PointerHandler.CanTakeOverFromAnything
@@ -31,12 +34,15 @@ WheelHandler {
 
   onWheel: function(event) {
     if (!root.view) return
+    var previous = root.view.contentY
     root.view.contentY = Model.wheelScrollByPixels(root.view.contentY,
-      Model.wheelPixels(event.angleDelta.y, event.pixelDelta.y),
+      Model.wheelPixels(event.angleDelta.y, event.pixelDelta.y,
+        root.speedMultiplier),
       root.view.contentHeight, root.view.height,
       root.view.originY, root.view.topMargin, root.view.bottomMargin)
     // Not dead despite `blocking`: a flick already in flight from a drag
     // goes on decelerating from where it was and fights every turn after.
     root.view.cancelFlick()
+    event.accepted = Math.abs(root.view.contentY - previous) > 0.01
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,7 @@
       "maxMessages": 25,
       "heavyMessageRendering": "Show plain text first",
       "contentDirection": "Auto",
+      "scrollSpeedPercent": 160,
       "defaultQuery": "in:inbox",
       "notifyNewMail": "On",
       "oauthPort": 9481,

--- a/tests/qml/imports/qs/Ui/PanelSlider.qml
+++ b/tests/qml/imports/qs/Ui/PanelSlider.qml
@@ -1,0 +1,20 @@
+import QtQuick
+
+Item {
+  property real value: 0
+  property real minimum: 0
+  property real maximum: 1
+  property real step: 0.05
+  property bool integer: false
+  property color trackColor: "transparent"
+  property color fillColor: "transparent"
+  property color knobColor: "transparent"
+  property color tickColor: "transparent"
+  property int tickCount: 0
+  property bool dragging: false
+  property real liveValue: value
+  signal moved(real value)
+  signal released(real value)
+  implicitWidth: 200
+  implicitHeight: 24
+}

--- a/tests/qml/imports/qs/Ui/qmldir
+++ b/tests/qml/imports/qs/Ui/qmldir
@@ -7,6 +7,7 @@ PanelActionButton 1.0 PanelActionButton.qml
 PanelSeparator 1.0 PanelSeparator.qml
 PanelSectionHeader 1.0 PanelSectionHeader.qml
 PanelToolTip 1.0 PanelToolTip.qml
+PanelSlider 1.0 PanelSlider.qml
 ToggleSwitch 1.0 ToggleSwitch.qml
 Dropdown 1.0 Dropdown.qml
 BarWidget 1.0 BarWidget.qml

--- a/tests/qml/tst_service_settings.qml
+++ b/tests/qml/tst_service_settings.qml
@@ -68,6 +68,16 @@ Item {
       compare(shellStore.updatedEntry.unifiedCalendarView, true)
     }
 
+    function test_scroll_speed_defaults_faster_and_persists_a_clamped_value() {
+      mailService.applySettings({})
+      compare(mailService.scrollSpeedPercent, 160)
+      compare(mailService.scrollSpeedMultiplier, 1.6)
+
+      mailService.setScrollSpeedPercent(237)
+      compare(mailService.scrollSpeedPercent, 250)
+      compare(shellStore.updatedEntry.scrollSpeedPercent, 250)
+    }
+
     function test_unified_mailboxes_setting_defaults_off_and_persists_changes() {
       mailService.applySettings({})
       compare(mailService.unifiedMailboxes, false)

--- a/tests/qml/tst_settings_sidebar.qml
+++ b/tests/qml/tst_settings_sidebar.qml
@@ -77,6 +77,8 @@ Item {
     property int accountCount: 1
     property int inboxUnread: 0
     property real bodyZoom: 1
+    property real scrollSpeedMultiplier: 1.6
+    property int scrollSpeedPercent: 160
     property string bodyMode: "reader"
     property string providerId: "imap"
     property string pluginDir: ""
@@ -147,6 +149,7 @@ Item {
     }
     function preferredSendAs(_recipients) { return null }
     function refreshRecipientContacts() {}
+    function setScrollSpeedPercent(value) { scrollSpeedPercent = Math.round(value) }
     function cursorOffset(_id, _delta) { return "" }
     function clearSelection() {
       selectedId = ""
@@ -237,6 +240,8 @@ Item {
     function init() {
       mailService.anyAccountReady = true
       mailService.hasSavedAccounts = true
+      mailService.scrollSpeedPercent = 160
+      mailService.scrollSpeedMultiplier = 1.6
       app.opened = true
       window().width = 980
       app.backToList()
@@ -267,10 +272,31 @@ Item {
       view.contentY = 0
 
       mouseWheel(view, view.width / 2, view.height / 2, 0, -120)
-      compare(view.contentY, 240, "one notch, in the real hierarchy")
+      compare(view.contentY, 384, "the Quick preset, in the real hierarchy")
 
       mouseWheel(view, view.width / 2, view.height / 2, 0, 120)
       compare(view.contentY, 0)
+    }
+
+    function test_scroll_controls_reach_the_service() {
+      var slider = named(app, "scrollSpeedSlider")
+      verify(slider, "the settings page exposes the pane-speed slider")
+      compare(slider.value, 2)
+      var faster = named(app, "scrollSpeedFaster")
+      var slower = named(app, "scrollSpeedSlower")
+      verify(faster && slower, "keyboard-reachable step buttons flank the slider")
+      faster.clicked()
+      compare(mailService.scrollSpeedPercent, 250)
+      slower.clicked()
+      compare(mailService.scrollSpeedPercent, 160)
+      slider.released(4)
+      compare(mailService.scrollSpeedPercent, 400)
+
+      var view = flick()
+      view.contentY = 0
+      mouseWheel(view, view.width / 2, view.height / 2, 0, -120)
+      compare(view.contentY, 960,
+        "the changed setting immediately changes this pane's distance")
     }
 
     function test_the_rail_lists_the_pages_sections_in_order() {

--- a/tests/qml/tst_wheel_scroll.qml
+++ b/tests/qml/tst_wheel_scroll.qml
@@ -23,7 +23,7 @@ Item {
     contentHeight: 5000
     boundsBehavior: Flickable.StopAtBounds
 
-    Omamail.WheelScroller { view: view }
+    Omamail.WheelScroller { id: speedHandler; view: view; speedMultiplier: 1.6 }
   }
 
   Flickable {
@@ -65,6 +65,7 @@ Item {
 
     function init() {
       view.contentY = 0
+      speedHandler.speedMultiplier = 1.6
       margined.contentY = -margined.topMargin
       headed.contentY = headed.originY
       bare.contentY = 0
@@ -74,7 +75,7 @@ Item {
 
     function test_one_notch_moves_three_lines_worth() {
       mouseWheel(view, 200, 150, 0, -120)
-      compare(view.contentY, 240)
+      compare(view.contentY, 384)
     }
 
     // The whole point. A high-resolution wheel reports one notch as many
@@ -82,7 +83,7 @@ Item {
     // where a bare Flickable is eight times short.
     function test_a_finely_reporting_wheel_moves_the_same_distance() {
       for (var i = 0; i < 8; i++) mouseWheel(view, 200, 150, 0, -15)
-      compare(view.contentY, 240, "eight fractions of a notch are still one notch")
+      compare(view.contentY, 384, "eight fractions of a notch are still one notch")
 
       for (var j = 0; j < 8; j++) mouseWheel(bare, 200, 150, 0, -15)
       wait(400)
@@ -92,24 +93,30 @@ Item {
 
     function test_three_notches_move_three_notches() {
       mouseWheel(view, 200, 150, 0, -360)
-      compare(view.contentY, 720)
+      compare(view.contentY, 1152)
+    }
+
+    function test_a_live_speed_change_reaches_the_same_pane() {
+      speedHandler.speedMultiplier = 2.4
+      mouseWheel(view, 200, 150, 0, -120)
+      compare(view.contentY, 576)
     }
 
     // Uncapped: ten notches as one event and as ten events agree. A per-event
     // cap put the chunking dependence back at the coarse end.
     function test_a_free_spinning_wheel_is_not_capped() {
       mouseWheel(view, 200, 150, 0, -1200)
-      compare(view.contentY, 2400)
+      compare(view.contentY, 3840)
 
       view.contentY = 0
       for (var i = 0; i < 10; i++) mouseWheel(view, 200, 150, 0, -120)
-      compare(view.contentY, 2400, "however the ten notches arrive")
+      compare(view.contentY, 3840, "however the ten notches arrive")
     }
 
     function test_it_scrolls_back_up() {
       view.contentY = 500
       mouseWheel(view, 200, 150, 0, 120)
-      compare(view.contentY, 260)
+      compare(view.contentY, 116)
     }
 
     // ------------------------------------------------------- the bounds

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -926,8 +926,26 @@ for (let i = 0; i < 8; i++) fine += model.wheelDistance(-NOTCH / 8)
 assert.strictEqual(fine, -120, "eight fractions of a notch are still one notch")
 
 assert.strictEqual(model.wheelDistance(-3 * NOTCH), -360, "three notches")
+assert.strictEqual(model.wheelDistance(-NOTCH, 1.6), -192,
+  "the configured multiplier changes the distance")
+assert.strictEqual(model.wheelDistanceForDeltas(-24, -NOTCH, 2), -48,
+  "a physical pixel delta wins and follows the configured multiplier")
+assert.strictEqual(model.wheelDistanceForDeltas(0, -NOTCH, 2), -240,
+  "an angle delta remains the fallback")
 assert.strictEqual(model.wheelDistance(0), 0)
 assert.strictEqual(model.wheelDistance(null), 0)
+
+assert.strictEqual(model.scrollSpeedPercent(undefined), 160)
+assert.strictEqual(model.scrollSpeedPercent(237), 250)
+assert.strictEqual(model.scrollSpeedPercent(10), 75)
+assert.strictEqual(model.scrollSpeedPercent(900), 400)
+assert.strictEqual(model.scrollSpeedMultiplier(160), 1.6)
+assert.strictEqual(model.scrollSpeedLevel(75), 0)
+assert.strictEqual(model.scrollSpeedLevel(160), 2)
+assert.strictEqual(model.scrollSpeedLevel(400), 4)
+assert.strictEqual(model.scrollSpeedPercentForLevel(4), 400)
+assert.strictEqual(model.scrollSpeedLabel(75), "Gentle")
+assert.strictEqual(model.scrollSpeedLabel(400), "Rapid")
 
 // Nothing is capped. A cap on one event would put the chunking dependence
 // straight back at the coarse end: a free-spinning wheel delivers ten notches
@@ -940,8 +958,12 @@ assert.strictEqual(asTen, model.wheelDistance(-10 * NOTCH),
   "ten notches move the same distance however they arrive")
 
 // Where the view lands, inside what it can actually reach.
-assert.strictEqual(model.wheelScrollTarget(0, -NOTCH, 5000, 300), 120)
-assert.strictEqual(model.wheelScrollTarget(500, NOTCH, 5000, 300), 380)
+assert.strictEqual(model.wheelScrollTarget(0, -NOTCH, 5000, 300), 240)
+assert.strictEqual(model.wheelScrollTarget(500, NOTCH, 5000, 300), 260)
+assert.strictEqual(model.wheelScrollTarget(0, -NOTCH, 5000, 300,
+  0, 0, 0, 1.6), 384)
+assert.strictEqual(model.wheelScrollTargetForDeltas(0, -30, -NOTCH,
+  5000, 300, 0, 0, 0, 2), 120)
 assert.strictEqual(model.wheelScrollTarget(0, 2 * NOTCH, 5000, 300), 0,
   "there is nothing above the first row")
 assert.strictEqual(model.wheelScrollTarget(4700, -2 * NOTCH, 5000, 300), 4700)
@@ -951,12 +973,12 @@ assert.strictEqual(model.wheelScrollTarget(0, -2 * NOTCH, 100, 300), 0,
 // A margined view scrolled up at the top stays in its margin. With a floor of
 // 0 this moved *down* to 0 in answer to a scroll up.
 assert.strictEqual(model.wheelScrollTarget(-50, NOTCH, 5000, 300, 0, 50, 70), -50)
-assert.strictEqual(model.wheelScrollTarget(-50, -NOTCH, 5000, 300, 0, 50, 70), 70)
+assert.strictEqual(model.wheelScrollTarget(-50, -NOTCH, 5000, 300, 0, 50, 70), 190)
 assert.strictEqual(model.wheelScrollTarget(4770, -NOTCH, 5000, 300, 0, 50, 70), 4770,
   "and the bottom margin is reachable rather than cut off")
 
 // A ListView with a header: one notch is one notch, not a jump to 0.
-assert.strictEqual(model.wheelScrollTarget(-200, -NOTCH, 4200, 300, -200, 0, 0), -80)
+assert.strictEqual(model.wheelScrollTarget(-200, -NOTCH, 4200, 300, -200, 0, 0), 40)
 assert.strictEqual(model.wheelScrollTarget(-200, NOTCH, 4200, 300, -200, 0, 0), -200,
   "and the header stays reachable")
 
@@ -967,7 +989,7 @@ assert.strictEqual(model.wheelScrollByPixels(500, 40, 5000, 300), 460)
 assert.strictEqual(model.wheelScrollByPixels(0, 40, 5000, 300), 0,
   "there is nothing above the first row")
 assert.strictEqual(model.wheelScrollTarget(0, -NOTCH, 5000, 300),
-  model.wheelScrollByPixels(0, model.wheelDistance(-NOTCH), 5000, 300),
+  model.wheelScrollByPixels(0, model.wheelPixels(-NOTCH, 0), 5000, 300),
   "a notch is the pixel helper fed a notch's worth")
 
 assert.strictEqual(model.WHEEL_GAIN, 2)


### PR DESCRIPTION
Split from #137 so scroll-speed configuration can be reviewed and adopted independently.

## Summary

- Add five named speed presets from Gentle through Rapid.
- Persist the selected speed and update existing panes immediately.
- Apply the setting consistently to wheel and pixel-delta scrolling across mail, reader, compose, calendar, settings, setup, and pickers.
- Keep high-resolution input and scroll bounds behavior covered by tests.

## Verification

- Complete JavaScript and shell/source suites pass.
- Complete QML suite, native Outlook HTTP harness, and sidebar safety harness pass.
- QML lint, plugin manifest validation, and diff checks pass.