### PR TITLE
Add direct mail and calendar navigation

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -387,9 +387,15 @@ Item {
   // Mailboxes lands in.
   function openSettings() {
     dismissHelp()
-    if (page === "settings") return
     settingsScroll.stop()
     settingsFlick.contentY = 0
+    // A second request is useful recovery, not a no-op: if the page was
+    // already selected while its popup was still relinquishing focus, bring
+    // its viewport home and focus it again.
+    if (page === "settings") {
+      Qt.callLater(function() { focusScope.applyContextFocus() })
+      return
+    }
     pushEntry("settings")
   }
 
@@ -1443,6 +1449,7 @@ Item {
           // same place however the control was pressed.
           IconButton {
             id: menuButton
+            objectName: "menu-button"
             anchors.verticalCenter: parent.verticalCenter
             iconName: "menu"
             tooltipText: "Menu"
@@ -1453,6 +1460,39 @@ Item {
             onClicked: {
               var scene = mapToGlobal(0, height)
               appMenu.openAt(scene.x, scene.y)
+            }
+          }
+
+          IconButton {
+            id: mailViewButton
+            objectName: "mail-view-button"
+            anchors.verticalCenter: parent.verticalCenter
+            visible: !root.composing
+            iconName: "mail"
+            tooltipText: "Mail · Ctrl+Shift+M"
+            foreground: root.dim
+            hoverColor: root.foreground
+            fontFamily: root.fontFamily
+            selected: !root.showPage && !root.calendarVisible
+            enabled: root.ready
+            onClicked: root.backToList()
+          }
+
+          IconButton {
+            id: calendarViewButton
+            objectName: "calendar-view-button"
+            anchors.verticalCenter: parent.verticalCenter
+            visible: !root.composing
+            iconName: "calendar"
+            tooltipText: "Calendar · Ctrl+Shift+C"
+            foreground: root.dim
+            hoverColor: root.foreground
+            fontFamily: root.fontFamily
+            selected: !root.showPage && root.calendarVisible
+            enabled: root.ready
+            onClicked: {
+              root.showCalendar()
+              calendarView.refresh()
             }
           }
         }
@@ -1605,10 +1645,6 @@ Item {
           slots: root.sidebarSlots
           numbersVisible: focusScope.ctrlHeld
           onMailboxSelected: function(key) { root.goMailbox(key) }
-          onCalendarRequested: {
-            root.showCalendar()
-            calendarView.refresh()
-          }
           // Not a search: the provider decides what selecting a label means,
           // and on IMAP it is a folder rather than a term to look for.
           onLabelSelected: function(labelId, name) {
@@ -2294,7 +2330,10 @@ Item {
           root.showCalendar()
           calendarView.refresh()
         }
-        onSetupRequested: root.openSettings()
+        // Let the Popup finish closing before replacing everything below it.
+        // On the live shell, doing both in the row's release handler could
+        // restore the old focus/navigation state over the newly opened page.
+        onSetupRequested: Qt.callLater(root.openSettings)
         onSwitchAccountRequested: accountSwitcher.openCentered()
         onProjectRequested: if (root.service) root.service.openProjectPage()
         onAuthorRequested: if (root.service) root.service.openAuthorPage()

--- a/components/AppMenu.qml
+++ b/components/AppMenu.qml
@@ -7,6 +7,7 @@ import "Menu.js" as Menu
 // Links out, plus the handful of actions that have no natural home on screen.
 Item {
   id: root
+  objectName: "app-menu"
 
   required property color textColor
   required property color popupBackgroundColor
@@ -79,6 +80,11 @@ Item {
   signal switchAccountRequested()
   signal projectRequested()
   signal authorRequested()
+
+  // Exposed for the window's integration test. Popup content lives in its own
+  // visual hierarchy, so walking down from App cannot otherwise reach the row
+  // a real pointer clicks.
+  readonly property alias settingsAction: settingsRow
 
   anchors.fill: root.showTrigger ? undefined : parent
   implicitWidth: root.showTrigger ? Style.space(24) : 0
@@ -174,6 +180,7 @@ Item {
       }
       MenuRow {
         id: settingsRow
+        objectName: "app-menu-settings"
         text: "Settings..."
         onActivated: { menu.close(); root.setupRequested() }
       }

--- a/components/MailboxSidebar.qml
+++ b/components/MailboxSidebar.qml
@@ -24,7 +24,6 @@ Item {
 
   signal mailboxSelected(string key)
   signal labelSelected(string labelId, string name)
-  signal calendarRequested()
 
   // The numbered list App.qml also gives the keys, so a badge and the key that
   // opens the row it sits on cannot disagree.
@@ -51,7 +50,7 @@ Item {
     anchors.left: parent.left
     anchors.right: edge.left
     anchors.top: parent.top
-    anchors.bottom: footer.top
+    anchors.bottom: parent.bottom
     contentWidth: width
     contentHeight: column.implicitHeight + Style.space(12)
     clip: true
@@ -129,28 +128,6 @@ Item {
         }
       }
     }
-  }
-
-  // Calendar stays fixed at the foot of the rail while mailbox labels scroll.
-  Column {
-    id: footer
-    anchors.left: parent.left
-    anchors.right: edge.left
-    anchors.bottom: parent.bottom
-
-    Entry {
-      x: Style.space(6)
-      label: "Calendar"
-      icon: "calendar"
-      selected: root.calendarSelected
-      onActivated: root.calendarRequested()
-    }
-
-    Item {
-      width: parent.width
-      height: Style.space(6)
-    }
-
   }
 
   // One row: an icon that is always there, a name that appears when there is

--- a/tests/qml/tst_settings_sidebar.qml
+++ b/tests/qml/tst_settings_sidebar.qml
@@ -329,6 +329,34 @@ Item {
       tryCompare(rail, "activeKey", "mailboxes")
     }
 
+    function test_header_buttons_switch_directly_between_mail_and_calendar() {
+      var mail = named(app, "mail-view-button")
+      var calendar = named(app, "calendar-view-button")
+      verify(mail && calendar, "the header exposes both direct view buttons")
+      mouseClick(calendar)
+      compare(app.currentView, "calendar")
+      compare(calendar.selected, true)
+      mouseClick(mail)
+      compare(app.currentView, "list")
+      compare(mail.selected, true)
+    }
+
+    function test_hamburger_settings_row_opens_settings() {
+      app.backToList()
+      waitForRendering(app)
+      var menu = named(app, "menu-button")
+      var appMenu = named(app, "app-menu")
+      verify(menu && appMenu, "the hamburger and its menu exist")
+      var settingsRow = appMenu.settingsAction
+      verify(settingsRow, "the menu exposes its Settings row")
+      mouseClick(menu)
+      tryVerify(function() { return settingsRow.visible }, 1000,
+        "the Settings row is visible in the open menu")
+      mouseClick(settingsRow)
+      tryCompare(app, "showSettings", true)
+      compare(app.currentView, "list", "Settings is a page over mail")
+    }
+
     // Narrow, the rail has no room; the page keeps the whole width and its
     // own scroll, which is all it ever had.
     function test_a_narrow_window_has_no_rail() {

--- a/tests/test_source.sh
+++ b/tests/test_source.sh
@@ -426,20 +426,19 @@ python3 - <<'PY'
 from pathlib import Path
 
 sidebar = Path("components/MailboxSidebar.qml").read_text()
-footer = sidebar[sidebar.index("id: footer"):sidebar.index("component Entry:")]
-if 'label: "Calendar"' not in footer or "calendarRequested" not in footer:
-    raise SystemExit("test_source.sh: Calendar must stay fixed at the foot of the sidebar")
-calendar = footer.index('label: "Calendar"')
-if "Style.space(6)" not in footer[calendar:]:
-    raise SystemExit("test_source.sh: Calendar must keep breathing room at the sidebar foot")
+if 'label: "Calendar"' in sidebar or "calendarRequested" in sidebar:
+    raise SystemExit("test_source.sh: Calendar navigation must not be duplicated in the sidebar")
+if "anchors.bottom: parent.bottom" not in sidebar:
+    raise SystemExit("test_source.sh: mailbox labels must use the space freed below the sidebar")
 
 app = Path("App.qml").read_text()
 sidebar_use = app[app.index("id: sidebar"):app.index("MailboxTabs {")]
 if "!root.calendarVisible" in sidebar_use or "calendarSelected: root.calendarVisible" not in sidebar_use:
     raise SystemExit("test_source.sh: the mailbox sidebar must remain visible and select Calendar")
-header = app[app.index("id: headerRight"):app.index("// mailbox as a whole")]
-if 'iconName: root.calendarVisible ? "mail" : "calendar"' in header:
-    raise SystemExit("test_source.sh: Calendar navigation belongs in the sidebar, not the header")
+header = app[app.index("id: headerLeft"):app.index("id: searchSlot")]
+for button in ('objectName: "mail-view-button"', 'objectName: "calendar-view-button"'):
+    if button not in header:
+        raise SystemExit("test_source.sh: Mail and Calendar navigation must stay in the header")
 
 calendar = Path("components/CalendarView.qml").read_text()
 if "CalendarSidebar {" in calendar:


### PR DESCRIPTION
Split from #137 so the navigation changes can be reviewed and adopted independently.

## Summary

- Add direct Mail and Calendar buttons to the header.
- Remove the now-duplicated Calendar entry at the bottom of the folders and labels pane.
- Let the labels list use the freed sidebar space.
- Defer Settings navigation until the hamburger popup closes and restore focus on repeated visits.

## Visual evidence

The composite below uses the same synthetic account and window size to show the header before and after, direct Calendar navigation, the freed sidebar space, and Settings navigation.

![Before and after evidence for direct Mail and Calendar navigation](https://raw.githubusercontent.com/tumbleweedlabs/omamail/pr-evidence/pr-145-direct-navigation.png)

## Verification

- Complete JavaScript and shell/source suites pass.
- Complete QML suite, native Outlook HTTP harness, and sidebar safety harness pass.
- QML lint, plugin manifest validation, and diff checks pass.
