### PR TITLE
Let markReadAutomatically leave read state to explicit actions

### DIFF
--- a/App.qml
+++ b/App.qml
@@ -577,8 +577,9 @@ Item {
   // override is a per-message decision about one specific message and does not.
   function openMessage(id) {
     if (!service) return
-    // Opening marks it read itself, so a dwell still counting down for the
-    // same message has nothing left to do.
+    // Opening marks it read itself — or, with automatic marking off, leaves it
+    // for an explicit action — so a dwell still counting down for the same
+    // message has nothing left to do either way.
     markReadDwell.stop()
     pendingComposeMode = ""
     pendingDraftId = ""
@@ -774,6 +775,7 @@ Item {
   function armReadDwell() {
     if (!service || markReadDwell.dwelledOn === "") return
     if (!canPreview || !previewShowing) return
+    if (!service.markReadAutomatically) return
     // Still the message on screen: a search and a mailbox switch both drop the
     // selection without moving the cursor off the row.
     if (service.selectedId !== markReadDwell.dwelledOn) return
@@ -798,6 +800,7 @@ Item {
     onTriggered: {
       if (!root.service || dwelledOn === "") return
       if (!root.canPreview) return
+      if (!root.service.markReadAutomatically) return
       if (root.cursorId !== dwelledOn) return
       // And it has to still be the message on screen: a search and a mailbox
       // switch both drop the selection without moving the cursor off the row.

--- a/Service.qml
+++ b/Service.qml
@@ -74,6 +74,7 @@ Item {
     showBarIcon: true,
     unifiedMailboxes: false,
     previewOnCursor: false,
+    markReadAutomatically: true,
     markReadDelaySec: 2
   })
   property var settings: defaultSettingValues
@@ -260,6 +261,12 @@ Item {
   readonly property bool previewOnCursor: !!settings
     && settings.previewOnCursor === true
 
+  // Whether opening a message or dwelling on its cursor preview changes its
+  // read state. Missing and malformed values keep the existing behavior; only
+  // an explicit false opts into manual marking.
+  readonly property bool markReadAutomatically: !settings
+    || settings.markReadAutomatically !== false
+
   // How long the cursor has to stay before a previewed message counts as
   // read. Clamped rather than trusted: this is a hand-editable file, and a
   // negative interval on a Timer never fires at all.
@@ -354,6 +361,10 @@ Item {
 
   function setPreviewOnCursor(value) {
     persistSetting("previewOnCursor", value === true)
+  }
+
+  function setMarkReadAutomatically(value) {
+    persistSetting("markReadAutomatically", value === true)
   }
 
   // The same rule on the way in: what cannot be read as a count is written as
@@ -1538,7 +1549,7 @@ Item {
     selectionHost = null
   }
   function markPreviewRead(id) {
-    if (!id) return false
+    if (!markReadAutomatically || !id) return false
     if (unified) {
       var host = hostForId(id)
       return host ? host.markPreviewRead(sourceIdFor(id)) : false

--- a/account/MailAccount.qml
+++ b/account/MailAccount.qml
@@ -97,6 +97,8 @@ Item {
   readonly property int oauthPort: OAuth.normalizedPort(setting("oauthPort", OAuth.DEFAULT_PORT))
   readonly property int undoSendSeconds: Outbox.normalizeDelay(
     setting("undoSendSeconds", Outbox.DEFAULT_DELAY_SECONDS))
+  readonly property bool markReadAutomatically:
+    setting("markReadAutomatically", true) !== false
 
   // Built by the loaders at the bottom, so both are null for one frame while an
   // account switches provider. Every use guards for that rather than assuming.
@@ -1171,14 +1173,15 @@ Item {
       root.rememberMember(summary)
       root.loadMembers()
       // A preview is not opening; only an opened message is marked read here.
-      if (Model.marksReadOnArrival(summary, root.selectionIsPreview))
+      if (Model.marksReadOnArrival(summary, root.selectionIsPreview,
+          root.markReadAutomatically))
         root.act(messageId, "markRead", true)
     })
   }
 
   // Mark the message the dwell started on, if it is still unread.
   function markPreviewRead(id) {
-    if (!Model.previewReadable(messages, id)) return false
+    if (!markReadAutomatically || !Model.previewReadable(messages, id)) return false
     act(String(id), "markRead", true)
     return true
   }

--- a/account/Model.js
+++ b/account/Model.js
@@ -1586,9 +1586,11 @@ function settingsScrollTarget(sections, key, contentHeight, viewportHeight) {
 // message it passed read without any of them having been looked at, which is
 // the reason moving stopped opening in the first place — so the panel marks a
 // previewed message read once the cursor has stayed on it, and arrival leaves
-// it alone.
-function marksReadOnArrival(summary, isPreview) {
-  return !!summary && summary.unread === true && isPreview !== true
+// it alone. A manual-only preference leaves both an opened message and a
+// previewed one alone until an explicit read action is taken.
+function marksReadOnArrival(summary, isPreview, markReadAutomatically) {
+  return markReadAutomatically !== false
+    && !!summary && summary.unread === true && isPreview !== true
 }
 
 // Whether a dwell on a previewed message has anything to mark: it has to still

--- a/components/SettingsPage.qml
+++ b/components/SettingsPage.qml
@@ -353,6 +353,57 @@ Column {
     }
   }
 
+  Rectangle {
+    width: parent.width
+    implicitHeight: Math.max(autoReadText.implicitHeight, autoReadSwitch.implicitHeight)
+      + Style.space(16)
+    radius: Style.cornerRadius
+    color: Style.normalFillFor(root.textColor, root.accentColor)
+
+    Column {
+      id: autoReadText
+      anchors.left: parent.left
+      anchors.leftMargin: Style.space(12)
+      anchors.right: autoReadSwitch.left
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(2)
+
+      Text {
+        width: parent.width
+        text: "Mark messages read automatically"
+        color: root.textColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.bodySmall
+        textFormat: Text.PlainText
+      }
+
+      Text {
+        width: parent.width
+        text: "Opening a message or dwelling on a cursor preview marks it read. "
+          + "Turn this off to use Shift+I or the message menu instead"
+        color: root.dimColor
+        font.family: root.panelFontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+        textFormat: Text.PlainText
+      }
+    }
+
+    ToggleSwitch {
+      id: autoReadSwitch
+      objectName: "markReadAutomaticallySwitch"
+      anchors.right: parent.right
+      anchors.rightMargin: Style.space(10)
+      anchors.verticalCenter: parent.verticalCenter
+      checked: !root.service || root.service.markReadAutomatically !== false
+      foreground: root.textColor
+      accent: root.accentColor
+      onToggled: if (root.service)
+        root.service.setMarkReadAutomatically(!root.service.markReadAutomatically)
+    }
+  }
+
   // Showing a message as the cursor reaches it, and the dwell that keeps that
   // from reading a mailbox by holding an arrow key down.
   Rectangle {
@@ -381,10 +432,14 @@ Column {
       }
 
       Text {
+        objectName: "previewOnCursorCaption"
         width: parent.width
         text: "Show a message as soon as j, k or an arrow reaches it, instead of "
-          + "waiting for Enter. A previewed message is marked read only once the "
-          + "cursor has stayed on it, so stepping through a list does not read it. "
+          + "waiting for Enter. "
+          + (!root.service || root.service.markReadAutomatically !== false
+            ? "A previewed message is marked read only once the cursor has stayed "
+              + "on it, so stepping through a list does not read it. "
+            : "A previewed message stays unread until you mark it read. ")
           + "Not applied in a narrow window, where the reader takes the list's place."
         color: root.dimColor
         font.family: root.panelFontFamily
@@ -411,6 +466,7 @@ Column {
   Rectangle {
     width: parent.width
     visible: !!root.service && root.service.previewOnCursor
+      && root.service.markReadAutomatically !== false
     implicitHeight: Math.max(dwellText.implicitHeight, dwellSeconds.implicitHeight)
       + Style.space(16)
     radius: Style.cornerRadius

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -38,7 +38,7 @@ readonly property string keyContext:
 | Context | What it is | What it binds |
 |---|---|---|
 | `list` | The message list | The mailbox keys |
-| `reader` | A message open | The mailbox keys, plus reply/forward and zoom. `j`/`k` move the cursor; `o` or `Enter` opens what they landed on. With *Preview as the cursor moves* on, moving also shows the message, and it counts as read once the cursor has stayed on it |
+| `reader` | A message open | The mailbox keys, plus reply/forward and zoom. `j`/`k` move the cursor; `o` or `Enter` opens what they landed on. With *Preview as the cursor moves* on, moving also shows the message, and it counts as read once the cursor has stayed on it when automatic marking is enabled |
 | `search` | A query being typed | `Escape`, and the modified keys |
 | `compose` | A draft being written | `Escape`, `Ctrl+Return`, and the modified keys |
 | `assistant` | Typing or reading in the AI dock | `Return`/`Enter` sends, `Escape`, and the modified keys |

--- a/manifest.json
+++ b/manifest.json
@@ -49,6 +49,7 @@
       "openOnClick": "Window",
       "showBarIcon": true,
       "previewOnCursor": false,
+      "markReadAutomatically": true,
       "markReadDelaySec": 2
     },
     "schema": [
@@ -86,6 +87,13 @@
         "description": "Show a message as soon as the cursor reaches it, instead of waiting for Enter. Off by default because stepping through a list would otherwise mark every message it passed read; with this on, a previewed message is marked read only once the cursor has stayed on it. Not applied in a narrow window, where the reader takes the list's place."
       },
       {
+        "key": "markReadAutomatically",
+        "type": "boolean",
+        "label": "Mark messages read automatically",
+        "defaultValue": true,
+        "description": "Mark a message read when you open it or leave a cursor preview on it. Turn this off to mark messages read only with Shift+I or the message menu."
+      },
+      {
         "key": "markReadDelaySec",
         "type": "integer",
         "label": "Mark a previewed message read after (seconds)",
@@ -93,7 +101,7 @@
         "max": 30,
         "step": 1,
         "defaultValue": 2,
-        "description": "How long the cursor has to stay on a message before it counts as read. 0 marks it read as soon as it is previewed. Only applies while Preview as the cursor moves is on; Enter always marks it read."
+        "description": "How long the cursor has to stay on a message before it counts as read. 0 marks it read as soon as it is previewed. Only applies while Preview as the cursor moves and automatic marking are on; Enter marks it read when automatic marking is on."
       },
       {
         "key": "heavyMessageRendering",

--- a/tests/qml/tst_manual_read.qml
+++ b/tests/qml/tst_manual_read.qml
@@ -1,0 +1,135 @@
+import QtQuick 2.15
+import QtTest 1.3
+import "../../account" as Account
+
+// The read-on-open path belongs to MailAccount, not only to the model helper:
+// this test drives the real detail callback and records whether it dispatches
+// an automatic provider mutation.
+Item {
+  width: 400
+  height: 300
+
+  QtObject {
+    id: record
+    property var modified: []
+
+    function reset() { modified = [] }
+  }
+
+  Component {
+    id: client
+
+    QtObject {
+      property var refusals: ({})
+      property var absentMailboxes: []
+      property string email: "ada@example.org"
+
+      function handle() { return ({ aborted: false }) }
+
+      function getMessage(id, full, callback) {
+        callback({
+          id: String(id),
+          labelIds: ["INBOX", "UNREAD"],
+          payload: {
+            mimeType: "text/plain",
+            body: ({ data: "Qm9keQ" }),
+            headers: [
+              { name: "From", value: "Ada <ada@example.org>" },
+              { name: "Subject", value: "A message" },
+              { name: "Date", value: "Mon, 01 Sep 2026 00:00:00 +0000" }
+            ]
+          }
+        }, "")
+        return handle()
+      }
+
+      function modifyMessage(id, add, remove, callback) {
+        record.modified = record.modified.concat([String(id)])
+        if (typeof callback === "function") callback({}, "")
+        return handle()
+      }
+
+      function listMessages() { return handle() }
+      function getMessages() { return handle() }
+      function getLabels(callback) {
+        if (typeof callback === "function") callback([], "")
+        return handle()
+      }
+      function getProfile(callback) {
+        if (typeof callback === "function") callback({ email: email }, "")
+        return handle()
+      }
+      function getSendAs(callback) {
+        if (typeof callback === "function") callback([], "")
+        return handle()
+      }
+      function getAttachment() { return handle() }
+      function abortRequest(handle) { if (handle) handle.aborted = true }
+    }
+  }
+
+  Account.MailAccount {
+    id: account
+    pluginDir: "/tmp/omamail-manual-read-test"
+    accountId: "ada@example.org"
+    configuredEmail: "ada@example.org"
+    providerId: "gmail"
+    clientOverride: client
+    active: false
+    windowOpen: false
+    settings: ({ markReadAutomatically: false })
+  }
+
+  TestCase {
+    name: "ManualRead"
+    when: windowShown
+
+    function row() {
+      return {
+        id: "m1", subject: "A message", unread: true, starred: false,
+        inInbox: true, labelIds: ["INBOX", "UNREAD"]
+      }
+    }
+
+    function init() {
+      record.reset()
+      account.messages = [row()]
+      account.previewMessages = []
+      account.listLoaded = true
+      account.listLoading = false
+      account.settings = ({ markReadAutomatically: false })
+      account.auth.credentials = ({
+        clientId: "123-test.apps.googleusercontent.com",
+        clientSecret: "synthetic",
+        projectId: "test"
+      })
+      account.auth.toolsChecked = true
+      account.auth.missingTools = []
+      account.auth.loggedIn = true
+      account.auth.refreshBusy = true
+    }
+
+    function ready() {
+      tryVerify(function() { return account.ready }, 2000,
+        "the test mailbox is ready")
+      tryVerify(function() { return account.api !== null }, 2000,
+        "the test client is loaded")
+    }
+
+    function test_opening_does_not_mark_read_in_manual_mode() {
+      ready()
+      account.select("m1", false)
+      tryVerify(function() { return account.detailPainted }, 1000,
+        "the message detail arrived")
+      compare(record.modified.length, 0,
+        "opening does not dispatch a read mutation")
+    }
+
+    function test_explicit_mark_read_still_dispatches() {
+      ready()
+      verify(account.act("m1", "markRead"), "the explicit action is accepted")
+      compare(record.modified, ["m1"],
+        "manual mark-read still reaches the provider")
+    }
+  }
+}

--- a/tests/qml/tst_preview_on_cursor.qml
+++ b/tests/qml/tst_preview_on_cursor.qml
@@ -24,6 +24,7 @@ Item {
     property bool ready: true
     property bool anyAccountReady: true
     property bool previewOnCursor: true
+    property bool markReadAutomatically: true
     property bool selectionIsPreview: false
     property int markReadDelaySec: 2
     property bool sendPending: false
@@ -191,6 +192,7 @@ Item {
       app.resetNavigation()
       app.cursorId = ""
       mailService.previewOnCursor = true
+      mailService.markReadAutomatically = true
       mailService.markReadDelaySec = 2
       mailService.selectedId = ""
       mailService.selectCount = 0
@@ -271,6 +273,28 @@ Item {
       app.moveCursor(1)
       compare(app.cursorId, "m1")
       compare(mailService.selectCount, 0, "moving is not opening")
+    }
+
+    function test_manual_only_mode_leaves_a_preview_unread() {
+      mailService.markReadAutomatically = false
+      mailService.markReadDelaySec = 0
+      app.moveCursor(1)
+      tryCompare(mailService, "selectedId", "m1", 1000)
+      wait(500)
+      compare(mailService.markedRead.length, 0,
+        "manual-only mode never reads a preview")
+    }
+
+    // Turned off while a dwell is already counting down. The timer was armed
+    // under the old answer, so it has to ask again when it fires.
+    function test_manual_only_mode_set_mid_dwell_reads_nothing() {
+      mailService.markReadDelaySec = 1
+      app.moveCursor(1)
+      tryCompare(mailService, "selectedId", "m1", 1000)
+      mailService.markReadAutomatically = false
+      wait(1400)
+      compare(mailService.markedRead.length, 0,
+        "the answer when the dwell fires is the one that counts")
     }
 
     // ---------------------------------------------------------- the dwell

--- a/tests/qml/tst_service_settings.qml
+++ b/tests/qml/tst_service_settings.qml
@@ -129,6 +129,23 @@ Item {
       compare(shellStore.updatedEntry.previewOnCursor, true)
     }
 
+    function test_automatic_read_defaults_on_and_can_be_disabled() {
+      mailService.applySettings({})
+      compare(mailService.markReadAutomatically, true)
+
+      mailService.applySettings({ markReadAutomatically: "no" })
+      compare(mailService.markReadAutomatically, true,
+        "only an explicit false opts out")
+
+      mailService.setMarkReadAutomatically(false)
+      compare(mailService.markReadAutomatically, false)
+      compare(shellStore.updatedEntry.markReadAutomatically, false)
+
+      mailService.setMarkReadAutomatically(true)
+      compare(mailService.markReadAutomatically, true)
+      compare(shellStore.updatedEntry.markReadAutomatically, true)
+    }
+
     // Zero is a real answer here — read it the instant it is previewed — so
     // nothing that merely coerces to zero may be read as somebody asking for
     // it. A file that lost the key, or holds a word, gets the default dwell.

--- a/tests/qml/tst_settings_read_marking.qml
+++ b/tests/qml/tst_settings_read_marking.qml
@@ -1,0 +1,96 @@
+import QtQuick 2.15
+import QtTest 1.3
+import qs.Commons
+import "../../components" as Omamail
+
+// What Settings says about read state has to match what the app does with it.
+// With automatic marking off nothing marks a message read on its own, so the
+// preview row must not promise a dwell that reads one, and the dwell row has
+// nothing left to configure.
+Item {
+  width: 600
+  height: 1600
+
+  QtObject {
+    id: mailService
+
+    property bool unifiedCalendarView: false
+    property bool alwaysShowImages: false
+    property bool alwaysRenderHeavyMessages: false
+    property int undoSendSeconds: 10
+    property var accountSummaries: []
+    property var auth: null
+    property bool previewOnCursor: true
+    property bool markReadAutomatically: true
+    property int markReadDelaySec: 2
+
+    function setMarkReadAutomatically(value) { markReadAutomatically = value === true }
+    function setPreviewOnCursor(value) { previewOnCursor = value === true }
+  }
+
+  QtObject {
+    id: calendarController
+
+    property var sourceList: ({ version: 1, sources: [] })
+    property bool savingSource: false
+    signal calendarSaved(bool ok, string error)
+
+    function addCalDavCalendar(_source, _password) {}
+    function removeCalendar(_sourceId) {}
+    function updateCalendarPassword(_source, _password) {}
+  }
+
+  Omamail.SettingsPage {
+    id: settings
+    width: parent.width
+    service: mailService
+    calendarController: calendarController
+    textColor: Color.foreground
+    dimColor: Color.foreground
+    accentColor: Color.accent
+    urgentColor: Color.accent
+    panelFontFamily: "monospace"
+  }
+
+  TestCase {
+    name: "SettingsReadMarking"
+    when: windowShown
+
+    function init() {
+      mailService.previewOnCursor = true
+      mailService.markReadAutomatically = true
+    }
+
+    function test_the_switch_turns_automatic_marking_off() {
+      var toggle = findChild(settings, "markReadAutomaticallySwitch")
+      verify(toggle !== null)
+      compare(toggle.checked, true)
+
+      toggle.toggled()
+      compare(mailService.markReadAutomatically, false)
+      compare(toggle.checked, false)
+    }
+
+    // The preview row used to say a previewed message is read once the cursor
+    // stays on it, which stops being true the moment marking is manual.
+    function test_the_preview_caption_follows_the_setting() {
+      var caption = findChild(settings, "previewOnCursorCaption")
+      verify(caption !== null)
+      verify(caption.text.indexOf("marked read only once") >= 0)
+
+      mailService.markReadAutomatically = false
+      compare(caption.text.indexOf("marked read only once"), -1,
+        "no dwell reads anything, so the caption does not promise one")
+      verify(caption.text.indexOf("stays unread") >= 0)
+    }
+
+    function test_the_dwell_row_is_hidden_when_nothing_would_use_it() {
+      var field = findChild(settings, "markReadDelayField")
+      verify(field !== null)
+      compare(field.parent.visible, true)
+
+      mailService.markReadAutomatically = false
+      compare(field.parent.visible, false)
+    }
+  }
+}

--- a/tests/qml/tst_unified_routing.qml
+++ b/tests/qml/tst_unified_routing.qml
@@ -388,5 +388,25 @@ Item {
       compare(ada().searchQuery, "invoice")
       compare(bob().searchQuery, "invoice")
     }
+
+    // ------------------------------------------------ reading on its own
+
+    // Turning automatic marking off is one answer for the merged list, so it
+    // has to reach every mailbox in it — and a dwell routed through the
+    // service to the mailbox that owns the row must mark nothing.
+    function test_manual_marking_reaches_every_mailbox() {
+      service.applySettings({ unifiedMailboxes: true, markReadAutomatically: false })
+      wait(20)
+      compare(ada().markReadAutomatically, false)
+      compare(bob().markReadAutomatically, false,
+        "not only the mailbox that happens to be active")
+      compare(service.markPreviewRead(Unified.unifiedId(bobId, "1")), false,
+        "an unread row in the other mailbox is left unread")
+      compare(bob().messages[0].unread, true)
+
+      service.applySettings({ unifiedMailboxes: true })
+      wait(20)
+      compare(bob().markReadAutomatically, true, "and a missing key is the default again")
+    }
   }
 }

--- a/tests/test_model.js
+++ b/tests/test_model.js
@@ -1226,6 +1226,12 @@ assert.strictEqual(model.readingStatusLine(false, "", ""), "Not connected")
 assert.strictEqual(model.marksReadOnArrival({ unread: true }, false), true)
 assert.strictEqual(model.marksReadOnArrival({ unread: true }, true), false,
   "stepping down a list would otherwise read every message it passed")
+assert.strictEqual(model.marksReadOnArrival({ unread: true }, false, false), false,
+  "manual-only mode leaves an opened message unread")
+assert.strictEqual(model.marksReadOnArrival({ unread: true }, true, false), false,
+  "manual-only mode leaves a preview unread")
+assert.strictEqual(model.marksReadOnArrival({ unread: true }, false, true), true,
+  "automatic mode still reads an opened message")
 assert.strictEqual(model.marksReadOnArrival({ unread: false }, false), false)
 assert.strictEqual(model.marksReadOnArrival(null, false), false)
 


### PR DESCRIPTION
Opening a message marks it read, and so does the dwell when *Preview as the cursor moves* is on. Some people triage by reading and want read state to mean "I dealt with this", which today they can only get back by pressing Shift+U after every message they look at. This adds a `markReadAutomatically` setting, on by default, that leaves read state entirely to the explicit actions when it is turned off: Shift+I, *Mark read* in the row and message menus, and *Mark these read*.

Both automatic paths are gated, and nothing else in the codebase changes read state on its own. Opening goes through the detail callback in `MailAccount`, which asks `Model.marksReadOnArrival` — that rule now takes the setting as its third argument, so the decision stays in the node-tested model. The dwell is refused in three places, because each is reachable on its own: `App.qml` when it arms and again when it fires (the setting can change while it counts down), `Service.markPreviewRead` for the merged list, and `MailAccount.markPreviewRead` for the account that owns the row. The server side needed nothing: IMAP and Outlook fetch with `BODY.PEEK`, and Gmail `messages.get` and JMAP `Email/get` change no flags.

Only an explicit `false` turns it off. A settings file written before the key existed, `null`, or a hand-edited value of another shape keeps today's behaviour, the same rule `showBarIcon` follows. Each account reads the key through the `settings` object the service already hands down, and `applySettings` replaces that object whole, so a toggle takes effect in every mailbox at once, including a merged list.

In Settings the new row sits above *Preview as the cursor moves*. With automatic marking off, the dwell row is hidden, since it has nothing left to configure, and the preview row's caption stops promising that a message is read once the cursor stays on it.

One thing is not verified: HEY. Opening a HEY message runs `hey threads <topic>`, and I could not establish whether HEY itself marks a posting seen when a thread is read that way. If it does, this setting cannot hold for HEY accounts; the same would already be true of today's preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiVANSY4mTxRF584tcmbah

## Verification

`make validate` green on `2359dc6`: the QML suite (594 tests) and the Outlook HTTP (4) and sidebar text (64) harnesses, every node, shell and python suite, `qmllint`, `omarchy plugin validate .` and `git diff --check`. Qt 6.11.2 on Arch.

Every new assertion was run against `main` with only the tests applied, and fails there:

- `tests/test_model.js`: "manual-only mode leaves an opened message unread".
- `tests/qml/tst_manual_read.qml`: `test_opening_does_not_mark_read_in_manual_mode`, Actual 1 Expected 0. This drives a real `MailAccount` through `select` → `getMessage` callback → `act` → `modifyMessage`; `test_explicit_mark_read_still_dispatches` passes on both, which is the point.
- `tests/qml/tst_preview_on_cursor.qml`: `test_manual_only_mode_leaves_a_preview_unread`, Actual 1 Expected 0; and `test_manual_only_mode_set_mid_dwell_reads_nothing`, where the setting is turned off after the dwell has armed, Actual 1 Expected 0.
- `tests/qml/tst_service_settings.qml`: `test_automatic_read_defaults_on_and_can_be_disabled`, Actual undefined Expected true.
- `tests/qml/tst_unified_routing.qml`: `test_manual_marking_reaches_every_mailbox`, Actual undefined Expected false.
- `tests/qml/tst_settings_read_marking.qml`: all three cases (switch, preview caption, dwell row).

A fresh agent, given only the diff and `AGENTS.md`, reviewed it. It traced every read path (open, dwell, notification click, bar preview, rail members, cached bodies, merged list, the assistant) and found none that still marks read with the setting off; security verdict PASS, since the change is one boolean on the existing `persistSetting`/`applySettings` path. It asked for four changes, all made: the preview caption was inaccurate with the setting off, the merged list and a mid-dwell toggle were untested, and a dwell caption clause had become unreachable. It also noted that the Settings text names Shift+I literally rather than through `Keymap`; the neighbouring captions already name `j, k` and `Enter` the same way, so I kept it consistent with them.

**Not yet done, which is why this is a draft:** the change has not been driven by hand on a screen, and the before/after screenshots `AGENTS.md` asks for are not attached yet. They will be added — light and dark theme, three-column and mini — before this is marked ready.

## Release Notes

- A new setting, *Mark messages read automatically*, lets you keep messages unread when you open or preview them, so they are marked read only when you choose to.
