### PR TITLE
Give the load-more test the urgent colour its list requires

### DIFF
--- a/tests/qml/tst_load_more.qml
+++ b/tests/qml/tst_load_more.qml
@@ -39,6 +39,7 @@ Item {
       service: fakeService
       textColor: Color.foreground
       accentColor: Color.accent
+      urgentColor: Color.accent
       dimColor: Color.foreground
       panelFontFamily: "monospace"
     }


### PR DESCRIPTION
## What went wrong

`make test-qml` fails at `634b4a3` with nothing applied:

```
FAIL!  : qmltestrunner::tst_load_more::compile() Required property urgentColor was not initialized
   Loc: [components/MessageList.qml(25)]
Totals: 638 passed, 1 failed
```

`components/MessageList.qml:25` declares `required property color urgentColor`, and `tests/qml/tst_load_more.qml` sets `textColor`, `accentColor` and `dimColor` but not that one, so the file does not compile. `make test-qml` stops there, which takes `test_outlook_http.py` and `test_sidebar_text.py` down with it and leaves `make validate` unable to be green. CI does not cover it: the release workflow runs `test-js` and `test-shell-portable` only.

Reproduction: `make test-qml` on a clean checkout of main.

## What changed

One line in the test: `urgentColor: Color.accent`, beside the three colours already there. `MessageRow` defaults `urgentColor` to `accentColor`, so that is the colour the row would have drawn anyway, and no assertion in the file depends on it.

## Verification

- `qmltestrunner -input tests/qml/tst_load_more.qml` — 7 passed, 0 failed.
- `make test-qml` — 638 passed, 0 failed, and the two Python fixtures behind it run again.