### PR TITLE
Save an explicit authority for personal Microsoft accounts

### DIFF
--- a/ui/components/OutlookSetupPage.qml
+++ b/ui/components/OutlookSetupPage.qml
@@ -55,7 +55,9 @@ Column {
     if (address === "") return null
     var clientId = validatedClientId()
     if (clientId === "") return null
-    var tenant = workSwitch.checked ? "organizations" : ""
+    // The native backend needs an explicit authority; saving an empty string
+    // lets device sign-in succeed but breaks subsequent account-bound refresh.
+    var tenant = workSwitch.checked ? "organizations" : "consumers"
     var send = workSwitch.checked && graphSwitch.checked ? "graph" : ""
     var imap = Outlook.settings(address, tenant, send)
     imap.tenant = tenant

--- a/ui/tests/qml/tst_outlook_boundaries.qml
+++ b/ui/tests/qml/tst_outlook_boundaries.qml
@@ -122,6 +122,18 @@ Item {
       compare(label.textFormat, Text.PlainText,
         "Server error messages must not be interpreted as resource-bearing HTML")
     }
+    function test_personal_account_saves_explicit_authority() {
+      var host = readyHost()
+      var service = createTemporaryObject(serviceFactory, parent, { auth: host.auth })
+      var page = createTemporaryObject(pageFactory, parent, { service: service })
+      verify(page !== null)
+      compare(page.accountValues().imap.tenant, "consumers")
+      var work = findChild(page, "outlook-work-switch")
+      work.checked = true
+      compare(page.accountValues().imap.tenant, "organizations")
+      work.checked = false
+      compare(page.accountValues().imap.tenant, "consumers")
+    }
     function test_cancel_matches_google_signin_and_allows_retry() {
       var host = readyHost()
       var service = createTemporaryObject(serviceFactory, parent, { auth: host.auth })


### PR DESCRIPTION
Personal Outlook/Hotmail setup currently saves `imap.tenant` as an empty string when the work/school switch is off. Device sign-in normalizes that value to `consumers`, so Microsoft consent can succeed, but the native account-bound credential resolver reads the saved empty string literally and rejects the token destination. Subsequent mail requests fail with `invalid_params`, shown as “Mail request failed”. Signing in again saves the same invalid value.

Persist `consumers` explicitly for personal accounts, keeping `organizations` for work/school accounts. Both are already supported by the pinned backend; no backend API change or release is needed. This changes the saved value only, not the setup page's appearance or the OAuth permissions and credential destinations.

To reproduce on main, configure a personal Outlook/Hotmail account with the work/school switch off, complete sign-in, then request its folders. The setup values contain an empty tenant and the account-bound request fails. The new regression checks the real setup component's personal → work → personal settings.

Existing entries with an empty tenant are not automatically migrated by this patch. Saving the affected account through the corrected setup page, or signing in again, writes the valid value.

## Verification

`make validate` passes locally with Rust/Cargo 1.98.1 and Qt 6.11.2 on Omarchy 4.0.3: Rust unit/integration tests, JavaScript and shell checks, 807 main QML cases, 6 native Outlook HTTP cases, 64 sidebar cases, the native HTML resource-request security test, qmllint (with warnings), plugin validation, and `git diff --check`.

The new `OutlookBoundaryReview::test_personal_account_saves_explicit_authority` test was observed failing against the original code (empty string instead of `consumers`) and passing with the fix. The targeted suite passes all 12 cases.

Live: after correcting the previously saved personal-account values locally and installing the setup fix, read-only folder requests succeeded for two Hotmail accounts, and the user confirmed both accounts work in Omamail. This live recovery included correcting existing saved settings; it is not evidence of an automatic migration.

A fresh, empty-context agent reviewed the diff and affected settings/credential path. No blocking findings; scoped security verdict PASS. It noted the existing-entry limitation documented above. Work/school behavior is covered by the regression test, not a live organizational account. No layout, label, theme or other visual changes are included.

## Release Notes

- Save valid sign-in settings for personal Outlook and Hotmail accounts so signing in again no longer leaves mail requests failing.
