### PR TITLE
Walk a recurrence from the range it is asked for, not from its DTSTART

### DIFF
--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -196,7 +196,7 @@ function recurrenceUntil(value) {
     Number(match[4] || 0), Number(match[5] || 0), Number(match[6] || 0)).getTime()
 }
 
-function recurrenceStarts(event, rangeEnd) {
+function recurrenceStarts(event, rangeStart, rangeEnd) {
   if (!event || !event.start || !event.recurrenceRule) return []
   var parts = recurrenceParts(event.recurrenceRule)
   var frequency = String(parts.FREQ || "").toUpperCase()
@@ -220,6 +220,22 @@ function recurrenceStarts(event, rangeEnd) {
   var rangeLimit = Number(rangeEnd) || base.getTime()
   var limit = zoned ? rangeLimit + 86400000
     : Math.min(rangeLimit, until > 0 ? until + 1 : rangeLimit)
+
+  // Every test below is a delta from `base`, so the walk can begin on any day
+  // and still match the same ones. Begin it two days short of the range rather
+  // than at DTSTART: the two days cover the zone offset a zoned cursor carries
+  // (no zone sits more than 14 hours from UTC), and a rule from years back no longer pays for every day since it started
+  // on each refresh — nor runs into the ceiling below before reaching the
+  // range at all. COUNT is the one rule that counts from the start, so it is
+  // still walked from there.
+  var from = Number(rangeStart) || 0
+  if (countLimit === 0 && from > 0) {
+    var skipped = Math.floor((from - 2 * 86400000 - base.getTime()) / 86400000)
+    if (skipped > 0) {
+      if (utc) cursor.setUTCDate(cursor.getUTCDate() + skipped)
+      else cursor.setDate(cursor.getDate() + skipped)
+    }
+  }
 
   for (var scanned = 0; scanned < 10000 && cursor.getTime() < limit; scanned++) {
     var cursorYear = datePart(cursor, "getFullYear", "getUTCFullYear", utc)
@@ -319,7 +335,7 @@ function expandRecurringEvents(events, startMs, endMs) {
     var excluded = {}
     var exclusions = Array.isArray(master.excludedMs) ? master.excludedMs : []
     for (var x = 0; x < exclusions.length; x++) excluded[Number(exclusions[x])] = true
-    var starts = recurrenceStarts(master, endMs)
+    var starts = recurrenceStarts(master, startMs, endMs)
     for (var o = 0; o < starts.length; o++) {
       var key = String(master.uid) + "\n" + Number(starts[o])
       var replacement = overrides[key]

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -237,6 +237,35 @@ const utcRecurringEvents = feed.eventsFromCaldav(utcRecurringXml, "work",
 assert.strictEqual(utcRecurringEvents.length, 1)
 assert.strictEqual(utcRecurringEvents[0].start.ms, Date.UTC(2026, 8, 18, 12, 0))
 
+// A rule from long ago is walked from the range it is asked for, not from its
+// DTSTART. Walking from 1990 hit the loop's 10 000-day ceiling twenty-seven
+// years in and returned nothing for 2026; the rules that did reach the range
+// paid for every day since they began, on the shell's main thread, on every
+// refresh — a weekly event from 2023 cost a quarter of a second each.
+const ancientXml = recurringXml
+  .replace("RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=TH", "RRULE:FREQ=WEEKLY;BYDAY=TH")
+  .replace(/20240208T140000/g, "19900104T140000")
+  .replace(/20240208T150000/g, "19900104T150000")
+const ancientEvents = feed.eventsFromCaldav(ancientXml, "work",
+  Date.UTC(2026, 7, 23), Date.UTC(2026, 8, 24))
+assert.deepStrictEqual(JSON.parse(JSON.stringify(ancientEvents.map(function(event) { return event.start.ms }))), [
+  Date.UTC(2026, 7, 27, 12, 0), Date.UTC(2026, 8, 10, 12, 0), Date.UTC(2026, 8, 18, 12, 0)
+], "every Thursday in range, minus the EXDATE, plus the moved one")
+assert.deepStrictEqual(JSON.parse(JSON.stringify(ancientEvents.map(function(event) { return event.summary }))),
+  ["Standup", "Standup", "Moved standup"])
+
+// COUNT is the one rule that has to be counted from the start, so it still is:
+// ten Thursdays from July reach 3 September and no further, whatever the range.
+const countedXml = recurringXml
+  .replace("RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=TH", "RRULE:FREQ=WEEKLY;BYDAY=TH;COUNT=10")
+  .replace(/20240208T140000/g, "20260702T140000")
+  .replace(/20240208T150000/g, "20260702T150000")
+const countedEvents = feed.eventsFromCaldav(countedXml, "work",
+  Date.UTC(2026, 7, 23), Date.UTC(2026, 8, 24))
+assert.deepStrictEqual(JSON.parse(JSON.stringify(countedEvents.map(function(event) { return event.start.ms }))), [
+  Date.UTC(2026, 7, 27, 12, 0), Date.UTC(2026, 8, 18, 12, 0)
+], "27 August is the ninth, 3 September the tenth and excluded, 17 September is past COUNT")
+
 const days = feed.monthDays(2026, 7, 1)
 assert.strictEqual(days.length, 42)
 assert.strictEqual(days[0].isoDate, "2026-07-27")


### PR DESCRIPTION
## Summary

With a few CalDAV calendars that hold long-running recurring events, every calendar refresh pins the shell's main thread for well over Hyprland's ANR threshold. The user sees Hyprland's "not responding" dialog on the Omamail window, and the whole `omarchy-shell` process (bar, launcher, every other plugin) freezes for the same period. The time goes to `recurrenceStarts()` in `calendar/Calendar.js`, which advances a cursor one day at a time from the event's original `DTSTART` to the end of the requested range, doing full calendar and time-zone arithmetic on every step, on the main thread.

## Environment

- Omamail 0.8.1 (c5d87ef, which this branch is based on); `main` at 7f7c1f0 (v0.8.2 + #151) does not change the code involved
- Omarchy 4.0.2, Quickshell 0.3.1, Hyprland 0.56.2, Arch Linux
- Four CalDAV sources (iCloud), 40 VEVENT resources in total, 22 recurring masters
- Hyprland `misc:enable_anr_dialog = true`, `misc:anr_missed_pings = 3` (Omarchy default); Hyprland pings every 1.5 s (`src/managers/ANRManager.cpp`, `TIMER_TIMEOUT`), so a main-thread stall of ~4.5 s is enough to show the dialog

## What happens

1. Open the Omamail window (or wait for the 600 s bar-preview timer in `Service.qml`, or restart the shell).
2. Each CalDAV source is fetched by `calendar-transport.sh`; on `onExited` the reply is parsed with `Calendar.eventsFromCaldav(...)`, which calls `expandRecurringEvents` → `recurrenceStarts` for every master.
3. The main thread of the `quickshell` process stays at 100 % for the duration. Sampled `/proc/<pid>/task/<pid>/stat` at 0.5 s intervals while opening the window: 50 busy ticks per 0.5 s, state `R`, continuously from t+2 s to t+19 s. Hyprland shows the ANR dialog after about 4.5 s of that.

The bar is a layer-shell surface, so the dialog only appears while the Omamail toplevel exists. The freeze itself happens on every refresh whether the window is open or not.

## Measurements

The same code path, run in Node 26 (V8) on the exact `calendarData` the plugin had cached, with a one-month range (`eventsFromCaldav(xml, id, start, end)` per source). V8 is several times faster than QV4 at this kind of code, so these are lower bounds for what the shell pays:

| Source | Resources | Recurring masters | Occurrences out | `eventsFromCaldav` |
|---|---|---|---|---|
| A | 14 | 9 | 15 | 1 320 ms |
| B | 10 | 4 | 22 | 599 ms |
| C | 13 | 9 | 39 | 60 ms |
| D | 3 | 0 | 3 | 2 ms |
| **Total** | 40 | 22 | 79 | **~2.0 s** |

Per-master cost of `recurrenceStarts(master, rangeEnd)`, top entries:

| Occurrences returned | Rule | DTSTART | Time |
|---|---|---|---|
| 183 | `FREQ=WEEKLY` | 2023-04 (TZID=Europe/Brussels) | 254 ms |
| 5 | `FREQ=YEARLY` | 2022-09 (TZID) | 243 ms |
| 176 | `FREQ=WEEKLY` | 2023-05 (TZID) | 242 ms |
| 5 | `FREQ=YEARLY` | 2022-09 (TZID) | 241 ms |
| 3 | `FREQ=YEARLY;INTERVAL=2;BYMONTH=10` | 2022-10 (TZID) | 233 ms |
| 4 | `FREQ=YEARLY` | 2023-09 (TZID) | 192 ms |
| 22 | `FREQ=WEEKLY;INTERVAL=8;BYDAY=TH` | 2023-05 (TZID) | 187 ms |
| 62 | `FREQ=WEEKLY` | 2025-08 (TZID) | 72 ms |
| 8 | `FREQ=WEEKLY;UNTIL=…` | 2026-08 (TZID) | 9 ms |

The cost tracks **days between DTSTART and the range end**, not the number of occurrences: a yearly birthday from 2022 (5 hits) costs the same as a weekly meeting from 2023 (183 hits), about 0.17 ms per day walked in V8. Source C has as many masters as source A but they all started in 2026, hence 60 ms instead of 1 320 ms.

Two things I ruled out:

- **Time-zone parsing is not the hot spot.** Memoising `timezoneDocument(blocks)`/`timezoneFor` per `(tzid, blocks)` so `timeInZone` no longer re-parses the VTIMEZONE on every day: total unchanged (2 104 ms). Replacing `timeInZone` with a constant-offset stub: still 1 971 ms. The loop body itself (`datePart` ×6, `calendarDayNumber` ×2, `weekNumber` ×2, `matchesByDay`, a `Date` mutation per iteration) is what costs, multiplied by the number of days walked.
- **The cache does not help across refreshes.** `CalendarCache` stores expanded occurrences, so every refresh re-fetches and re-expands from the raw ICS. Each cached occurrence also carries its full `calendarData` (ICS + the complete historical VTIMEZONE), which is why `~/.cache/omamail/calendar-bar.json` sits at 4.7 MB for 8 ranges × 70 events and is rewritten in full every 10 minutes. Bounded by `MAX_RANGES`, but not free on the same thread.

## Where the time goes

`calendar/Calendar.js`, `recurrenceStarts()`:

```js
var cursor = new Date(base.getTime())          // base = DTSTART
…
for (var scanned = 0; scanned < 10000 && cursor.getTime() < limit; scanned++) {
  // six datePart() calls, two calendarDayNumber(), two weekNumber(), matchesByDay()…
  var occurrenceMs = cursor.getTime()
  if (zoned) occurrenceMs = Ics.timeInZone({…}, tzid, source.timezones).ms   // every day, matched or not
  …
  if (utc) cursor.setUTCDate(cursor.getUTCDate() + 1) else cursor.setDate(cursor.getDate() + 1)
}
```

A weekly event from April 2023 asked for September 2026 walks ~1 250 days to return the ~5 that fall in the range, and does so again on the next refresh.

## The change

`recurrenceStarts(event, rangeStart, rangeEnd)` now takes the range start. Every match the loop makes is a delta from `base` (day, week, month or year delta modulo `INTERVAL`), so the cursor can begin on any day and still match the same ones. It begins two days short of `rangeStart`: the slack covers the offset a zoned cursor carries (wall clock stored as UTC). `COUNT` is the one rule that has to be counted from the beginning, so a rule with `COUNT` still walks from DTSTART. Nothing else in the loop changed; `expandRecurringEvents` passes `startMs` through.

Cost goes from O(days since DTSTART) to O(days in range). Same four calendars, same harness: **2.0 s → 180 ms** in V8 (A: 1 320 → 55 ms, B: 599 → 62 ms). In the shell, opening the window with the same data went from 18 s of solid main-thread CPU to about 4 s spread over 40 s with no burst above 0.5 s, so the ANR dialog can no longer trigger from this path.

Not in this PR, noted for later: moving the parse off the main thread would make any slow source harmless whatever its shape, and each cached occurrence still carries its full `calendarData`, which is why the bar cache is 4.7 MB.

## Verification

`make validate` green on 562bc60 (test-js 30 files, test-shell, test-qml, qml-check, `omarchy plugin validate .`, `git diff --check`; the two qmllint warnings it prints are in `bar/BarPreview.qml`, untouched here). `tests/test_calendar_feed.js` gains two cases and both fail with the change reverted: a weekly Thursday rule with `DTSTART` in January 1990 asked for 23 August–24 September 2026 returns its three rows (27 August, 10 September, the moved 18 September) minus the `EXDATE` on 3 September, where `main` hits the 10 000-day ceiling in 2017 and returns only the detached override; and a `COUNT=10` weekly rule from 2 July 2026 returns 27 August and the moved 18 September only, since 3 September is the tenth and excluded and 17 September is past the count.

Live: Omarchy 4.0.2 / Quickshell 0.3.1 / Hyprland 0.56.2, four iCloud CalDAV sources plus one Gmail calendar, month view and bar preview, before and after, with the main thread of the `quickshell` process sampled from `/proc` every 0.5 s while the window opened. Before: 18 s at 100 % and Hyprland's not-responding dialog. After: about 4 s of CPU spread over 40 s, no half-second above 92 %, no dialog. Same rows in the month grid and the bar preview.

A fresh agent reviewed the diff: verdict safe. It confirmed the WEEKLY delta (`weekNumber`) depends only on calendar fields, so skipping ahead cannot shift alignment; that COUNT rules still walk from DTSTART; and that the `occurrenceMs >= event.start.ms` guard is unaffected because the skip only fires when the range start is past DTSTART. Its one finding, that the two-day slack should say why it bounds every zone offset, is in the comment now. It noted no test with a near-14 h offset or a MONTHLY/YEARLY `BYMONTHDAY` rule far from its start; the delta logic is frequency-agnostic, so those were left out.

## Release Notes

- Calendars with recurring events that started years ago no longer freeze the shell on every refresh, and a rule older than 27 years shows its occurrences again instead of nothing.
