### PR TITLE
Read a page through a window and wait out a throttled read

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ test-qml:
 	QT_QPA_PLATFORM=offscreen QT_QUICK_BACKEND=software \
 		$(QMLTESTRUNNER) -import $(CURDIR)/tests/qml/imports -input tests/qml
 	python3 tests/test_outlook_http.py "$(QMLTESTRUNNER)"
+	python3 tests/test_gmail_http.py "$(QMLTESTRUNNER)"
 	python3 tests/test_sidebar_text.py "$(QMLTESTRUNNER)"
 
 # Both engines on the same fixtures. The QML column is the one that decides

--- a/providers/GmailApi.js
+++ b/providers/GmailApi.js
@@ -90,12 +90,11 @@ function responseError(status, payload, fallback) {
     reason = String(payload.error.errors[0].reason || "")
 
   if (status === 401) return "Google rejected the session. Sign in again"
-  if (status === 403 && reason === "rateLimitExceeded") return "Gmail is rate limiting this account. Try again shortly"
+  if (rateLimited(status, payload)) return "Gmail is rate limiting this account. Try again shortly"
   if (status === 403 && /Gmail API has not been used/i.test(detail))
     return "The Gmail API is not enabled for this Google Cloud project"
   if (status === 403) return detail ? redact(detail) : "Google refused this request"
   if (status === 404) return "That message is no longer in the mailbox"
-  if (status === 429) return "Gmail is rate limiting this account. Try again shortly"
   if (status === 0) return "Could not reach Gmail. Check the network connection"
   if (status >= 500) return "Gmail is having trouble right now. Try again shortly"
   if (detail) return redact(detail)
@@ -107,6 +106,58 @@ function rateLimitSuffix(retryAfter) {
   if (!isFinite(seconds) || seconds <= 0) return ""
   if (seconds < 60) return " (retry in " + seconds + "s)"
   return " (retry in " + Math.ceil(seconds / 60) + " min)"
+}
+
+// ------------------------------------------------------------ rate limits
+//
+// How many message reads of one page may be in the air at once. Gmail charges
+// five quota units for a `messages.get` and allows one user 250 a second, so a
+// fifty-row page sent all at once is exactly the ceiling — and the
+// `messages.list` that found the ids shares that second, which is what turns
+// the ceiling into a 403. Ten leaves room for the rest of the panel's traffic
+// and still overlaps the round trips, which is why they were sent together in
+// the first place.
+var MAX_PARALLEL_READS = 10
+
+// Google counts its ceiling per second, so the first wait already outlasts the
+// window that refused the request. Three attempts, then the failure is the
+// caller's to show.
+var MAX_RATE_LIMIT_RETRIES = 3
+var BASE_RETRY_DELAY_MS = 1200
+var MAX_RETRY_DELAY_MS = 15000
+
+// Throttling, as opposed to a refusal that waiting cannot fix. 429 says so by
+// itself; 403 is also how Gmail reports a missing scope, a disabled API and a
+// suspended account, so that one is only throttling when the reason says it is.
+function rateLimited(status, payload) {
+  if (status === 429) return true
+  if (status !== 403) return false
+  var error = payload && payload.error ? payload.error : null
+  if (!error || typeof error === "string") return false
+  // Two envelopes, because Gmail answers in the legacy one and the rest of
+  // Google has moved on: `errors[].reason` and `status`. A 403 read out of
+  // neither is a refusal waiting cannot fix.
+  if (String(error.status || "") === "RESOURCE_EXHAUSTED") return true
+  var reason = ""
+  if (error.errors && error.errors.length > 0) reason = String(error.errors[0].reason || "")
+  return reason === "rateLimitExceeded" || reason === "userRateLimitExceeded"
+}
+
+// How long to wait before sending a throttled request again, or 0 when it must
+// not be sent again at all. A `Retry-After` Google names is used instead of the
+// backoff, but never for longer than MAX_RETRY_DELAY_MS: a header asking for an
+// hour would park the mailbox on a wait no reader is watching, and the refusals
+// that really do last that long — a daily quota — are not the reasons this
+// answers to. Without a header the wait doubles per attempt and carries jitter,
+// so two accounts refused in the same second do not come back in the same one.
+function retryDelayMs(status, payload, retryAfter, attempt) {
+  if (!rateLimited(status, payload)) return 0
+  var count = Math.max(0, Math.floor(Number(attempt) || 0))
+  if (count >= MAX_RATE_LIMIT_RETRIES) return 0
+  var named = Number(String(retryAfter === undefined || retryAfter === null ? "" : retryAfter).trim())
+  if (isFinite(named) && named > 0) return Math.min(Math.ceil(named * 1000), MAX_RETRY_DELAY_MS)
+  var backoff = Math.min(BASE_RETRY_DELAY_MS * Math.pow(2, count), MAX_RETRY_DELAY_MS)
+  return backoff + Math.floor(Math.random() * 250)
 }
 
 // ------------------------------------------------------------------ paths

--- a/providers/GmailApiClient.qml
+++ b/providers/GmailApiClient.qml
@@ -15,9 +15,10 @@ Item {
   required property var auth
 
   // Gmail's list endpoint returns ids only, so every page costs one list call
-  // plus one metadata call per message. Those are fired together rather than
-  // in sequence: 25 sequential round trips to Google is most of a second of
-  // staring at an empty panel.
+  // plus one metadata call per message. Those overlap rather than run in
+  // sequence — 25 sequential round trips to Google is most of a second of
+  // staring at an empty panel — but no more than Api.MAX_PARALLEL_READS of them
+  // are in the air at once, for the reason written beside that constant.
   property int inFlight: 0
   readonly property bool busy: inFlight > 0
 
@@ -38,7 +39,17 @@ Item {
   readonly property int requestTimeoutMs: 30000
 
   function newHandle() {
-    return { aborted: false, timedOut: false, xhr: null, deadline: null, children: [] }
+    return { aborted: false, timedOut: false, counted: false, xhr: null, deadline: null,
+      retry: null, children: [] }
+  }
+
+  // The in-flight count belongs to the handle rather than to the call, because
+  // a request that is re-sent — a stale token, a throttled page — is still the
+  // same one request as far as `busy` is concerned.
+  function release(handle) {
+    if (!handle || !handle.counted) return
+    handle.counted = false
+    root.inFlight = Math.max(0, root.inFlight - 1)
   }
 
   // Stopped and destroyed together, because a Timer that outlives its request
@@ -50,10 +61,44 @@ Item {
     handle.deadline = null
   }
 
+  // Stopped and destroyed like the deadline is: a retry that fires after the
+  // caller has moved on re-sends a page nobody is waiting for.
+  function clearRetry(handle) {
+    if (!handle || !handle.retry) return
+    handle.retry.stop()
+    handle.retry.destroy()
+    handle.retry = null
+  }
+
+  // Waiting holds the in-flight count, so `busy` stays true across the pause
+  // and no caller is told the page failed. Answers false when there is no
+  // wait to be had: re-sending immediately is the burst this exists to
+  // prevent, so the caller reports the refusal instead.
+  function scheduleRetry(handle, delayMs, action) {
+    if (!handle || handle.aborted) return false
+    clearRetry(handle)
+    handle.retry = retryComponent.createObject(root, { interval: delayMs })
+    if (!handle.retry) return false
+    handle.retry.triggered.connect(function() {
+      if (!root) return
+      root.clearRetry(handle)
+      if (handle.aborted) return
+      action()
+    })
+    handle.retry.start()
+    return true
+  }
+
+  // A request waiting out a refusal has no reply left to arrive: `abort()` on
+  // the previous one already drove it to DONE, so this is the only place its
+  // in-flight count can be given back. `release` counts once per handle, so
+  // the ordinary path releasing it again in the reply is not a second one.
   function abortRequest(handle) {
     if (!handle) return
     handle.aborted = true
     clearDeadline(handle)
+    clearRetry(handle)
+    release(handle)
     if (handle.xhr && handle.xhr.abort) handle.xhr.abort()
     handle.xhr = null
     var children = handle.children || []
@@ -68,26 +113,30 @@ Item {
     return error
   }
 
-  function request(method, path, query, body, callback, retried, existingHandle) {
+  function request(method, path, query, body, callback, retried, existingHandle, attempt) {
     var handle = existingHandle || newHandle()
     var url = Api.safeApiUrl(path)
     if (!url) {
+      release(handle)
       if (typeof callback === "function")
         callback(0, null, "Something went wrong while contacting Gmail", null)
       return handle
     }
     url = Api.appendQuery(url, query)
 
-    if (retried !== true) root.inFlight++
+    if (!handle.counted) {
+      handle.counted = true
+      root.inFlight++
+    }
 
     auth.withAccessToken(function(token, tokenError) {
       if (!root) return
       if (handle.aborted) {
-        root.inFlight = Math.max(0, root.inFlight - 1)
+        root.release(handle)
         return
       }
       if (!token) {
-        root.inFlight = Math.max(0, root.inFlight - 1)
+        root.release(handle)
         if (typeof callback === "function") callback(0, null, tokenError || "Not signed in", null)
         return
       }
@@ -100,7 +149,7 @@ Item {
         if (!root) return
         if (handle.xhr === xhr) handle.xhr = null
         if (handle.aborted) {
-          root.inFlight = Math.max(0, root.inFlight - 1)
+          root.release(handle)
           return
         }
         root.clearDeadline(handle)
@@ -109,10 +158,28 @@ Item {
         // freshness check and the request reaching Google.
         if (xhr.status === 401 && retried !== true) {
           auth.invalidateAccessToken()
-          root.request(method, path, query, body, callback, true, handle)
+          root.request(method, path, query, body, callback, true, handle, attempt)
           return
         }
-        root.inFlight = Math.max(0, root.inFlight - 1)
+        // Throttling is the one failure the panel can answer on its own:
+        // Gmail counts its ceiling per second and says nothing a reader can
+        // act on. Waiting it out beats handing the mailbox an error it would
+        // only clear on the next poll two minutes later.
+        //
+        // Reads only, and that is the whole of the rule. A 401 can be re-sent
+        // because it says Google never got as far as the request; a throttling
+        // refusal can come from a front end with the write already committed
+        // behind it, and a re-sent `messages/send` is a second message in
+        // somebody's inbox that nothing can take back.
+        var waitMs = String(method || "GET").toUpperCase() === "GET"
+          ? Api.retryDelayMs(xhr.status, payload,
+            xhr.getResponseHeader ? xhr.getResponseHeader("Retry-After") : "", attempt)
+          : 0
+        if (waitMs > 0 && root.scheduleRetry(handle, waitMs, function() {
+          root.request(method, path, query, body, callback, retried, handle,
+            (Number(attempt) || 0) + 1)
+        })) return
+        root.release(handle)
         var ok = xhr.status >= 200 && xhr.status < 300
         // A request the deadline gave up on arrives here exactly as a failed
         // one does — `abort()` drives readyState to DONE with status 0, which
@@ -202,13 +269,14 @@ Item {
     return handle
   }
 
-  // Fetches every id at once and calls back once, with the results in the
-  // order the ids were given rather than the order Google answered in. A list
-  // search may also take `progress`, which receives the payloads as Google
-  // answers so cached rows can be filled in without waiting for the slowest
-  // request on the page. Answers close enough to share a frame are batched:
-  // repainting and sorting the whole list once per one of 25 parallel replies
-  // costs far more than the few milliseconds of extra latency reveal.
+  // Fetches every id through a window of Api.MAX_PARALLEL_READS and calls back
+  // once, with the results in the order the ids were given rather than the
+  // order Google answered in. A list search may also take `progress`, which
+  // receives the payloads as Google answers so cached rows can be filled in
+  // without waiting for the slowest read on the page. Answers close enough to
+  // share a frame are batched: repainting and sorting the whole list once per
+  // parallel reply costs far more than the few milliseconds of extra latency
+  // reveal.
   function getMessages(ids, full, callback, existingHandle, progress) {
     var handle = existingHandle || newHandle()
     var list = Array.isArray(ids) ? ids : []
@@ -262,19 +330,44 @@ Item {
       callback(ordered, firstError)
     }
 
-    for (var i = 0; i < list.length; i++) {
-      (function(index) {
-        var child = root.getMessage(list[index], full, function(payload, error) {
-          if (handle.aborted) return
-          if (error && !firstError) firstError = error
-          results[index] = payload
-          queueProgress(payload)
-          remaining--
-          if (remaining === 0) finish()
-        })
-        handle.children.push(child)
-      })(i)
+    var started = 0
+    var active = 0
+    var pumping = false
+
+    // A window rather than the whole page at once: Gmail's quota is counted
+    // per second, and a page of metadata reads in one breath is the burst that
+    // earns a 403 rateLimitExceeded. Api.MAX_PARALLEL_READS still overlaps the
+    // round trips, so a page arrives in a few rounds instead of one staircase
+    // of them.
+    //
+    // One loop, never nested. A read can answer while it is being started —
+    // there is no credential yet, or the id is not one a url can be built from
+    // — and its callback comes back here; `pumping` turns that into another
+    // turn of the loop already running instead of a frame on top of it, which
+    // on a large page is the difference between a page and a stack overflow.
+    function pump() {
+      if (pumping) return
+      pumping = true
+      while (!handle.aborted && started < list.length && active < Api.MAX_PARALLEL_READS) {
+        (function(index) {
+          active++
+          var child = root.getMessage(list[index], full, function(payload, error) {
+            active--
+            if (handle.aborted) return
+            if (error && !firstError) firstError = error
+            results[index] = payload
+            queueProgress(payload)
+            remaining--
+            if (remaining === 0) finish()
+            else pump()
+          })
+          handle.children.push(child)
+        })(started++)
+      }
+      pumping = false
     }
+
+    pump()
     return handle
   }
 
@@ -407,9 +500,9 @@ Item {
   }
 
   // One Timer per request in flight, created and destroyed around it. A single
-  // shared one cannot work: requests here are fired together — a page of
-  // messages is one list call plus one metadata call each — and they finish in
-  // whatever order Google answers.
+  // shared one cannot work: requests here overlap — a page of messages is one
+  // list call plus one metadata call each — and they finish in whatever order
+  // Google answers.
   Component {
     id: deadlineComponent
 
@@ -420,6 +513,14 @@ Item {
 
   Component {
     id: progressTimerComponent
+
+    Timer {
+      repeat: false
+    }
+  }
+
+  Component {
+    id: retryComponent
 
     Timer {
       repeat: false

--- a/tests/test_gmail_api.js
+++ b/tests/test_gmail_api.js
@@ -181,6 +181,62 @@ assert.strictEqual(api.sendAsFor(aliases, "waiting@example.org"), null)
 assert.strictEqual(api.sendAsFor(aliases, ""), null)
 assert.strictEqual(api.sendAsFor(null, "me@example.com"), null)
 
+// ----------------------------------------------------------- rate limits
+//
+// 429 is throttling on its own. 403 is also how Gmail reports a missing scope,
+// a disabled API and a suspended account, so the reason string is what decides
+// whether waiting can fix it.
+const throttled = { error: { errors: [{ reason: "rateLimitExceeded" }] } }
+const perUser = { error: { errors: [{ reason: "userRateLimitExceeded" }] } }
+const forbidden = { error: { errors: [{ reason: "insufficientPermissions" }] } }
+assert.strictEqual(api.rateLimited(429, null), true)
+assert.strictEqual(api.rateLimited(403, throttled), true)
+assert.strictEqual(api.rateLimited(403, perUser), true)
+assert.strictEqual(api.rateLimited(403, forbidden), false)
+assert.strictEqual(api.rateLimited(403, null), false)
+assert.strictEqual(api.rateLimited(500, null), false)
+
+// The newer Google envelope names the same condition in `status` rather than in
+// a reason, and a 403 read out of neither envelope is not throttling.
+assert.strictEqual(api.rateLimited(403, { error: { status: "RESOURCE_EXHAUSTED" } }), true)
+assert.strictEqual(api.rateLimited(429, { error: { status: "RESOURCE_EXHAUSTED" } }), true)
+assert.strictEqual(api.rateLimited(403, { error: { errors: [] } }), false)
+assert.strictEqual(api.rateLimited(403, { error: "insufficient scope" }), false)
+
+// Every reason the client waits on reads the same way to the person holding the
+// mailbox. Google's own prose for this one names a timestamp and a quota metric.
+assert.strictEqual(
+  api.responseError(403, { error: { message: "User-rate limit exceeded. Retry after 2026-01-01T00:00:00Z",
+    errors: [{ reason: "userRateLimitExceeded" }] } }, "fallback"),
+  "Gmail is rate limiting this account. Try again shortly")
+assert.strictEqual(api.responseError(429, { error: { status: "RESOURCE_EXHAUSTED" } }, "fallback"),
+  "Gmail is rate limiting this account. Try again shortly")
+assert.strictEqual(
+  api.responseError(403, { error: { message: "Request had insufficient authentication scopes.",
+    errors: [{ reason: "insufficientPermissions" }] } }, "fallback"),
+  "Request had insufficient authentication scopes.")
+
+// Google's own wait wins, capped so a long one cannot park the panel.
+assert.strictEqual(api.retryDelayMs(429, null, "3", 0), 3000)
+assert.strictEqual(api.retryDelayMs(429, null, "600", 0), 15000)
+assert.strictEqual(api.retryDelayMs(403, throttled, "0.5", 0), 500)
+assert.strictEqual(api.retryDelayMs(403, forbidden, "3", 0), 0,
+  "a permission failure is not a wait")
+assert.strictEqual(api.retryDelayMs(429, null, "3", api.MAX_RATE_LIMIT_RETRIES), 0,
+  "the attempts run out")
+
+// No usable header: the wait doubles per attempt and carries jitter under a
+// quarter second, so two accounts refused together do not return together.
+function delayWithin(attempt, retryAfter, low, high) {
+  const value = api.retryDelayMs(429, null, retryAfter, attempt)
+  assert.ok(value >= low && value < high,
+    "attempt " + attempt + " waited " + value + ", expected " + low + "-" + high)
+}
+delayWithin(0, null, 1200, 1450)
+delayWithin(1, "", 2400, 2650)
+delayWithin(2, "Wed, 21 Oct 2015 07:28:00 GMT", 4800, 5050)
+delayWithin(2, "-1", 4800, 5050)
+
 // -------------------------------------------------------------- browsing
 
 assert.strictEqual(api.webMessageUrl("18f3a", 0), "https://mail.google.com/mail/u/0/#all/18f3a")

--- a/tests/test_gmail_http.py
+++ b/tests/test_gmail_http.py
@@ -1,0 +1,235 @@
+"""Exercise GmailApiClient's window on a page and its wait on a throttled read.
+
+Only the API base is replaced with a loopback fixture; `request`, `getMessages`,
+the retry timer, the backoff in `GmailApi.retryDelayMs` and XMLHttpRequest are
+the production code. Gmail counts its quota per second, so a page goes out
+through a window and a throttled read is waited out rather than handed to the
+mailbox as a failed page — while a 403 waiting cannot fix, an aborted read, and
+any write must not be sent twice.
+"""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+ROOT = Path(__file__).resolve().parents[1]
+lock = threading.Lock()
+hits = {}
+
+THROTTLED = json.dumps({
+    "error": {"code": 403, "message": "User-rate limit exceeded.",
+              "errors": [{"reason": "rateLimitExceeded", "message": "User-rate limit exceeded."}]},
+}).encode()
+FORBIDDEN = json.dumps({
+    "error": {"code": 403, "message": "Request had insufficient authentication scopes.",
+              "errors": [{"reason": "insufficientPermissions"}]},
+}).encode()
+EXHAUSTED = json.dumps({"error": {"code": 429, "status": "RESOURCE_EXHAUSTED",
+                                  "message": "Quota exceeded."}}).encode()
+
+
+def count(name):
+    with lock:
+        hits[name] = hits.get(name, 0) + 1
+        return hits[name]
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_):
+        pass
+
+    def answer(self, status, body, headers=None):
+        try:
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            for name, value in (headers or {}).items():
+                self.send_header(name, value)
+            self.end_headers()
+            self.wfile.write(body)
+        except (BrokenPipeError, ConnectionResetError):
+            pass  # Aborting a read is one of the things under test.
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        self.rfile.read(length)
+        # A write is refused the same way a read is, and must be left refused.
+        count("modify")
+        self.answer(429, EXHAUSTED, {"Retry-After": "1"})
+
+    def do_GET(self):
+        name = self.path.partition("?")[0].rsplit("/", 1)[-1]
+        seen = count(name)
+        if name.startswith("m"):
+            self.answer(200, json.dumps({"id": name, "labelIds": ["INBOX"]}).encode())
+        elif name == "throttled":
+            # Refused once with the wait Google names, then answered: a read
+            # that survives its own throttling is the point.
+            if seen == 1:
+                self.answer(403, THROTTLED, {"Retry-After": "1"})
+            else:
+                self.answer(200, json.dumps({"id": "throttled"}).encode())
+        elif name in ("capped", "abandoned"):
+            self.answer(429, EXHAUSTED, {"Retry-After": "1"})
+        elif name == "forbidden":
+            self.answer(403, FORBIDDEN)
+        else:
+            self.send_error(404)
+
+
+QML = r'''
+import QtQuick
+import QtTest
+import @PROVIDERS@ as Providers
+import @API@ as Api
+
+Item {
+  QtObject {
+    id: fakeAuth
+    function withAccessToken(callback) { callback("synthetic-token", "") }
+    function invalidateAccessToken() {}
+  }
+  Providers.GmailApiClient {
+    id: client
+    auth: fakeAuth
+  }
+  TestCase {
+    name: "GmailThrottling"
+    when: windowShown
+    function initTestCase() { Api.API_BASE = @ENDPOINT@ }
+
+    // Gmail's ceiling is counted per second, so the count that matters is how
+    // many reads the client has issued at once — raised before the network is
+    // involved, which is why the fixture can answer every one of them at once
+    // and still measure the window.
+    function test_1_a_page_is_read_through_a_window() {
+      var ids = []
+      for (var i = 0; i < 30; i++) ids.push("m" + i)
+      var peak = 0
+      var watch = function() { if (client.inFlight > peak) peak = client.inFlight }
+      client.inFlightChanged.connect(watch)
+      var finished = false
+      var failure = "not called"
+      client.getMessages(ids, false, function(messages, error) {
+        finished = true
+        failure = error
+      })
+      tryVerify(function() { return finished }, 20000)
+      client.inFlightChanged.disconnect(watch)
+      compare(failure, "")
+      verify(peak > 1, "the reads still overlap rather than run one at a time: " + peak)
+      verify(peak <= Api.MAX_PARALLEL_READS,
+        "at most " + Api.MAX_PARALLEL_READS + " reads in flight, saw " + peak)
+      tryCompare(client, "inFlight", 0, 5000)
+    }
+
+    function test_2_a_throttled_read_is_waited_out() {
+      var message = null
+      var failure = "not called"
+      var started = Date.now()
+      client.getMessage("throttled", false, function(payload, error) {
+        message = payload
+        failure = error
+      })
+      wait(400)
+      compare(failure, "not called", "the mailbox is not told anything while the wait runs")
+      verify(client.busy, "and the client stays busy across it")
+      tryVerify(function() { return failure !== "not called" }, 20000)
+      compare(failure, "", "the read succeeds on the answer after the wait")
+      compare(message.id, "throttled")
+      verify(Date.now() - started >= 1000, "Google's own Retry-After is honoured")
+      tryCompare(client, "inFlight", 0, 5000)
+    }
+
+    function test_3_a_read_that_stays_throttled_fails_in_the_end() {
+      var failure = "not called"
+      client.getMessage("capped", false, function(payload, error) { failure = error })
+      tryVerify(function() { return failure !== "not called" }, 30000)
+      verify(failure.indexOf("rate limiting") >= 0, "the mailbox is told why: " + failure)
+      tryCompare(client, "inFlight", 0, 5000)
+    }
+
+    function test_4_a_refusal_waiting_cannot_fix_is_not_waited_out() {
+      var failure = "not called"
+      var started = Date.now()
+      client.getMessage("forbidden", false, function(payload, error) { failure = error })
+      tryVerify(function() { return failure !== "not called" }, 8000)
+      verify(failure !== "", "a missing scope is still a failure")
+      verify(Date.now() - started < 1000,
+        "and is not waited on: " + (Date.now() - started) + "ms")
+      tryCompare(client, "inFlight", 0, 5000)
+    }
+
+    // A page abandoned mid-wait is how every mailbox switch and every poll
+    // ends the previous one. The reply that would have given the in-flight
+    // count back has already arrived and been refused, so the abort is the
+    // only thing left to give it back.
+    function test_5_an_abandoned_wait_gives_its_slot_back() {
+      var handle = client.getMessage("abandoned", false, function(payload, error) {})
+      tryCompare(client, "inFlight", 1, 5000)
+      wait(500)
+      verify(client.busy, "the read is waiting rather than finished")
+      client.abortRequest(handle)
+      compare(client.inFlight, 0, "an abandoned wait is not counted for ever")
+      compare(client.busy, false)
+      wait(1500)
+      compare(client.inFlight, 0, "and the wait it dropped never runs")
+    }
+
+    // A throttling refusal can be answered by a front end with the write
+    // already committed behind it, so a write is refused once and left refused.
+    function test_6_a_throttled_write_is_not_sent_again() {
+      var failure = "not called"
+      var started = Date.now()
+      client.modifyMessage("m1", ["STARRED"], [], function(payload, error) { failure = error })
+      tryVerify(function() { return failure !== "not called" }, 8000)
+      verify(failure.indexOf("rate limiting") >= 0, "the mailbox is told why: " + failure)
+      verify(Date.now() - started < 1000, "and nothing waited on it")
+      tryCompare(client, "inFlight", 0, 5000)
+    }
+  }
+}
+'''
+
+
+def main():
+    runner = sys.argv[1] if len(sys.argv) > 1 else "/usr/lib/qt6/bin/qmltestrunner"
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with tempfile.TemporaryDirectory(prefix="omamail-gmail-http-") as directory:
+            source = QML.replace("@PROVIDERS@", json.dumps((ROOT / "providers").as_uri()))
+            source = source.replace("@API@", json.dumps((ROOT / "providers/GmailApi.js").as_uri()))
+            source = source.replace("@ENDPOINT@", json.dumps(f"http://127.0.0.1:{server.server_port}"))
+            fixture = Path(directory) / "tst_gmail_http.qml"
+            fixture.write_text(source)
+            env = dict(os.environ, QT_QPA_PLATFORM="offscreen", QT_QUICK_BACKEND="software",
+                       QT_QPA_PLATFORMTHEME="", NO_PROXY="127.0.0.1,localhost", no_proxy="127.0.0.1,localhost")
+            subprocess.run([runner, "-import", str(ROOT / "tests/qml/imports"),
+                            "-input", str(fixture)], env=env, check=True, timeout=180)
+        reads = sorted(name for name in hits if name.startswith("m") and name != "modify")
+        assert len(reads) == 30, hits
+        assert all(hits[name] == 1 for name in reads), hits
+        assert hits.get("throttled") == 2, hits
+        # Three waits and no fourth: MAX_RATE_LIMIT_RETRIES is a ceiling on the
+        # retries, so the first send plus three of them is four reads.
+        assert hits.get("capped") == 4, hits
+        assert hits.get("forbidden") == 1, hits
+        assert hits.get("abandoned") == 1, hits
+        assert hits.get("modify") == 1, hits
+        print("Gmail throttling: page windowed, Retry-After honoured, backoff bounded, "
+              "abandoned wait released, permission failure and write not retried")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What went wrong

Two Gmail accounts, both over the Gmail API, `maxMessages` at its default of 50. Opening the window — or switching accounts, or any poll that finds a page the cache does not hold — put `Gmail is rate limiting this account. Try again shortly` in the bar, with no `(retry in Ns)` because Google sent no `Retry-After`. The count and the list then stayed as they were until the next poll two minutes later.

Reproduction, one account, cold cache:

1. `maxMessages` at 50.
2. Delete `~/.cache/omamail` and open the window on a mailbox with 50+ messages.
3. `Alt+A` to the second account and back, twice.

`getMessages()` fetched the page with every id in the air at once — its own comment said *"Fetches every id at once"*. Gmail allows one user 250 quota units a second and charges five for a `messages.get`, so a 50-row page is exactly the ceiling, and the `messages.list` that found the ids shares that second. Google answers the overflow with `403 rateLimitExceeded` (the legacy envelope, `error.errors[0].reason`), and `request()` retried nothing but `401` — so the refusal went straight to the mailbox as a failed page.

## What changed

- **A page is read through a window.** `getMessages()` keeps `Api.MAX_PARALLEL_READS` (10) reads in the air and starts the next as each lands: 50 units a round rather than 250 at once. The reads still overlap, which is why they were sent together in the first place; they are just no longer all of them. One flat loop, not recursion — a read can answer synchronously (no credential yet, or an id no URL can be built from) and its callback re-enters the pump, which on a large page would otherwise be one stack frame per id.
- **A throttled read is waited out instead of handed to the mailbox.** `GmailApi.retryDelayMs()` uses a `Retry-After` Google names, capped at 15s, and otherwise doubles from 1.2s with jitter, three attempts. `GmailApi.rateLimited()` decides what may be sent again: `429` always, `403` only for `rateLimitExceeded`/`userRateLimitExceeded` or `status: RESOURCE_EXHAUSTED` — because `403` is also how Gmail reports a missing scope, a disabled API and a suspended account, none of which waiting fixes.
- **Reads only.** A `401` can be re-sent because it says Google never processed the request; a throttling refusal can come from a front end with the write already committed behind it, and a re-sent `messages/send` is a second message nothing can take back. The retry is gated on `GET`.
- **The in-flight count moved from the call to the handle** (`handle.counted`, `release()`). A request that is sent again is one request as far as `busy` is concerned, and the pause holds the count so no caller is told the page failed mid-wait. `abortRequest()` releases it: a handle abandoned during a wait has no reply left to arrive — `abort()` already drove the previous one to DONE — and every mailbox switch and poll abandons the page before it (`MailAccount.qml:704, 723, 1510, 1892`). `release()` counts once per handle, so the ordinary reply releasing it again is not a second release.
- A waiting retry is part of the request and dies with it. If its Timer cannot be created the request fails instead of being re-sent with no wait at all — that would be the very burst this exists to prevent.
- `responseError()` now routes every reason the client treats as throttling to the one sentence a reader can act on; `userRateLimitExceeded` used to fall through to Google's own prose about quota metrics and timestamps.

Deliberately not done: a client-level FIFO like `JmapClient`'s `Jmap.makeQueue`. The window caps the one fan-out that earns the refusal and the retry covers the residual case where a list or a label read shares the same second. A queue over every Gmail request is the fuller answer and would want `makeQueue` to stop belonging to a JMAP file — glad to do that instead if you would rather have it.

## Tests

`tests/test_gmail_http.py` — loopback fixture, production `request()`, `getMessages()`, retry Timer and XMLHttpRequest; wired into `test-qml` beside the Outlook fixture. Six cases: a 30-id page never exceeds the window while every read is answered at once; a read refused once with `Retry-After: 1` succeeds and the mailbox is told nothing during the wait; a read that stays refused fails after four attempts and says why; a `403 insufficientPermissions` fails on the first answer in under a second; a page abandoned mid-wait gives its in-flight slot back; a throttled `POST` is refused once and left refused.

Against a pristine `634b4a3`, three of them fail:

```
FAIL!  : test_1_a_page_is_read_through_a_window() 'at most undefined reads in flight, saw 30'
FAIL!  : test_2_a_throttled_read_is_waited_out() the mailbox is not told anything while the wait runs
FAIL!  : test_5_an_abandoned_wait_gives_its_slot_back() 'the read is waiting rather than finished'
```

`tests/test_gmail_api.js` covers the two decisions directly: both `403` envelopes and the reasons that are not throttling, `Retry-After` winning and being capped, an HTTP-date and a negative falling through to the backoff, the attempts running out, and the reader-facing sentence for each throttling reason.

## Verification

- `make test-js` — green. `make test-shell` — green. `make qml-check` — no warning on either changed file. `omarchy plugin validate .` — clean.
- `make test-qml` — 645 passed, 0 failed, plus this fixture's 8 and the other two, **with #172 applied**. Without it, `tst_load_more::compile()` fails at `634b4a3` on its own and stops the target before the Python fixtures; that is why it is a separate one-line pull request rather than part of this one.
- By hand, two real Gmail accounts, `maxMessages` back at 50, cache deleted: mailbox opened and both accounts switched through repeatedly. No rate-limit message since.
- This diff was reviewed by a second agent with no part in writing it; the gating of the retry to reads and the release on abort are both its findings. One it raised is left standing and is pre-existing: `MailAccount.fetchSummaries()` discards the handle `getMessages()` returns, so those reads cannot be aborted, and the retry now extends how long such an orphan page can live. It is worth a separate change either way.

No interface change, so no screenshots.

## Release Notes

- Gmail mailboxes no longer report `Gmail is rate limiting this account` when a page of mail loads: a page is now fetched a few reads at a time, and a read Google throttles is waited out and retried rather than failing the page. Sending and other writes are never retried.