### PR TITLE
test: Hold the plugin's own directory to tests, whatever the host says

### DIFF
--- a/tests/qml/tst_plugin_dir.qml
+++ b/tests/qml/tst_plugin_dir.qml
@@ -1,0 +1,76 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../.." as Omamail
+
+// Where the plugin's scripts are found. A host that hands the service a public
+// copy of the manifest strips its private fields, and the service must still
+// know its own directory: without it every command is built as "/scripts/..."
+// and nothing that shells out can start.
+Item {
+  Omamail.Service {
+    id: withoutManifest
+    manifest: null
+  }
+
+  // What a shell that strips private fields actually passes: the public
+  // manifest, with `id` and `name` but no `__sourceDir`.
+  Omamail.Service {
+    id: publicManifest
+    manifest: ({ id: "omamail", name: "Omamail", version: "0.8.2" })
+  }
+
+  // A manifest that still carries the private field, which the directory is
+  // deliberately independent of.
+  Omamail.Service {
+    id: hostSaidWhere
+    manifest: ({ id: "omamail", __sourceDir: "/opt/somewhere-else" })
+  }
+
+  TestCase {
+    name: "PluginDir"
+
+    // The repository root, which is where Service.qml lives and so what the
+    // service should work out for itself.
+    function root() {
+      var url = String(Qt.resolvedUrl("../.."))
+      var path = decodeURIComponent(url.substring("file://".length))
+      return path.length > 1 && path.charAt(path.length - 1) === "/"
+        ? path.substring(0, path.length - 1) : path
+    }
+
+    function test_a_service_with_no_manifest_still_knows_its_directory() {
+      compare(withoutManifest.pluginDir, root())
+    }
+
+    function test_a_manifest_without_the_private_field_falls_back_to_the_file() {
+      compare(publicManifest.pluginDir, root(),
+        "a host that strips __sourceDir must not leave the scripts unrooted")
+    }
+
+    function test_the_directory_is_absolute_and_has_no_trailing_slash() {
+      var dir = publicManifest.pluginDir
+      compare(dir.charAt(0), "/")
+      verify(dir.charAt(dir.length - 1) !== "/", dir)
+      verify(dir.indexOf("file://") < 0, dir)
+    }
+
+    // The command every script is named against is rooted, rather than the
+    // "/scripts/mail-transport.sh" an empty directory produced.
+    function test_a_script_command_is_rooted_under_the_plugin() {
+      var command = publicManifest.pluginDir + "/scripts/mail-transport.sh"
+      compare(command, root() + "/scripts/mail-transport.sh")
+      verify(command.indexOf("//scripts") < 0, command)
+      verify(command !== "/scripts/mail-transport.sh")
+    }
+
+    // The directory is worked out from the file and nothing else. A manifest
+    // that still carries `__sourceDir` does not move it, so the plugin behaves
+    // the same whether the host keeps the private field, strips it, or passes
+    // no manifest at all — which is three different hosts today.
+    function test_the_directory_does_not_depend_on_the_manifest() {
+      compare(hostSaidWhere.pluginDir, root())
+      compare(hostSaidWhere.pluginDir, publicManifest.pluginDir)
+      compare(hostSaidWhere.pluginDir, withoutManifest.pluginDir)
+    }
+  }
+}


### PR DESCRIPTION
Closes #163.

This started as a fix. While it sat, #115 landed the same reading of
`Qt.resolvedUrl(".")` on `main`, so the fix is yours already and this branch is
now just the regressions for it, rebased onto it.

## Why it is worth covering

`pluginDir` is load-bearing in a way that fails silently. Every script this
plugin runs is named against it — the mail transport, the config store, the
keyring, `pkce.sh`, contact suggestions, the mailto registration, the calendar
writers. When it reads empty, the commands go out as `"/scripts/..."`, every
one of them fails to start, and nothing says why: the mailbox reports "Not
connected", "Save client" appears to do nothing, and an Outlook sign-in cannot
keep its refresh token because the keyring command never runs. #163 describes
the same thing arriving as a Gmail sign-in that never proceeds.

It is also a boundary the host controls and can change again. That is the case
for pinning the behaviour rather than the implementation.

## The tests

`tests/qml/tst_plugin_dir.qml`, six cases:

- a service with no manifest at all works out the checkout's own directory;
- so does one given the public manifest a stripping host passes;
- so does one whose manifest still carries `__sourceDir` — the directory is
  deliberately independent of the host, so all three agree;
- it is absolute, carries no trailing slash and no `file://`;
- a script command built from it is rooted under the plugin rather than at `/`,
  which is the shape the bug actually produced.

Five of the six fail against the previous `manifest.__sourceDir` reading,
including the `"/scripts/mail-transport.sh"` symptom itself. The third is the
one that does not: it passed before because a manifest carrying the field was
the only case that used to work.

## Verification

`QT_QPA_PLATFORMTHEME= make validate` passes on this head. Qt 6.11.2,
Omarchy 4.0.3.

Driven by hand as well, on a third-party install: before the fix the shell
logged a `Process failed to start` for every `"/scripts/..."` command and the
window read "Not connected"; after it, those stop and the mailbox refreshes.
@tlehman confirmed the same independently on #163, including the Gmail path.

## A separate snag, not fixed here

`tests/qml/tst_agent_ownership.qml:94` asserts
`pluginDir.indexOf("/omamail") >= 0`, so `make validate` fails whenever the
checkout directory is not itself named `omamail` — a git worktree, a fork
cloned under another name, or a CI path. It passes from a directory of that
name and fails from any other, which is how I met it. Left alone here since it
is not this branch's business, but it is worth loosening to something that does
not depend on what the directory is called.
