### PR TITLE
Let a press on a menu row end at the menu row

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,24 @@ different features and only one of them is here.
   bug this rule exists to prevent.
 - A popup that would overflow flips to the other side of its trigger, then
   clamps to the window edge, then clamps to zero. All three, in that order.
+- A popup is `modal: true` with `dim: false`. Modality is what makes a press
+  outside it end at the overlay: a non-modal popup closes on that press *and*
+  lets it through, so putting a menu away also acted on whatever the menu was
+  covering. `dim` is off because the modality is there for the grab and not for
+  a scrim — the window behind a menu does not darken.
+- A clickable row inside a popup is a `MouseArea`, and so is anything the popup
+  may be drawn over. A `TapHandler` takes a *passive* grab: it answers the
+  press and lets it carry on down, so two of them stacked one over the other
+  both fire on the same release — choosing from a menu drawn over the mailbox
+  rail chose from the menu and switched the mailbox under it. Modality does not
+  help here, because an open popup does not stop a handler beneath it from
+  answering a press; only the exclusive grab a `MouseArea` takes does.
+  `tests/qml/tst_menu_over_rail.qml` holds both halves.
+- A control can both open and close its own popup, because the press that
+  closes a modal one never reaches the control. A non-modal popup needed a
+  "closed a moment ago" timestamp to tell the two apart; there is no such
+  timestamp any more, and reintroducing one would be the second mechanism for
+  something modality already does.
 
 ## Keys and focus
 

--- a/components/AccountSwitcher.qml
+++ b/components/AccountSwitcher.qml
@@ -131,7 +131,9 @@ Item {
     width: Style.space(250)
     implicitHeight: rows.implicitHeight + Style.space(8)
     padding: Style.space(4)
-    modal: false
+    // Modal and undimmed; see AGENTS.md, "Popups and their triggers".
+    modal: true
+    dim: false
     focus: true
     closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
     onHeightChanged: root.place()
@@ -246,8 +248,9 @@ Item {
         }
 
         HoverHandler { id: unifiedHover }
-        TapHandler {
-          onTapped: {
+        MouseArea {
+          anchors.fill: parent
+          onClicked: {
             menu.close()
             root.unifiedChosen()
           }
@@ -377,8 +380,9 @@ Item {
           }
 
           HoverHandler { id: rowHover }
-          TapHandler {
-            onTapped: {
+          MouseArea {
+            anchors.fill: parent
+            onClicked: {
               menu.close()
               root.accountChosen(row.index)
             }
@@ -441,6 +445,9 @@ Item {
     }
 
     HoverHandler { id: plainHover }
-    TapHandler { onTapped: plainRow.activated() }
+    MouseArea {
+      anchors.fill: parent
+      onClicked: plainRow.activated()
+    }
   }
 }

--- a/components/AppMenu.qml
+++ b/components/AppMenu.qml
@@ -100,7 +100,9 @@ Item {
     width: Style.space(210)
     implicitHeight: menuItems.implicitHeight + Style.space(8)
     padding: Style.space(4)
-    modal: false
+    // Modal and undimmed; see AGENTS.md, "Popups and their triggers".
+    modal: true
+    dim: false
     focus: true
     closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
     onHeightChanged: root.place()
@@ -200,8 +202,8 @@ Item {
     }
   }
 
-  // `enabled` is Item's own, and it already stops the handlers below from
-  // firing, so a disabled row only has to look disabled.
+  // `enabled` is Item's own, and a disabled item does not deliver a press to
+  // anything it contains, so a disabled row only has to look disabled.
   component MenuRow: MenuActionRow {
     width: menu.width - menu.leftPadding - menu.rightPadding
     textColor: root.textColor

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -312,24 +312,18 @@ DropArea {
     if (typeof root.service.switchTo === "function") root.service.switchTo(accountId)
   }
 
-  // When a control opens a popup that closes on a press outside itself, the
-  // press that reaches the control has already closed it — so by the time the
-  // release becomes a click, `opened` reads false and the toggle opens it
-  // straight back up. The control could never be used to put its own popup
-  // away, and it flickers instead. The moment it closed is what tells "the
-  // user wants this open" apart from "this just closed under the same press".
-  property double fromMenuClosedAt: 0
-
-  function reopeningAfterOutsidePress(closedAt) {
-    return Date.now() - closedAt < 250
-  }
-
+  // The button both opens and closes the menu, and it can, because the menu is
+  // modal: the press that closes it is taken by the overlay and never reaches
+  // the button, so the click that follows finds the menu already shut and
+  // opens it again. A non-modal popup could not be toggled by its own control
+  // — the press closed it before the release became a click, and the toggle
+  // opened it straight back up — which is what the timestamp this replaces was
+  // for. One mechanism now, and it is the one the menus already needed.
   function toggleFromMenu() {
     if (fromMenu.opened) {
       fromMenu.close()
       return
     }
-    if (reopeningAfterOutsidePress(fromMenuClosedAt)) return
     fromMenu.open()
   }
 
@@ -1459,13 +1453,16 @@ DropArea {
     width: Math.min(Style.space(360), root.width - Style.space(36))
     implicitHeight: Math.min(fromRows.implicitHeight + Style.space(8), Style.space(260))
     padding: Style.space(4)
-    modal: false
+    // Modal, for the same reason the other menus in this window are: a press
+    // outside a non-modal popup closes it and lands in whatever it was drawn
+    // over, and this one is drawn over the recipient fields.
+    modal: true
+    dim: false
     focus: opened
     z: 50
     closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
     onHeightChanged: root.placeFromMenu()
     onOpened: root.placeFromMenu()
-    onClosed: root.fromMenuClosedAt = Date.now()
     background: Rectangle {
       radius: Style.cornerRadius
       color: Qt.rgba(root.popupBackgroundColor.r, root.popupBackgroundColor.g,
@@ -1527,7 +1524,10 @@ DropArea {
         }
 
         HoverHandler { id: fromHover }
-        TapHandler { onTapped: root.chooseFrom(fromRow.modelData) }
+        MouseArea {
+          anchors.fill: parent
+          onClicked: root.chooseFrom(fromRow.modelData)
+        }
       }
     }
   }

--- a/components/ContactsPicker.qml
+++ b/components/ContactsPicker.qml
@@ -25,6 +25,12 @@ Item {
 
   signal contactChosen(var contact, string target)
 
+  // The popup's own content, which is not in this item's children: a
+  // `QQC.Popup` puts it under the window's overlay. `AccountSwitcher` exposes
+  // its rows the same way and for the same reason — a test has no other route
+  // to a row it means to press.
+  readonly property alias pickerContent: contentColumn
+
   anchors.fill: parent
   z: 60
 
@@ -56,18 +62,15 @@ Item {
     menu.close()
   }
 
-  // The popup closes on a press outside itself, and the control that opens it
-  // is outside it — so the press that looks like "close this" has already done
-  // so, and a plain `opened ? close() : openAt()` would reopen it on the
-  // release every time. The moment it closed is what separates the two.
-  property double closedAt: 0
-
+  // The control both opens and closes this, and it can, because the popup is
+  // modal: the press that closes it is taken by the overlay and never reaches
+  // the control. See `ComposeView.toggleFromMenu` for what a non-modal popup
+  // needed instead.
   function toggleAt(sceneX, sceneY) {
     if (menu.opened) {
       close()
       return
     }
-    if (Date.now() - closedAt < 250) return
     openAt(sceneX, sceneY)
   }
 
@@ -84,12 +87,13 @@ Item {
     width: Math.min(Style.space(340), root.width - Style.space(24))
     implicitHeight: Math.min(contentColumn.implicitHeight + Style.space(16), Style.space(420))
     padding: Style.space(8)
-    modal: false
+    // Modal and undimmed; see AGENTS.md, "Popups and their triggers".
+    modal: true
+    dim: false
     focus: true
     closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
     onHeightChanged: root.place()
     onOpened: root.place()
-    onClosed: root.closedAt = Date.now()
 
     background: Rectangle {
       radius: Style.cornerRadius
@@ -254,8 +258,17 @@ Item {
           }
 
           HoverHandler { id: contactHover }
-          TapHandler {
-            onTapped: {
+
+          // The rest of the row is "+ To" with a bigger target, so it stops
+          // short of the pills: filling the row would cover them, and taking
+          // the press exclusively — which is the point of using a `MouseArea`
+          // here at all — would leave Cc and Bcc unreachable.
+          MouseArea {
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            anchors.right: actionPills.left
+            onClicked: {
               root.contactChosen(contactRow.modelData, "to")
               menu.close()
             }

--- a/components/LabelPicker.qml
+++ b/components/LabelPicker.qml
@@ -82,7 +82,9 @@ Item {
     width: Math.min(Style.space(340), root.width - Style.space(24))
     implicitHeight: card.implicitHeight + Style.space(16)
     padding: Style.space(8)
-    modal: false
+    // Modal and undimmed; see AGENTS.md, "Popups and their triggers".
+    modal: true
+    dim: false
     focus: true
     closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
     onHeightChanged: root.place()
@@ -200,8 +202,9 @@ Item {
 
           HoverHandler { id: rowHover }
 
-          TapHandler {
-            onTapped: {
+          MouseArea {
+            anchors.fill: parent
+            onClicked: {
               root.cursorIndex = labelRow.index
               root.chooseCursor()
             }

--- a/components/MailboxSidebar.qml
+++ b/components/MailboxSidebar.qml
@@ -257,7 +257,15 @@ Item {
     }
 
     HoverHandler { id: hover }
-    TapHandler { onTapped: entry.activated() }
+    // A `MouseArea` rather than a `TapHandler`: a handler takes a passive grab
+    // and answers a press that was never meant for it, so pressing a rail row
+    // to dismiss a menu drawn over the rail both closed the menu and switched
+    // the mailbox underneath. A `MouseArea` grabs exclusively, and the menu
+    // above it is what the press reaches.
+    MouseArea {
+      anchors.fill: parent
+      onClicked: entry.activated()
+    }
 
     // The tooltip is how the rail stays usable while collapsed, and it carries
     // the count too, which the dot can only hint at.

--- a/components/MenuActionRow.qml
+++ b/components/MenuActionRow.qml
@@ -37,5 +37,13 @@ Rectangle {
   }
 
   HoverHandler { id: hover }
-  TapHandler { onTapped: root.activated() }
+  // A `MouseArea` rather than a `TapHandler`, and the difference is what the
+  // press does to everything under it. A handler takes a passive grab and
+  // leaves the press to carry on down the stack, so a row in a menu drawn over
+  // the rail chose from the menu *and* activated the rail row beneath it in the
+  // same click. A `MouseArea` grabs exclusively, which ends the press here.
+  MouseArea {
+    anchors.fill: parent
+    onClicked: root.activated()
+  }
 }

--- a/components/MessageMenu.qml
+++ b/components/MessageMenu.qml
@@ -135,7 +135,9 @@ Item {
     width: Style.space(200)
     implicitHeight: rows.implicitHeight + Style.space(8)
     padding: Style.space(4)
-    modal: false
+    // Modal and undimmed; see AGENTS.md, "Popups and their triggers".
+    modal: true
+    dim: false
     focus: true
     closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
     onHeightChanged: root.place()

--- a/tests/qml/tst_account_switcher.qml
+++ b/tests/qml/tst_account_switcher.qml
@@ -28,6 +28,15 @@ Item {
       unread: 2, active: true, signedIn: true, busy: false, error: "" }
   ]
 
+  // What sits behind the menu. A press that reaches this has gone through an
+  // open popup, which is the thing a menu exists to stop.
+  MouseArea {
+    id: behind
+    anchors.fill: parent
+    property int presses: 0
+    onClicked: presses += 1
+  }
+
   Omamail.AccountSwitcher {
     id: switcher
     anchors.fill: parent
@@ -231,6 +240,36 @@ Item {
       keyClick(Qt.Key_O)
       compare(chosenSpy.count, 1)
       compare(chosenSpy.signalArguments[0][0], 1)
+    }
+
+    // Putting the menu away is putting the menu away, and nothing else. A
+    // non-modal popup closes on an outside press and lets that same press
+    // through: the click that dismissed the menu also landed on whatever the
+    // menu had been covering — a row selected, a mailbox switched, by somebody
+    // who was only trying to get rid of it.
+    function test_a_press_outside_closes_the_menu_and_stops_there() {
+      behind.presses = 0
+      switcher.openCentered()
+      verify(switcher.opened, "the menu is open")
+
+      mouseClick(behind, behind.width - 10, behind.height - 10)
+
+      compare(switcher.opened, false, "the press outside closes it")
+      compare(behind.presses, 0, "and does not reach what it was covering")
+    }
+
+    // The other half: modality must not cost the menu its own mouse.
+    function test_a_row_still_answers_the_mouse() {
+      behind.presses = 0
+      switcher.openCentered()
+      var rows = accountRows()
+      verify(rows.length > 1, "the menu drew its rows")
+
+      mouseClick(rows[1], rows[1].width / 2, rows[1].height / 2)
+
+      compare(chosenSpy.count, 1, "the row under the pointer was chosen")
+      compare(switcher.opened, false, "and choosing closes the menu")
+      compare(behind.presses, 0, "with nothing reaching past it")
     }
   }
 }

--- a/tests/qml/tst_compose_recipients.qml
+++ b/tests/qml/tst_compose_recipients.qml
@@ -71,6 +71,19 @@ Item {
       return null
     }
 
+    // Popup content is not in the compose view's child tree until the popup
+    // has been opened, and the pills are named by what they say.
+    function havingText(item, wanted) {
+      if (!item) return null
+      if (item.text === wanted && item.width > 0) return item
+      var values = item.children || []
+      for (var i = 0; i < values.length; i++) {
+        var found = havingText(values[i], wanted)
+        if (found) return found
+      }
+      return null
+    }
+
     function init() {
       mailService.sendPending = false
       mailService.sending = false
@@ -283,6 +296,50 @@ Item {
       picker.contactChosen({ name: "Bob", email: "bob@example.com" }, "cc")
       compare(compose.ccVisible, true)
       compare(named(compose, "compose-cc-field").text, "Bob <bob@example.com>")
+    }
+
+    // A contact row is "+ To" over its whole width, which is why it carries a
+    // `MouseArea` — one that takes the press exclusively, so it cannot reach
+    // past the menu. That area has to stop at the pills. Filling the row
+    // covered them, and because it grabs rather than passes the press on, Cc
+    // and Bcc became unreachable: every pill added the contact to To.
+    function test_the_cc_pill_adds_to_cc_and_not_to_to() {
+      compose.begin("new", null, "", [])
+      var picker = named(compose, "compose-contacts-picker")
+      verify(picker)
+      picker.open()
+      // A popup builds and places its contents on the first open, so a press
+      // aimed at a row before that lands nowhere.
+      waitForRendering(compose)
+
+      var pill = havingText(picker.pickerContent, "+ Cc")
+      verify(pill, "the row offers a Cc pill")
+      mouseClick(pill, pill.width / 2, pill.height / 2)
+
+      compare(compose.ccVisible, true, "the Cc field is shown")
+      verify(named(compose, "compose-cc-field").text.indexOf("@") >= 0,
+        "the address went to Cc")
+      compare(named(compose, "compose-to-field").text, "",
+        "and not to To, which is what covering the pill did")
+    }
+
+    // The picker is modal, so that a press outside it closes it without also
+    // landing in the compose field underneath. Modality moves the keyboard,
+    // though, and picking an address is the middle of typing one: the field
+    // has to be ready for the next name the moment the picker goes.
+    function test_picking_leaves_the_keyboard_in_the_field() {
+      compose.begin("new", null, "", [])
+      var picker = named(compose, "compose-contacts-picker")
+      verify(picker)
+
+      picker.open()
+      verify(compose.contactsPickerOpened, "the picker is open")
+      picker.contactChosen({ name: "Alice", email: "alice@example.com" }, "to")
+      picker.close()
+
+      var field = named(compose, "compose-to-field")
+      compare(field.text, "Alice <alice@example.com>")
+      verify(field.activeFocus, "the field the address went into is the one that types")
     }
   }
 }

--- a/tests/qml/tst_menu_over_rail.qml
+++ b/tests/qml/tst_menu_over_rail.qml
@@ -1,0 +1,264 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../.." as Omamail
+
+// A menu drawn over the mailbox rail, and what a press on it reaches.
+//
+// The account menu opens from the address in the status line, which is at the
+// bottom left, so it goes up from there across the rail's own rows. Two
+// different presses used to reach those rows through it, and the fixture below
+// is only what the window needs to be built and opened — the fake mailbox
+// answers what `App.qml` reads, and nothing here drives mail.
+Item {
+  width: 900
+  height: 600
+
+  QtObject { id: fakeShell; function hide(_id) {} }
+
+  QtObject {
+    id: fakeAuth
+    property bool credentialsPresent: false
+    property bool loggedIn: false
+    property bool loginBusy: false
+    property bool toolsChecked: true
+    property bool toolsPresent: true
+    property bool credentialsWriteBusy: false
+    property var missingTools: []
+    property string lastError: ""
+    property string clientId: ""
+    property string clientDescription: ""
+    property string credentialsPath: ""
+    property var credentials: null
+    property var settings: ({ imapHost: "", imapPort: 993, smtpHost: "", smtpPort: 465,
+      username: "", aliases: [], insecure: false })
+    function recheck() {}
+    function saveCredentials() {}
+  }
+
+  QtObject {
+    id: mailService
+
+    property bool ready: true
+    property bool anyAccountReady: true
+    property bool hasSavedAccounts: true
+    property bool sendPending: false
+    property bool sending: false
+    property bool windowOpen: false
+    property bool sidebarCollapsed: false
+    property bool alwaysShowImages: false
+    property bool unifiedCalendarView: false
+    property bool selectedReaderEmpty: false
+    property bool selectedReaderTooHeavy: false
+    property bool selectedTooHeavy: false
+    property bool detailLoading: false
+    property bool detailPainted: false
+    property bool canOpenOnWeb: false
+    property bool canRespondToInvite: false
+    property bool rsvpSending: false
+    property bool canArchive: true
+    property bool canStar: true
+    property bool canSpam: true
+    property bool canTrash: true
+    property bool canMarkRead: true
+    property bool canMarkUnread: true
+    property bool accountDraftOpen: false
+    property bool signInProgress: false
+    property int sendSecondsRemaining: 10
+    property int accountCount: 1
+    property int inboxUnread: 0
+    property real bodyZoom: 1
+    property string bodyMode: "reader"
+    property string providerId: "imap"
+    property string pluginDir: ""
+    property string accountEmail: "me@example.com"
+    property string accountAddress: "me@example.com"
+    property string activeAccountId: "me@example.com"
+    property string mailboxKey: "inbox"
+    property string searchQuery: ""
+    property string rawQuery: ""
+    property string selectedId: ""
+    property string lastError: ""
+    property string actionStatus: ""
+    property string syncedLabel: ""
+    property string recipientContactStatus: ""
+    property var auth: fakeAuth
+    property var accountSummaries: [{ provider: "imap", email: "me@example.com" }]
+    property var mailboxes: []
+    property var labels: []
+    property var messages: []
+    property var selectedAttachments: []
+    property var selectedInvite: null
+    property var selectedResponse: ""
+    property var recipientContacts: []
+    property var sendAsAliases: []
+    property var sendIdentities: []
+    property var calendarController: null
+    property var selectedBody: ({ text: "", source: "" })
+    property var selectedMessage: null
+
+    signal accountAdded()
+    signal replySent()
+
+    // What the window calls while it is being opened, and what choosing an
+    // account from the menu calls. None of them has to do anything here: this
+    // test is about which of them are reached, not what they do.
+    function selectMailbox(key) { mailboxKey = String(key || "") }
+    function switchToIndex(_index) { return true }
+    function clearSelection() { selectedId = "" }
+    function select(id) { selectedId = String(id || "") }
+    function search(_query) {}
+    function refresh() {}
+    function preferredSendAs(_recipients) { return null }
+    function refreshRecipientContacts() {}
+    function cursorOffset(_id, _delta) { return "" }
+    function editingIndex() { return 0 }
+    function fail(text) { lastError = String(text || "") }
+    function note(text) { actionStatus = String(text || "") }
+    function refuseUnavailableAction(_action) { return false }
+  }
+
+  Omamail.App {
+    id: app
+    service: mailService
+    shell: fakeShell
+  }
+
+  SignalSpy { id: railSpy; signalName: "activated" }
+  SignalSpy { id: chosenSpy; signalName: "accountChosen" }
+
+  // A menu drawn over the rail, which is where the account menu opens: the
+  // address in the status line is at the bottom left, and the menu goes up
+  // from it across the mailbox rows.
+  //
+  // Both halves of a click leaked into those rows, by two different routes.
+  // Choosing from the menu went through the menu row and fired the rail row
+  // beneath it, because a `TapHandler` takes a passive grab and lets the press
+  // carry on down. Pressing a rail row to dismiss the menu fired it too, for
+  // the same reason: modality stops an item from seeing the press, and a
+  // handler is not an item. So the rows on both sides of this are `MouseArea`s
+  // now, which grab exclusively, and the press ends where it landed.
+  TestCase {
+    name: "MenuOverRail"
+    when: windowShown
+
+    function collect(item, accept, out) {
+      if (!item) return out
+      if (accept(item)) out.push(item)
+      var kids = item.children || []
+      for (var i = 0; i < kids.length; i++) collect(kids[i], accept, out)
+      return out
+    }
+
+    function menuRows(item, out) {
+      if (!item) return out
+      if (item.objectName === "account-row") out.push(item)
+      var kids = item.children || []
+      for (var i = 0; i < kids.length; i++) menuRows(kids[i], out)
+      return out
+    }
+
+    function railRows() {
+      return collect(app, function(it) {
+        return typeof it.activated === "function" && it.label !== undefined
+          && it.icon !== undefined && it.width > 0
+      }, [])
+    }
+
+    function switcher() {
+      return collect(app, function(it) {
+        return typeof it.openAt === "function" && it.accounts !== undefined
+      }, [])[0]
+    }
+
+    // Enough rows that the rail reaches the part of the window the menu is
+    // drawn over. A short rail leaves the menu hanging in empty space, which
+    // is the arrangement in which this bug cannot be seen at all.
+    function init() {
+      var boxes = []
+      for (var n = 0; n < 20; n++) {
+        boxes.push({ key: "box" + n, label: "Mailbox " + n, icon: "inbox" })
+      }
+      mailService.mailboxes = boxes
+      app.open("{}")
+      // The rail has to have been laid out before anything can ask what the
+      // menu is drawn over.
+      waitForRendering(app)
+    }
+
+    function openOverTheRail() {
+      var sw = switcher()
+      verify(sw, "the window has an account menu")
+      sw.accounts = [
+        { id: "a@x", email: "a@x", label: "A", unread: 1, active: true,
+          signedIn: true, busy: false, error: "" },
+        { id: "b@x", email: "b@x", label: "B", unread: 0, active: false,
+          signedIn: true, busy: false, error: "" }
+      ]
+      var where = sw.mapToGlobal(0, 0)
+      sw.openAt(where.x + 8, where.y + sw.height - 12)
+      // A popup builds its contents on its first open, so its height — and
+      // therefore where `place` puts it — settles a frame later.
+      waitForRendering(app)
+      verify(sw.opened, "the menu is open")
+      return sw
+    }
+
+    function test_choosing_from_the_menu_leaves_the_rail_alone() {
+      var sw = openOverTheRail()
+      var rail = railRows()
+      var rows = menuRows(sw.menuRows, [])
+      verify(rows.length > 1, "the menu drew its rows")
+
+      // The row to press is one the menu actually covers; anywhere else and
+      // the test proves nothing.
+      var pressed = null
+      var covered = null
+      for (var m = 0; m < rows.length && !covered; m++) {
+        var at = rows[m].mapToGlobal(rows[m].width / 2, rows[m].height / 2)
+        for (var i = 0; i < rail.length; i++) {
+          var corner = rail[i].mapToGlobal(0, 0)
+          if (at.x >= corner.x && at.x <= corner.x + rail[i].width
+              && at.y >= corner.y && at.y <= corner.y + rail[i].height) {
+            pressed = rows[m]
+            covered = rail[i]
+            break
+          }
+        }
+      }
+      verify(covered, "a menu row is drawn over a rail row")
+
+      railSpy.target = covered
+      railSpy.clear()
+      chosenSpy.target = sw
+      chosenSpy.clear()
+      mouseClick(pressed, pressed.width / 2, pressed.height / 2)
+
+      compare(sw.opened, false, "choosing closes the menu")
+      compare(chosenSpy.count, 1, "the account the pointer was on is the one chosen")
+      compare(railSpy.count, 0, "and the rail row under it is not also chosen")
+    }
+
+    function test_pressing_the_rail_to_dismiss_the_menu_only_dismisses_it() {
+      var sw = openOverTheRail()
+      var rail = railRows()
+      var rows = menuRows(sw.menuRows, [])
+
+      // A rail row the menu does not cover: pressing it is "outside".
+      var menuTop = rows[0].mapToGlobal(0, 0).y
+      var free = null
+      for (var i = 0; i < rail.length && !free; i++) {
+        var corner = rail[i].mapToGlobal(0, 0)
+        // Above where the menu begins, so pressing it is a press outside.
+        if (corner.y + rail[i].height < menuTop) free = rail[i]
+      }
+      verify(free, "a rail row sits above the menu")
+
+      railSpy.target = free
+      railSpy.clear()
+      mouseClick(free, free.width / 2, free.height / 2)
+
+      compare(sw.opened, false, "the press outside closes the menu")
+      compare(railSpy.count, 0, "and does not also switch the mailbox it landed on")
+    }
+  }
+}

--- a/tests/qml/tst_popup_keys.qml
+++ b/tests/qml/tst_popup_keys.qml
@@ -27,10 +27,14 @@ Item {
   Shortcut { sequence: "j"; onActivated: host.windowShortcut = "j" }
   Shortcut { sequence: "Alt+A"; onActivated: host.windowShortcut = "alt-a" }
 
+  // Modal and undimmed, which is what every popup in this window is: the rule
+  // being held to here is about keys, and it has to be held to on the shape
+  // the app actually ships.
   QQC.Popup {
     id: focusedPopup
     width: 100; height: 80
-    modal: false
+    modal: true
+    dim: false
     focus: true
     closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
     contentItem: Item {
@@ -46,7 +50,8 @@ Item {
   QQC.Popup {
     id: unfocusedPopup
     width: 100; height: 80
-    modal: false
+    modal: true
+    dim: false
     focus: false
     closePolicy: QQC.Popup.CloseOnEscape | QQC.Popup.CloseOnPressOutside
   }


### PR DESCRIPTION
The account menu opens from the address in the status line, at the bottom
left, and goes up from there across the mailbox rail. Choosing a mailbox
from it also activated the rail row the menu was drawn over: the account
switched and the mailbox switched with it, in one click, and the second
half of that was never asked for. Pressing a rail row to dismiss the menu
did the same thing — the menu closed and the mailbox changed.

Both halves are the same mistake, and it is not modality. The rows in
these menus were drawn with a `TapHandler`, and so are the rows on the
rail. A handler takes a *passive* grab: it answers the press and lets it
carry on down the stack, so two of them stacked one over the other both
saw the same press and both fired their tap on the release. A `MouseArea`
takes the exclusive grab instead, and the press ends where it landed. The
rows on both sides of this are `MouseArea`s now — every clickable row in
the five popups, and the rail rows underneath them.

Modality is the other half of the story and is here too, because the two
routes into a window are not the same. A non-modal popup closes on an
outside press and lets that press through to whatever *item* is under it,
so dismissing a menu drawn over the message list also selected the row it
was covering. `modal: true` stops that; `dim: false` keeps it from
darkening the window behind a menu, which is not what modality is here
for. The two halves are not interchangeable and both are load-bearing:
with only the `MouseArea`s, pressing the rail to dismiss the menu still
switched the mailbox; with only modality, choosing from the menu still
did. An open popup does not stop a `TapHandler` beneath it from answering
a press — which is the whole reason the rail rows had to change as well.

Both rules are in AGENTS.md now, under *Popups and their triggers*, rather
than pasted into five files that each know half of them.

Two things follow from modality and are worth naming. A control can open
*and* close its own popup now, because the press that closes a modal one
never reaches the control — so the "closed a moment ago" timestamps that
`ComposeView` and `ContactsPicker` kept for that are gone, along with the
250ms window in which they silently dropped a genuine reopen. And while
any of these menus is up, a press outside it puts it away and does nothing
else: right-clicking a different message row no longer moves the row menu
there in one click, and middle-click-archive is swallowed. That is what
dismissing a menu should cost, but it is a change.

## Verification

`make validate` green on this commit — which runs the QML suite: `validate`
depends on `test`, and `test` on `test-qml`. 453 QML tests, 0 failed.

`tests/qml/tst_menu_over_rail.qml` is the reproduction, driven through the
real window: it fills the rail with enough rows to reach the part of the
window the menu is drawn over, opens the menu where the status line opens
it, and watches the rail row under the pointer. Both gestures — choosing
from the menu, and pressing the rail to dismiss it — report one activation
of the covered rail row against `main`'s components and none with the
change. A short rail is the arrangement in which this bug cannot be seen
at all, which is why the test builds a long one.

`tests/qml/tst_account_switcher.qml` gains the item-side pair: a press
outside the menu closes it without reaching the surface behind, and a row
still answers its own mouse. The first fails against the unfixed code with
"and does not reach what it was covering".

`tests/qml/tst_compose_recipients.qml` gains two. A contact's `+ Cc` pill
puts the address in Cc — it fails against the first draft of this change,
which had covered the pills; see below. And picking an address leaves the
keyboard in the field it went into, which is the one thing modality could
have cost the compose view.

`tests/qml/tst_popup_keys.qml`'s fixtures are modal now. AGENTS.md points
at that file to hold the rule that a popup answers its own keys, and it
was holding it for a shape the app no longer ships.

A fresh agent reviewed the diff against AGENTS.md. It found a blocker I
had shipped: the row-wide `MouseArea` in `ContactsPicker` was declared
after the `+ To` / `+ Cc` / `+ Bcc` pills and covered them, so every pill
added to To — the exclusive grab that fixes this bug is exactly what made
that unreachable, where the old handler had let the press through to the
button. It also found a fifth popup with the same defect, `ComposeView`'s
From menu, which the first draft missed; the dead reopen guards; a stale
comment in `AppMenu`; and that the new test file had been copied whole
from `tst_app_navigation.qml`, header comment and 180 lines of unused
fixture included. All are fixed here. Its security verdict was PASS.

Not done, and needed before this merges: driving it on a screen. These are
offscreen tests and they cannot see a menu that lands four pixels off or a
hover that stopped following the pointer. Somebody has to open the account
menu, the message menu, the app menu, the label picker, the contacts
picker and the From menu with the mouse, in a light theme and a dark one
and at both window sizes, and put a screenshot here.

## Release Notes

- Choosing an account from the menu no longer also switches the mailbox
  the menu was covering, and dismissing a menu no longer acts on whatever
  was underneath it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
