### PR TITLE
Stop rebuilding the merged view for a window that is not showing one

### DIFF
--- a/Service.qml
+++ b/Service.qml
@@ -876,6 +876,12 @@ Item {
   // What the merge reads: one entry per mailbox, labelled so a row can say
   // where it came from.
   readonly property var unifiedSources: {
+    // Nothing reads this list unless the merged view is on — every consumer
+    // is `unified ? Unified.something(...) : the account's own answer` — and
+    // building it is not free: a list change bumps `listEpoch` several times
+    // for every mailbox opened, and each bump walked every account's rows for
+    // a list nobody was looking at.
+    if (!unified) return []
     var _epoch = listEpoch
     var out = []
     var accounts = accountList ? accountList.accounts : []
@@ -898,6 +904,7 @@ Item {
   // What the merge reads for everything that is not a row: whether each
   // mailbox is still working, has more to offer, or has something to say.
   readonly property var unifiedStates: {
+    if (!unified) return []
     var _epoch = listEpoch
     var out = []
     var accounts = accountList ? accountList.accounts : []
@@ -924,6 +931,7 @@ Item {
   // mailboxes that turned out not to be there, and those arrive while the app
   // is running. Reading them here is what makes the intersection follow them.
   readonly property var unifiedAbilities: {
+    if (!unified) return []
     var _epoch = listEpoch
     var out = []
     var accounts = accountList ? accountList.accounts : []
@@ -945,7 +953,8 @@ Item {
   }
 
 
-  readonly property var unifiedMessages: Unified.mergeMessages(unifiedSources)
+  readonly property var unifiedMessages: unified
+    ? Unified.mergeMessages(unifiedSources) : []
 
   // The mailbox every account is showing. A unified view puts them all on the
   // same rail row, so this is the row rather than one account's idea of it —

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -660,7 +660,8 @@ Item {
     for (var i = 0; i < restored.length; i++)
       restored[i].time = Mail.relativeTime(restored[i].date, now)
 
-    messages = restored
+    // Only when a row differs; see `Model.sameSummaries`.
+    if (!Model.sameSummaries(messages, restored)) messages = restored
     resultEstimate = entry ? Math.max(entry.estimate, restored.length) : restored.length
     nextPageToken = entry ? entry.nextPageToken : ""
     listLoaded = true

--- a/account/Model.js
+++ b/account/Model.js
@@ -635,6 +635,76 @@ function showListFooter(messageCount) {
   return Math.max(0, Number(messageCount) || 0) > 0
 }
 
+// Whether two summaries carry the same values, one field at a time.
+//
+// Rows arrive rebuilt rather than reused: `Cache.hydrate` copies every entry
+// out of the store on every read, so two paints of an unchanged mailbox share
+// no object and `===` on the rows themselves always says "different". The
+// comparison has to look at what a row says, not at which object says it.
+//
+// Depth-limited rather than open-ended, and the bound is what keeps a cycle —
+// or a provider payload nobody anticipated — from hanging the list. A summary
+// reaches three levels down at its deepest, a thread's member ids and a
+// recipient's own fields, and the bound is four: one level of headroom, not a
+// snug fit. A structure deeper than that reads as changed, which repaints a
+// list that may not have needed it; the opposite default would hide real mail.
+function sameSummaryValue(left, right, depth) {
+  if (left === right) return true
+  if (!left || !right) return false
+  if (typeof left !== "object" || typeof right !== "object") return false
+  // A date is a value here, not a structure: `Cache.hydrate` builds a new one
+  // out of `dateMs` on every read, so only the instant it names can be equal.
+  if (typeof left.getTime === "function" || typeof right.getTime === "function") {
+    return typeof left.getTime === "function" && typeof right.getTime === "function"
+      && left.getTime() === right.getTime()
+  }
+  if (depth <= 0) return false
+  var leftIsList = Array.isArray(left)
+  if (leftIsList !== Array.isArray(right)) return false
+  if (leftIsList) {
+    if (left.length !== right.length) return false
+    for (var i = 0; i < left.length; i++) {
+      if (!sameSummaryValue(left[i], right[i], depth - 1)) return false
+    }
+    return true
+  }
+  // Both key sets, and a field holding `undefined` counts as one the row does
+  // not have. That is what a round trip through the cache does to it —
+  // `JSON.stringify` drops the key — so a live row carrying one and the
+  // restored copy of it are the same row, and reading only the left side's
+  // keys would have made this answer differently depending on which list was
+  // handed in first.
+  for (var key in left) {
+    if (!Object.prototype.hasOwnProperty.call(left, key)) continue
+    if (!sameSummaryValue(left[key], right[key], depth - 1)) return false
+  }
+  for (var extra in right) {
+    if (!Object.prototype.hasOwnProperty.call(right, extra)) continue
+    if (Object.prototype.hasOwnProperty.call(left, extra)) continue
+    if (right[extra] !== undefined) return false
+  }
+  return true
+}
+
+// Whether a list of summaries says what the list already on screen says.
+//
+// Cache-first painting runs on every visit to a query, and what it restores is
+// usually exactly what is already drawn — the service keeps running while the
+// window is shut, so reopening it, or stepping back to a mailbox, restores the
+// rows that never went away. Assigning them anyway is not free: every consumer
+// of the list recomputes, which on this list is measured in tenths of a
+// second. So the assignment is made only when a row actually differs.
+function sameSummaries(previous, next) {
+  var before = Array.isArray(previous) ? previous : []
+  var after = Array.isArray(next) ? next : []
+  if (before === after) return true
+  if (before.length !== after.length) return false
+  for (var i = 0; i < after.length; i++) {
+    if (!sameSummaryValue(before[i], after[i], 4)) return false
+  }
+  return true
+}
+
 function removeById(list, id) {
   var source = Array.isArray(list) ? list : []
   var out = []

--- a/account/Unified.js
+++ b/account/Unified.js
@@ -32,17 +32,38 @@ function messageTime(item) {
   return Number(item && item.internalDate) || 0
 }
 
-// Newest first, with ties broken by account and id so the order is total.
-// Without that second term two rows sharing a timestamp could swap places
+// What breaks a tie between two rows that arrived at the same instant: the
+// account and the id together. Without it such a pair could swap places
 // between one merge and the next and the cursor would move on its own, which
-// is not hypothetical: one message copied to two of these mailboxes arrives
-// with the same date in both.
-function compareRows(left, right) {
-  var difference = messageTime(right) - messageTime(left)
-  if (difference !== 0) return difference
+// is not hypothetical — one message copied to two of these mailboxes arrives
+// with the same date in both. `mergeMessages` has already dropped a repeat of
+// that pair, so this never answers 0 for two rows that are actually different,
+// and the order it completes is total whatever `Array.prototype.sort` does
+// with equal keys.
+function compareTiebreak(left, right) {
   var leftKey = String(left && left.accountId || "") + " " + String(left && left.id || "")
   var rightKey = String(right && right.accountId || "") + " " + String(right && right.id || "")
   return leftKey < rightKey ? -1 : (leftKey > rightKey ? 1 : 0)
+}
+
+// Newest first, over rows whose time has already been read.
+//
+// The time is read on the way into the sort rather than inside it, because
+// `messageTime` is not a cheap read: the date it reaches for has crossed from
+// the account that owns the row into this engine, and converting it back costs
+// about a third of a millisecond. Once per row that is nothing; inside a
+// comparator it was the most expensive thing the merged view did, because a
+// sort asks several times as many questions as it has rows — a merge of two
+// 25-row mailboxes spent 244ms in `sort` and 1ms building the rows it was
+// sorting, and spent it again on every list change, of which opening one
+// mailbox makes several.
+//
+// The rows themselves are handed on unchanged: a sort key is this file's
+// business and has no place in the shape the panel reads.
+function compareTimedRows(left, right) {
+  var difference = right.at - left.at
+  if (difference !== 0) return difference
+  return compareTiebreak(left.row, right.row)
 }
 
 // ------------------------------------------------------------------- row ids
@@ -194,21 +215,22 @@ function mergeMessages(sources) {
       // that carries the mailbox.
       if (item.thread) copy.thread = composeThread(accountId, item.thread)
       copy.sourceLabel = String(source.label || "Mailbox")
-      out.push(copy)
+      // Read off the copy, whose fields the loop above has already pulled
+      // across, rather than reaching into the row a second time.
+      out.push({ at: messageTime(copy), row: copy })
     }
   }
-  out.sort(compareRows)
+  out.sort(compareTimedRows)
   // Truncated at the shallowest watermark, so the list has no hole in the
   // middle of it. A merge of one source, or of sources that have all run out,
   // keeps everything.
   var floor = pageWatermark(values)
-  if (floor <= 0) return out
-  var complete = []
+  var rows = []
   for (var k = 0; k < out.length; k++) {
-    if (messageTime(out[k]) < floor) break
-    complete.push(out[k])
+    if (floor > 0 && out[k].at < floor) break
+    rows.push(out[k].row)
   }
-  return complete
+  return rows
 }
 
 // Which account a row belongs to. Read out of the id rather than looked up:

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -1261,3 +1261,98 @@ assert.strictEqual(model.previewReadable(dwelt, ""), false)
   deepEqual(slashed.map(function (r) { return [r.path, r.depth] }), [["a", 0], ["a.b", 0]],
     "a slash server does not nest on a dot")
 }
+
+// A cache-first paint restores rows the list is usually already showing, and
+// `Cache.hydrate` rebuilds every one of them, so the rows are never the same
+// objects. Only their values can say whether anything changed.
+function summaryRows() {
+  return [
+    { id: "m1", subject: "One", unread: true, from: { email: "a@x", display: "A" },
+      to: [{ name: "Me", email: "me@x", display: "Me" }],
+      thread: { id: "t1", count: 2, memberIds: ["m1", "m0"] }, date: new Date(3000) },
+    { id: "m2", subject: "Two", unread: false, from: { email: "b@x", display: "B" },
+      to: [], thread: { id: "t2", count: 0, memberIds: [] }, date: new Date(2000) }
+  ]
+}
+
+const painted = summaryRows()
+assert.strictEqual(model.sameSummaries(painted, summaryRows()), true,
+  "rebuilt rows carrying the same values are the same list")
+assert.strictEqual(model.sameSummaries(painted, painted), true)
+assert.strictEqual(model.sameSummaries([], []), true)
+assert.strictEqual(model.sameSummaries(null, undefined), true, "neither list has rows")
+
+// Anything a row says differently is a change, however deep it sits. The
+// deepest a summary actually goes is a thread's member ids and a recipient's
+// own fields, so the comparison has to reach both.
+const markedRead = summaryRows()
+markedRead[0].unread = false
+assert.strictEqual(model.sameSummaries(painted, markedRead), false, "a row was read")
+
+const renamed = summaryRows()
+renamed[0].from.display = "Someone else"
+assert.strictEqual(model.sameSummaries(painted, renamed), false,
+  "a nested field is still a field")
+
+const addressed = summaryRows()
+addressed[0].to[0].email = "someone@else"
+assert.strictEqual(model.sameSummaries(painted, addressed), false,
+  "a recipient's own field, two levels down")
+
+const grown = summaryRows()
+grown[0].to.push({ email: "cc@x" })
+assert.strictEqual(model.sameSummaries(painted, grown), false, "a recipient arrived")
+
+const answered = summaryRows()
+answered[0].thread.memberIds.push("m3")
+assert.strictEqual(model.sameSummaries(painted, answered), false,
+  "a conversation gained a member, three levels down")
+
+// A field the new row carries and the old one does not is a change the
+// comparison has to see, which reading only the old row's keys would miss.
+const tagged = summaryRows()
+tagged[0].pinned = true
+assert.strictEqual(model.sameSummaries(painted, tagged), false, "a field appeared")
+
+// Where a row sits is part of what the list says: the cursor steps by index.
+const reordered = summaryRows()
+reordered.reverse()
+assert.strictEqual(model.sameSummaries(painted, reordered), false,
+  "the same rows in another order are another list")
+
+// A date is the instant it names: hydrate builds a new Date on every read.
+assert.strictEqual(model.sameSummaries([{ id: "m", date: new Date(1000) }],
+  [{ id: "m", date: new Date(1000) }]), true)
+assert.strictEqual(model.sameSummaries([{ id: "m", date: new Date(1000) }],
+  [{ id: "m", date: new Date(2000) }]), false)
+assert.strictEqual(model.sameSummaries([{ id: "m", date: new Date(1000) }],
+  [{ id: "m", date: null }]), false, "a row that lost its date changed")
+
+// The answer cannot depend on which list was handed in first. A field holding
+// `undefined` is a field the row does not have — `JSON.stringify` drops the key
+// on the way to the cache, so a live row carrying one and the copy restored
+// from disk are the same row — and a field that holds a value is a difference
+// read from either side.
+const withUndefined = [{ id: "m1", subject: "One", snippet: undefined }]
+const withoutKey = [{ id: "m1", subject: "One" }]
+assert.strictEqual(model.sameSummaries(withUndefined, withoutKey), true,
+  "a key the cache drops is not a change")
+assert.strictEqual(model.sameSummaries(withoutKey, withUndefined), true,
+  "and it is not a change the other way round either")
+
+const withValue = [{ id: "m1", subject: "One", snippet: "new" }]
+assert.strictEqual(model.sameSummaries(withValue, withoutKey), false)
+assert.strictEqual(model.sameSummaries(withoutKey, withValue), false,
+  "a field that arrived is a change read from either side")
+
+// A shorter or longer list is a different list without looking at a row.
+assert.strictEqual(model.sameSummaries(painted, [painted[0]]), false)
+assert.strictEqual(model.sameSummaries([painted[0]], painted), false)
+
+// Deeper than the bound reads as changed rather than as equal: repainting a
+// list that did not need it is recoverable, hiding mail that did is not. A
+// summary nests three deep at most, so the bound is not in a row's way.
+const deep = { id: "m", a: { b: { c: { d: { e: 1 } } } } }
+const alsoDeep = { id: "m", a: { b: { c: { d: { e: 1 } } } } }
+assert.strictEqual(model.sameSummaries([deep], [alsoDeep]), false,
+  "the comparison stops rather than following an unbounded structure")

--- a/tests/test_unified.js
+++ b/tests/test_unified.js
@@ -98,7 +98,51 @@ assert.strictEqual(unified.mergeMessages([
 ]).length, 1)
 
 deepEqual(unified.mergeMessages(null), [])
+
 deepEqual(unified.mergeMessages([]), [])
+
+// The merge reads each row's time once, not once per comparison.
+//
+// It used to sort with `messageTime` inside the comparator, and a sort asks
+// several times as many questions as it has rows. The time is not a cheap read
+// — the date has crossed from the account that owns the row into the panel's
+// engine, and converting it back costs about a third of a millisecond — so a
+// merge of two 25-row mailboxes spent 244ms in `sort` alone, paid again on
+// every list change. The count is what keeps that from coming back.
+let timeReads = 0
+function countingTime(at) {
+  return { getTime: function() { timeReads += 1; return at } }
+}
+const unsorted = []
+for (let i = 0; i < 8; i++) {
+  unsorted.push({ id: String(i), subject: "s" + i, date: countingTime(1000 + (i % 3) * 1000) })
+}
+const timed = unified.mergeMessages([{ id: "a@x", label: "A", messages: unsorted }])
+assert.strictEqual(timed.length, 8)
+assert.strictEqual(timeReads, 8,
+  "one read per row, not one per comparison: " + timeReads + " reads for 8 rows")
+
+// Newest first, and the tie broken by id, with the times read that way.
+deepEqual(timed.map(function(row) { return row.sourceId }), ["2", "5", "1", "4", "7", "0", "3", "6"])
+
+// A row out of the merge carries no sort key of its own: the order is this
+// file's business and the panel reads the row's own fields.
+assert.strictEqual(timed[0].at, undefined)
+assert.strictEqual(timed[0].row, undefined)
+
+// A source with more to come is asked for one more time than its rows: the
+// watermark reads the oldest row it reported, to find where the merge has to
+// stop. That is the one read on top of the per-row one, and naming it here is
+// what keeps the count above from being read as "the merge never reads a time
+// anywhere else".
+timeReads = 0
+const paging = []
+for (let i = 0; i < 4; i++) {
+  paging.push({ id: String(i), subject: "s" + i, date: countingTime(4000 - i * 100) })
+}
+unified.mergeMessages([{ id: "a@x", label: "A", messages: paging, hasMore: true }])
+assert.strictEqual(timeReads, 5,
+  "one per row, plus the watermark's read of the oldest: " + timeReads)
 
 // Providers disagree about which field carries the time, and all of them have
 // to sort against each other.


### PR DESCRIPTION
Opening the window took a second, and switching between Inbox and Unread
took between half a second and a second and a half, on a mailbox holding
twenty-five rows. None of it was the network and none of it was the rows:
the cache read and the hydration measured zero, and drawing no rows at all
made no difference. It was `listEpoch`.

Every account bumps that epoch whenever its list, its loading flag, its
loaded flag, its paging or its error changes, and four properties are
computed from it — `unifiedSources`, `unifiedStates`, `unifiedAbilities`
and `unifiedMessages`. They were computed whether or not the merged view
was on, so a single mailbox paid to have every account's rows copied and
sorted into a list nobody was looking at. One bump cost about 115ms, and
one mailbox switch makes five or six of them.

Two things are wrong there, and they are separate. The first is that the
work happened at all: every consumer of those four properties already
reads `unified ? Unified.something(...) : the account's own answer`, so
nothing reads them unless the merged view is on. They return an empty list
now when it is not.

The second is the sort, which is what the merged view spends its own time
on. `messageTime` reaches into a row for a date that has crossed from the
account that owns it into this engine, and converting it back costs about
a third of a millisecond. Once per row that is nothing; inside a sort
comparator it is everything, because a sort asks several times as many
questions as it has rows — a merge of two 25-row mailboxes spent 244ms in
`sort` and 1ms building the rows it was sorting. The time is read once per
row on the way in and carried beside it now, and the rows come out of the
merge with the same shape they went in with.

Last, a cache-first paint no longer hands the list rows it is already
showing. `Cache.hydrate` rebuilds every row on every read, so two paints of
an unchanged mailbox share no object and `===` always said "different";
`Model.sameSummaries` compares what the rows say instead, to a bounded
depth, and the assignment is skipped when nothing differs. Reopening a
window onto a mailbox nothing has happened to is the ordinary case, and it
was repainting the whole list for it.

## Verification

`make validate` green on this commit, rebased onto v0.8.2 — and it does
run the QML suite: `validate` depends on `test`, and `test` on `test-qml`.
482 + 4 + 64 QML tests, 0 failed.

The rebase took one conflict, in `tests/test_model.js`, where main and this
branch had both appended a block to the end of the file; both are kept. The
audit that the four properties have no unguarded reader was redone against
the rebased tree, main having added about a hundred lines to `Service.qml`
in between: all thirteen call sites are still `unified ? ... : ...`, and
`tests/qml/tst_unified_routing.qml` still reads `unifiedAbilities` under a
merged fixture.

Measured on a two-account IMAP setup with 25 rows per mailbox, by timing
the toggle-to-mapped interval and by instrumenting `selectMailbox`:

| | before | after |
|---|---|---|
| click to window on screen | 947–1219 ms | 180–352 ms |
| switch to Unread | 579–586 ms | 26–27 ms |
| switch to Inbox | 743–1493 ms | 25–31 ms |
| switch, merged view on | 833–1057 ms | 173–189 ms |

`tests/test_unified.js` gains a count of how many times the merge reads a
row's time: 8 rows, 8 reads, and a paging source read once more than its
rows for the watermark. Against the old comparator the first reports 30
and fails. `tests/test_model.js` gains `sameSummaries` — rebuilt rows with
the same values, a change at every depth a summary actually reaches, a
reordering, a field that is `undefined` on one side and absent on the
other read from both directions, and the depth bound. Against
`origin/main` it fails at the first call. The bound is 4 where a summary
reaches 3; the tests admit either, and the comment says so rather than
pretending the fit is snug.

By hand, in the installed plugin: opening the window, stepping between
Inbox and Unread, and switching accounts, on two IMAP mailboxes.

A fresh agent reviewed the diff against AGENTS.md. It found no correctness
fault in any of the three changes, and proved the consumer audit and the
`unified` on/off/on transitions empirically rather than by reading. What
it did find is fixed here: `sameSummaryValue` was asymmetric — a key
holding `undefined` on one side and absent on the other compared equal one
way round and different the other, which is the ordinary case because
`JSON.stringify` drops such a key on the way to the cache — and two
comments described code that had moved. It also noted that `bar/Preview.js`
still sorts with `messageTime` inside its comparator; that list is capped
at three rows per account, so it is left alone here rather than widening
this change. Its security verdict was PASS.

## Release Notes

- The mail window opens in a fraction of the time it did, and switching
  between mailboxes is no longer a visible pause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
