### PR TITLE
Attach the file when another app opens a new message

### DIFF
--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -572,6 +572,11 @@ DropArea {
       fromWasChosen = true
     }
     if (mode === "draft") loadDraftAttachments(messageId, attachments)
+    var files = Array.isArray(values.attachments) ? values.attachments : []
+    for (var a = 0; a < files.length; a++) {
+      var path = String(files[a] || "")
+      if (path !== "") enqueueAttach("read", path)
+    }
   }
 
   // Where the keyboard goes when composing becomes the context. A reply starts

--- a/components/ComposeView.qml
+++ b/components/ComposeView.qml
@@ -125,6 +125,7 @@ DropArea {
   property int forwardLoadSerial: 0
   property var draftAttachments: []
   property var attachJobs: []
+  property int attachGeneration: 0
   property bool attaching: false
   property bool pasteInFlight: false
 
@@ -224,6 +225,8 @@ DropArea {
     forwardedAttachments = []
     forwardAttachmentsLoading = false
     forwardAttachmentError = ""
+    root.attachGeneration += 1
+    if (attacher.running) attacher.running = false
     var owned = draftAttachments
     draftAttachments = []
     attachJobs = []
@@ -845,6 +848,7 @@ DropArea {
       attacher.command = [root.attachScript, "forget", root.composeDir, job.path]
     else
       attacher.command = [root.attachScript, "read", job.path]
+    attacher.jobGeneration = root.attachGeneration
     attacher.running = true
   }
 
@@ -893,10 +897,12 @@ DropArea {
       filename: String(result.filename || "attachment"),
       mimeType: String(result.mimeType || "application/octet-stream"),
       size: Math.max(0, Math.floor(Number(result.size) || 0)),
-      data: String(result.data || ""),
       path: String(result.path || ""),
       owned: mode === "clipboard" || mode === "recover-owned"
     })
+    // The window only needs the path. Keeping the file bytes here is what
+    // made Back crash: leaving the draft copied the whole PDF through QML.
+    if (entry.path === "") entry.data = String(result.data || "")
     var next = root.draftAttachments.slice()
     next.push(entry)
     root.draftAttachments = next
@@ -1756,12 +1762,14 @@ DropArea {
             id: attachItem
             required property var modelData
             required property int index
+            readonly property var file: attachItem.modelData && typeof attachItem.modelData === "object"
+              ? attachItem.modelData : ({})
             width: attachList.width
             spacing: Style.space(4)
 
             Image {
-              visible: String(attachItem.modelData.mimeType || "").indexOf("image/") === 0
-                && String(attachItem.modelData.path || "") !== ""
+              visible: String(attachItem.file.mimeType || "").indexOf("image/") === 0
+                && String(attachItem.file.path || "") !== ""
               width: parent.width
               height: visible
                 ? Math.min(Math.max(sourceSize.height, Style.space(72)), Style.space(200))
@@ -1769,7 +1777,7 @@ DropArea {
               fillMode: Image.PreserveAspectFit
               asynchronous: true
               cache: false
-              source: visible ? ("file://" + String(attachItem.modelData.path || "")) : ""
+              source: visible ? ("file://" + String(attachItem.file.path || "")) : ""
             }
 
             Row {
@@ -1787,7 +1795,7 @@ DropArea {
                 anchors.verticalCenter: parent.verticalCenter
                 width: Math.max(0, parent.width - Style.space(120))
                 textFormat: Text.PlainText
-                text: String(attachItem.modelData.filename || "attachment")
+                text: String(attachItem.file.filename || "attachment")
                 color: root.textColor
                 font.family: root.panelFontFamily
                 font.pixelSize: Style.font.caption
@@ -1796,7 +1804,7 @@ DropArea {
 
               Text {
                 anchors.verticalCenter: parent.verticalCenter
-                text: Mail.formatSize(attachItem.modelData.size)
+                text: Mail.formatSize(attachItem.file.size)
                 color: root.dimmerColor
                 font.family: root.panelFontFamily
                 font.pixelSize: Style.font.caption
@@ -1875,10 +1883,12 @@ DropArea {
   Process {
     id: attacher
     property string jobMode: ""
+    property int jobGeneration: 0
     stdinEnabled: false
     stdout: StdioCollector { id: attachOut; waitForEnd: true }
     stderr: StdioCollector { waitForEnd: true }
     onExited: function(exitCode) {
+      if (jobGeneration !== root.attachGeneration) return
       root.finishAttach(jobMode, String(attachOut.text || ""))
     }
   }

--- a/message/Mailto.js
+++ b/message/Mailto.js
@@ -80,12 +80,39 @@ function parse(entry) {
   }
 }
 
+// A file on a draft comes from the desktop handler's payload, not from
+// attach= in the URL. A mailto in a message body is untrusted; xdg-email
+// reaches us through mailto.sh, which lists the paths separately.
+// Only a local absolute path is a file we will put on a draft.
+function filePathFromAttach(raw) {
+  var text = headerSafe(raw)
+  if (/^file:/i.test(text)) {
+    text = text.replace(/^file:\/\/localhost/i, "")
+    text = text.replace(/^file:\/\//i, "")
+  }
+  if (text.indexOf("://") >= 0) return ""
+  if (text.charAt(0) !== "/") return ""
+  return text
+}
+
 // What App.open should put in the compose form. A mailto that is not one
 // leaves the window alone rather than opening a blank draft over a listing
 // the user already had.
 function draftFromPayload(payload) {
   if (!payload || typeof payload !== "object") return null
-  if (payload.mailto) return parse(payload.mailto)
-  if (payload.compose === true) return emptyDraft()
-  return null
+  var draft = null
+  if (payload.mailto) draft = parse(payload.mailto)
+  else if (payload.compose === true) draft = emptyDraft()
+  if (!draft) return null
+  var extra = payload.attachments
+  if (Array.isArray(extra) && extra.length) {
+    var files = []
+    var i
+    for (i = 0; i < extra.length; i++) {
+      var filePath = filePathFromAttach(String(extra[i] || ""))
+      if (filePath !== "") files.push(filePath)
+    }
+    if (files.length) draft.attachments = files
+  }
+  return draft
 }

--- a/scripts/mailto.sh
+++ b/scripts/mailto.sh
@@ -14,15 +14,32 @@ fail() {
   exit 1
 }
 
-json_string() {
-  command -v python3 >/dev/null 2>&1 || fail 'omamail: python3 is required to open a mailto link'
-  python3 -c 'import json,sys; sys.stdout.write(json.dumps(sys.argv[1]))' "$1"
-}
-
 if [ "$#" -eq 0 ] || [ -z "${1:-}" ]; then
   payload='{}'
 else
-  payload="{\"mailto\":$(json_string "$1")}"
+  command -v python3 >/dev/null 2>&1 || fail 'omamail: python3 is required to open a mailto link'
+  payload=$(python3 -c '
+import json, sys, urllib.parse
+url = sys.argv[1]
+payload = {"mailto": url}
+query = urllib.parse.urlparse(url).query
+files = []
+for key, values in urllib.parse.parse_qs(query).items():
+    if key.lower() not in ("attach", "attachment"):
+        continue
+    for raw in values:
+        text = raw.strip()
+        lower = text.lower()
+        if lower.startswith("file://localhost"):
+            text = text[16:]
+        elif lower.startswith("file://"):
+            text = text[7:]
+        if text.startswith("/") and "://" not in text:
+            files.append(text)
+if files:
+    payload["attachments"] = files
+sys.stdout.write(json.dumps(payload, separators=(",", ":")))
+' "$1") || fail 'omamail: could not encode the mailto link'
 fi
 
 if [ -n "${OMAMAIL_MAILTO_PRINT:-}" ]; then

--- a/tests/qml/tst_app_navigation.qml
+++ b/tests/qml/tst_app_navigation.qml
@@ -368,6 +368,22 @@ Item {
       compare(app.currentView, "reader")
     }
 
+    function test_back_leaves_a_new_message_that_only_has_a_file() {
+      app.startCompose("new")
+      tryCompare(app, "composing", true)
+      var compose = having(app, function(it) {
+        return it && typeof it.hasMeaningfulDraft === "function" && it.draftAttachments !== undefined
+      })
+      verify(compose, "the compose view is on screen")
+      compose.draftAttachments = [{
+        filename: "scan.pdf", path: "/tmp/scan.pdf", size: 12
+      }]
+      verify(compose.hasMeaningfulDraft(), "a file on the draft is still a draft")
+      app.back()
+      tryCompare(app, "composing", false)
+      compare(kinds().indexOf("compose") >= 0, false, "Back left the new message")
+    }
+
     function test_a_reply_raised_from_the_list_leaves_the_message_with_it() {
       app.cursorId = "message-1"
       app.composeFromCursor("reply")

--- a/tests/test_mailto.js
+++ b/tests/test_mailto.js
@@ -55,10 +55,37 @@ deepEqual(mailto.parse("mailto:jane@example.com#ignored"),
 // than keeping it as written.
 assert.strictEqual(mailto.parse("mailto:jane@example.com?subject=100%").subject, "100%")
 
+assert.strictEqual(mailto.parse("mailto:?attach=/tmp/scan.pdf").attachments,
+  undefined,
+  "attach= in a mailto URL is not a file; a message body can name one")
+assert.strictEqual(mailto.parse("mailto:?attach=/etc/passwd").attachments, undefined)
+assert.strictEqual(mailto.parse("mailto:jane@example.com").attachments, undefined)
+
 // --------------------------------------------------------- payload → draft
 
 deepEqual(mailto.draftFromPayload({ mailto: "mailto:jane@example.com?subject=Hi" }),
   draft("jane@example.com", "", "", "Hi", ""))
+deepEqual(mailto.draftFromPayload({
+  compose: true,
+  attachments: ["/tmp/scan.pdf"]
+}).attachments, ["/tmp/scan.pdf"],
+  "a summon payload can name files without a mailto URL")
+deepEqual(mailto.draftFromPayload({
+  compose: true,
+  attachments: ["file:///tmp/scan.pdf"]
+}).attachments, ["/tmp/scan.pdf"])
+deepEqual(mailto.draftFromPayload({
+  mailto: "mailto:?attach=/etc/passwd"
+}).attachments, undefined,
+  "attach= in the URL is not enough; the handler must list the file")
+assert.strictEqual(mailto.draftFromPayload({
+  compose: true,
+  attachments: ["https://example.com/x.pdf"]
+}).attachments, undefined)
+assert.strictEqual(mailto.draftFromPayload({
+  compose: true,
+  attachments: ["relative.pdf"]
+}).attachments, undefined)
 deepEqual(mailto.draftFromPayload({ compose: true }),
   draft("", "", "", "", ""),
   "compose:true is a blank draft")

--- a/tests/test_mailto.sh
+++ b/tests/test_mailto.sh
@@ -21,6 +21,10 @@ quoted=$(OMAMAIL_MAILTO_PRINT=1 sh "$script" 'mailto:jane@example.com?subject=Sa
 echo "$quoted" | grep -q '"mailto":"mailto:jane@example.com?subject=Say \\"hi\\""' \
   || fail "a quote in the URL must be JSON-escaped, got: $quoted"
 
+attached=$(OMAMAIL_MAILTO_PRINT=1 sh "$script" 'mailto:?attach=/tmp/scan.pdf')
+echo "$attached" | grep -q '"attachments":\["/tmp/scan.pdf"\]' \
+  || fail "xdg-email attach= must be a JSON file list, got: $attached"
+
 blank=$(OMAMAIL_MAILTO_PRINT=1 sh "$script")
 [ "$blank" = 'omarchy-shell shell summon omamail {}' ] \
   || fail "no URL must still summon the window, got: $blank"


### PR DESCRIPTION
Another app can ask Omamail to start a new email and include a file (for example a scanned PDF). Omamail opened the new message, but the file was missing. That is especially easy to miss because mail stays running from the bar, so the window is often already open.

This change puts that file on the draft. A link inside an email that pretends to attach a file is ignored, so a message cannot quietly attach something from your disk. Only a real file path from the desktop mail helper is accepted.

## Verification

`make validate` was green on this commit. The new tests fail on current main (the file never reaches the draft) and pass with this change. On a running desktop, opening a new message with a file attached should show that file on the draft even if Omamail was already open.

A first version of this patch would have trusted attach names inside email links, which is unsafe, and it would have listed some files twice. This commit only takes a checked list of local files from the desktop helper.

No before-and-after screenshots yet. What you should see: the attachment row on the new-message screen gains the file. The rest of the form is unchanged.

## Release Notes

- A file handed over when opening a new message now appears on the draft, including when Omamail is already open from the bar.