### PR TITLE
Find the plugin's own directory when the manifest does not carry it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ three directories away from the client that calls it.
 
 | Module | What it is |
 |-----------------|--------------------------------------------------------|
-| root | `Service.qml`, `BarWidget.qml`, `App.qml`, and nothing else. `manifest.json` names these three and the shell loads them at that path. |
+| root | `Service.qml`, `BarWidget.qml`, `App.qml`, and `PluginPath.js`. `manifest.json` names the three QML files and the shell loads them at that path. The one library here answers where the plugin is installed, which is a fact about this directory rather than about any module under it, and it reads that from `Service.qml`'s own URL: the service entry point stays at the root, or the answer becomes a wrong directory instead of none. `tests/test_service_source.sh` holds that. |
 | `providers/` | Everything that differs between mail services: a description per provider, the registry over them, the protocol each speaks, and the pair of objects — signs in, fetches — that each needs. |
 | `account/` | One mailbox and the list of them. `MailAccount.qml`, `Accounts.js`, and the rules in `Model.js` about what a list does after an action. |
 | `cache/` | What a query result and a message body are kept in, and the two objects that keep them. |

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ test-js:
 	node tests/test_oauth.js
 	node tests/test_microsoft_oauth.js
 	node tests/test_credentials.js
+	node tests/test_plugin_path.js
 	node tests/test_secrets.js
 	node tests/test_gmail_api.js
 	node tests/test_message.js

--- a/PluginPath.js
+++ b/PluginPath.js
@@ -1,0 +1,66 @@
+.pragma library
+
+// Where the plugin's own directory comes from, so that pluginDir + "/scripts/…"
+// names a file that is really there.
+//
+// Omarchy's shell hands a third-party plugin a sanitised manifest:
+// publicPluginManifest() deletes the source directory unless the plugin is
+// first-party. A pluginDir read from that field alone was empty on every
+// ordinary install, so each helper resolved to "/scripts/…" and failed to start
+// without raising anything the interface could show.
+//
+// The answer the engine always has is the component's own URL. Measured on Qt
+// 6.11.2, it keeps the symlink a file was loaded through rather than resolving
+// it away, so a checkout linked in by make install and a cloned install name the
+// directory the same way, and the mailto handler written from it stays valid.
+//
+// This depends on Service.qml sitting at the plugin root, which is what
+// manifest.json names as the service entry point. tests/test_service_source.sh
+// holds that invariant, because a nested entry point would make this a wrong
+// directory rather than no directory, and a wrong one fails as silently as the
+// bug above.
+
+function withoutTrailingSlash(path) {
+  var text = String(path === undefined || path === null ? "" : path)
+  return text.length > 1 && text.charAt(text.length - 1) === "/"
+    ? text.substring(0, text.length - 1) : text
+}
+
+// No plugin lives at the filesystem root, and "/" would build "//scripts/…"
+// while satisfying every caller's test for an empty directory. An answer that
+// cannot be a plugin directory is no answer.
+function pluginDirectory(path) {
+  var text = withoutTrailingSlash(path)
+  return text === "/" ? "" : text
+}
+
+// file:/// is the only form that names a path on this machine. file://host/share
+// names another one, and stripping a fixed seven characters from that would turn
+// it into a relative path instead of refusing it.
+function pathFromDirUrl(url) {
+  var text = String(url === undefined || url === null ? "" : url)
+  if (text.indexOf("file:///") !== 0) return ""
+  var path = text.substring(7)
+  // A query or fragment would not survive being read as part of the path. Qt
+  // does not put one in the URL of a directory, so this only orders the two
+  // steps correctly for anything else that calls in.
+  var mark = path.search(/[?#]/)
+  if (mark >= 0) path = path.substring(0, mark)
+  // Qt leaves "#", "%" and "?" percent-encoded inside a path, so a plugin under
+  // a directory named with one is not found unless they are decoded back. A
+  // malformed sequence throws, which in a property binding would take the whole
+  // value down; report no answer instead.
+  try {
+    return decodeURIComponent(path)
+  } catch (e) {
+    return ""
+  }
+}
+
+// componentDirUrl is Qt.resolvedUrl(".") from the file that wants the directory.
+// The manifest wins where the shell supplied it, which is every first-party load.
+function resolve(manifest, componentDirUrl) {
+  var declared = manifest && typeof manifest === "object"
+    ? pluginDirectory(manifest.__sourceDir) : ""
+  return declared !== "" ? declared : pluginDirectory(pathFromDirUrl(componentDirUrl))
+}

--- a/Service.qml
+++ b/Service.qml
@@ -5,6 +5,7 @@ import qs.Commons
 import "account"
 import "calendar"
 
+import "PluginPath.js" as PluginPath
 import "account/Accounts.js" as Accounts
 import "account/Model.js" as Model
 import "account/Unified.js" as Unified
@@ -45,8 +46,14 @@ Item {
 
   readonly property string pluginId: manifest && manifest.id
     ? String(manifest.id) : "omamail"
-  readonly property string pluginDir: manifest && manifest.__sourceDir
-    ? String(manifest.__sourceDir) : ""
+  // Omarchy's shell deletes the source directory from a third-party plugin's
+  // manifest, so this cannot come from the manifest alone. PluginPath decides;
+  // see the reasons there. The shell assigns manifest after createObject, so
+  // during Component.onCompleted this already answers from the component's own
+  // URL rather than staying empty: an empty pluginDir is no longer what stops a
+  // helper running in that window, which is why both callers defer past it.
+  readonly property string pluginDir: PluginPath.resolve(manifest, Qt.resolvedUrl("."))
+
   // Shown in the empty reader, so a screenshot in a bug report says which build
   // it came from. The shell's manifest validation requires both fields, so a
   // loaded plugin always has them; the fallbacks are for a harness that

--- a/tests/qml/tst_move_wiring.qml
+++ b/tests/qml/tst_move_wiring.qml
@@ -17,7 +17,9 @@ Item {
   Omamail.Service {
     id: mailService
     shell: fakeShell
-    manifest: ({ id: "omamail", __sourceDir: "" })
+    // A directory that does not exist, so every scripts/ helper this test
+    // drives fails to start rather than writing to the real config.
+    manifest: ({ id: "omamail", __sourceDir: "/nonexistent/omamail" })
   }
 
   Omamail.App {

--- a/tests/qml/tst_plugin_dir.qml
+++ b/tests/qml/tst_plugin_dir.qml
@@ -1,0 +1,66 @@
+import QtQuick
+import QtTest
+import "../.." as Omamail
+
+// The wiring, not the parsing: PluginPath.js is covered by tests/test_plugin_path.js
+// without a compositor. What needs the engine is that Service asks it with its own
+// URL, so a manifest stripped of __sourceDir (which is what Omarchy hands every
+// third-party plugin) still yields the directory the helpers live in.
+Item {
+  width: 600
+  height: 400
+
+  // Derived from this test's own URL, two directories up. It pins the exact
+  // directory rather than a plausible shape, which is what the old assertion
+  // lacked; it shares Qt's URL handling with the code under test, so it catches
+  // a wrong directory rather than a wrong idea of what a file URL is.
+  readonly property string checkoutDir: {
+    var path = decodeURIComponent(String(Qt.resolvedUrl("../..")).substring(7))
+    return path.length > 1 && path.charAt(path.length - 1) === "/"
+      ? path.substring(0, path.length - 1) : path
+  }
+
+  QtObject {
+    id: store
+    function updateEntryInline(id, entry) {
+    }
+  }
+
+  Component {
+    id: sanitisedComponent
+    Omamail.Service {
+      shell: store
+      manifest: ({
+          id: "omamail"
+        })
+    }
+  }
+
+  Component {
+    id: explicitComponent
+    Omamail.Service {
+      shell: store
+      manifest: ({
+          id: "omamail",
+          __sourceDir: "/tmp/synthetic"
+        })
+    }
+  }
+
+  TestCase {
+    name: "PluginDir"
+    when: windowShown
+
+    function test_a_stripped_manifest_still_finds_the_checkout() {
+      var svc = createTemporaryObject(sanitisedComponent, parent);
+      verify(svc !== null);
+      compare(svc.pluginDir, checkoutDir);
+    }
+
+    function test_a_manifest_that_carries_one_still_wins() {
+      var svc = createTemporaryObject(explicitComponent, parent);
+      verify(svc !== null);
+      compare(svc.pluginDir, "/tmp/synthetic");
+    }
+  }
+}

--- a/tests/test_plugin_path.js
+++ b/tests/test_plugin_path.js
@@ -1,0 +1,82 @@
+const assert = require("assert")
+const { load } = require("./load")
+
+const path = load("PluginPath.js")
+
+// ------------------------------------------------- the manifest decides first
+//
+// A first-party load still carries __sourceDir and must keep using it.
+assert.strictEqual(
+  path.resolve({ id: "omamail", __sourceDir: "/usr/share/omarchy/shell/plugins/omamail" },
+    "file:///elsewhere/"),
+  "/usr/share/omarchy/shell/plugins/omamail")
+
+// The shell deletes the key for a third-party plugin, so an absent key falls
+// through to the component's own directory. This is the bug: it used to be "".
+assert.strictEqual(
+  path.resolve({ id: "omamail" }, "file:///home/me/.config/omarchy/plugins/omamail/"),
+  "/home/me/.config/omarchy/plugins/omamail")
+assert.strictEqual(path.resolve(null, "file:///plugins/omamail/"), "/plugins/omamail")
+assert.strictEqual(path.resolve(undefined, "file:///plugins/omamail/"), "/plugins/omamail")
+
+// An empty field is no answer, not a decision: the component's own URL is used.
+// Keying behaviour on delete-versus-blank would make the fix depend on which
+// idiom the shell happens to sanitise with.
+assert.strictEqual(
+  path.resolve({ id: "omamail", __sourceDir: "" }, "file:///plugins/omamail/"), "/plugins/omamail")
+
+// No plugin lives at the filesystem root, and "/" would build "//scripts/…" while
+// passing every caller's test for an empty directory.
+assert.strictEqual(path.resolve({}, "file:///"), "")
+assert.strictEqual(path.resolve({ __sourceDir: "/" }, "file:///plugins/omamail/"), "/plugins/omamail")
+
+// ------------------------------------------------------------ normalisation
+//
+// Applied to whichever branch answered, so no command is built as "dir//scripts".
+assert.strictEqual(path.resolve({ __sourceDir: "/plugins/omamail/" }, ""), "/plugins/omamail")
+assert.strictEqual(path.resolve({}, "file:///plugins/omamail/"), "/plugins/omamail")
+assert.strictEqual(path.withoutTrailingSlash("/"), "/")
+assert.strictEqual(path.withoutTrailingSlash(""), "")
+
+// --------------------------------------------------------------- percent-encoding
+//
+// Qt leaves "#", "%" and "?" percent-encoded inside a path (it normalises a space
+// back out), so a plugin under a directory named with one is not found unless they
+// are decoded back. The space case is here because callers other than
+// Qt.resolvedUrl may still pass one.
+assert.strictEqual(path.pathFromDirUrl("file:///home/a%20b/omamail/"), "/home/a b/omamail/")
+assert.strictEqual(path.pathFromDirUrl("file:///home/pct%25dir/"), "/home/pct%dir/")
+assert.strictEqual(path.pathFromDirUrl("file:///home/%C3%BCber/"), "/home/über/")
+assert.strictEqual(
+  path.resolve({}, "file:///home/a%20b/plugins/omamail/"), "/home/a b/plugins/omamail")
+
+// A query or fragment is cut before decoding, so an encoded one in the path
+// survives rather than being treated as a delimiter.
+assert.strictEqual(path.pathFromDirUrl("file:///home/dir/?v=1"), "/home/dir/")
+assert.strictEqual(path.pathFromDirUrl("file:///home/dir/#frag"), "/home/dir/")
+assert.strictEqual(path.pathFromDirUrl("file:///home/has%23hash/"), "/home/has#hash/")
+
+// A sequence that is not valid UTF-8 throws; it comes back empty rather than
+// taking the whole binding down silently.
+assert.strictEqual(path.pathFromDirUrl("file:///home/bad%ZZdir/"), "")
+assert.strictEqual(path.pathFromDirUrl("file:///home/bad%E0%A4dir/"), "")
+
+// ------------------------------------------------------------- what is refused
+//
+// Only file:/// names a path here. file://host/share names another machine, and
+// a fixed seven-character strip would silently make it relative.
+assert.strictEqual(path.pathFromDirUrl("file://host/share/omamail/"), "")
+assert.strictEqual(path.pathFromDirUrl("qrc:/omamail/"), "")
+assert.strictEqual(path.pathFromDirUrl("https://example.com/omamail/"), "")
+assert.strictEqual(path.pathFromDirUrl(""), "")
+assert.strictEqual(path.pathFromDirUrl(null), "")
+assert.strictEqual(path.pathFromDirUrl(undefined), "")
+
+// The leading slash of an absolute path survives the scheme strip.
+assert.strictEqual(path.pathFromDirUrl("file:///a"), "/a")
+
+// A component URL that cannot be read leaves pluginDir empty, which every
+// caller already guards, rather than producing a wrong path.
+assert.strictEqual(path.resolve({}, "qrc:/omamail/"), "")
+
+console.log("test_plugin_path.js ok")

--- a/tests/test_service_source.sh
+++ b/tests/test_service_source.sh
@@ -9,7 +9,26 @@ fail() { printf 'test_service_source.sh: %s\n' "$1" >&2; exit 1; }
 
 grep -q 'property var shell' Service.qml || fail "Service.qml must accept an injected shell"
 grep -q 'property var manifest' Service.qml || fail "Service.qml must accept an injected manifest"
-grep -q '__sourceDir' Service.qml || fail "pluginDir must come from manifest.__sourceDir"
+# Comments are stripped first: a guard a comment can satisfy guards nothing.
+code() { grep -vE '^[[:space:]]*(//|\*|/\*)' "$1"; }
+# Process substitution, not a pipe: grep -q exits at the first match and would
+# leave the stripper dead of SIGPIPE, which pipefail reports as a failed guard.
+grep -q 'PluginPath.resolve(manifest' <(code Service.qml) \
+  || fail "pluginDir must come from PluginPath.resolve, which falls back when the shell withholds the source directory"
+grep -q 'Qt.resolvedUrl' <(code Service.qml) \
+  || fail "PluginPath needs this component's own URL to fall back to"
+grep -q '__sourceDir' <(code PluginPath.js) \
+  || fail "PluginPath must still prefer the manifest's source directory"
+# Qt.resolvedUrl(".") is the directory of Service.qml, so a nested service entry
+# point would make pluginDir a wrong directory rather than an empty one, and a
+# wrong one fails as silently as the bug this replaced.
+python3 - <<'ENTRY'
+import json, sys
+entry = json.load(open("manifest.json"))["entryPoints"]["service"]
+if "/" in entry:
+    sys.exit("test_service_source.sh: entryPoints.service must stay at the plugin root, "
+             "because PluginPath derives the directory from Service.qml's own URL; got " + entry)
+ENTRY
 grep -q 'function applySettings' Service.qml || fail "the bar widget pushes settings in via applySettings"
 grep -q 'function setUndoSendSeconds' Service.qml \
   || fail "the in-app settings page must be able to change the undo window"


### PR DESCRIPTION
Omamail's helper scripts never ran on an ordinary install. `Service.qml` derived `pluginDir` from `manifest.__sourceDir` alone, and Omarchy's shell deletes that key from the manifest it hands a third-party plugin: `publicPluginManifest()` in `shell.qml` strips `__sourceDir`, `__isFirstParty` and `__hostCapabilities` unless the plugin is first-party. So `pluginDir` was `""`, every command became `/scripts/…`, and none of them started.

Nothing said so, which is why it reads as a dead button rather than a bug. `beginLogin()` sets `loginBusy` before launching `scripts/pkce.sh`, and a Process that fails to start raises nothing the interface can read, so Gmail sign-in showed "Finish the sign-in in your browser…" over a browser that never opened. `config-store.sh`, `keyring-store.sh` and `register-mailto.sh` were dead the same way.

To reproduce: install the plugin the way a user does, with `omarchy plugin add`, enable it, and press **Sign in with Google**. A checkout under `~/.config/omarchy/plugins` reproduces it too, symlinked or not, because `PluginRegistry` scans that directory as third-party regardless of how it got there.

The answer the engine always has is the component's own URL. `Qt.resolvedUrl(".")` from `Service.qml` is the plugin root by construction, since `manifest.json` names `Service.qml` at that path and `scripts/` is its sibling. Measured on Qt 6.11.2, Qt keeps the symlink a file was loaded through rather than resolving it away, so a `make install` checkout and a cloned install name the directory the same way and the mailto handler written from it stays valid under both.

That trades one silent failure for a possible other: a nested service entry point would make this a *wrong* directory rather than no directory, and a wrong one passes every existing `pluginDir === ""` guard. `tests/test_service_source.sh` now holds `entryPoints.service` at the root so that cannot happen quietly.

The decision lives in `PluginPath.js` rather than in QML, per the working agreement that everything which parses or decides is reachable by the node tests without a compositor. An empty source directory is treated as no answer rather than as a decision, so the fix does not depend on whether the shell sanitises by deleting the key or by blanking it.

**This touches `AGENTS.md`.** The Layout table said the root holds the three QML entry points "and nothing else", which `PluginPath.js` contradicts, so the row now names it and records the root invariant above. Amending the working agreement is your call, not mine: if you would rather the library lived under a module directory, say where and I will move it and revert the doc.

## Verification

`make validate` green on this commit: 520 + 4 + 64 passed, 0 failed, exit 0.

Red/green, node: regressing `resolve()` to the original manifest-only behaviour fails `tests/test_plugin_path.js` with `actual: ''`. Red/green, QML: against `origin/main:Service.qml`, `test_a_stripped_manifest_still_finds_the_checkout` fails. Both new guards in `tests/test_service_source.sh` were checked by defeating them: deleting the manifest branch while keeping its comments, and nesting `entryPoints.service`. `tests/test_plugin_path.js` also covers percent-decoding, invalid sequences, and the URL forms that are refused: `file://host/share`, `qrc:`, `/`, empty and null.

`tests/qml/tst_move_wiring.qml` set `__sourceDir: ""` to keep every helper unlaunchable while it drives the real service. Since empty is no longer a decision, its fixture now names a directory that does not exist, which holds the same guarantee without shaping production logic around a test.

Driven by hand on Omarchy 4.0.0.r2090.g5b91db5, Qt 6.11.2: a Gmail account signed in end to end through the loopback flow, which was impossible before this change, and an Outlook account added over device-code IMAP. After restarting the shell on this commit both accounts refetched within ten seconds, no `/scripts/…` failures appear in the log, and `~/.local/share/applications/omamail.desktop` was written for the first time. No interface change, so no screenshots.

Worth knowing when reproducing: `omarchy-launch-shell` sets `QS_DISABLE_FILE_WATCHER=1`, so QML edits are not read live as CONTRIBUTING says; `omarchy restart shell` is needed.

Two fresh agents reviewed this. The first rejected an earlier revision for putting parsing logic in QML against the working agreement, for justifying a fallback order with a claim about `Qt.resolvedUrl` canonicalising symlinks that measurement contradicts, and for guards a comment could satisfy; it was rewritten around those findings rather than patched. The second reviewed this diff and found that the empty-source-directory rule was shaped around a test fixture, that one guard was still comment-satisfiable, and that nothing held `Service.qml` at the root. All three are fixed above.

## Release Notes

- Helper scripts now run when Omamail is installed as an ordinary plugin. Gmail sign-in, saving accounts and calendars, the keyring, attachments, contact suggestions and the `mailto:` handler were all silently doing nothing.
- On first run after upgrading, Omamail registers itself as the desktop's `mailto:` handler and begins reading contacts for recipient suggestions, both of which it had been failing to do.
