### PR TITLE
feat: link related Omarchy projects

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -949,6 +949,12 @@ footer p:last-child { margin-bottom: 0; }
   <div class="wrap">
     <p data-zh="Omamail 是一个独立项目，与 Google、Microsoft 和 37signals 均无关联。Gmail 是 Google LLC 的商标；Outlook 是 Microsoft Corporation 的商标；HEY 是 37signals, LLC 的商标。">Omamail is an independent project and is not affiliated with Google, Microsoft or 37signals. Gmail is a trademark of Google LLC; Outlook is a trademark of Microsoft Corporation; HEY is a trademark of 37signals, LLC.</p>
     <p><span data-zh="作者">By</span> <a href="https://github.com/huacnlee">Jason Lee</a> · <a href="https://github.com/huacnlee/omamail/blob/main/LICENSE">MIT</a> · <a href="https://github.com/huacnlee/omamail">github.com/huacnlee/omamail</a> · <a href="https://omarchy.org">omarchy.org</a></p>
+    <div class="related-projects">
+      <p><span data-zh="更多 Omarchy 项目">More Omarchy projects</span></p>
+      <p><a href="https://github.com/huacnlee/omasend">Omasend</a> — <span data-zh="Omarchy 原生 LocalSend 客户端。通过局域网分享文件、文件夹和文字，使用 GPUI Kit 构建，支持 Linux、macOS 和 Windows。">A native LocalSend client for Omarchy. Share files, folders, and text over your local network. Built with GPUI Kit for Linux, macOS, and Windows.</span></p>
+      <p><a href="https://github.com/huacnlee/omarchy-mihoro">omarchy-mihoro</a> — <span data-zh="Mihoro 的 Omarchy 顶栏面板。监控代理、切换规则、全局和直连模式，并管理订阅。">An Omarchy bar panel for Mihoro. Monitor your proxy, switch between Rule, Global, and Direct modes, and manage subscriptions.</span></p>
+      <p><a href="https://github.com/huacnlee/omarchy-which-key">omarchy-which-key</a> — <span data-zh="桌面端快捷键指南。按住 Super，即可查看当前 Omarchy 与 Hyprland 快捷键。">Which Key for the desktop. Hold Super to see a shortcut guide drawn from your active Omarchy and Hyprland keybindings.</span></p>
+    </div>
   </div>
 </footer>
 


### PR DESCRIPTION
## Summary

- add related Omarchy projects to the end of the website footer
- link Omasend, omarchy-mihoro, and omarchy-which-key on GitHub
- provide English and Simplified Chinese copy

## Test Plan

- visually checked the footer at 1440px with reduced motion
- verified all three GitHub links return HTTP 200
- `git diff --check`

`make test` reaches the shell portability suite but fails on macOS because an existing test uses GNU-only `stat -c`; this HTML-only change does not touch that script.