### PR TITLE
Add optional system theme styling

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -184,6 +184,14 @@ Item {
     Math.min(accent.hslSaturation, 0.55),
     accent.hslLightness, 1.0)
 
+  MailPalette {
+    id: mailPalette
+    enabled: root.systemThemeStyling
+    baseBackground: root.background
+    baseText: root.foreground
+    baseUrgent: root.urgent
+  }
+
   readonly property string fontFamily: Style.font.family
 
   function copyText(text) {
@@ -215,6 +223,11 @@ Item {
   // service holds it because it is written to disk: a size somebody reached for
   // is theirs until they change it, not until they close the window.
   readonly property real bodyZoom: service ? service.bodyZoom : 1.0
+  readonly property bool systemThemeStyling: !!service
+    && service.systemThemeStyling === true
+  readonly property color labelsPaneBackground: mailPalette.sidebarSurface
+  readonly property color inboxPaneBackground: mailPalette.listSurface
+  readonly property color readerPaneBackground: mailPalette.readerSurface
   // 0 means "proportional"; anything else is a width somebody dragged to.
   property real listWidth: 0
 
@@ -1601,6 +1614,18 @@ Item {
           textColor: root.foreground
           accentColor: root.accent
           dimColor: root.dim
+          backgroundColor: root.labelsPaneBackground
+          systemThemeStyling: root.systemThemeStyling
+          selectedSurfaceColor: mailPalette.selectedSurface
+          hoverSurfaceColor: mailPalette.hoverSurface
+          activeTextColor: mailPalette.activeText
+          unreadColor: mailPalette.unread
+          starColor: mailPalette.starred
+          sentColor: mailPalette.sent
+          draftColor: mailPalette.drafts
+          labelColor: mailPalette.labels
+          calendarColor: mailPalette.calendar
+          dangerColor: mailPalette.danger
           panelFontFamily: root.fontFamily
           slots: root.sidebarSlots
           numbersVisible: focusScope.ctrlHeld
@@ -1628,6 +1653,12 @@ Item {
           visible: root.compact && !root.showPage && !root.composing && root.currentView === "list"
           textColor: root.foreground
           accentColor: root.accent
+          systemThemeStyling: root.systemThemeStyling
+          unreadColor: mailPalette.unread
+          starColor: mailPalette.starred
+          sentColor: mailPalette.sent
+          draftColor: mailPalette.drafts
+          dangerColor: mailPalette.danger
           panelFontFamily: root.fontFamily
           // The account's own mailboxes, not a fixed set: this row and the
           // sidebar it replaces on a narrow window must offer the same ones.
@@ -1657,6 +1688,11 @@ Item {
           visible: width > 0 && !root.showPage && !root.composing
             && !root.calendarVisible
 
+          Rectangle {
+            anchors.fill: parent
+            color: root.inboxPaneBackground
+          }
+
           // The scroller fills the column so its bar sits on the column edge;
           // the breathing room is padding on the content, not a margin on the
           // viewport, which would push the bar inward with it.
@@ -1682,6 +1718,12 @@ Item {
               textColor: root.foreground
               accentColor: root.accent
               dimColor: root.dim
+              systemThemeStyling: root.systemThemeStyling
+              selectedSurfaceColor: mailPalette.selectedSurface
+              hoverSurfaceColor: mailPalette.hoverSurface
+              unreadColor: mailPalette.unread
+              starColor: mailPalette.starred
+              sourceColor: mailPalette.labels
               panelFontFamily: root.fontFamily
               cursorId: root.cursorId
               onMessageActivated: function(id) { root.openMessage(id) }
@@ -1747,11 +1789,13 @@ Item {
             && (!root.compact || root.currentView === "reader")
           service: root.service
           textColor: root.foreground
-          backgroundColor: root.background
+          backgroundColor: root.readerPaneBackground
           accentColor: root.accent
           linkColor: root.link
           dimColor: root.dim
           dimmerColor: root.dimmer
+          systemThemeStyling: root.systemThemeStyling
+          starColor: mailPalette.starred
           popupBackgroundColor: root.popupBackground
           popupBorderColor: root.popupBorder
           leadingBoundaryOverlap: listSplitter.visible ? listSplitter.width : 0
@@ -2049,6 +2093,11 @@ Item {
               dimColor: root.dim
               accentColor: root.accent
               urgentColor: root.urgent
+              unreadColor: mailPalette.unread
+              starColor: mailPalette.starred
+              draftColor: mailPalette.drafts
+              labelColor: mailPalette.labels
+              calendarColor: mailPalette.calendar
               panelFontFamily: root.fontFamily
               onClientSetupRequested: root.openClientSetup()
               // Which kind first, then the form for it.

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ QML_FILES := Service.qml BarWidget.qml App.qml \
 	components/MenuActionRow.qml components/MenuSeparatorLine.qml \
 	components/KeyRouter.qml \
 	components/WheelScroller.qml \
+	components/MailPalette.qml \
 	components/ActionIcon.qml \
 	components/IconButton.qml \
 	components/IconTextButton.qml \

--- a/Service.qml
+++ b/Service.qml
@@ -62,6 +62,7 @@ Item {
     maxMessages: 25,
     heavyMessageRendering: Html.HEAVY_MESSAGE_RENDERING_DEFAULT,
     contentDirection: Direction.MODE_DEFAULT,
+    systemThemeStyling: false,
     defaultQuery: "in:inbox",
     notifyNewMail: "On",
     oauthPort: 9481,
@@ -87,6 +88,8 @@ Item {
     && settings.unifiedCalendarView === true
   readonly property bool unifiedMailboxes: !!settings
     && settings.unifiedMailboxes === true
+  readonly property bool systemThemeStyling: !!settings
+    && settings.systemThemeStyling === true
 
   // Whether the bar draws an envelope for this.
   //
@@ -173,6 +176,10 @@ Item {
 
   function setContentDirection(value) {
     persistSetting("contentDirection", Direction.normalizeMode(value))
+  }
+
+  function setSystemThemeStyling(value) {
+    persistSetting("systemThemeStyling", value === true)
   }
 
   function setUnifiedCalendarView(value) {

--- a/calendar/Palette.js
+++ b/calendar/Palette.js
@@ -33,5 +33,9 @@ function parse(raw) {
     var value = values[key] || values[ANSI_KEYS[key]] || ""
     if (value !== "") result[key] = value
   }
+  // Mail chrome uses terminal orange for labels. It is intentionally not a
+  // calendar slot, so this exposes the value without changing that UI's
+  // stable choices or ordering.
+  if (values.orange) result.orange = values.orange
   return result
 }

--- a/components/MailPalette.qml
+++ b/components/MailPalette.qml
@@ -1,0 +1,71 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import "../calendar/Palette.js" as Palette
+
+// Theme-reactive mail roles. Like the weather palette, color is selective:
+// neutral/muted structure for large surfaces and the terminal accent only for
+// state that deserves attention. Optional `omamail.*` shell.toml roles let a
+// theme override the defaults without teaching this view about that theme.
+QtObject {
+  id: root
+
+  property bool enabled: false
+  property color baseBackground: Color.background
+  property color baseText: Color.foreground
+  property color baseUrgent: Color.urgent
+  property var terminalValues: ({})
+  readonly property string palettePath: Quickshell.env("HOME")
+    + "/.local/state/omarchy/current/theme/colors.toml"
+
+  function role(name, fallbackColor) {
+    if (typeof Color.pick !== "function" || typeof Color.flatColor !== "function")
+      return fallbackColor
+    var configured = Color.pick("omamail." + name, "")
+    return configured === "" ? fallbackColor
+      : Color.flatColor(configured, fallbackColor)
+  }
+
+  function terminal(name, fallbackColor) {
+    var value = terminalValues[String(name || "").toLowerCase()]
+    return typeof value === "string" && value !== "" ? value : fallbackColor
+  }
+
+  function alpha(color, amount) {
+    return Qt.rgba(color.r, color.g, color.b, amount)
+  }
+
+  readonly property color primary: role("accent", Color.accent)
+  readonly property color muted: role("muted",
+    typeof Color.muted !== "undefined" ? Color.muted : baseText)
+  readonly property color unread: role("unread", terminal("cyan", primary))
+  readonly property color starred: role("starred", terminal("yellow", primary))
+  readonly property color sent: role("sent", terminal("green", primary))
+  readonly property color drafts: role("drafts", terminal("magenta", primary))
+  readonly property color labels: role("labels", terminal("orange", starred))
+  readonly property color calendar: role("calendar", terminal("green", primary))
+  readonly property color danger: role("danger", terminal("red", baseUrgent))
+
+  // Large areas stay close to the terminal background. The accent is reserved
+  // for selection, matching the weather plugin's cards instead of washing an
+  // entire pane with one saturated hue.
+  readonly property color sidebarSurface: enabled
+    ? alpha(muted, 0.10) : baseBackground
+  readonly property color listSurface: enabled
+    ? alpha(unread, 0.03) : baseBackground
+  readonly property color readerSurface: enabled
+    ? alpha(drafts, 0.018) : baseBackground
+  readonly property color selectedSurface: alpha(primary, 0.15)
+  readonly property color hoverSurface: alpha(primary, 0.065)
+  readonly property color activeText: primary
+
+  property FileView paletteFile: FileView {
+    path: root.palettePath
+    watchChanges: true
+    printErrors: false
+    onLoaded: root.terminalValues = Palette.parse(text())
+    onFileChanged: reload()
+    onLoadFailed: root.terminalValues = ({})
+  }
+}

--- a/components/MailboxSidebar.qml
+++ b/components/MailboxSidebar.qml
@@ -19,6 +19,18 @@ Item {
   required property color accentColor
   required property color dimColor
   required property string panelFontFamily
+  property color backgroundColor: "transparent"
+  property bool systemThemeStyling: false
+  property color selectedSurfaceColor: Style.selectedFillFor(textColor, accentColor)
+  property color hoverSurfaceColor: Style.hoverFillFor(textColor, accentColor)
+  property color activeTextColor: accentColor
+  property color unreadColor: accentColor
+  property color starColor: accentColor
+  property color sentColor: accentColor
+  property color draftColor: accentColor
+  property color labelColor: accentColor
+  property color calendarColor: accentColor
+  property color dangerColor: accentColor
   property bool collapsed: false
   property bool calendarSelected: false
 
@@ -31,7 +43,25 @@ Item {
   property var slots: []
   property bool numbersVisible: false
 
+  function mailboxColor(key) {
+    if (key === "inbox" || key === "unread") return root.unreadColor
+    if (key === "starred" || key === "flagged") return root.starColor
+    if (key === "sent") return root.sentColor
+    if (key === "drafts") return root.draftColor
+    if (key === "trash" || key === "spam") return root.dangerColor
+    return root.activeTextColor
+  }
+
+  function stateSurface(color, amount) {
+    return Qt.rgba(color.r, color.g, color.b, amount)
+  }
+
   readonly property var userLabels: Model.railLabels(root.service ? root.service.labels : [])
+
+  Rectangle {
+    anchors.fill: parent
+    color: root.backgroundColor
+  }
 
   // The rail's own edge. The list already draws one on its far side, so
   // without this the icons sit on the same surface as the messages.
@@ -84,6 +114,7 @@ Item {
             && root.service.mailboxKey === modelData.key
             && root.service.searchQuery === "" && root.service.rawQuery === ""
           slotNumber: Model.slotNumberOf(root.slots, "mailbox", modelData.key)
+          semanticColor: root.mailboxColor(modelData.key)
           onActivated: root.mailboxSelected(modelData.key)
         }
       }
@@ -122,6 +153,7 @@ Item {
           icon: "label"
           slotNumber: Model.slotNumberOf(root.slots, "label", modelData.id)
           count: modelData.unread
+          semanticColor: root.labelColor
           selected: !root.calendarSelected && !!root.service && root.service.rawQuery !== ""
             && root.service.rawQuery
               === Provider.labelQuery(root.service.providerId, modelData.rawName)
@@ -143,6 +175,7 @@ Item {
       label: "Calendar"
       icon: "calendar"
       selected: root.calendarSelected
+      semanticColor: root.calendarColor
       onActivated: root.calendarRequested()
     }
 
@@ -162,6 +195,7 @@ Item {
     property int count: 0
     property bool selected: false
     property int slotNumber: 0
+    property color semanticColor: root.activeTextColor
     signal activated()
 
     // The badge names the key, not the position: the tenth row is opened by
@@ -173,8 +207,12 @@ Item {
     implicitHeight: Style.space(28)
     radius: Style.cornerRadius
     color: entry.selected
-      ? Style.selectedFillFor(root.textColor, root.accentColor)
-      : (hover.hovered ? Style.hoverFillFor(root.textColor, root.accentColor) : "transparent")
+      ? (root.systemThemeStyling ? root.stateSurface(entry.semanticColor, 0.15)
+        : Style.selectedFillFor(root.textColor, root.accentColor))
+      : (hover.hovered
+        ? (root.systemThemeStyling ? root.hoverSurfaceColor
+          : Style.hoverFillFor(root.textColor, root.accentColor))
+        : "transparent")
 
     ActionIcon {
       id: glyph
@@ -184,7 +222,8 @@ Item {
       anchors.verticalCenter: parent.verticalCenter
       name: entry.icon
       iconSize: Style.font.icon
-      color: entry.selected ? root.textColor : root.dimColor
+      color: entry.selected && root.systemThemeStyling
+        ? entry.semanticColor : (entry.selected ? root.textColor : root.dimColor)
       visible: !(entry.showsNumber && root.collapsed)
     }
 
@@ -224,7 +263,8 @@ Item {
       anchors.verticalCenter: parent.verticalCenter
       textFormat: Text.PlainText
       text: entry.label
-      color: entry.selected ? root.textColor : root.dimColor
+      color: entry.selected && root.systemThemeStyling
+        ? entry.semanticColor : (entry.selected ? root.textColor : root.dimColor)
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.bodySmall
       font.bold: entry.selected
@@ -238,7 +278,7 @@ Item {
       anchors.rightMargin: Style.space(8)
       anchors.verticalCenter: parent.verticalCenter
       text: Model.badgeText(entry.count, 999)
-      color: root.accentColor
+      color: root.systemThemeStyling ? entry.semanticColor : root.accentColor
       font.family: root.panelFontFamily
       font.pixelSize: Style.font.caption
       font.bold: true
@@ -253,7 +293,7 @@ Item {
       width: Style.space(5)
       height: width
       radius: width / 2
-      color: root.accentColor
+      color: root.systemThemeStyling ? entry.semanticColor : root.accentColor
     }
 
     HoverHandler { id: hover }

--- a/components/MailboxTabs.qml
+++ b/components/MailboxTabs.qml
@@ -13,6 +13,12 @@ Flickable {
   required property color textColor
   required property color accentColor
   required property string panelFontFamily
+  property bool systemThemeStyling: false
+  property color unreadColor: accentColor
+  property color starColor: accentColor
+  property color sentColor: accentColor
+  property color draftColor: accentColor
+  property color dangerColor: accentColor
   property string current: "inbox"
   // Provider-specific, and handed down rather than looked up: this row must
   // never offer a mailbox the account on screen does not have.
@@ -22,6 +28,15 @@ Flickable {
 
   signal selected(string key)
   signal chipHovered(int index, bool isHovered)
+
+  function mailboxColor(key) {
+    if (key === "inbox" || key === "unread") return root.unreadColor
+    if (key === "starred" || key === "flagged") return root.starColor
+    if (key === "sent") return root.sentColor
+    if (key === "drafts") return root.draftColor
+    if (key === "trash" || key === "spam") return root.dangerColor
+    return root.accentColor
+  }
 
   // Scrolling a six-segment control in a narrow window is worse than not
   // offering two of the segments: All mail and Trash are places you go looking
@@ -114,7 +129,9 @@ Flickable {
             text: segment.modelData.key === "unread" && root.unread > 0
               ? segment.modelData.label + " " + root.unread
               : segment.modelData.label
-            foreground: root.textColor
+            foreground: root.systemThemeStyling
+              && root.current === segment.modelData.key
+              ? root.mailboxColor(segment.modelData.key) : root.textColor
             bordered: false
             selected: root.current === segment.modelData.key
             hasCursor: root.cursorIndex === segment.index

--- a/components/MessageList.qml
+++ b/components/MessageList.qml
@@ -23,6 +23,12 @@ Column {
   required property color dimColor
   required property string panelFontFamily
   property string cursorId: ""
+  property bool systemThemeStyling: false
+  property color selectedSurfaceColor: Style.selectedFillFor(textColor, accentColor)
+  property color hoverSurfaceColor: Style.hoverFillFor(textColor, accentColor)
+  property color unreadColor: accentColor
+  property color starColor: accentColor
+  property color sourceColor: accentColor
 
   signal messageActivated(string id)
   signal menuRequested(string id, real sceneX, real sceneY)
@@ -53,6 +59,12 @@ Column {
       textColor: root.textColor
       accentColor: root.accentColor
       dimColor: root.dimColor
+      systemThemeStyling: root.systemThemeStyling
+      selectedSurfaceColor: root.selectedSurfaceColor
+      hoverSurfaceColor: root.hoverSurfaceColor
+      unreadColor: root.unreadColor
+      starColor: root.starColor
+      sourceColor: root.sourceColor
       panelFontFamily: root.panelFontFamily
       hasCursor: root.cursorId === modelData.id
       selected: root.service.selectedId === modelData.id

--- a/components/MessageReader.qml
+++ b/components/MessageReader.qml
@@ -25,6 +25,8 @@ Item {
   required property color popupBorderColor
   required property real leadingBoundaryOverlap
   required property color dimmerColor
+  property bool systemThemeStyling: false
+  property color starColor: accentColor
   required property string panelFontFamily
   // Which of the three ways of reading a message this window is set to. The
   // window's preference, not this message's: it may not be the one on screen,
@@ -52,6 +54,11 @@ Item {
   signal composeRequested(string mode)
   signal mailtoRequested(string url)
   signal actionRequested(string action)
+
+  Rectangle {
+    anchors.fill: parent
+    color: root.backgroundColor
+  }
 
   // ------------------------------------------------------- the conversation
 
@@ -307,8 +314,10 @@ Item {
       iconName: "star"
       filled: !!root.summary && root.summary.starred
       tooltipText: (root.summary && root.summary.starred ? "Unstar" : "Star") + " · s"
-      foreground: root.summary && root.summary.starred ? root.accentColor : root.dimColor
-      hoverColor: root.accentColor
+      foreground: root.summary && root.summary.starred
+        ? (root.systemThemeStyling ? root.starColor : root.accentColor)
+        : root.dimColor
+      hoverColor: root.systemThemeStyling ? root.starColor : root.accentColor
       fontFamily: root.panelFontFamily
       onClicked: if (root.service && root.summary) root.service.toggleStar(root.selectedId)
     }

--- a/components/MessageRow.qml
+++ b/components/MessageRow.qml
@@ -28,6 +28,12 @@ Rectangle {
   property bool conversations: false
   property bool hasCursor: false
   property bool selected: false
+  property bool systemThemeStyling: false
+  property color selectedSurfaceColor: Style.selectedFillFor(textColor, accentColor)
+  property color hoverSurfaceColor: Style.hoverFillFor(textColor, accentColor)
+  property color unreadColor: accentColor
+  property color starColor: accentColor
+  property color sourceColor: accentColor
   // How the direction of this message's own text is arrived at. Passed down
   // like every other fact a row draws, because a row decides nothing.
   property string contentDirection: Direction.MODE_DEFAULT
@@ -70,8 +76,10 @@ Rectangle {
   implicitHeight: body.implicitHeight + Style.space(14)
   radius: Style.cornerRadius
   color: selected
-    ? Style.selectedFillFor(textColor, accentColor)
-    : (hot ? Style.hoverFillFor(textColor, accentColor) : "transparent")
+    ? (systemThemeStyling ? selectedSurfaceColor
+      : Style.selectedFillFor(textColor, accentColor))
+    : (hot ? (systemThemeStyling ? hoverSurfaceColor
+      : Style.hoverFillFor(textColor, accentColor)) : "transparent")
 
   MouseArea {
     id: mouse
@@ -102,7 +110,7 @@ Rectangle {
     height: width
     radius: width / 2
     visible: root.summary.unread
-    color: root.accentColor
+    color: root.systemThemeStyling ? root.unreadColor : root.accentColor
   }
 
   Column {
@@ -197,7 +205,7 @@ Rectangle {
         width: Math.min(implicitWidth, Math.floor(parent.width / 3))
         textFormat: Text.PlainText
         text: root.sourceLabel
-        color: root.accentColor
+        color: root.systemThemeStyling ? root.sourceColor : root.accentColor
         font.family: root.panelFontFamily
         font.pixelSize: Style.font.caption
         elide: Text.ElideRight
@@ -252,8 +260,10 @@ Rectangle {
       iconName: "star"
       filled: root.summary.starred
       tooltipText: (root.summary.starred ? "Unstar" : "Star") + " · s"
-      foreground: root.summary.starred ? root.accentColor : root.dimColor
-      hoverColor: root.accentColor
+      foreground: root.summary.starred
+        ? (root.systemThemeStyling ? root.starColor : root.accentColor)
+        : root.dimColor
+      hoverColor: root.systemThemeStyling ? root.starColor : root.accentColor
       iconSize: Style.font.iconSmall
       size: Style.space(24)
       fontFamily: root.panelFontFamily

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -21,6 +21,11 @@ Column {
   required property color accentColor
   required property color urgentColor
   required property string panelFontFamily
+  property color unreadColor: accentColor
+  property color starColor: accentColor
+  property color draftColor: accentColor
+  property color labelColor: accentColor
+  property color calendarColor: accentColor
 
   signal clientSetupRequested()
   signal addRequested()
@@ -38,6 +43,7 @@ Column {
   // below it in the rail's map as well as on screen. The calendars section
   // is a component with its own heading, so its top stands in.
   readonly property var sections: [
+    { key: "appearance", title: "Appearance", y: appearanceHeading.y },
     { key: "bar", title: "Bar", y: barHeading.y },
     { key: "reading", title: "Reading", y: readingHeading.y },
     { key: "notifications", title: "Notifications", y: notificationsHeading.y },
@@ -47,6 +53,8 @@ Column {
     { key: "oauth", title: "Google OAuth client", y: oauthHeading.y }
   ]
   readonly property var auth: service ? service.auth : null
+  readonly property bool colorful: !!root.service
+    && root.service.systemThemeStyling === true
 
   function signatureAccount(id) {
     for (var i = 0; i < signatureAccounts.length; i++)
@@ -140,6 +148,65 @@ Column {
     font.family: root.panelFontFamily
     font.pixelSize: Style.font.heading
     font.bold: true
+  }
+
+  // ------------------------------------------------------------ appearance
+
+  Text {
+    id: appearanceHeading
+    text: "APPEARANCE"
+    color: root.colorful ? root.draftColor : root.dimColor
+    font.family: root.panelFontFamily
+    font.pixelSize: Style.font.caption
+    font.letterSpacing: 1
+  }
+
+  Rectangle {
+    width: parent.width
+    implicitHeight: Math.max(themeText.implicitHeight, themeSwitch.implicitHeight)
+      + Style.space(16)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+
+    Column {
+      id: themeText
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(12)
+      anchors.right: themeSwitch.left
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(2)
+
+      Text {
+        width: parent.width
+        text: "System theme styling"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+      }
+
+      Text {
+        width: parent.width
+        text: "Use the terminal palette for subtle surfaces and accent selected mail"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+      }
+    }
+
+    ToggleSwitch {
+      id: themeSwitch
+      objectName: "systemThemeStylingSwitch"
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      checked: !!root.service && root.service.systemThemeStyling === true
+      foreground: root.textColor
+      accent: root.accentColor
+      onToggled: if (root.service)
+        root.service.setSystemThemeStyling(!root.service.systemThemeStyling)
+    }
   }
 
   // ------------------------------------------------------------------- bar

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,7 @@
       "maxMessages": 25,
       "heavyMessageRendering": "Show plain text first",
       "contentDirection": "Auto",
+      "systemThemeStyling": false,
       "defaultQuery": "in:inbox",
       "notifyNewMail": "On",
       "oauthPort": 9481,
@@ -58,6 +59,13 @@
         "label": "Show the icon in the bar",
         "defaultValue": true,
         "description": "Turn this off to run Omamail with no envelope in the bar. Mail is still checked and still notifies; only the icon goes. With it off the window opens from a keybinding or a terminal and nowhere else, so bind a key first: o.bind(\"SUPER + SHIFT + G\", \"Omamail\", \"omarchy shell shell toggle omamail '{}'\")"
+      },
+      {
+        "key": "systemThemeStyling",
+        "type": "boolean",
+        "label": "System theme styling",
+        "defaultValue": false,
+        "description": "Use the terminal palette for subtle pane structure and accent selected folders and mail. Colors update automatically when the system theme changes."
       },
       {
         "key": "refreshIntervalSec",

--- a/tests/qml/tst_service_settings.qml
+++ b/tests/qml/tst_service_settings.qml
@@ -68,6 +68,15 @@ Item {
       compare(shellStore.updatedEntry.unifiedCalendarView, true)
     }
 
+    function test_system_theme_styling_defaults_off_and_persists() {
+      mailService.applySettings({})
+      compare(mailService.systemThemeStyling, false)
+
+      mailService.setSystemThemeStyling(true)
+      compare(mailService.systemThemeStyling, true)
+      compare(shellStore.updatedEntry.systemThemeStyling, true)
+    }
+
     function test_unified_mailboxes_setting_defaults_off_and_persists_changes() {
       mailService.applySettings({})
       compare(mailService.unifiedMailboxes, false)

--- a/tests/qml/tst_settings_sidebar.qml
+++ b/tests/qml/tst_settings_sidebar.qml
@@ -77,6 +77,7 @@ Item {
     property int accountCount: 1
     property int inboxUnread: 0
     property real bodyZoom: 1
+    property bool systemThemeStyling: false
     property string bodyMode: "reader"
     property string providerId: "imap"
     property string pluginDir: ""
@@ -147,6 +148,7 @@ Item {
     }
     function preferredSendAs(_recipients) { return null }
     function refreshRecipientContacts() {}
+    function setSystemThemeStyling(value) { systemThemeStyling = value === true }
     function cursorOffset(_id, _delta) { return "" }
     function clearSelection() {
       selectedId = ""
@@ -237,6 +239,7 @@ Item {
     function init() {
       mailService.anyAccountReady = true
       mailService.hasSavedAccounts = true
+      mailService.systemThemeStyling = false
       app.opened = true
       window().width = 980
       app.backToList()
@@ -278,7 +281,7 @@ Item {
       verify(rail && rail.visible, "a wide window has a rail")
       var page = named(app, "settings-page")
       var keys = page.sections.map(function(s) { return s.key })
-      compare(keys.join(","), "bar,reading,notifications,writing,mailboxes,calendars,oauth")
+      compare(keys.join(","), "appearance,bar,reading,notifications,writing,mailboxes,calendars,oauth")
       for (var i = 1; i < page.sections.length; i++)
         verify(page.sections[i].y > page.sections[i - 1].y, "sections are laid out top to bottom")
       for (var j = 0; j < keys.length; j++)
@@ -293,7 +296,7 @@ Item {
       var view = flick()
       verify(view, "the page scrolls inside a Flickable")
       compare(view.contentY, 0)
-      compare(rail.activeKey, "bar",
+      compare(rail.activeKey, "appearance",
         "the top of the page is the first section, whichever that is")
       compare(app.navKinds.join(","), "list,settings")
 
@@ -324,9 +327,20 @@ Item {
       // Scrolled by other means — the wheel, say — the highlight still
       // follows the page, because the page is what it describes.
       view.contentY = 0
-      tryCompare(rail, "activeKey", "bar")
+      tryCompare(rail, "activeKey", "appearance")
       view.contentY = sectionY(page, "mailboxes") + 5
       tryCompare(rail, "activeKey", "mailboxes")
+    }
+
+    function test_system_theme_styling_reaches_the_service_and_panes() {
+      var theme = named(app, "systemThemeStylingSwitch")
+      verify(theme, "the settings page exposes system theme styling")
+      theme.toggled()
+      compare(mailService.systemThemeStyling, true)
+      verify(String(app.labelsPaneBackground) !== String(app.background),
+        "turning styling on adds a muted labels surface")
+      verify(String(app.inboxPaneBackground) !== String(app.background),
+        "and a restrained accent surface behind the list")
     }
 
     // Narrow, the rail has no room; the page keeps the whole width and its

--- a/tests/test_calendar_palette.js
+++ b/tests/test_calendar_palette.js
@@ -11,11 +11,13 @@ const parsed = palette.parse([
   'yellow = "#c9b26d"',
   'color4 = "#5fa2d5"',
   'magenta = "#b07aa1"',
-  'color6 = "#7ec0ae"'
+  'color6 = "#7ec0ae"',
+  'orange = "#de8f67"'
 ].join("\n"))
 deepEqual(parsed, {
   accent: "#ff7a00", red: "#d45941", green: "#578c60",
-  yellow: "#c9b26d", blue: "#5fa2d5", magenta: "#b07aa1", cyan: "#7ec0ae"
+  yellow: "#c9b26d", blue: "#5fa2d5", magenta: "#b07aa1", cyan: "#7ec0ae",
+  orange: "#de8f67"
 })
 
 assert.strictEqual(palette.normalizeKey("blue"), "blue")


### PR DESCRIPTION
Split from #137 so system-theme styling can be reviewed and adopted independently.

## Summary

- Add an opt-in System theme styling setting.
- Read and watch the active Omarchy terminal palette.
- Assign restrained semantic colors to pane surfaces, selected mail, unread state, stars, folders, drafts, sent mail, and destructive mailboxes.
- Preserve the existing visual treatment when the option is disabled.

## Visual evidence

The composite below uses the same synthetic mailbox and compares disabled and enabled states under dark and light Omarchy themes, including selected mail, unread mail, and the reader pane.

![Before and after evidence for optional system theme styling](https://raw.githubusercontent.com/tumbleweedlabs/omamail/pr-evidence/pr-144-system-theme-styling.png)

## Verification

- Complete JavaScript and shell/source suites pass.
- Complete QML suite, native Outlook HTTP harness, and sidebar safety harness pass.
- QML lint, plugin manifest validation, and diff checks pass.
