### PR TITLE
Add Microsoft 365 connection checks to Outlook settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "omamail"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omamail"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 publish = false
 

--- a/backend-api.json
+++ b/backend-api.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": 1,
+  "apiVersion": 2,
   "protocolVersion": 1,
   "methods": [
     "system.info",
@@ -95,6 +95,7 @@
     "auth.store",
     "auth.clear",
     "outlook.graphSend",
+    "outlook.connectionCheck",
     "hey.probe",
     "hey.status",
     "hey.profile",
@@ -173,6 +174,18 @@
     "jmap.stream.close"
   ],
   "contractCases": [
+    {
+      "name": "missing Outlook connection",
+      "method": "outlook.connectionCheck",
+      "params": {
+        "accountId": "outlook:missing@example.org"
+      },
+      "equals": {
+        "mail": false,
+        "graph": false,
+        "calendar": false
+      }
+    },
     {
       "name": "strict handshake parameters",
       "method": "system.info",

--- a/docs/BACKEND-RUNTIME.md
+++ b/docs/BACKEND-RUNTIME.md
@@ -124,7 +124,7 @@ required merge check must pass before merging. Publishing after merging would
 leave plugin users exposed to the mismatch. Runtime handshake still requires the
 exact plugin-local binary pin, even when a newer release reports the same API.
 
-The contract runner currently exercises 13 methods and checks the full advertised
+The contract runner currently exercises 14 methods and checks the full advertised
 inventory. It covers representative mail processing and cached reader behavior,
 not every provider operation or every possible QML argument. API reviewers must
 extend fixtures for newly used behavior; passing these tests is not a proof of

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "omamail",
   "name": "Omamail",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": "huacnlee",
   "license": "MIT",
   "homepage": "https://huacnlee.github.io/omamail/",

--- a/src/backend/methods.rs
+++ b/src/backend/methods.rs
@@ -93,6 +93,7 @@ pub const ALL: &[&str] = &[
     "auth.store",
     "auth.clear",
     "outlook.graphSend",
+    "outlook.connectionCheck",
     "hey.probe",
     "hey.status",
     "hey.profile",

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -185,6 +185,9 @@ impl Session {
         if method == "outlook.graphSend" {
             return Box::pin(self.auth.call(method, params)).await;
         }
+        if method == "outlook.connectionCheck" {
+            return Box::pin(crate::providers::outlook::connection_check(params)).await;
+        }
         if method == "attachment.read" {
             let params = params.clone();
             return tokio::task::spawn_blocking(move || crate::attachment::read(&params))
@@ -400,7 +403,7 @@ pub fn dispatch(method: &str, params: &Value) -> Result<Value, &'static str> {
     match method {
         "system.info" => Ok(json!({
             "name": "omamail", "version": env!("CARGO_PKG_VERSION"),
-            "protocol": 1, "apiVersion": 1, "methods": methods::ALL
+            "protocol": 1, "apiVersion": 2, "methods": methods::ALL
         })),
         "system.quit" => Ok(json!({"quitReady": true})),
         "accounts.list" => account::list(),

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -13,6 +13,7 @@ pub mod hey_access;
 pub mod hey_actions;
 pub mod imap;
 pub mod jmap;
+pub mod outlook;
 
 const CAPABILITIES: &[&str] = &[
     "labels",

--- a/src/providers/outlook.rs
+++ b/src/providers/outlook.rs
@@ -1,0 +1,117 @@
+//! Microsoft 365 connection diagnostics. Provider payloads and credentials
+//! stay inside Rust; the public result is deliberately capability booleans.
+
+use serde_json::{Value, json};
+use std::{future::Future, time::Duration};
+
+async fn within_graph_deadline<F>(future: F, deadline: Duration) -> (bool, bool)
+where
+    F: Future<Output = (bool, bool)>,
+{
+    tokio::time::timeout(deadline, future)
+        .await
+        .unwrap_or((false, false))
+}
+
+fn account_id(params: &Value) -> Result<&str, &'static str> {
+    let fields = params.as_object().ok_or("invalid_params")?;
+    if fields.len() != 1 || fields.keys().any(|key| key != "accountId") {
+        return Err("invalid_params");
+    }
+    let account = fields
+        .get("accountId")
+        .and_then(Value::as_str)
+        .filter(|value| value.starts_with("outlook:") && value.len() <= 1024)
+        .ok_or("invalid_params")?;
+    if account.chars().any(char::is_control) {
+        return Err("invalid_params");
+    }
+    Ok(account)
+}
+
+pub async fn connection_check(params: &Value) -> Result<Value, &'static str> {
+    let account = account_id(params)?.to_owned();
+    let settings_account = account.clone();
+    let configured = tokio::task::spawn_blocking(move || {
+        crate::auth::settings("outlook", &settings_account).is_ok()
+    })
+    .await
+    .map_err(|_| "worker_failed")?;
+    if !configured {
+        return Ok(json!({"mail":false,"graph":false,"calendar":false}));
+    }
+    // Each provider state machine is large enough to overflow the backend
+    // worker's stack when nested in one combined future. Separate Tokio tasks
+    // keep their state on the heap and let the independent probes overlap.
+    let mail_account = account.clone();
+    let mail = tokio::spawn(async move {
+        crate::providers::imap::call("imap.check", &json!({"accountId":mail_account}))
+            .await
+            .is_ok()
+    });
+    let graph_account = account.clone();
+    let graph_and_calendar = tokio::spawn(async move {
+        // The frontend expires ordinary RPCs after 30 seconds. Bound the
+        // entire Graph chain, including token-lock and keyring waits, rather
+        // than only the final HTTP request.
+        within_graph_deadline(
+            async move {
+                let Ok(token) = crate::auth::access_token("outlook", &graph_account, "graph").await
+                else {
+                    return (false, false);
+                };
+                let request = json!({
+                    "source": {
+                        "id": "microsoft-connection-check",
+                        "kind": "microsoft",
+                        "accountId": graph_account
+                    },
+                    "operation": "list",
+                    "start": "2000-01-01T00:00:00.000Z",
+                    "end": "2000-01-01T00:00:01.000Z"
+                });
+                let calendar = crate::calendar::call(&request, Some(&token)).await.is_ok();
+                (true, calendar)
+            },
+            Duration::from_secs(27),
+        )
+        .await
+    });
+    let (mail, graph_and_calendar) = tokio::join!(mail, graph_and_calendar);
+    let mail = mail.unwrap_or(false);
+    let (graph, calendar) = graph_and_calendar.unwrap_or((false, false));
+    Ok(json!({"mail":mail,"graph":graph,"calendar":calendar}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connection_check_accepts_only_one_outlook_account_id() {
+        assert_eq!(
+            account_id(&json!({"accountId":"outlook:person@example.org"})),
+            Ok("outlook:person@example.org")
+        );
+        for value in [
+            json!({}),
+            json!({"accountId":"imap:person@example.org"}),
+            json!({"accountId":"outlook:person@example.org","extra":true}),
+            json!({"accountId":17}),
+        ] {
+            assert_eq!(account_id(&value), Err("invalid_params"));
+        }
+    }
+
+    #[tokio::test]
+    async fn graph_deadline_covers_the_entire_probe() {
+        let started = std::time::Instant::now();
+        let result = within_graph_deadline(
+            std::future::pending::<(bool, bool)>(),
+            Duration::from_millis(20),
+        )
+        .await;
+        assert_eq!(result, (false, false));
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+}

--- a/tests/test_backend_process.py
+++ b/tests/test_backend_process.py
@@ -50,7 +50,7 @@ Scope {
     id: backend
     executable: __BINARY__
     expectedVersion: __VERSION__
-    expectedApiVersion: 1
+    expectedApiVersion: __API_VERSION__
     onReadyChanged: {
       if (!ready || root.began) return
       root.began = true
@@ -153,6 +153,7 @@ def main():
         raise SystemExit("Quickshell is required: install it, then rerun make test-backend-process")
     binary = ROOT / "target/debug/omamail"
     version = tomllib.loads((ROOT / "Cargo.toml").read_text())["package"]["version"]
+    api_version = json.loads((ROOT / "backend-api.json").read_text())["apiVersion"]
     with tempfile.TemporaryDirectory(prefix="omamail-backend-process-") as directory:
         temporary = Path(directory)
         env = os.environ.copy()
@@ -178,6 +179,7 @@ def main():
         qml = QML.replace("__MODULE__", '"backend"')
         qml = qml.replace("__BINARY__", json.dumps(str(binary)))
         qml = qml.replace("__VERSION__", json.dumps(version))
+        qml = qml.replace("__API_VERSION__", str(api_version))
         expected = base64.urlsafe_b64encode(b"\x00\xff\r\n" + b"abc123" * 200000).decode().rstrip("=")
         qml = qml.replace("__EXPECTED__", json.dumps(expected))
         config = temporary / "shell.qml"

--- a/ui/Service.qml
+++ b/ui/Service.qml
@@ -2031,6 +2031,16 @@ Item {
   function signIn() { if (current) current.signIn() }
   function cancelSignIn() { if (current) current.cancelSignIn() }
   function signOut() { if (current) current.signOut() }
+  function checkMicrosoftConnection(callback) {
+    var host = current
+    if (!host || typeof host.checkMicrosoftConnection !== "function") {
+      if (typeof callback === "function") callback({ mail: false, graph: false, calendar: false })
+      return
+    }
+    host.checkMicrosoftConnection(function(report) {
+      if (root.current === host && typeof callback === "function") callback(report)
+    })
+  }
 
   // The password providers' sign-in. Gmail's is a browser and answers false,
   // which is what lets one setup page ask without checking first.

--- a/ui/account/MailAccount.qml
+++ b/ui/account/MailAccount.qml
@@ -617,6 +617,32 @@ Item {
     })
   }
 
+  // The Outlook settings page asks Rust to prove each boundary without sending
+  // a message or changing a calendar. Rust returns only capability booleans;
+  // credentials and provider responses never cross into QML.
+  function checkMicrosoftConnection(callback) {
+    if (typeof callback !== "function") return
+    var report = { mail: false, graph: false, calendar: false }
+    if (providerId !== "outlook" || !auth || !auth.loggedIn || !backend || !backend.ready) {
+      callback(report)
+      return
+    }
+    var owner = auth
+    var expectedAccount = accountId
+    function current() {
+      return providerId === "outlook" && auth === owner && owner.loggedIn
+        && accountId === expectedAccount
+    }
+    backend.call("outlook.connectionCheck", { accountId: expectedAccount }, function(result, error) {
+      if (!current()) return
+      callback({
+        mail: !error && !!result && result.mail === true,
+        graph: !error && !!result && result.graph === true,
+        calendar: !error && !!result && result.calendar === true
+      })
+    })
+  }
+
   function loadProfile() {
     if (!ready || profile) return
     if (cacheStore.loaded && cacheStore.store.profile) profile = cacheStore.store.profile

--- a/ui/components/OutlookSetupPage.qml
+++ b/ui/components/OutlookSetupPage.qml
@@ -29,6 +29,9 @@ Column {
   readonly property bool graphConsentNeeded: root.signedIn && !!auth && auth.graphConsentNeeded === true
   readonly property bool usingBuiltinClient: Microsoft.isValidClientId(Microsoft.BUILTIN_CLIENT_ID)
   readonly property bool toolsMissing: !!auth && auth.toolsChecked && auth.missingTools.length > 0
+  property bool connectionBusy: false
+  property var connectionReport: null
+  property int connectionSerial: 0
 
   spacing: Style.space(16)
 
@@ -90,6 +93,23 @@ Column {
     service.configureCurrentAccountAndSignInOAuth(values)
   }
 
+  function checkConnection() {
+    if (!root.signedIn || root.connectionBusy || !root.service) return
+    var serial = ++root.connectionSerial
+    root.connectionBusy = true
+    root.connectionReport = null
+    errorText.text = ""
+    root.service.checkMicrosoftConnection(function(report) {
+      if (serial !== root.connectionSerial) return
+      root.connectionBusy = false
+      root.connectionReport = ({
+        mail: !!report && report.mail === true,
+        graph: !!report && report.graph === true,
+        calendar: !!report && report.calendar === true
+      })
+    })
+  }
+
   function syncFromStore() {
     if (!service) return
     addressField.text = String(service.accountAddress || "")
@@ -101,7 +121,12 @@ Column {
 
   // The auth object is rebuilt when the entry is saved, so the switches are
   // read again from whichever one is current.
-  onAuthChanged: syncFromStore()
+  onAuthChanged: {
+    connectionSerial++
+    connectionBusy = false
+    connectionReport = null
+    syncFromStore()
+  }
   Component.onCompleted: syncFromStore()
 
   Connections {
@@ -109,6 +134,12 @@ Column {
     ignoreUnknownSignals: true
     function onLastErrorChanged() {
       if (root.auth && root.auth.lastError !== "") errorText.text = root.auth.lastError
+    }
+    function onLoggedInChanged() {
+      if (root.signedIn) return
+      root.connectionSerial++
+      root.connectionBusy = false
+      root.connectionReport = null
     }
     function onGraphRefused(reason) { errorText.text = String(reason || "") }
   }
@@ -256,6 +287,20 @@ Column {
       font.pixelSize: Style.font.caption
       wrapMode: Text.WordWrap
     }
+
+    Text {
+      objectName: "outlook-connection-status"
+      textFormat: Text.PlainText
+      width: parent.width
+      visible: root.connectionReport !== null
+      text: visible ? Microsoft.connectionStatus(root.connectionReport,
+        !!root.auth && String(root.auth.configuredSend || "") === "graph",
+        !!root.auth && Microsoft.isWorkTenant(root.auth.tenant)) : ""
+      color: Microsoft.connectionReady(root.connectionReport) ? root.textColor : root.dangerColor
+      font.family: root.panelFontFamily
+      font.pixelSize: Style.font.caption
+      wrapMode: Text.WordWrap
+    }
   }
 
   Column {
@@ -361,6 +406,17 @@ Column {
         onActivated: Qt.openUrlExternally(tooltipText)
       }
     }
+  }
+
+  Button {
+    objectName: "outlook-check-connection"
+    visible: root.signedIn
+    text: root.connectionBusy ? "Checking Microsoft 365..." : "Check Microsoft 365"
+    enabled: !root.connectionBusy && !root.busy && !(root.auth && root.auth.refreshBusy === true)
+    foreground: root.textColor
+    bordered: true
+    fontSize: Style.font.bodySmall
+    onClicked: root.checkConnection()
   }
 
   Row {

--- a/ui/providers/MicrosoftOAuth.js
+++ b/ui/providers/MicrosoftOAuth.js
@@ -375,6 +375,29 @@ function missingScopeMessage(missing) {
     + " permission. Check the app registration and sign in again"
 }
 
+// A connection check reports capabilities, never provider diagnostics. Keep
+// its wording here with the rest of Microsoft's presentation rules so the
+// setup page only owns the asynchronous button state.
+function connectionStatus(report, graphSend, workAccount) {
+  var value = report || {}
+  return [
+    "Account type: " + (workAccount === true ? "Work or school" : "Personal Microsoft account"),
+    "Mail access: " + (value.mail === true ? "Connected" : "Check the sign-in and IMAP access"),
+    "Microsoft Graph: " + (value.graph === true
+      ? "Mail.Send and Calendars.ReadWrite granted"
+      : "Check the app permissions and sign in again"),
+    "Calendar: " + (value.calendar === true
+      ? "Reachable"
+      : "Check Calendars.ReadWrite and sign in again"),
+    "Sending: " + (graphSend === true ? "Microsoft Graph selected" : "SMTP selected")
+  ].join("\n")
+}
+
+function connectionReady(report) {
+  var value = report || {}
+  return value.mail === true && value.graph === true && value.calendar === true
+}
+
 function refreshFailureDisposition(result) {
   return result && result.invalidGrant ? "signed_out" : "retry"
 }

--- a/ui/tests/qml/tst_outlook_boundaries.qml
+++ b/ui/tests/qml/tst_outlook_boundaries.qml
@@ -37,8 +37,10 @@ Item {
       property var auth
       property string accountAddress: "alice@hotmail.com"
       property int starts: 0
+      property var connectionCallback: null
       function cancelSignIn() { auth.cancelLogin() }
       function configureCurrentAccountAndSignInOAuth(values) { starts++ }
+      function checkMicrosoftConnection(callback) { connectionCallback = callback }
     }
   }
   TestCase {
@@ -164,6 +166,82 @@ Item {
       compare(signIn.enabled, true)
       host.auth.refreshBusy = true
       compare(signIn.enabled, false, "not offered while a refresh is under way, which would make it do nothing")
+    }
+    function test_connection_check_reports_capabilities_without_provider_diagnostics() {
+      var host = readyHost()
+      var service = createTemporaryObject(serviceFactory, parent, { auth: host.auth })
+      var page = createTemporaryObject(pageFactory, parent, { service: service })
+      host.auth.loggedIn = true
+      var button = findChild(page, "outlook-check-connection")
+      var status = findChild(page, "outlook-connection-status")
+      verify(button !== null)
+      verify(status !== null)
+      compare(button.visible, true)
+      button.clicked()
+      compare(button.enabled, false)
+      compare(button.text, "Checking Microsoft 365...")
+      verify(service.connectionCallback !== null)
+      service.connectionCallback({ mail: true, graph: true, calendar: true,
+        privateDiagnostic: "synthetic provider secret" })
+      compare(button.enabled, true)
+      compare(button.text, "Check Microsoft 365")
+      compare(status.visible, true)
+      verify(status.text.indexOf("Mail access: Connected") >= 0)
+      verify(status.text.indexOf("Microsoft Graph: Mail.Send and Calendars.ReadWrite granted") >= 0)
+      verify(status.text.indexOf("Calendar: Reachable") >= 0)
+      verify(status.text.indexOf("synthetic provider secret") < 0,
+        "provider diagnostics must not reach the setup page")
+      service.connectionCallback = null
+      button.clicked()
+      verify(service.connectionCallback !== null)
+      host.auth.loggedIn = false
+      compare(button.visible, false)
+      compare(status.visible, false)
+      compare(page.connectionBusy, false,
+        "signing out must invalidate an outstanding diagnostic")
+      service.connectionCallback({ mail: true, graph: true, calendar: true })
+      compare(status.visible, false,
+        "a late diagnostic must not reappear after sign-out")
+    }
+    function test_account_connection_check_uses_only_saved_boundaries() {
+      var host = readyHost()
+      var backend = Transports.install(host.api)
+      host.backend = backend
+      host.api.backend = backend
+      host.auth.backend = backend
+      host.auth.loggedIn = true
+      wait(1)
+      backend.testCalls = []
+      var report = null
+      host.checkMicrosoftConnection(function(value) { report = value })
+      compare(backend.testCalls.length, 1)
+      compare(backend.testCalls[0].method, "outlook.connectionCheck")
+      compare(backend.testCalls[0].params.accountId, "outlook:alice@hotmail.com")
+      verify(JSON.stringify(backend.testCalls[0].params).indexOf("synthetic") < 0,
+        "the connection check must forward only the saved account identity")
+      Transports.reply(backend.testCalls[0], { mail: true, graph: true, calendar: true,
+        privateDiagnostic: "must not cross the account boundary" }, "")
+      verify(report !== null)
+      compare(report.mail, true)
+      compare(report.graph, true)
+      compare(report.calendar, true)
+      compare(report.privateDiagnostic, undefined)
+
+      report = null
+      host.checkMicrosoftConnection(function(value) { report = value })
+      compare(backend.testCalls.length, 2)
+      host.auth.loggedIn = false
+      Transports.reply(backend.testCalls[1], { mail: true, graph: true, calendar: true }, "")
+      compare(report, null, "a result arriving after sign-out must be discarded")
+
+      host.auth.loggedIn = true
+      host.checkMicrosoftConnection(function(value) { report = value })
+      compare(backend.testCalls.length, 3)
+      Transports.reply(backend.testCalls[2], null, "synthetic failure")
+      verify(report !== null)
+      compare(report.mail, false)
+      compare(report.graph, false)
+      compare(report.calendar, false)
     }
   }
 }

--- a/ui/tests/test_microsoft_oauth.js
+++ b/ui/tests/test_microsoft_oauth.js
@@ -58,6 +58,12 @@ assert.strictEqual(microsoft.missingGraphScope("openid profile User.Read"), true
 deepEqual(microsoft.missingMailScopes(""), [])
 deepEqual(microsoft.missingMailScopes("IMAP.AccessAsUser.All SMTP.Send"), [])
 assert.ok(microsoft.graphScopeMessage().indexOf("Mail.Send") >= 0)
+assert.strictEqual(microsoft.connectionReady({ mail: true, graph: true, calendar: true }), true)
+assert.strictEqual(microsoft.connectionReady({ mail: true, graph: true, calendar: false }), false)
+assert.strictEqual(microsoft.connectionStatus({ mail: true, graph: true, calendar: true }, true, true),
+  "Account type: Work or school\nMail access: Connected\nMicrosoft Graph: Mail.Send and Calendars.ReadWrite granted\nCalendar: Reachable\nSending: Microsoft Graph selected")
+assert.ok(microsoft.connectionStatus({ mail: false, graph: false, calendar: false }, false)
+  .indexOf("SMTP selected") >= 0)
 assert.strictEqual(microsoft.isValidClientId(clientId), true)
 assert.strictEqual(microsoft.isValidClientId("not-a-guid"), false)
 assert.strictEqual(microsoft.isValidClientId(""), false)


### PR DESCRIPTION
The Outlook settings page gains a saved-account connection check that separates IMAP mail access, Microsoft Graph grants and calendar access. The Rust backend performs the probes and returns only `mail`, `graph` and `calendar` booleans; the settings page also identifies the saved account type and sending method. It sends no message and changes no calendar event. Normal OAuth refresh may rotate a stored credential.

The connection check is part of unreleased API 5 above the published 0.10.3/API-4 backend. Upstream's release pin, mail methods and released contract are preserved. The button is offered only when the connected backend supports API 5, and the account adapter refuses to dispatch it on an older backend. The fixed requirement remains valid after a release or when later API revisions are introduced. IMAP and Graph run in separate tasks, with 22-second and 27-second deadlines respectively.

## Verification (2026-09-15)

- Head `33224a2` integrates upstream `3460ac8` (0.10.3/API 4). Full `make validate` passes, including 904 main-suite QML cases, HTTP 6/6, sidebar 64/64, standalone composition, both lint targets and plugin validation.
- The standalone Rust suite passes with upstream's `standalone,integration-test-credentials` fixture features. The production standalone binary was rebuilt without the test-only feature. All six Linux CTest targets and all 22 native agent bridge tests pass.
- Full local API-5 contract: 24 exercised /177 advertised methods; standalone API-5 contract: 23/169. Published 0.10.3 archives were SHA256-verified; its actual x86_64 API-4 binary passes the released view (23/176). Exact released-contract equality passes.
- An isolated Linux host smoke test against the actual standalone backend completed API-5 handshake/shutdown. API-4 feature refusal and API-5 enablement have regressions; the Service test was observed failing with the old threshold before repair. Native resource tests reject a stale API-4 bundle.
- Fresh independent review found no actionable integration defects. Security: NOT VERIFIED for native platform release certification, which still requires native credential/platform evidence and hosted jobs. This is not a live Microsoft-account retest; no real account or credentials were used. Existing fixed-origin and bounded, boolean-only diagnostic boundaries were inspected with no demonstrated regression.

## UI evidence and readiness

The following visual evidence was captured on `7a60138`; the connection-check presentation is retained. Upstream now also supplies a standalone host; the retained captures below are plugin evidence, not fresh standalone screenshots. `make validate` was previously run successfully on `7a60138` on 2026-09-13 (837 main-suite QML cases, plus the HTTP and sidebar suites). Twenty refreshed captures exercise the current production Outlook settings component with installed Omarchy controls in Quickshell 0.3.1 on Wayland: Catppuccin and Catppuccin Latte palettes, 1180×900 and 760×720 logical viewports at 1.6× display scale. Matching before/idle pairs use upstream `6f91932`; additional after captures show loading, success and failure. Mouse events start the check, while a synthetic service supplies results; no live credentials are used.

The visible difference is the new connection-check button; running it adds account type, mail, Graph, calendar and sending-method status without removing Save changes or Sign out. The feature-specific loading and result states have no before equivalent.

The current comparison images below are uploaded GitHub attachments. UI evidence: retained plugin flow captures; BLOCK for the new standalone host's on-screen comparison, which is not established by offscreen tests.

A separate on-screen check used the real Omarchy host shell and registered envelope widget, the production App/settings/components and CalendarController, and an isolated HOME with synthetic accounts and backend/auth replies. The panel was opened from the envelope; Ctrl+, and Escape navigation, mouse activation, Tab/Enter/Space activation, connection results, calendar discovery/refresh, visibility and color persistence were exercised. Catppuccin and Catppuccin Latte were checked at 1180×900 and the smallest supported width (760×720). Only the isolated shell theme changed. This verifies the affected UI in its real host, not live OAuth/provider compatibility; fixture-only unrelated account-summary/mock warnings remain outside this scoped UI verdict.

The host-shell check found the connection button was skipped by Tab because the shared Button defaults to non-focusable. It now opts into the shared control's keyboard behavior; a regression fails against the old component and passes after the fix. No new shortcut or backend behavior is introduced.

Ready for maintainer review; hosted checks still need upstream fork-workflow authorization. No backend release, upstream merge or approval has been performed.

**After — original Microsoft 365 connection check, account details masked**

<img width="1889" height="944" alt="Microsoft 365 connection check with masked account details" src="https://github.com/user-attachments/assets/39c13d31-a62a-4586-8a4d-f6648c931756" />

## Current comparison captures

<details>
<summary>Dark — Catppuccin / wide — before, after, and result states</summary>

**Before — upstream 6f91932**

<img width="760" alt="outlook-catppuccin-wide-before-final" src="https://github.com/user-attachments/assets/b4638218-6831-43f1-b178-bfe68affb79d" />

**After — 7a60138, idle**

<img width="760" alt="outlook-catppuccin-wide-idle-final" src="https://github.com/user-attachments/assets/984eee5d-ac2b-4509-86c3-1cf034cd9b0e" />

**After — busy**

<img width="760" alt="outlook-catppuccin-wide-busy-final" src="https://github.com/user-attachments/assets/3dadb914-1518-44c8-9c85-dbdb7a469438" />

**After — success**

<img width="760" alt="outlook-catppuccin-wide-success-final" src="https://github.com/user-attachments/assets/40c41e23-8a8b-43f8-a664-e8a0123e0d20" />

**After — error**

<img width="760" alt="outlook-catppuccin-wide-error-final" src="https://github.com/user-attachments/assets/eb6a3070-e938-4e19-bcef-b8b207ea9c76" />

</details>

<details>
<summary>Dark — Catppuccin / compact — before, after, and result states</summary>

**Before — upstream 6f91932**

<img width="760" alt="outlook-catppuccin-compact-before-final" src="https://github.com/user-attachments/assets/f9ba3908-307b-435e-b9d3-72c266910101" />

**After — 7a60138, idle**

<img width="760" alt="outlook-catppuccin-compact-idle-final" src="https://github.com/user-attachments/assets/c20d791e-ae29-4b12-a2c6-cd8699aafaec" />

**After — busy**

<img width="760" alt="outlook-catppuccin-compact-busy-final" src="https://github.com/user-attachments/assets/ed1db361-65c5-4a2b-af7f-5b76c75d7a1f" />

**After — success**

<img width="760" alt="outlook-catppuccin-compact-success-final" src="https://github.com/user-attachments/assets/9ce7a389-bc2f-4f49-b716-505ee201f99f" />

**After — error**

<img width="760" alt="outlook-catppuccin-compact-error-final" src="https://github.com/user-attachments/assets/d0f2f7bf-2a52-4a7c-88ad-1109a8e852e5" />

</details>

<details>
<summary>Light — Catppuccin Latte / wide — before, after, and result states</summary>

**Before — upstream 6f91932**

<img width="760" alt="outlook-catppuccin-latte-wide-before-final" src="https://github.com/user-attachments/assets/c727e181-f9ec-4f65-b2b3-de94a7168296" />

**After — 7a60138, idle**

<img width="760" alt="outlook-catppuccin-latte-wide-idle-final" src="https://github.com/user-attachments/assets/b13c6f52-780d-4bd1-8492-e46bd2d06129" />

**After — busy**

<img width="760" alt="outlook-catppuccin-latte-wide-busy-final" src="https://github.com/user-attachments/assets/315b9b62-c48a-4090-90ba-dcaa71bea107" />

**After — success**

<img width="760" alt="outlook-catppuccin-latte-wide-success-final" src="https://github.com/user-attachments/assets/bac2a312-ac0c-44bd-8e4c-3bdb527038d9" />

**After — error**

<img width="760" alt="outlook-catppuccin-latte-wide-error-final" src="https://github.com/user-attachments/assets/002ced6c-e709-40dd-9168-b506705b416e" />

</details>

<details>
<summary>Light — Catppuccin Latte / compact — before, after, and result states</summary>

**Before — upstream 6f91932**

<img width="760" alt="outlook-catppuccin-latte-compact-before-final" src="https://github.com/user-attachments/assets/71ddcb42-c9d7-46f1-9f22-fe50d9b4e93c" />

**After — 7a60138, idle**

<img width="760" alt="outlook-catppuccin-latte-compact-idle-final" src="https://github.com/user-attachments/assets/51cb863a-aec9-4209-93d4-80b3bf2087d6" />

**After — busy**

<img width="760" alt="outlook-catppuccin-latte-compact-busy-final" src="https://github.com/user-attachments/assets/e39f47c4-9aae-4441-a944-565b2e865614" />

**After — success**

<img width="760" alt="outlook-catppuccin-latte-compact-success-final" src="https://github.com/user-attachments/assets/ee4a3343-9eda-4354-a10e-ad2dcb94418f" />

**After — error**

<img width="760" alt="outlook-catppuccin-latte-compact-error-final" src="https://github.com/user-attachments/assets/bcf43457-2cd1-46c7-a902-c2a1e5f94f0a" />

</details>


## On-screen host-shell examples

These supplementary captures use synthetic accounts and replies, as described above. Matching before/after component comparisons remain in the four sections above.

<details>
<summary>shell dark compact</summary>

<img width="760" alt="shell-dark-compact" src="https://github.com/user-attachments/assets/7bc7256f-dfd1-47cf-bda3-f62472d33d91" />

</details>

<details>
<summary>shell dark wide</summary>

<img width="760" alt="shell-dark-wide" src="https://github.com/user-attachments/assets/b7e79737-6713-4cef-8bf0-0035ec6cebda" />

</details>

<details>
<summary>shell light compact</summary>

<img width="760" alt="shell-light-compact" src="https://github.com/user-attachments/assets/26572710-8d75-4b8c-a76a-0847f865b822" />

</details>

## Release Notes

- Outlook and Microsoft 365 settings can check mail access, Graph permissions, calendar access and the selected sending method when the connected backend supports the feature.
