### PR TITLE
Fix native calendar errors with provider recovery guidance

### DIFF
--- a/ui/calendar/Calendar.js
+++ b/ui/calendar/Calendar.js
@@ -533,6 +533,19 @@ function graphResponseError(status, responseText) {
   return detail !== "" ? "Microsoft Graph answered: " + detail : "Microsoft Graph answered " + status
 }
 
+// Keep native backend diagnostics private while giving each provider an
+// actionable recovery path. This deliberately does not depend on backend
+// error-message semantics, so it remains compatible with the pinned API.
+function nativeRequestError(kind) {
+  if (kind === "microsoft")
+    return "Microsoft calendar request failed. Check Graph permissions in Settings, then sign in again"
+  if (kind === "google")
+    return "Google calendar request failed. Sign in again and check Calendar access"
+  if (kind === "caldav")
+    return "CalDAV calendar request failed. Check its server address and password in Settings"
+  return "The calendar request failed"
+}
+
 function googleEventsUrl(startMs, endMs) {
   return "https://www.googleapis.com/calendar/v3/calendars/primary/events?"
     + "singleEvents=true&orderBy=startTime&maxResults=2500"

--- a/ui/calendar/CalendarController.qml
+++ b/ui/calendar/CalendarController.qml
@@ -279,12 +279,7 @@ Item {
     service.backend.call("calendar.request", params, function(result, error) {
       var reason = ""
       if (error) {
-        var code = String(error.code || error)
-        if (code === "calendar_auth_required" || code === "calendar_auth_refused")
-          reason = "Sign in again to access this calendar"
-        else if (code === "calendar_password_missing") reason = "Set this calendar's password in Settings"
-        else if (code === "calendar_origin_refused") reason = "The event's address is outside this calendar's server"
-        else reason = "The calendar request failed"
+        reason = Calendar.nativeRequestError(String(source && source.kind || ""))
       }
       callback(result, reason)
     })

--- a/ui/tests/qml/tst_calendar_controller.qml
+++ b/ui/tests/qml/tst_calendar_controller.qml
@@ -10,9 +10,11 @@ Item {
     id: mailService
 
     property var requests: []
+    property var nextResult: ({ body: "{}", status: 200 })
+    property var nextError: null
     property var backend: ({ call: function(method, params, callback) {
       mailService.requests.push({ method: method, params: params })
-      callback({ body: "{}", status: 200 }, null)
+      callback(mailService.nextResult, mailService.nextError)
     } })
     property bool unifiedCalendarView: false
     property var accountSummaries: [
@@ -52,6 +54,8 @@ Item {
       // the function, so a restore on its last line does not run and one real
       // failure becomes a cascade that hides it.
       mailService.requests = []
+      mailService.nextResult = ({ body: "{}", status: 200 })
+      mailService.nextError = null
       mailService.unifiedCalendarView = false
       controller.accountId = "imap:work@example.com"
       controller.refreshScope = ""
@@ -76,6 +80,29 @@ Item {
       compare(mailService.requests[0].method, "calendar.request")
       compare(mailService.requests[0].params.source.accountId, "one@gmail.com")
       verify(mailService.requests[0].params.token === undefined)
+    }
+
+    function test_native_request_explains_microsoft_recovery() {
+      mailService.nextResult = null
+      mailService.nextError = ({ code: -32000, message: "calendar_auth_refused" })
+      var called = false
+      controller.nativeRequest({ kind: "microsoft" }, "list", {}, function(result, error) {
+        compare(result, null)
+        compare(error, "Microsoft calendar request failed. Check Graph permissions in Settings, then sign in again")
+        called = true
+      })
+      verify(called)
+    }
+
+    function test_native_request_does_not_display_backend_diagnostics() {
+      mailService.nextResult = null
+      mailService.nextError = ({ code: -32000, message: "private backend diagnostic" })
+      var called = false
+      controller.nativeRequest({ kind: "microsoft" }, "list", {}, function(_result, error) {
+        compare(error, "Microsoft calendar request failed. Check Graph permissions in Settings, then sign in again")
+        called = true
+      })
+      verify(called)
     }
 
     function sourceIds(list) {

--- a/ui/tests/test_calendar_feed.js
+++ b/ui/tests/test_calendar_feed.js
@@ -27,6 +27,8 @@ assert.strictEqual(feed.googleResponseError(403, JSON.stringify({
 })), "Google Calendar permission is missing. Sign out and sign in again")
 assert.strictEqual(feed.googleResponseError(500, "not json"),
   "Google Calendar returned HTTP 500")
+assert.strictEqual(feed.nativeRequestError("google"),
+  "Google calendar request failed. Sign in again and check Calendar access")
 
 const week = feed.weekDays(new Date(2026, 7, 23).getTime(), 1)
 assert.strictEqual(week.length, 7)
@@ -574,6 +576,12 @@ console.log("test_calendar_feed.js ok")
   assert.strictEqual(feed.graphResponseError(401, "{}"), "Microsoft refused the calendar request. Sign in again")
   assert.ok(feed.graphResponseError(400, JSON.stringify({ error: { code: "ErrorInvalidRequest", message: "Bad start" } })).indexOf("Bad start") > 0)
   assert.strictEqual(feed.graphResponseError(500, "not json"), "Microsoft Graph answered 500")
+  assert.strictEqual(feed.nativeRequestError("microsoft"),
+    "Microsoft calendar request failed. Check Graph permissions in Settings, then sign in again")
+  assert.strictEqual(feed.nativeRequestError("caldav"),
+    "CalDAV calendar request failed. Check its server address and password in Settings")
+  assert.strictEqual(feed.nativeRequestError("unknown"),
+    "The calendar request failed")
 
   const made = feed.createEvent({ title: "Plan", startMs: Date.UTC(2026, 8, 9, 9), endMs: Date.UTC(2026, 8, 9, 10) }, 1000)
   assert.strictEqual(made.graph.subject, "Plan")


### PR DESCRIPTION
Native calendar requests currently collapse every backend failure to “The calendar request failed.” That leaves people without a useful next step, even though the configured calendar provider is already known.

This change keeps backend diagnostics private and uses only the existing provider kind to offer a safe recovery path: Microsoft users are directed to Graph permissions and reauthentication, Google users to reauthentication and Calendar access, and CalDAV users to their server address and password. Because it does not depend on backend error codes or messages, the pinned backend and API contract remain unchanged.

## Verification

Current head `6d1b7e8` incorporates upstream `3460ac8` (0.10.3/API4). `make validate` passes, including Rust, JavaScript, shell/security, plugin QML, standalone composition, both qmllint checks and plugin validation. The merge preserves upstream's native CalDAV credential-write/refresh test alongside our error regressions (targeted controller suite 13/13). The actual SHA256-verified x86_64 published backend passes its released API4 contract. This integration does not change our production error text or layout; retained screenshots describe the same PR behavior. Cross-platform release certification and hosted fork-CI authorization remain external.

The final JavaScript and QML regression tests were copied onto an unchanged `origin/main` snapshot. The JavaScript test failed because `nativeRequestError` did not exist, and the QML suite failed both new assertions because Microsoft failures still rendered as “The calendar request failed.”

A fresh independent agent reviewed the final diff and found no issues; security verdict PASS. The review confirmed that the mapping uses only `source.kind`, exposes no backend diagnostics, and requires no backend API revision or release.

The affected dark-theme, 1000 × 700 calendar view was rendered before and after with a synthetic Microsoft failure. No live mailbox was contacted, and the screenshots and diff contain no email addresses, messages, account identifiers, tokens, or other personal data.

Before, every provider failure showed only the generic calendar request message:

<img width="1000" height="700" alt="Before: generic native calendar error" src="https://github.com/user-attachments/assets/c2945629-80b1-45a2-82b6-a9b9d8b403f8" />

After, the same Microsoft failure identifies the provider and points to Graph permissions and reauthentication:

<img width="1000" height="700" alt="After: Microsoft calendar recovery guidance" src="https://github.com/user-attachments/assets/bb9c7010-fde7-45a2-88f1-b5aa8cce9205" />

## Release Notes

- Calendar failures now identify Microsoft, Google, or CalDAV and suggest the relevant account or server settings to check.
