### PR TITLE
Discover every calendar under one CalDAV account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ test-shell-portable:
 	bash tests/test_attachment_save.sh
 	bash tests/test_attachment.sh
 	bash tests/test_calendar_transport.sh
+	bash tests/test_calendar_propfind.sh
 	bash tests/test_calendar_write.sh
 	bash tests/test_calendar_delete.sh
 	bash tests/test_release_notes.sh

--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -72,11 +72,16 @@ function discoverHomeSetPropfind() {
     + '<d:prop><c:calendar-home-set/></d:prop></d:propfind>'
 }
 
+// No calendar-color property: a discovered calendar's colorKey is assigned
+// the same way every other source's is, a hash of its id through
+// Palette.defaultKey, because AGENTS.md's Colors section holds here too — a
+// server's own literal colour has no path into a palette that is themed, not
+// configured, and asking for a property this never reads would only be
+// asking for it.
 function discoverCollectionsPropfind() {
   return '<?xml version="1.0" encoding="utf-8"?>'
-    + '<d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" '
-    + 'xmlns:ic="http://apple.com/ns/ical/">'
-    + '<d:prop><d:resourcetype/><d:displayname/><ic:calendar-color/>'
+    + '<d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">'
+    + '<d:prop><d:resourcetype/><d:displayname/>'
     + '<c:supported-calendar-component-set/></d:prop></d:propfind>'
 }
 
@@ -135,6 +140,13 @@ function tagText(block, localName) {
 // The raw inner blocks of every <d:response> in a multistatus reply, shared
 // by the REPORT parser below and by calendar discovery: both walk the same
 // envelope and differ only in which properties they read out of it.
+//
+// Neither looks at which <d:propstat><d:status> a property came under: a
+// server that could not answer a property is expected to leave it out of
+// every propstat's <d:prop> rather than echo it empty under a 404 one, so
+// the first occurrence of a named element anywhere in the response is
+// already the answered one. This is the same trust every CalDAV call here
+// already places in a compliant server, not a new one.
 function multistatusResponses(xml) {
   var input = String(xml || "")
   var pattern = /<(?:[A-Za-z0-9_-]+:)?response(?:\s[^>]*)?>([\s\S]*?)<\/(?:[A-Za-z0-9_-]+:)?response>/gi
@@ -786,11 +798,6 @@ function supportsVevent(componentSetBlock) {
   return /<(?:[A-Za-z0-9_-]+:)?comp\b[^>]*\bname\s*=\s*["']VEVENT["']/i.test(componentSetBlock)
 }
 
-function discoveredCalendarColor(value) {
-  var match = /^#([0-9a-fA-F]{6})/.exec(String(value || "").trim())
-  return match ? ("#" + match[1].toLowerCase()) : ""
-}
-
 // The calendar collections a Depth:1 PROPFIND on the calendar-home-set
 // found, each resolved to an address on the account's own origin. A response
 // whose href cannot be resolved there is dropped rather than surfaced with a
@@ -805,11 +812,7 @@ function discoveredCalendars(xml, homeSetUrl) {
     if (!supportsVevent(tagBlock(block, "supported-calendar-component-set"))) continue
     var url = resolveDiscoveredUrl(homeSetUrl, tagText(block, "href"))
     if (url === "") continue
-    out.push({
-      url: url,
-      name: tagText(block, "displayname") || "Calendar",
-      color: discoveredCalendarColor(tagText(block, "calendar-color"))
-    })
+    out.push({ url: url, name: tagText(block, "displayname") || "Calendar" })
   }
   return out
 }

--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -57,6 +57,29 @@ function caldavReport(startMs, endMs) {
     + '</c:comp-filter></c:comp-filter></c:filter></c:calendar-query>'
 }
 
+// The three PROPFIND bodies calendar discovery sends in sequence: who the
+// signed-in user is, where their calendars live, and what is in that
+// collection. RFC 5397 and RFC 4791 define the first two properties; the
+// third is a plain WebDAV listing.
+function discoverPrincipalPropfind() {
+  return '<?xml version="1.0" encoding="utf-8"?>'
+    + '<d:propfind xmlns:d="DAV:"><d:prop><d:current-user-principal/></d:prop></d:propfind>'
+}
+
+function discoverHomeSetPropfind() {
+  return '<?xml version="1.0" encoding="utf-8"?>'
+    + '<d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">'
+    + '<d:prop><c:calendar-home-set/></d:prop></d:propfind>'
+}
+
+function discoverCollectionsPropfind() {
+  return '<?xml version="1.0" encoding="utf-8"?>'
+    + '<d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" '
+    + 'xmlns:ic="http://apple.com/ns/ical/">'
+    + '<d:prop><d:resourcetype/><d:displayname/><ic:calendar-color/>'
+    + '<c:supported-calendar-component-set/></d:prop></d:propfind>'
+}
+
 function decodeXml(value) {
   return String(value || "")
     .replace(/&lt;/g, "<")
@@ -109,14 +132,37 @@ function tagText(block, localName) {
   return match ? decodeXmlText(match[1]) : ""
 }
 
-function caldavResponses(xml) {
+// The raw inner blocks of every <d:response> in a multistatus reply, shared
+// by the REPORT parser below and by calendar discovery: both walk the same
+// envelope and differ only in which properties they read out of it.
+function multistatusResponses(xml) {
   var input = String(xml || "")
   var pattern = /<(?:[A-Za-z0-9_-]+:)?response(?:\s[^>]*)?>([\s\S]*?)<\/(?:[A-Za-z0-9_-]+:)?response>/gi
   var out = []
   var match
-  while ((match = pattern.exec(input)) !== null) {
-    var data = tagText(match[1], "calendar-data")
-    if (data !== "") out.push({ href: tagText(match[1], "href"), data: data })
+  while ((match = pattern.exec(input)) !== null) out.push(match[1])
+  return out
+}
+
+// A block's inner XML for a container element, undecoded: a discovery prop
+// such as <d:current-user-principal> holds a child <d:href>, not text of its
+// own, so the caller can run tagText on what this returns rather than on
+// entity-decoded markup.
+function tagBlock(block, localName) {
+  var name = String(localName || "").replace(/[^A-Za-z0-9_-]/g, "")
+  if (name === "") return ""
+  var pattern = new RegExp("<(?:[A-Za-z0-9_-]+:)?" + name
+    + "(?:\\s[^>]*)?>([\\s\\S]*?)</(?:[A-Za-z0-9_-]+:)?" + name + ">", "i")
+  var match = pattern.exec(String(block || ""))
+  return match ? match[1] : ""
+}
+
+function caldavResponses(xml) {
+  var responses = multistatusResponses(xml)
+  var out = []
+  for (var i = 0; i < responses.length; i++) {
+    var data = tagText(responses[i], "calendar-data")
+    if (data !== "") out.push({ href: tagText(responses[i], "href"), data: data })
   }
   return out
 }
@@ -630,6 +676,103 @@ function caldavEventUrl(sourceUrl, event) {
   if (uid === "") return ""
   var root = base.charAt(base.length - 1) === "/" ? base : base + "/"
   return root + encodeURIComponent(uid) + ".ics"
+}
+
+// Resolves a PROPFIND-discovered href against the account address's origin,
+// on the same rule caldavEventUrl applies to a server-written event href: an
+// absolute answer is accepted only on the account's own scheme, host and
+// port. Discovery walks two more server answers than a REPORT ever does
+// before it reaches a calendar's own address, so this is the one place that
+// judgement has to hold for every one of them — a compromised or
+// misconfigured principal or calendar-home-set response must not be able to
+// hand this account's credentials to a different origin than the one the
+// user typed in Settings.
+function resolveDiscoveredUrl(accountUrl, href) {
+  var base = String(accountUrl || "")
+  var origin = urlOrigin(base)
+  if (origin === "") return ""
+  var value = String(href || "")
+  if (value === "" || /\s/.test(value)) return ""
+  if (/^https:\/\//i.test(value) || value.substring(0, 2) === "//") {
+    var candidate = value.substring(0, 2) === "//" ? "https:" + value : value
+    return urlOrigin(candidate) === origin ? candidate : ""
+  }
+  if (value.charAt(0) === "/") return urlAuthority(base) + value
+  var collection = base.charAt(base.length - 1) === "/" ? base : base + "/"
+  return collection + value
+}
+
+// The href a PROPFIND response gives for a container property such as
+// <d:current-user-principal> or <c:calendar-home-set>, resolved against the
+// request's own origin. Absent when the server did not answer the property
+// at all, which is the ordinary shape of "not supported here" — a 404
+// propstat still parses, its <d:prop> just has nothing inside the container.
+function discoveredContainerUrl(xml, accountUrl, containerLocalName) {
+  var responses = multistatusResponses(xml)
+  for (var i = 0; i < responses.length; i++) {
+    var inner = tagBlock(responses[i], containerLocalName)
+    if (inner === "") continue
+    var href = tagText(inner, "href")
+    if (href === "") continue
+    var resolved = resolveDiscoveredUrl(accountUrl, href)
+    if (resolved !== "") return resolved
+  }
+  return ""
+}
+
+function discoveredPrincipalUrl(xml, accountUrl) {
+  return discoveredContainerUrl(xml, accountUrl, "current-user-principal")
+}
+
+function discoveredHomeSetUrl(xml, accountUrl) {
+  return discoveredContainerUrl(xml, accountUrl, "calendar-home-set")
+}
+
+// A resourcetype naming a real calendar, not the scheduling inbox or outbox
+// CalDAV Scheduling (RFC 6638) adds beside it: both also carry {CALDAV:}calendar,
+// but neither holds events a user meant to add here.
+function isCalendarCollection(resourceTypeBlock) {
+  if (!/<(?:[A-Za-z0-9_-]+:)?calendar\b/i.test(resourceTypeBlock)) return false
+  if (/<(?:[A-Za-z0-9_-]+:)?schedule-inbox\b/i.test(resourceTypeBlock)) return false
+  if (/<(?:[A-Za-z0-9_-]+:)?schedule-outbox\b/i.test(resourceTypeBlock)) return false
+  return true
+}
+
+// Whether the collection's declared component set includes VEVENT. A
+// collection that declares a set without VEVENT in it is a task list or a
+// journal, not a calendar this feature reads events from; one that declares
+// no set at all has not said either way, so it is kept rather than dropped.
+function supportsVevent(componentSetBlock) {
+  if (componentSetBlock === "") return true
+  return /<(?:[A-Za-z0-9_-]+:)?comp\b[^>]*\bname\s*=\s*["']VEVENT["']/i.test(componentSetBlock)
+}
+
+function discoveredCalendarColor(value) {
+  var match = /^#([0-9a-fA-F]{6})/.exec(String(value || "").trim())
+  return match ? ("#" + match[1].toLowerCase()) : ""
+}
+
+// The calendar collections a Depth:1 PROPFIND on the calendar-home-set
+// found, each resolved to an address on the account's own origin. A response
+// whose href cannot be resolved there is dropped rather than surfaced with a
+// blank address: nothing offered here can be added without ending up back
+// through resolveDiscoveredUrl regardless.
+function discoveredCalendars(xml, homeSetUrl) {
+  var responses = multistatusResponses(xml)
+  var out = []
+  for (var i = 0; i < responses.length; i++) {
+    var block = responses[i]
+    if (!isCalendarCollection(tagBlock(block, "resourcetype"))) continue
+    if (!supportsVevent(tagBlock(block, "supported-calendar-component-set"))) continue
+    var url = resolveDiscoveredUrl(homeSetUrl, tagText(block, "href"))
+    if (url === "") continue
+    out.push({
+      url: url,
+      name: tagText(block, "displayname") || "Calendar",
+      color: discoveredCalendarColor(tagText(block, "calendar-color"))
+    })
+  }
+  return out
 }
 
 function compareEvents(left, right) {

--- a/calendar/Calendar.js
+++ b/calendar/Calendar.js
@@ -720,6 +720,45 @@ function discoveredContainerUrl(xml, accountUrl, containerLocalName) {
   return ""
 }
 
+// The last status line in a response's dumped headers — last, because a
+// redirect curl did not follow and a `100 Continue` curl received before it
+// both leave an earlier status line in the same dump, and the final answer
+// is the one this decides on.
+function lastHttpStatus(headersText) {
+  var lines = String(headersText || "").split(/\r?\n/)
+  var status = 0
+  for (var i = 0; i < lines.length; i++) {
+    var match = /^HTTP\/\S+\s+(\d\d\d)/.exec(lines[i])
+    if (match) status = Number(match[1])
+  }
+  return status
+}
+
+function lastLocationHeader(headersText) {
+  var lines = String(headersText || "").split(/\r?\n/)
+  var location = ""
+  for (var i = 0; i < lines.length; i++) {
+    var match = /^location:\s*(\S+)/i.exec(lines[i])
+    if (match) location = match[1]
+  }
+  return location
+}
+
+// RFC 6764: a CalDAV client that only knows a bare server address is
+// supposed to try /.well-known/caldav there first and follow the redirect —
+// Fastmail, among others, answers a request for the address alone with a
+// plain 404 and only the well-known path names where the real service lives.
+// Resolved on the same rule as any other discovered address: a redirect to
+// a different origin is not one hop closer to this account's calendars, it
+// is somewhere this account's credentials must not follow.
+function discoveredWellKnownUrl(headersText, accountUrl) {
+  var status = lastHttpStatus(headersText)
+  if (status < 300 || status >= 400) return ""
+  var location = lastLocationHeader(headersText)
+  if (location === "") return ""
+  return resolveDiscoveredUrl(accountUrl, location)
+}
+
 function discoveredPrincipalUrl(xml, accountUrl) {
   return discoveredContainerUrl(xml, accountUrl, "current-user-principal")
 }

--- a/calendar/CalendarController.qml
+++ b/calendar/CalendarController.qml
@@ -48,7 +48,18 @@ Item {
   property string sourceWritePayload: ""
   property string sourceSecret: ""
   property var sourceBeingSaved: null
+  // The batch a discovered-calendars add is writing passwords for, kept
+  // apart from sourceBeingSaved: that one is a single manually-added
+  // calendar and ends in exactly one keyring write, while this is zero or
+  // more and ends the same way addCalDavCalendar does only after every one
+  // of them is stored.
+  property var sourcesBeingSaved: []
   property bool savingSource: false
+  property bool discovering: false
+  property string discoveryStage: ""
+  property string discoveryAccountUrl: ""
+  property string discoveryStageUrl: ""
+  property string discoveryCredentials: ""
   property bool clockRunning: false
   property double nowMs: Date.now()
   property bool refreshAfterSourceWrite: false
@@ -116,6 +127,7 @@ Item {
 
   signal passwordSaved(bool ok, string error)
   signal calendarSaved(bool ok, string error)
+  signal calendarsDiscovered(bool ok, string error, var calendars)
   signal eventCreated(bool ok, string error)
   signal eventUpdated(bool ok, string error)
   signal eventDeleted(bool ok, string error)
@@ -383,6 +395,101 @@ Item {
     savingSource = true
     sourceWriter.command = [pluginDir + "/scripts/config-store.sh", "calendars.json"]
     sourceWriter.running = true
+  }
+
+  // Finds every calendar collection under one CalDAV account rather than
+  // asking for each calendar's own address by hand: PROPFIND for the
+  // signed-in principal, PROPFIND that for the calendar-home-set, then
+  // PROPFIND the home-set at Depth:1 for its children. A server that does
+  // not answer one of the first two steps still gets a chance at the last
+  // one against whatever address was given — many servers accept a
+  // home-set or even a calendar collection URL directly, and the discovery
+  // request that URL sees is server-supplied, so resolveDiscoveredUrl keeps
+  // holding it to the account's own origin at every step.
+  function discoverCalendars(accountUrl, username, password) {
+    if (discovering || savingSource) return
+    var url = String(accountUrl || "").trim()
+    var user = String(username || "").trim()
+    var pass = String(password || "")
+    if (!/^https:\/\//i.test(url)) {
+      calendarsDiscovered(false, "Use an HTTPS CalDAV server address", [])
+      return
+    }
+    if (user === "") { calendarsDiscovered(false, "Add the account username", []); return }
+    if (pass === "") { calendarsDiscovered(false, "Add the account password", []); return }
+    discoveryAccountUrl = url
+    discoveryCredentials = user + ":" + pass
+    pass = ""
+    discovering = true
+    runDiscoveryStep("principal", url, Calendar.discoverPrincipalPropfind(), "0")
+  }
+
+  function runDiscoveryStep(stage, url, body, depth) {
+    discoveryStage = stage
+    discoveryStageUrl = url
+    discoveryTransport.command = [pluginDir + "/scripts/calendar-propfind.sh"]
+    discoveryTransport.requestLine = Mail.encodeBase64(url) + " "
+      + Mail.encodeBase64(discoveryCredentials) + " "
+      + Mail.encodeBase64(depth) + " " + Mail.encodeBase64(body) + "\n"
+    discoveryTransport.running = true
+  }
+
+  function finishDiscovery(ok, error, calendars) {
+    discovering = false
+    discoveryStage = ""
+    discoveryStageUrl = ""
+    discoveryCredentials = ""
+    calendarsDiscovered(ok, String(error || ""), Array.isArray(calendars) ? calendars : [])
+  }
+
+  // Adds every calendar the caller picked from a discoverCalendars result in
+  // one config write, then stores the one account password against each of
+  // them in turn — the same password, because CalDAV discovery only ever
+  // runs against one set of credentials.
+  function addDiscoveredCalendars(selected, username, secret) {
+    if (savingSource) return
+    var values = Array.isArray(selected) ? selected : []
+    if (values.length === 0) { calendarSaved(false, "Choose at least one calendar"); return }
+    if (String(secret || "") === "") { calendarSaved(false, "Add the account password"); return }
+    var next = sourceList
+    var added = []
+    for (var i = 0; i < values.length; i++) {
+      var candidate = { kind: "caldav", name: values[i].name, url: values[i].url,
+        username: String(username || "") }
+      candidate.id = Sources.sourceId(candidate)
+      var checked = Sources.validate(candidate)
+      if (!checked.ok) continue
+      next = Sources.add(next, checked.source)
+      added.push(checked.source)
+    }
+    if (added.length === 0) {
+      calendarSaved(false, "None of the discovered calendars could be added")
+      return
+    }
+    sourceBeingSaved = null
+    sourcesBeingSaved = added
+    sourceSecret = String(secret)
+    sourceWritePayload = Sources.serialize(next)
+    refreshAfterSourceWrite = true
+    savingSource = true
+    sourceWriter.command = [pluginDir + "/scripts/config-store.sh", "calendars.json"]
+    sourceWriter.running = true
+  }
+
+  function storeNextDiscoveryPassword() {
+    if (sourcesBeingSaved.length === 0) {
+      sourceSecret = ""
+      savingSource = false
+      calendarSaved(true, "")
+      if (rangeStart && rangeEnd) refresh(rangeStart, rangeEnd)
+      return
+    }
+    var pending = sourcesBeingSaved.slice()
+    var source = pending.shift()
+    sourcesBeingSaved = pending
+    discoveryPasswordStore.command = [pluginDir + "/scripts/keyring-store.sh"]
+      .concat(Sources.keyringAttributes(source.id))
+    discoveryPasswordStore.running = true
   }
 
   function removeCalendar(sourceId) {
@@ -657,11 +764,16 @@ Item {
       if (exitCode !== 0) {
         root.savingSource = false
         root.sourceSecret = ""
+        root.sourcesBeingSaved = []
         root.refreshAfterSourceWrite = false
         root.calendarSaved(false, String(sourceWriteError.text || "Could not save the calendar"))
         return
       }
       root.sourceList = Sources.load(root.sourceWritePayload)
+      if (root.sourcesBeingSaved.length > 0) {
+        root.storeNextDiscoveryPassword()
+        return
+      }
       if (!root.sourceBeingSaved) {
         root.savingSource = false
         root.calendarSaved(true, "")
@@ -691,6 +803,60 @@ Item {
       }
       root.calendarSaved(true, "")
       if (root.rangeStart && root.rangeEnd) root.refresh(root.rangeStart, root.rangeEnd)
+    }
+  }
+
+  Process {
+    id: discoveryPasswordStore
+    stdinEnabled: true
+    stderr: StdioCollector { id: discoveryPasswordError; waitForEnd: true }
+    onStarted: write(root.sourceSecret + "\n")
+    onExited: function(exitCode) {
+      if (exitCode !== 0) {
+        root.sourceSecret = ""
+        root.sourcesBeingSaved = []
+        root.savingSource = false
+        root.calendarSaved(false, String(discoveryPasswordError.text || "Could not save the password"))
+        return
+      }
+      root.storeNextDiscoveryPassword()
+    }
+  }
+
+  Process {
+    id: discoveryTransport
+    property string requestLine: ""
+    stdinEnabled: true
+    stdout: StdioCollector { id: discoveryOutput; waitForEnd: true }
+    stderr: StdioCollector { waitForEnd: true }
+    onStarted: { write(requestLine); requestLine = "" }
+    onExited: function(exitCode) {
+      var lines = String(discoveryOutput.text || "").split("\n")
+      var status = Number(lines[0])
+      var body = lines.length > 1
+        ? Mail.decodeBase64Url(lines[1].replace(/\+/g, "-").replace(/\//g, "_")) : ""
+      var ok = exitCode === 0 && status === 0
+      var requestUrl = root.discoveryStageUrl
+      if (root.discoveryStage === "principal") {
+        var principalUrl = (ok ? Calendar.discoveredPrincipalUrl(body, requestUrl) : "") || requestUrl
+        root.runDiscoveryStep("homeset", principalUrl, Calendar.discoverHomeSetPropfind(), "0")
+        return
+      }
+      if (root.discoveryStage === "homeset") {
+        var homeSetUrl = (ok ? Calendar.discoveredHomeSetUrl(body, requestUrl) : "") || requestUrl
+        root.runDiscoveryStep("collections", homeSetUrl, Calendar.discoverCollectionsPropfind(), "1")
+        return
+      }
+      if (!ok) {
+        root.finishDiscovery(false, "Could not read calendars from that address", [])
+        return
+      }
+      var calendars = Calendar.discoveredCalendars(body, requestUrl)
+      if (calendars.length === 0) {
+        root.finishDiscovery(false, "No calendars were found at that address", [])
+        return
+      }
+      root.finishDiscovery(true, "", calendars)
     }
   }
 

--- a/calendar/CalendarController.qml
+++ b/calendar/CalendarController.qml
@@ -398,14 +398,15 @@ Item {
   }
 
   // Finds every calendar collection under one CalDAV account rather than
-  // asking for each calendar's own address by hand: PROPFIND for the
-  // signed-in principal, PROPFIND that for the calendar-home-set, then
-  // PROPFIND the home-set at Depth:1 for its children. A server that does
-  // not answer one of the first two steps still gets a chance at the last
-  // one against whatever address was given — many servers accept a
-  // home-set or even a calendar collection URL directly, and the discovery
-  // request that URL sees is server-supplied, so resolveDiscoveredUrl keeps
-  // holding it to the account's own origin at every step.
+  // asking for each calendar's own address by hand: RFC 6764's well-known
+  // redirect for a bare server address, PROPFIND for the signed-in
+  // principal, PROPFIND that for the calendar-home-set, then PROPFIND the
+  // home-set at Depth:1 for its children. A server that does not answer one
+  // of the first two PROPFIND steps still gets a chance at the last one
+  // against whatever address was given — many servers accept a home-set or
+  // even a calendar collection URL directly, and every address this walks
+  // through, redirected or discovered, is held to the account's own origin
+  // by resolveDiscoveredUrl before it is used for anything.
   function discoverCalendars(accountUrl, username, password) {
     if (discovering || savingSource) return
     var url = String(accountUrl || "").trim()
@@ -421,7 +422,9 @@ Item {
     discoveryCredentials = user + ":" + pass
     pass = ""
     discovering = true
-    runDiscoveryStep("principal", url, Calendar.discoverPrincipalPropfind(), "0")
+    var origin = Calendar.urlOrigin(url)
+    var wellKnownUrl = origin !== "" ? origin + "/.well-known/caldav" : url
+    runDiscoveryStep("wellknown", wellKnownUrl, Calendar.discoverPrincipalPropfind(), "0")
   }
 
   function runDiscoveryStep(stage, url, body, depth) {
@@ -835,8 +838,16 @@ Item {
       var status = Number(lines[0])
       var body = lines.length > 1
         ? Mail.decodeBase64Url(lines[1].replace(/\+/g, "-").replace(/\//g, "_")) : ""
+      var headers = lines.length > 3
+        ? Mail.decodeBase64Url(lines[3].replace(/\+/g, "-").replace(/\//g, "_")) : ""
       var ok = exitCode === 0 && status === 0
       var requestUrl = root.discoveryStageUrl
+      if (root.discoveryStage === "wellknown") {
+        var afterWellKnown = Calendar.discoveredWellKnownUrl(headers, root.discoveryAccountUrl)
+          || root.discoveryAccountUrl
+        root.runDiscoveryStep("principal", afterWellKnown, Calendar.discoverPrincipalPropfind(), "0")
+        return
+      }
       if (root.discoveryStage === "principal") {
         var principalUrl = (ok ? Calendar.discoveredPrincipalUrl(body, requestUrl) : "") || requestUrl
         root.runDiscoveryStep("homeset", principalUrl, Calendar.discoverHomeSetPropfind(), "0")

--- a/calendar/CalendarController.qml
+++ b/calendar/CalendarController.qml
@@ -54,12 +54,24 @@ Item {
   // more and ends the same way addCalDavCalendar does only after every one
   // of them is stored.
   property var sourcesBeingSaved: []
+  // How many addDiscoveredCalendars started with, so a keyring failure partway
+  // through a batch can say how many of them already have a password rather
+  // than just "could not save the password" — the config write that added
+  // all of them already committed, and is not rolled back on this failure.
+  property int sourcesBeingSavedTotal: 0
   property bool savingSource: false
   property bool discovering: false
   property string discoveryStage: ""
   property string discoveryAccountUrl: ""
   property string discoveryStageUrl: ""
   property string discoveryCredentials: ""
+  // Set for the one exited() this discoveryTransport run produces because
+  // cancelDiscovery() killed it, not because a server answered. Without it,
+  // that exited() is indistinguishable from a real reply: it would run the
+  // next stage or finishDiscovery with state cancelDiscovery() already
+  // cleared, and a fresh search started right after a cancel could receive
+  // the abandoned one's results once its request finally lands.
+  property bool discoveryCancelled: false
   property bool clockRunning: false
   property double nowMs: Date.now()
   property bool refreshAfterSourceWrite: false
@@ -445,6 +457,24 @@ Item {
     calendarsDiscovered(ok, String(error || ""), Array.isArray(calendars) ? calendars : [])
   }
 
+  // Stops a discovery in progress: killed, not merely disowned. Without
+  // this, a cancelled request kept running to whatever deadline curl gave
+  // it and controller.discovering stayed true until it did — the caller's
+  // "Find calendars" button would refuse a retry for as long as the
+  // abandoned request was still in flight, and once it did land,
+  // discoveryTransport.onExited would run the next PROPFIND stage or call
+  // finishDiscovery with a fresh search's URL already in discoveryAccountUrl,
+  // delivering the abandoned search's answer as the new one's.
+  function cancelDiscovery() {
+    if (!discovering) return
+    discoveryCancelled = true
+    discoveryTransport.running = false
+    discovering = false
+    discoveryStage = ""
+    discoveryStageUrl = ""
+    discoveryCredentials = ""
+  }
+
   // Adds every calendar the caller picked from a discoverCalendars result in
   // one config write, then stores the one account password against each of
   // them in turn — the same password, because CalDAV discovery only ever
@@ -471,6 +501,7 @@ Item {
     }
     sourceBeingSaved = null
     sourcesBeingSaved = added
+    sourcesBeingSavedTotal = added.length
     sourceSecret = String(secret)
     sourceWritePayload = Sources.serialize(next)
     refreshAfterSourceWrite = true
@@ -816,10 +847,16 @@ Item {
     onStarted: write(root.sourceSecret + "\n")
     onExited: function(exitCode) {
       if (exitCode !== 0) {
+        // The one that just failed was already shifted off the queue before
+        // this ran, so it is not counted as saved.
+        var saved = root.sourcesBeingSavedTotal - root.sourcesBeingSaved.length - 1
         root.sourceSecret = ""
         root.sourcesBeingSaved = []
         root.savingSource = false
-        root.calendarSaved(false, String(discoveryPasswordError.text || "Could not save the password"))
+        var detail = String(discoveryPasswordError.text || "Could not save the password")
+        root.calendarSaved(false, saved > 0
+          ? saved + " of " + root.sourcesBeingSavedTotal + " calendars were added before this failed: " + detail
+          : detail)
         return
       }
       root.storeNextDiscoveryPassword()
@@ -834,6 +871,11 @@ Item {
     stderr: StdioCollector { waitForEnd: true }
     onStarted: { write(requestLine); requestLine = "" }
     onExited: function(exitCode) {
+      // cancelDiscovery() killing this process produces an exited() of its
+      // own, indistinguishable from a real reply by exitCode alone — this is
+      // the one signal that tells the two apart, and it must be consumed
+      // before anything below reads state cancelDiscovery() already cleared.
+      if (root.discoveryCancelled) { root.discoveryCancelled = false; return }
       var lines = String(discoveryOutput.text || "").split("\n")
       var status = Number(lines[0])
       var body = lines.length > 1

--- a/components/CalendarSettings.qml
+++ b/components/CalendarSettings.qml
@@ -13,6 +13,9 @@ Column {
   required property color urgentColor
   required property string panelFontFamily
   property bool adding: false
+  property bool discovering: false
+  property var discoveryResults: []
+  property var discoverySelected: ({})
   property string passwordEditingId: ""
 
   width: parent ? parent.width : implicitWidth
@@ -189,13 +192,23 @@ Column {
     }
   }
 
-  IconTextButton {
-    visible: !root.adding
-    iconName: "plus"
-    text: "Add a calendar"
-    foreground: root.textColor
-    fontFamily: root.panelFontFamily
-    onClicked: root.adding = true
+  Row {
+    visible: !root.adding && !root.discovering
+    spacing: Style.space(6)
+    IconTextButton {
+      iconName: "plus"
+      text: "Add a calendar"
+      foreground: root.textColor
+      fontFamily: root.panelFontFamily
+      onClicked: root.adding = true
+    }
+    IconTextButton {
+      text: "Discover calendars..."
+      bordered: false
+      foreground: root.textColor
+      fontFamily: root.panelFontFamily
+      onClicked: root.discovering = true
+    }
   }
 
   Column {
@@ -258,6 +271,148 @@ Column {
     }
   }
 
+  Column {
+    width: parent.width
+    visible: root.discovering
+    spacing: Style.space(6)
+
+    TextField {
+      id: discoveryUrl
+      width: parent.width
+      visible: root.discoveryResults.length === 0
+      foreground: root.textColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.bodySmall
+      placeholderText: "CalDAV server address"
+    }
+    TextField {
+      id: discoveryUsername
+      width: parent.width
+      visible: root.discoveryResults.length === 0
+      foreground: root.textColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.bodySmall
+      placeholderText: "Username"
+    }
+    TextField {
+      id: discoveryPassword
+      width: parent.width
+      visible: root.discoveryResults.length === 0
+      password: true
+      foreground: root.textColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.bodySmall
+      placeholderText: "Password or app password"
+      onAccepted: root.findCalendars()
+    }
+
+    Row {
+      visible: root.discoveryResults.length === 0
+      spacing: Style.space(6)
+      IconTextButton {
+        text: root.controller && root.controller.discovering ? "Searching" : "Find calendars"
+        foreground: root.textColor
+        accent: root.accentColor
+        fontFamily: root.panelFontFamily
+        enabled: root.controller && !root.controller.discovering
+        onClicked: root.findCalendars()
+      }
+      IconTextButton {
+        text: "Cancel"
+        bordered: false
+        foreground: root.dimColor
+        fontFamily: root.panelFontFamily
+        onClicked: root.cancelDiscovery()
+      }
+    }
+
+    Text {
+      width: parent.width
+      visible: root.discoveryResults.length > 0
+      text: "Found " + root.discoveryResults.length + " calendar"
+        + (root.discoveryResults.length === 1 ? "" : "s") + ". Choose which to add:"
+      color: root.dimColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.caption
+      wrapMode: Text.WordWrap
+      textFormat: Text.PlainText
+    }
+
+    Column {
+      width: parent.width
+      visible: root.discoveryResults.length > 0
+      spacing: Style.space(4)
+
+      Repeater {
+        model: root.discoveryResults
+
+        Item {
+          width: root.width
+          height: Math.max(discoveredText.implicitHeight, discoveredSwitch.implicitHeight)
+
+          Column {
+            id: discoveredText
+            anchors.left: parent.left
+            anchors.right: discoveredSwitch.left
+            anchors.rightMargin: Style.space(10)
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: Style.space(2)
+
+            Text {
+              width: parent.width
+              text: String(modelData.name || "Calendar")
+              color: root.textColor
+              font.family: root.panelFontFamily
+              font.pixelSize: Style.font.bodySmall
+              elide: Text.ElideRight
+            }
+            Text {
+              width: parent.width
+              text: String(modelData.url || "")
+              color: root.dimColor
+              font.family: root.panelFontFamily
+              font.pixelSize: Style.font.caption
+              elide: Text.ElideMiddle
+            }
+          }
+
+          ToggleSwitch {
+            id: discoveredSwitch
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            checked: root.discoverySelected[modelData.url] !== false
+            foreground: root.textColor
+            accent: root.accentColor
+            onToggled: root.toggleDiscovered(modelData.url)
+          }
+        }
+      }
+
+      Row {
+        spacing: Style.space(6)
+        IconTextButton {
+          text: root.controller && root.controller.savingSource ? "Adding"
+            : "Add " + root.selectedDiscoveredCalendars().length + " calendar"
+              + (root.selectedDiscoveredCalendars().length === 1 ? "" : "s")
+          foreground: root.textColor
+          accent: root.accentColor
+          fontFamily: root.panelFontFamily
+          enabled: root.controller && !root.controller.savingSource
+            && root.selectedDiscoveredCalendars().length > 0
+          onClicked: root.controller.addDiscoveredCalendars(
+            root.selectedDiscoveredCalendars(), discoveryUsername.text, discoveryPassword.text)
+        }
+        IconTextButton {
+          text: "Cancel"
+          bordered: false
+          foreground: root.dimColor
+          fontFamily: root.panelFontFamily
+          onClicked: root.cancelDiscovery()
+        }
+      }
+    }
+  }
+
   Text {
     id: resultText
     width: parent.width
@@ -278,6 +433,39 @@ Column {
     }, calendarPassword.text)
   }
 
+  function findCalendars() {
+    resultText.text = ""
+    root.discoveryResults = []
+    root.discoverySelected = ({})
+    root.controller.discoverCalendars(discoveryUrl.text, discoveryUsername.text, discoveryPassword.text)
+  }
+
+  function toggleDiscovered(url) {
+    var next = {}
+    for (var key in root.discoverySelected) next[key] = root.discoverySelected[key]
+    next[url] = root.discoverySelected[url] === false
+    root.discoverySelected = next
+  }
+
+  function selectedDiscoveredCalendars() {
+    var out = []
+    for (var i = 0; i < root.discoveryResults.length; i++) {
+      var item = root.discoveryResults[i]
+      if (root.discoverySelected[item.url] !== false) out.push(item)
+    }
+    return out
+  }
+
+  function cancelDiscovery() {
+    root.discovering = false
+    root.discoveryResults = []
+    root.discoverySelected = ({})
+    discoveryUrl.text = ""
+    discoveryUsername.text = ""
+    discoveryPassword.text = ""
+    resultText.text = ""
+  }
+
   Connections {
     target: root.controller
     function onCalendarSaved(ok, error) {
@@ -289,6 +477,18 @@ Column {
       calendarPassword.text = ""
       root.adding = false
       root.passwordEditingId = ""
+      root.discovering = false
+      root.discoveryResults = []
+      root.discoverySelected = ({})
+      discoveryUrl.text = ""
+      discoveryUsername.text = ""
+      discoveryPassword.text = ""
+    }
+    function onCalendarsDiscovered(ok, error, calendars) {
+      if (!ok) { resultText.text = error; return }
+      resultText.text = ""
+      root.discoveryResults = calendars
+      root.discoverySelected = ({})
     }
   }
 }

--- a/components/CalendarSettings.qml
+++ b/components/CalendarSettings.qml
@@ -457,6 +457,10 @@ Column {
   }
 
   function cancelDiscovery() {
+    // Stops the request itself, not only this panel's view of it — without
+    // this, an abandoned search kept running and could still land on
+    // whatever the panel shows next, including a search typed after it.
+    if (root.controller) root.controller.cancelDiscovery()
     root.discovering = false
     root.discoveryResults = []
     root.discoverySelected = ({})

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -67,7 +67,7 @@ Outlook.com and Hotmail use Microsoft's OAuth device-code flow for delegated IMA
 - Actions: read/unread, star, archive, trash, untrash, report spam, mark all read
 - Compose, reply, reply-all, forward
 - Calendar invitations: full meeting detail, RSVP, and one-click Meet join
-- Calendar: month and week views over Google Calendar and CalDAV, with event create, edit and delete. Google calendars follow the current mailbox by default. A setting can combine every connected account in one view.
+- Calendar: month and week views over Google Calendar and CalDAV, with event create, edit and delete. Google calendars follow the current mailbox by default. A setting can combine every connected account in one view. A CalDAV account's server address can be discovered rather than added calendar by calendar: PROPFIND finds the signed-in principal, its calendar-home-set, and every calendar collection in it, and the ones chosen are added together under one password.
 - One-click unsubscribe from mailing lists that support it
 - Search using Gmail's own operator syntax
 - Unread badge in the bar; merged desktop notification for new mail

--- a/scripts/calendar-propfind.sh
+++ b/scripts/calendar-propfind.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# The CalDAV discovery verb, kept apart from calendar-transport.sh the way
+# that one's REPORT is kept apart from calendar-write.sh's PUT: one script,
+# one method. Fields cross base64-encoded on one line of stdin, so a password
+# never reaches the process table, and the config goes to curl's own stdin
+# rather than to a file on disk.
+set -eu
+
+fail() { printf '%s\n' "$1" >&2; exit 2; }
+decode() { printf '%s' "$1" | base64 -d 2>/dev/null || fail 'calendar-propfind.sh: bad base64 field'; }
+escape() { printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
+encode() { base64 < "$1" | tr -d '\n'; }
+
+. "$(dirname "$0")/curl-config.sh"
+
+IFS= read -r line || fail 'calendar-propfind.sh: no request on stdin'
+# The four fields are base64 and therefore contain no spaces.
+# shellcheck disable=SC2086
+set -- $line
+[ $# -eq 4 ] || fail 'calendar-propfind.sh: expected URL, credentials, depth and body'
+validate_config_fields "$@"
+
+url=$(decode "$1")
+credentials=$(decode "$2")
+depth=$(decode "$3")
+body=$(decode "$4")
+case "$url" in https://*) ;; *) fail 'calendar-propfind.sh: CalDAV requires HTTPS' ;; esac
+case "$depth" in 0|1) ;; *) fail 'calendar-propfind.sh: depth must be 0 or 1' ;; esac
+
+umask 077
+work=$(mktemp -d "${TMPDIR:-/tmp}/omamail-calendar-propfind.XXXXXX") \
+  || fail 'calendar-propfind.sh: no temporary directory'
+trap 'rm -rf "$work"' EXIT INT TERM HUP
+
+build_config() {
+  printf 'url = "%s"\n' "$(escape "$url")"
+  printf 'noproxy = "*"\n'
+  printf 'user = "%s"\n' "$(escape "$credentials")"
+  printf 'request = "PROPFIND"\n'
+  printf 'header = "Depth: %s"\n' "$depth"
+  printf 'header = "Content-Type: application/xml; charset=utf-8"\n'
+  printf 'data = "%s"\n' "$(escape "$body")"
+  printf 'proto = "=https"\n'
+  printf 'proto-redir = "=https"\n'
+}
+
+set +e
+build_config | curl -q --globoff --config - --silent --show-error \
+  --dump-header "$work/headers" --max-time 60 --connect-timeout 20 \
+  > "$work/out" 2> "$work/err"
+status=$?
+set -e
+
+printf '%s\n' "$status"
+encode "$work/out"
+printf '\n'
+encode "$work/err"
+printf '\n'

--- a/scripts/calendar-propfind.sh
+++ b/scripts/calendar-propfind.sh
@@ -4,6 +4,12 @@
 # one method. Fields cross base64-encoded on one line of stdin, so a password
 # never reaches the process table, and the config goes to curl's own stdin
 # rather than to a file on disk.
+#
+# curl is never told to follow a redirect (no --location): the response
+# headers go back to the caller instead, so calendar/Calendar.js can decide
+# whether a 3xx's Location is worth one more hop on the same rule it holds
+# every other discovered address to — the account's own origin, nothing
+# named by a server left to speak for itself.
 set -eu
 
 fail() { printf '%s\n' "$1" >&2; exit 2; }
@@ -55,4 +61,6 @@ printf '%s\n' "$status"
 encode "$work/out"
 printf '\n'
 encode "$work/err"
+printf '\n'
+encode "$work/headers"
 printf '\n'

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -517,18 +517,23 @@ assert.strictEqual(feed.discoveredHomeSetUrl(homeSetXml, "https://dav.example/pr
   "https://dav.example/dav/me/calendars/")
 
 const collectionsXml = '<?xml version="1.0"?>'
-  + '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" '
-  + 'xmlns:ic="http://apple.com/ns/ical/">'
-  // A real calendar with a colour and an explicit VEVENT-supporting set.
+  + '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">'
+  // A real calendar with an explicit VEVENT-supporting set.
   + '<d:response><d:href>/dav/me/calendars/work/</d:href><d:propstat><d:prop>'
   + '<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>'
-  + '<d:displayname>Work</d:displayname><ic:calendar-color>#4FA8DEFF</ic:calendar-color>'
+  + '<d:displayname>Work</d:displayname>'
   + '<c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set>'
   + '</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>'
   // A calendar that declares no component set at all: kept, not dropped.
   + '<d:response><d:href>/dav/me/calendars/family/</d:href><d:propstat><d:prop>'
   + '<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>'
   + '<d:displayname>Family</d:displayname>'
+  + '</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>'
+  // A same-directory relative href, with no leading slash: resolved against
+  // the home-set's own path, the way a bare filename resolves in a browser.
+  + '<d:response><d:href>shared/</d:href><d:propstat><d:prop>'
+  + '<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>'
+  + '<d:displayname>Shared</d:displayname>'
   + '</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>'
   // A task list: declares a component set with no VEVENT in it.
   + '<d:response><d:href>/dav/me/calendars/tasks/</d:href><d:propstat><d:prop>'
@@ -548,12 +553,11 @@ const collectionsXml = '<?xml version="1.0"?>'
   + '</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>'
   + '</d:multistatus>'
 const discovered = feed.discoveredCalendars(collectionsXml, "https://dav.example/dav/me/calendars/")
-assert.strictEqual(discovered.length, 2)
+assert.strictEqual(discovered.length, 3)
 assert.deepStrictEqual(JSON.parse(JSON.stringify(discovered.map(function(c) { return c.name }))),
-  ["Work", "Family"])
+  ["Work", "Family", "Shared"])
 assert.strictEqual(discovered[0].url, "https://dav.example/dav/me/calendars/work/")
-assert.strictEqual(discovered[0].color, "#4fa8de")
-assert.strictEqual(discovered[1].color, "")
+assert.strictEqual(discovered[2].url, "https://dav.example/dav/me/calendars/shared/")
 
 // Resolution against the home-set's own origin, the same rule caldavEventUrl
 // applies to a written event's href.

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -568,4 +568,37 @@ assert.strictEqual(feed.discoveredCalendars(
   crossOriginCollectionsXml, "https://dav.example/dav/me/calendars/").length, 0,
   "a collection reported on a different origin is dropped, not offered")
 
+// The RFC 6764 well-known redirect: a bare server address that answers 404
+// on its own (Fastmail does exactly this) still names the real service
+// through /.well-known/caldav, which curl is never told to follow itself.
+const redirectHeaders = "HTTP/1.1 301 Moved Permanently\r\n"
+  + "Location: https://dav.example/dav/calendars\r\n"
+  + "Content-Length: 0\r\n"
+assert.strictEqual(feed.discoveredWellKnownUrl(redirectHeaders, "https://dav.example/"),
+  "https://dav.example/dav/calendars")
+
+// A relative Location resolves against the account's own origin too.
+const relativeRedirectHeaders = "HTTP/1.1 302 Found\r\nLocation: /dav/calendars\r\n"
+assert.strictEqual(feed.discoveredWellKnownUrl(relativeRedirectHeaders, "https://dav.example/"),
+  "https://dav.example/dav/calendars")
+
+// A redirect naming a different origin is refused, the same as any other
+// discovered address.
+const crossOriginRedirectHeaders = "HTTP/1.1 301 Moved Permanently\r\n"
+  + "Location: https://evil.example/dav/calendars\r\n"
+assert.strictEqual(feed.discoveredWellKnownUrl(crossOriginRedirectHeaders, "https://dav.example/"), "")
+
+// No redirect at all — a direct 404, a 401, or a real 207 — leaves nothing
+// for the caller to follow.
+assert.strictEqual(feed.discoveredWellKnownUrl("HTTP/1.1 404 Not Found\r\n", "https://dav.example/"), "")
+assert.strictEqual(feed.discoveredWellKnownUrl("HTTP/1.1 207 Multi-Status\r\n", "https://dav.example/"), "")
+assert.strictEqual(feed.discoveredWellKnownUrl("", "https://dav.example/"), "")
+
+// The last status and Location win when a response dump holds more than one
+// (an early 100 Continue, or a redirect curl received but did not follow).
+const layeredHeaders = "HTTP/1.1 100 Continue\r\n\r\n"
+  + "HTTP/1.1 301 Moved Permanently\r\nLocation: https://dav.example/dav/calendars\r\n"
+assert.strictEqual(feed.discoveredWellKnownUrl(layeredHeaders, "https://dav.example/"),
+  "https://dav.example/dav/calendars")
+
 console.log("test_calendar_feed.js ok")

--- a/tests/test_calendar_feed.js
+++ b/tests/test_calendar_feed.js
@@ -470,4 +470,102 @@ assert.ok(googleUrl.indexOf("singleEvents=true") > 0)
 assert.ok(googleUrl.indexOf("orderBy=startTime") > 0)
 assert.ok(googleUrl.indexOf("timeMin=2026-08-01T00%3A00%3A00.000Z") > 0)
 
+// ------------------------------------------------------ calendar discovery
+
+assert.ok(feed.discoverPrincipalPropfind().indexOf("<d:current-user-principal/>") >= 0)
+assert.ok(feed.discoverHomeSetPropfind().indexOf("<c:calendar-home-set/>") >= 0)
+const collectionsBody = feed.discoverCollectionsPropfind()
+assert.ok(collectionsBody.indexOf("<d:resourcetype/>") >= 0)
+assert.ok(collectionsBody.indexOf("<c:supported-calendar-component-set/>") >= 0)
+
+const principalXml = '<?xml version="1.0"?>'
+  + '<d:multistatus xmlns:d="DAV:">'
+  + '<d:response><d:href>/</d:href><d:propstat><d:prop>'
+  + '<d:current-user-principal><d:href>/principals/me/</d:href></d:current-user-principal>'
+  + '</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>'
+  + '</d:multistatus>'
+assert.strictEqual(feed.discoveredPrincipalUrl(principalXml, "https://dav.example/"),
+  "https://dav.example/principals/me/")
+
+// A server that does not support the property still answers 207: the prop
+// element is simply empty, and that reads the same as "not found" here.
+const emptyPrincipalXml = '<?xml version="1.0"?>'
+  + '<d:multistatus xmlns:d="DAV:">'
+  + '<d:response><d:href>/</d:href><d:propstat><d:prop/>'
+  + '<d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response>'
+  + '</d:multistatus>'
+assert.strictEqual(feed.discoveredPrincipalUrl(emptyPrincipalXml, "https://dav.example/"), "")
+
+// A principal response naming a different origin is refused before its
+// address is ever used as the next request's target — discovery cannot be
+// handed off to a server the user did not configure.
+const crossOriginPrincipalXml = '<?xml version="1.0"?>'
+  + '<d:multistatus xmlns:d="DAV:">'
+  + '<d:response><d:href>/</d:href><d:propstat><d:prop>'
+  + '<d:current-user-principal><d:href>https://evil.example/principals/me/</d:href></d:current-user-principal>'
+  + '</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>'
+  + '</d:multistatus>'
+assert.strictEqual(feed.discoveredPrincipalUrl(crossOriginPrincipalXml, "https://dav.example/"), "")
+
+const homeSetXml = '<?xml version="1.0"?>'
+  + '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">'
+  + '<d:response><d:href>/principals/me/</d:href><d:propstat><d:prop>'
+  + '<c:calendar-home-set><d:href>/dav/me/calendars/</d:href></c:calendar-home-set>'
+  + '</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>'
+  + '</d:multistatus>'
+assert.strictEqual(feed.discoveredHomeSetUrl(homeSetXml, "https://dav.example/principals/me/"),
+  "https://dav.example/dav/me/calendars/")
+
+const collectionsXml = '<?xml version="1.0"?>'
+  + '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" '
+  + 'xmlns:ic="http://apple.com/ns/ical/">'
+  // A real calendar with a colour and an explicit VEVENT-supporting set.
+  + '<d:response><d:href>/dav/me/calendars/work/</d:href><d:propstat><d:prop>'
+  + '<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>'
+  + '<d:displayname>Work</d:displayname><ic:calendar-color>#4FA8DEFF</ic:calendar-color>'
+  + '<c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set>'
+  + '</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>'
+  // A calendar that declares no component set at all: kept, not dropped.
+  + '<d:response><d:href>/dav/me/calendars/family/</d:href><d:propstat><d:prop>'
+  + '<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>'
+  + '<d:displayname>Family</d:displayname>'
+  + '</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>'
+  // A task list: declares a component set with no VEVENT in it.
+  + '<d:response><d:href>/dav/me/calendars/tasks/</d:href><d:propstat><d:prop>'
+  + '<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>'
+  + '<d:displayname>Tasks</d:displayname>'
+  + '<c:supported-calendar-component-set><c:comp name="VTODO"/></c:supported-calendar-component-set>'
+  + '</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>'
+  // The scheduling inbox: carries {CALDAV:}calendar too, but is not one.
+  + '<d:response><d:href>/dav/me/calendars/inbox/</d:href><d:propstat><d:prop>'
+  + '<d:resourcetype><d:collection/><c:calendar/><c:schedule-inbox/></d:resourcetype>'
+  + '<d:displayname>Inbox</d:displayname>'
+  + '</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>'
+  // The home-set collection itself: a plain collection, not a calendar.
+  + '<d:response><d:href>/dav/me/calendars/</d:href><d:propstat><d:prop>'
+  + '<d:resourcetype><d:collection/></d:resourcetype>'
+  + '<d:displayname>calendars</d:displayname>'
+  + '</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>'
+  + '</d:multistatus>'
+const discovered = feed.discoveredCalendars(collectionsXml, "https://dav.example/dav/me/calendars/")
+assert.strictEqual(discovered.length, 2)
+assert.deepStrictEqual(JSON.parse(JSON.stringify(discovered.map(function(c) { return c.name }))),
+  ["Work", "Family"])
+assert.strictEqual(discovered[0].url, "https://dav.example/dav/me/calendars/work/")
+assert.strictEqual(discovered[0].color, "#4fa8de")
+assert.strictEqual(discovered[1].color, "")
+
+// Resolution against the home-set's own origin, the same rule caldavEventUrl
+// applies to a written event's href.
+const crossOriginCollectionsXml = '<?xml version="1.0"?>'
+  + '<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">'
+  + '<d:response><d:href>https://evil.example/work/</d:href><d:propstat><d:prop>'
+  + '<d:resourcetype><d:collection/><c:calendar/></d:resourcetype>'
+  + '<d:displayname>Work</d:displayname>'
+  + '</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>'
+  + '</d:multistatus>'
+assert.strictEqual(feed.discoveredCalendars(
+  crossOriginCollectionsXml, "https://dav.example/dav/me/calendars/").length, 0,
+  "a collection reported on a different origin is dropped, not offered")
+
 console.log("test_calendar_feed.js ok")

--- a/tests/test_calendar_propfind.sh
+++ b/tests/test_calendar_propfind.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_dir=$(cd "$(dirname "$0")/.." && pwd)
+work=$(mktemp -d /tmp/omamail-calendar-propfind-test.XXXXXX)
+trap 'rm -rf "$work"' EXIT
+
+mkdir -p "$work/bin"
+cat > "$work/bin/curl" <<'SH'
+#!/bin/sh
+config=$(cat)
+printf '%s' "$config" > "$CALENDAR_CURL_CONFIG"
+printf 'HTTP/1.1 207 Multi-Status\r\n' > "$CALENDAR_CURL_HEADERS"
+printf '<d:multistatus/>'
+exit 0
+SH
+chmod +x "$work/bin/curl"
+
+b64() { printf '%s' "$1" | base64 -w0; }
+export CALENDAR_CURL_CONFIG="$work/config"
+export CALENDAR_CURL_HEADERS="$work/headers"
+request="$(b64 'https://calendar.example/') $(b64 'me:secret') $(b64 '0') $(b64 '<propfind/>')"
+reply=$(printf '%s\n' "$request" | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-propfind.sh")
+
+grep -q 'url = "https://calendar.example/"' "$work/config"
+grep -q 'user = "me:secret"' "$work/config"
+grep -q 'request = "PROPFIND"' "$work/config"
+grep -q 'header = "Depth: 0"' "$work/config"
+grep -q 'data = "<propfind/>"' "$work/config"
+test "$(printf '%s\n' "$reply" | sed -n '1p')" = 0
+test "$(printf '%s\n' "$reply" | sed -n '2p' | base64 -d)" = '<d:multistatus/>'
+
+request_depth1="$(b64 'https://calendar.example/') $(b64 'me:secret') $(b64 '1') $(b64 '<propfind/>')"
+printf '%s\n' "$request_depth1" | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-propfind.sh" >/dev/null
+grep -q 'header = "Depth: 1"' "$work/config"
+
+if printf '%s\n' "$(b64 'http://calendar.example/') $(b64 'me:secret') $(b64 '0') $(b64 '<propfind/>')" \
+  | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-propfind.sh" >/dev/null 2>&1; then
+  echo 'plaintext calendar URL was accepted' >&2
+  exit 1
+fi
+
+if printf '%s\n' "$(b64 'https://calendar.example/') $(b64 'me:secret') $(b64 '2') $(b64 '<propfind/>')" \
+  | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-propfind.sh" >/dev/null 2>&1; then
+  echo 'a depth other than 0 or 1 was accepted' >&2
+  exit 1
+fi
+
+echo 'calendar-propfind.sh ok'

--- a/tests/test_calendar_propfind.sh
+++ b/tests/test_calendar_propfind.sh
@@ -6,11 +6,21 @@ work=$(mktemp -d /tmp/omamail-calendar-propfind-test.XXXXXX)
 trap 'rm -rf "$work"' EXIT
 
 mkdir -p "$work/bin"
+# calendar-propfind.sh reads back its own --dump-header file rather than a
+# side-channel env var, so the stub has to honor that real argument -- unlike
+# calendar-transport.sh's stub, which never reads the header dump it names.
 cat > "$work/bin/curl" <<'SH'
 #!/bin/sh
 config=$(cat)
 printf '%s' "$config" > "$CALENDAR_CURL_CONFIG"
-printf 'HTTP/1.1 207 Multi-Status\r\n' > "$CALENDAR_CURL_HEADERS"
+header_file=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dump-header) header_file=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$header_file" ] && printf 'HTTP/1.1 207 Multi-Status\r\n' > "$header_file"
 printf '<d:multistatus/>'
 exit 0
 SH
@@ -18,7 +28,6 @@ chmod +x "$work/bin/curl"
 
 b64() { printf '%s' "$1" | base64 -w0; }
 export CALENDAR_CURL_CONFIG="$work/config"
-export CALENDAR_CURL_HEADERS="$work/headers"
 request="$(b64 'https://calendar.example/') $(b64 'me:secret') $(b64 '0') $(b64 '<propfind/>')"
 reply=$(printf '%s\n' "$request" | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-propfind.sh")
 
@@ -29,6 +38,9 @@ grep -q 'header = "Depth: 0"' "$work/config"
 grep -q 'data = "<propfind/>"' "$work/config"
 test "$(printf '%s\n' "$reply" | sed -n '1p')" = 0
 test "$(printf '%s\n' "$reply" | sed -n '2p' | base64 -d)" = '<d:multistatus/>'
+# The dumped response headers come back too, so the caller can read a
+# redirect's Location without curl ever being told to follow it itself.
+test "$(printf '%s\n' "$reply" | sed -n '4p' | base64 -d)" = "$(printf 'HTTP/1.1 207 Multi-Status\r\n')"
 
 request_depth1="$(b64 'https://calendar.example/') $(b64 'me:secret') $(b64 '1') $(b64 '<propfind/>')"
 printf '%s\n' "$request_depth1" | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-propfind.sh" >/dev/null
@@ -45,5 +57,27 @@ if printf '%s\n' "$(b64 'https://calendar.example/') $(b64 'me:secret') $(b64 '2
   echo 'a depth other than 0 or 1 was accepted' >&2
   exit 1
 fi
+
+# The well-known redirect Fastmail and others answer a bare server address
+# with: curl is never told to follow it, so the redirect's own headers, not
+# a followed response, must be what comes back.
+cat > "$work/bin/curl" <<'SH'
+#!/bin/sh
+cat >/dev/null
+header_file=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dump-header) header_file=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$header_file" ] && printf 'HTTP/1.1 301 Moved Permanently\r\nLocation: https://calendar.example/dav/calendars\r\n' > "$header_file"
+exit 0
+SH
+redirect_reply=$(printf '%s\n' \
+  "$(b64 'https://calendar.example/.well-known/caldav') $(b64 'me:secret') $(b64 '0') $(b64 '<propfind/>')" \
+  | PATH="$work/bin:$PATH" "$project_dir/scripts/calendar-propfind.sh")
+test "$(printf '%s\n' "$redirect_reply" | sed -n '4p' | base64 -d)" \
+  = "$(printf 'HTTP/1.1 301 Moved Permanently\r\nLocation: https://calendar.example/dav/calendars\r\n')"
 
 echo 'calendar-propfind.sh ok'

--- a/tests/test_curl_config.py
+++ b/tests/test_curl_config.py
@@ -26,6 +26,7 @@ with tempfile.TemporaryDirectory(prefix="omamail-config-test-") as directory:
         ("calendar-transport.sh", [], [b"https://example.com/dav", b"user:secret", b"<query/>"], [0, 1, 2]),
         ("calendar-write.sh", [], [b"https://example.com/dav", b"user:secret", b"BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"], [0, 1]),
         ("calendar-delete.sh", [], [b"https://example.com/dav", b"user:secret"], [0, 1]),
+        ("calendar-propfind.sh", [], [b"https://example.com/dav", b"user:secret", b"0", b"<propfind/>"], [0, 1, 2, 3]),
         ("mail-transport.sh", ["imap"], [b"imaps://example.com/INBOX", b"user:secret", b"NOOP", b"UID SEARCH ALL"], [0, 1, 2, 3]),
         ("mail-transport.sh", ["imap-id"], [b"imaps://example.com/", b"imaps://example.com/INBOX", b"user:secret", b"ID NIL", b"NOOP"], [0, 1, 2, 3, 4]),
         ("mail-transport.sh", ["smtp"], [b"smtps://example.com/", b"user:secret", b"sender@example.com", b"Subject: Hello\r\n\r\nBody\r\n", b"to@example.com", b"next@example.com"], [0, 1, 2, 4, 5]),


### PR DESCRIPTION
Adding a CalDAV calendar to Omamail means finding and pasting each calendar's own collection URL by hand — a name, the exact address, a username, a password, one calendar at a time. That doesn't scale to an account with several calendars: Fastmail, Nextcloud, Radicale, Baïkal and most other CalDAV servers hand out one collection per calendar under a shared home address, and there is no page in most of their web UIs that simply lists every collection's raw URL. Finding each one by hand means digging through provider-specific docs or a browser calendar client's "share" dialog, once per calendar.

This adds a "Discover calendars..." button beside "Add a calendar" in Settings → Calendars. Given one CalDAV server address and one set of credentials, it walks the discovery chain a full-featured CalDAV client would: the RFC 6764 well-known redirect (so a bare provider address like `https://caldav.fastmail.com`, which some providers 404 on directly, still resolves), RFC 5397's current-user-principal, RFC 4791's calendar-home-set, and a Depth:1 listing of what's in it — filtered to calendars that actually hold events, with task lists and the CalDAV Scheduling inbox/outbox left out. The results come back as a checklist; the ones picked are added together under the same password, one keyring write per calendar.

Every server-supplied address along that chain is resolved and held to the account's own origin before it's used for anything — the well-known redirect's Location, the principal href, the home-set href, each calendar's own href — on the same rule `caldavEventUrl` already applies to a server-written event href. A response naming a different host or port is dropped rather than followed. The new transport (`scripts/calendar-propfind.sh`) follows the existing base64-over-stdin curl-config pattern used by every other CalDAV script here; curl is never told to follow a redirect itself, so a hop can be revalidated before it is taken.

## Verification

`make validate` green on 94b128d (node tests, source regressions, qmllint, `omarchy plugin validate`, and the offscreen QML suite — 581 passed, 0 failed).

New tests, watched failing against the unfixed base (upstream `main`, 77db4b1): `tests/test_calendar_feed.js` fails with `feed.discoverPrincipalPropfind is not a function`; `tests/test_calendar_propfind.sh` fails with the script missing; `tests/test_curl_config.py` fails asserting the (absent) script accepted valid input. All three pass on this branch.

Hand-driven: tested against a real Fastmail account (`caldav.fastmail.com`) — confirmed working, including recovering from Fastmail's bare-domain 404 via the well-known redirect, which is what the second commit here exists for. Observed in the dark Omarchy theme at the default (three-column) window size. Screenshot below is the Settings → Calendars panel with an already-configured calendar list redacted (their real CalDAV collection URLs). **Not verified**: light theme, and the narrow/mini window size — neither was reachable in the environment this was built in; a maintainer or a follow-up pass should cover them before merge.

<img width="1562" height="1904" alt="image" src="https://github.com/user-attachments/assets/b9421c2d-21cf-41a5-b4e0-dac92e913737">

A fresh agent with no context on this change reviewed the diff against AGENTS.md (per CONTRIBUTING.md's required process), with a security verdict of **PASS**: every discovered address is resolved through the same same-origin rule as `caldavEventUrl`, credentials never reach argv, and `calendar-propfind.sh` was fuzzed by hand with the same hostile-field battery `test_curl_config.py` uses (embedded CR/LF/NUL/control characters, curl-config injection) — all rejected before curl starts. It found four correctness gaps and a missing regression test. Fixed here: cancelling a discovery in progress now actually stops the request instead of leaving `controller.discovering` stuck true until an abandoned request's own deadline, and a stale result could otherwise land on a search typed after the cancel; a discovered calendar's colour was parsed and unit-tested but never used anywhere, and AGENTS.md's Colors section says why it shouldn't be — removed, along with the `ic:calendar-color` request property; `calendar-propfind.sh` had no entry in `test_curl_config.py`'s shared hostile-field cases, unlike every sibling CalDAV script — added. Left as-is, with reasons: no QML-level test covers the discovery Process chain, and a batch add's config write is not rolled back if a later keyring write fails. Both match the existing shape of every other CalDAV flow in this file exactly — none of REPORT, PUT, DELETE, or the single-calendar password-set queue have QML-level Process tests either, and `addCalDavCalendar`'s own write-then-keyring split already has the same no-rollback property. Changing that shape is a larger, separate change touching code this feature does not otherwise need to.

## Release Notes

- CalDAV calendars can now be found automatically: enter a server address and credentials once in Settings → Calendars → "Discover calendars...", and every calendar in the account is offered to add, instead of pasting each one's own address by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFRUwGKQ6EVk4AkH4Uy3gg
